### PR TITLE
refactor: rename doctor skill to hermit-doctor (v1.0.18)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "claude-code-hermit",
       "source": "./",
       "description": "A personal assistant that lives in your project — memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "author": {
         "name": "gtapps"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-hermit",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "A personal assistant that lives in your project — memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
   "author": {
     "name": "gtapps"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.0.18] - 2026-04-24
+
+### Changed
+
+- **hermit-doctor: rename from doctor** — avoids collision with Claude Code's built-in `/doctor` command; follows the `hermit-*` naming convention.
+- **hermit-start: align DEFAULT_CONFIG model with template** — `model` fallback was `None`; now `'sonnet'` to match `config.json.template`.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `skills/hermit-doctor/SKILL.md` | Renamed from `skills/doctor/`; heading, name, and activation keyword updated |
+| `state-templates/CLAUDE-APPEND.md` | `/doctor` → `/hermit-doctor` in quick-reference |
+| `CLAUDE.md` | `doctor` → `hermit-doctor` in skills list |
+| `docs/artifact-naming.md` | `/doctor` → `/hermit-doctor` |
+| `scripts/hermit-start.py` | `DEFAULT_CONFIG model: None` → `'sonnet'` |
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
+
+1. **Patch `/doctor` → `/hermit-doctor` in target-project `CLAUDE.md`:** find the Quick Reference line containing the backtick-quoted token `` `/doctor` ``. If `` `/hermit-doctor` `` is already present, or if neither token appears, skip without error. Otherwise replace `` `/doctor` `` with `` `/hermit-doctor` `` on that line only and write the file back.
+
+No `config.json` changes required.
+
 ## [1.0.17] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - **`/doctor` skill — six-check installation health report** — new `skills/doctor/` skill backed by `scripts/doctor-check.js`. Runs six read-only checks (config validity, hook registration, state file integrity, cost budget, proposal health, file permissions), writes `.claude-code-hermit/state/doctor-report.json`, and surfaces a summary block in SHELL.md. Exits 0 always (fail-open); individual check failures are recorded in the report. Three new tests in `tests/run-hooks.sh` (minimal install, corrupt state, missing config).
 
+- **`/doctor` → `/hermit-doctor` skill rename** — avoids collision with Claude Code's built-in `/doctor` command. Skill directory moved from `skills/doctor/` to `skills/hermit-doctor/`; `CLAUDE-APPEND.md` quick-reference and `CLAUDE.md` skills list updated. Internal `scripts/doctor-check.js` and `state/doctor-report.json` are unchanged.
+
 - **`docs/artifact-naming.md`** — new reference doc covering the four-bucket layout (`raw/`, `compiled/`, `state/`, `proposals/`), naming conventions, and frontmatter requirements for new domains and skills. Added to README docs table.
 
 - **Weekly reviews migrated to `compiled/`** — `scripts/weekly-review.js` now writes to `.claude-code-hermit/compiled/review-weekly-YYYY-Www.md` instead of the special-cased `.claude-code-hermit/reviews/` directory. Frontmatter gains `type: review`, `title`, `created` (ISO 8601 generation timestamp), `tags: [weekly, review]`; `generated: true` is preserved as an orthogonal machine-produced marker. Session-start injection now surfaces the latest review automatically via `newestByType`, and `knowledge-lint.js` stale-flags reviews after 60 days. The `reviews/` tolerance in `KNOWN_DIRS` (`scripts/startup-context.js`) and `state-templates/GITIGNORE-APPEND.txt` is removed. Obsidian `Latest Review.md` embed path updated. Fixes a pre-existing doc bug in `docs/frontmatter-contract.md` that declared the path as `reviews/W-YYYY-WNN.md` while code wrote `reviews/weekly-YYYY-WNN.md`.
@@ -45,6 +47,7 @@
 | `skills/docker-setup/SKILL.md` | `update` added to step 9 command reference |
 | `skills/hatch/SKILL.md` | `update-history.jsonl` added to state init list |
 | `skills/channel-responder/SKILL.md` | Slash command branch added to classifier |
+| `skills/hermit-doctor/SKILL.md` | Renamed from `skills/doctor/`; name and activation keyword updated |
 
 ### Upgrade Instructions
 
@@ -65,7 +68,9 @@ Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
 
 Declaring a `review` type in `knowledge-schema.md` is left to the operator — the schema is project-owned, so hermit-evolve does not append.
 
-9. **Interactive model migration:** if `config.model` is `null` or missing, ask the operator:
+9. **Patch `/doctor` → `/hermit-doctor` in target-project `CLAUDE.md`:** read the project's `CLAUDE.md` (not the plugin's). Find the line in the Quick Reference section that lists backtick-quoted hermit skill commands — it will contain `` `/doctor` `` (the form used by `state-templates/CLAUDE-APPEND.md`). If `` `/hermit-doctor` `` is already present, or if neither token appears in the file, skip without error (fail-open). Otherwise replace the token `` `/doctor` `` with `` `/hermit-doctor` `` on that line and write the file back. Do not alter any other line.
+
+10. **Interactive model migration:** if `config.model` is `null` or missing, ask the operator:
    > "Hermit now defaults to `"sonnet"` for new installs (matches the effective default on most tiers). Your hermit currently inherits the Claude Code default at launch. Pin it to `"sonnet"` (recommended), keep `null` (continue inheriting), or set another alias (`opus`, `haiku`, `best`)?"
    Apply the operator's choice. If they choose "keep null", write `null` explicitly. If they skip or close without answering, leave the key as-is.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ After install, run `/claude-code-hermit:hatch` in the target project to create t
 ## Plugin Structure
 
 - `agents/` — subagent definitions (session-mgr, hermit-config-validator, proposal-triage, reflection-judge; hermit plugins add more subagents)
-- `skills/` — skill definitions (namespaced as `/claude-code-hermit:*`): session, session-start, session-close, pulse, brief, watch, heartbeat, hermit-routines, hermit-settings, proposal-create, proposal-list, proposal-act, reflect, reflect-scheduled-checks, channel-responder, channel-setup, hatch, hermit-evolve, docker-setup, hermit-takeover, hermit-hand-back, smoke-test, test-run, obsidian-setup, cortex-refresh, cortex-sync, weekly-review, migrate, knowledge, doctor
+- `skills/` — skill definitions (namespaced as `/claude-code-hermit:*`): session, session-start, session-close, pulse, brief, watch, heartbeat, hermit-routines, hermit-settings, proposal-create, proposal-list, proposal-act, reflect, reflect-scheduled-checks, channel-responder, channel-setup, hatch, hermit-evolve, docker-setup, hermit-takeover, hermit-hand-back, smoke-test, test-run, obsidian-setup, cortex-refresh, cortex-sync, weekly-review, migrate, knowledge, hermit-doctor
 - `hooks/hooks.json` — hook registrations
 - `scripts/` — hook implementation scripts + boot scripts (hermit-start.py, hermit-stop.py)
 - `state-templates/` — templates copied into target projects by the `hatch` skill

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.17-green.svg" alt="Version 1.0.17" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.18-green.svg" alt="Version 1.0.18" /></a>
   <img src="https://img.shields.io/badge/Claude-Pro%20%7C%20Max-blueviolet.svg" alt="Claude Pro/Max Compatible" />
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
   <a href="docs/obsidian-setup.md"><img src="https://img.shields.io/badge/obsidian-active-7c3aed.svg" alt="Obsidian Integration" /></a>

--- a/docs/artifact-naming.md
+++ b/docs/artifact-naming.md
@@ -44,7 +44,7 @@ compliant path table.
   line pointing to the raw artifact(s) the compiled was derived from.
 - **Session injection:** every compiled file is surfaced to the model at session start
   via `scripts/startup-context.js`. Shared budget — `knowledge.compiled_budget_chars`
-  (default 1000) applies across **all** compiled files, not per-file. `/doctor` and
+  (default 1000) applies across **all** compiled files, not per-file. `/hermit-doctor` and
   `scripts/knowledge-lint.js` surface oversize.
 - **Foundational pinning:** tag a compiled artifact `foundational` to pin it to every
   session regardless of age.

--- a/scripts/hermit-start.py
+++ b/scripts/hermit-start.py
@@ -35,7 +35,7 @@ DEFAULT_CONFIG = {
     'sign_off': None,
     'channels': {},
     'remote': True,
-    'model': None,
+    'model': 'sonnet',
     'permission_mode': 'acceptEdits',
     'tmux_session_name': 'hermit-{project_name}',
     'scope': 'local',

--- a/skills/hermit-doctor/SKILL.md
+++ b/skills/hermit-doctor/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: doctor
-description: Returns a six-check health report on the hermit installation — config validity, hook registration, state file integrity, cost budget, proposal health, file permissions. Use when diagnosing an install, before a release, or after suspicious behavior. Activates on messages like "/doctor", "health check", "diagnose the hermit", "what's wrong", "run diagnostic".
+name: hermit-doctor
+description: Returns a six-check health report on the hermit installation — config validity, hook registration, state file integrity, cost budget, proposal health, file permissions. Use when diagnosing an install, before a release, or after suspicious behavior. Activates on messages like "/hermit-doctor", "health check", "diagnose the hermit", "what's wrong", "run diagnostic".
 ---
 
-# Doctor
+# Hermit Doctor
 
 Runs six read-only health checks against the current hermit install and surfaces the
 summary. Safe to run at any time. Produces no side effects beyond writing

--- a/state-templates/CLAUDE-APPEND.md
+++ b/state-templates/CLAUDE-APPEND.md
@@ -47,7 +47,7 @@ Rules:
 
 ## Quick Reference
 
-`/session-start` `/session` `/session-close` `/pulse` `/brief` `/heartbeat` `/watch` `/reflect` `/reflect-scheduled-checks` `/hermit-routines` `/hermit-settings` `/proposal-list` `/proposal-act` `/proposal-create` `/hermit-evolve` `/channel-setup` `/channel-responder` `/docker-setup` `/hermit-takeover` `/hermit-hand-back` `/hatch` `/smoke-test` `/obsidian-setup` `/cortex-refresh` `/cortex-sync` `/weekly-review` `/migrate` `/knowledge` `/doctor`
+`/session-start` `/session` `/session-close` `/pulse` `/brief` `/heartbeat` `/watch` `/reflect` `/reflect-scheduled-checks` `/hermit-routines` `/hermit-settings` `/proposal-list` `/proposal-act` `/proposal-create` `/hermit-evolve` `/channel-setup` `/channel-responder` `/docker-setup` `/hermit-takeover` `/hermit-hand-back` `/hatch` `/smoke-test` `/obsidian-setup` `/cortex-refresh` `/cortex-sync` `/weekly-review` `/migrate` `/knowledge` `/hermit-doctor`
 (All prefixed with `/claude-code-hermit:`)
 
 ## Operator Notification


### PR DESCRIPTION
## Summary
- Renames `/doctor` skill to `/hermit-doctor` to avoid collision with Claude Code's built-in `/doctor` command, following the existing `hermit-*` naming convention
- Updates CLAUDE.md, CLAUDE-APPEND.md quick-reference, and docs/artifact-naming.md
- Fixes stale `DEFAULT_CONFIG model: None` in hermit-start.py to match `config.json.template` (`'sonnet'`)
- Includes hermit-evolve upgrade step to patch `/doctor` → `/hermit-doctor` in already-hatched target projects

## Test plan
- [x] All 63 tests pass (`bash tests/run-all.sh`)
- [x] `skills/hermit-doctor/SKILL.md` exists; `skills/doctor/` does not
- [x] `grep -rn "/doctor\b" skills/ state-templates/ docs/ CLAUDE.md` returns zero user-facing hits
- [x] After merge: checkout main, tag `v1.0.18`, push tag, create GitHub release