### PR TITLE
feat(tooling): release-status and fleet-release skills, create-pr fix

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -46,7 +46,23 @@ Run the guardrails against these results before continuing.
 
 **Body:**
 
-- **Plugin release branch**: read `plugins/<slug>/CHANGELOG.md` and extract the `## [Unreleased]` section (everything between the `[Unreleased]` header and the next `## [` header). Use that as the Summary block — it was written for exactly this purpose. Append the squash-merge warning below.
+- **Plugin release branch**: detect which workflow applies and extract changelog content accordingly.
+
+  **Post-release-prep (standard):** Run `git log <base>..HEAD --oneline` and look for lines matching the release commit format `<slug> v<X.Y.Z>: <summary>` (e.g. `claude-code-dev-hermit v0.2.2: /dev-pr skill, watchdog infrastructure`). For each matched slug+version, extract the `## [X.Y.Z]` section from `plugins/<slug>/CHANGELOG.md`:
+
+  ```bash
+  awk -v ver="X.Y.Z" '
+    $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+    /^## \[/ && flag {exit}
+    flag {print}
+  ' plugins/<slug>/CHANGELOG.md
+  ```
+
+  For multi-plugin releases (multiple release commits on this branch), concatenate all sections in release order (core first), each preceded by a `### <slug> v<X.Y.Z>` heading.
+
+  **Pre-release-prep (fallback):** If no release commits are found (PR opened before `/release` prep runs), fall back to reading the `## [Unreleased]` section from `plugins/<slug>/CHANGELOG.md` using the slug inferred from the branch name.
+
+  Use the extracted content as the Summary block. Append the squash-merge warning below.
 - **Otherwise**: check for `.github/PULL_REQUEST_TEMPLATE.md`. If present, fill it in using the commit range + diff as context. If no template:
 
   ```
@@ -65,7 +81,7 @@ Append to the body after the Summary block:
 ---
 > ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the
 > SHA and strands the release tag on an orphan commit. After merging, run
-> `/release <slug>` from `main` to tag.
+> `/release <slug>` from `main` for each released plugin to tag.
 ```
 
 **Issue links:**

--- a/.claude/skills/fleet-release/SKILL.md
+++ b/.claude/skills/fleet-release/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: fleet-release
+description: Use this skill whenever the user wants to release, ship, prep, or cut versions for two or more plugins together on the current branch. Trigger on phrasings like "release both plugins", "ship them together", "release all changed plugins", "fleet release", "multi-plugin release", "release in order", or "release everything on this branch". Handles dependency ordering (core first), automatic required_core_version sync, and offers /create-pr when done.
+---
+
+# Fleet Release
+
+Orchestrate a multi-plugin release: determines order, runs each plugin's `/release` prep sequentially, injects cross-plugin `hermit-meta.json` sync between core and domain plugins, then offers `/create-pr`.
+
+**Does not tag.** Tags happen on `main` after the PR merges — the existing `/release` fast-path handles that.
+
+## Usage
+
+```
+/fleet-release [slug1 slug2 ...]   explicit list
+/fleet-release                     auto-detect from current branch
+/fleet-release --dry-run           show plan, no file changes
+```
+
+## Steps
+
+### 1. Validate branch
+
+Run `git branch --show-current`. If on `main` or the repo's default branch: stop — "Fleet release is for branch prep. Switch to a plugin branch (e.g. `dev-hermit/vX.Y.Z`) and re-run."
+
+### 2. Determine target plugins
+
+**Explicit slugs:** validate each exists at `plugins/<slug>/.claude-plugin/plugin.json`. For any unknown slug, abort and list available slugs.
+
+**Auto-detect (no args):** collect plugins where both:
+1. Files under `plugins/<slug>/` changed on this branch vs base: `git diff <base>..HEAD --name-only -- plugins/<slug>/` is non-empty
+2. `plugin.json` version is ahead of the last `<slug>--v*` tag — same "already-bumped" detection as `/release` step 2
+
+Skip plugins with no `plugin.json` version or no tags (unstructured). Note skipped plugins in output.
+
+If condition 1 holds but condition 2 does not (branch changes but version not bumped yet): include the plugin and note it will need a full `/release` prep run.
+
+### 3. Determine release order
+
+Rule — not a graph:
+1. `claude-code-hermit` goes first if present
+2. Remaining plugins in alphabetical order
+
+### 4. Determine version bumps and confirm upfront
+
+For each plugin in order:
+- If version is already ahead of last tag: mark as "already prepped at vX.Y.Z" — no bump step needed for it
+- Otherwise: inspect `git log <last-tag>..HEAD -- plugins/<slug>/` to suggest patch/minor bump (same heuristics as `/release` step 2)
+
+Present the full plan at once before touching any file:
+
+```
+Release plan:
+  claude-code-hermit       1.0.22 → 1.0.23  (patch)
+  claude-code-dev-hermit   already prepped at 0.2.2
+
+Dep sync after core prep:
+  claude-code-dev-hermit   required_core_version: >=1.0.22 → >=1.0.23
+
+Confirm? [Yes / Adjust versions]
+```
+
+Wait for confirmation. If the user adjusts, accept corrections before continuing.
+
+With `--dry-run`: stop here. Print the plan and exit without touching anything.
+
+### 5. Run `/release` prep for core (if in fleet)
+
+Invoke the full `/release claude-code-hermit` skill logic (steps 1–8 of that skill). Step 8 will detect non-main branch and stop before tagging — that is expected. Continue to step 6.
+
+### 6. Inject cross-plugin dep sync
+
+Immediately after core's prep commit, before any domain plugin runs:
+
+```bash
+NEW_CORE=$(jq -r .version plugins/claude-code-hermit/.claude-plugin/plugin.json)
+```
+
+For each domain plugin **in the fleet** that has `plugins/<slug>/.claude-plugin/hermit-meta.json`:
+
+```bash
+jq --arg v ">=$NEW_CORE" '
+  .required_core_version = $v |
+  .requires["claude-code-hermit"] = $v
+' plugins/<slug>/.claude-plugin/hermit-meta.json > tmp && mv tmp plugins/<slug>/.claude-plugin/hermit-meta.json
+```
+
+These changes will be staged and committed as part of each domain plugin's `/release` run in step 7 — no separate commit needed.
+
+**Only update plugins in this fleet.** Plugins not being released are not touched.
+
+### 7. Run `/release` prep for each domain plugin
+
+For each domain plugin in order, invoke the full `/release <slug>` skill logic. The updated `hermit-meta.json` from step 6 will be included in the files that release commit touches.
+
+### 8. Report and offer PR
+
+```
+Fleet release complete:
+  claude-code-hermit      v1.0.23  (commit abc1234)
+  claude-code-dev-hermit  v0.2.3   (commit def5678)
+```
+
+Use AskUserQuestion: "Open a PR for this fleet release?" with Yes / No. If yes, invoke `/create-pr`.

--- a/.claude/skills/fleet-release/trigger-evals.json
+++ b/.claude/skills/fleet-release/trigger-evals.json
@@ -1,0 +1,22 @@
+[
+  {"query": "do a fleet release for core and dev-hermit", "should_trigger": true},
+  {"query": "both plugins changed on this branch, release them in the right order", "should_trigger": true},
+  {"query": "run fleet-release and auto-detect what needs to ship", "should_trigger": true},
+  {"query": "release core first then dev-hermit, and sync the hermit-meta", "should_trigger": true},
+  {"query": "I need to release multiple plugins together, auto-detect which ones", "should_trigger": true},
+  {"query": "we touched both claude-code-hermit and claude-code-dev-hermit on this branch — ship them together", "should_trigger": true},
+  {"query": "release all changed plugins on this branch in dependency order", "should_trigger": true},
+  {"query": "orchestrate the release for core + dev-hermit", "should_trigger": true},
+  {"query": "/fleet-release --dry-run to see what would ship", "should_trigger": true},
+  {"query": "do the full multi-plugin release prep and then open a PR", "should_trigger": true},
+  {"query": "release claude-code-hermit", "should_trigger": false},
+  {"query": "what's ready to ship", "should_trigger": false},
+  {"query": "commit the dev-hermit changes", "should_trigger": false},
+  {"query": "open a PR for this branch", "should_trigger": false},
+  {"query": "release core to 1.0.23", "should_trigger": false},
+  {"query": "update the required_core_version in hermit-meta for dev-hermit", "should_trigger": false},
+  {"query": "run the tests for all plugins", "should_trigger": false},
+  {"query": "what's the dependency between dev-hermit and core", "should_trigger": false},
+  {"query": "merge the release branch to main", "should_trigger": false},
+  {"query": "can you check if the release commits are in the right format", "should_trigger": false}
+]

--- a/.claude/skills/release-status/SKILL.md
+++ b/.claude/skills/release-status/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: release-status
+description: Use this skill to answer "what's ready to ship?", "where does the release pipeline stand?", "any plugins awaiting tag?", "give me a pipeline overview/snapshot", or any pre-release-session check-in. Shows all plugins' current version, last tag, commits ahead, whether there are unreleased changes, and whether required_core_version is stale or unsatisfied. No mutations — read-only.
+---
+
+# Release Status
+
+Read-only diagnostic — `git status` for the release pipeline. No mutations.
+
+## Steps
+
+### 1. Collect plugin data
+
+Glob `plugins/*/.claude-plugin/plugin.json`. For each slug:
+
+```bash
+# version
+jq -r .version plugins/<slug>/.claude-plugin/plugin.json
+
+# last tag (double-dash format)
+git tag --list "<slug>--v*" | sort -V | tail -1
+
+# commits since last tag, scoped to this plugin's directory
+# use HEAD as base if no tag exists
+git rev-list <last-tag-or-HEAD>..HEAD --count -- plugins/<slug>/
+
+# non-empty [Unreleased] section
+awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag && NF' \
+  plugins/<slug>/CHANGELOG.md
+```
+
+For plugins with no `plugin.json` version or no recognizable tags: mark as `unstructured (skip)` and stop collecting data for that plugin.
+
+### 2. Get latest core reference
+
+```bash
+git tag --list "claude-code-hermit--v*" | sort -V | tail -1
+```
+
+Extract just the version number (strip `claude-code-hermit--v`). Call it `latest_core_version`.
+
+### 3. Read dependency constraints (domain plugins only)
+
+For each plugin that has `plugins/<slug>/.claude-plugin/hermit-meta.json`:
+
+```bash
+jq -r .required_core_version plugins/<slug>/.claude-plugin/hermit-meta.json
+```
+
+### 4. Determine status per plugin
+
+| Condition | Status |
+|-----------|--------|
+| `plugin.json` version > last tag version | `awaiting-tag` |
+| `[Unreleased]` section is non-empty | `prep-needed` |
+| version matches last tag, no `[Unreleased]` | `up-to-date` |
+| no version or no tags | `unstructured` |
+
+### 5. Apply core-req flags (domain plugins)
+
+Parse the version floor from `required_core_version` (the number after `>=`). Compare to `latest_core_version`:
+
+| Condition | Flag |
+|-----------|------|
+| floor > latest_core_version | `✗ ERROR: unsatisfied` |
+| floor == latest_core_version | `✓` |
+| floor < latest_core_version | `⚠ WARN: stale` |
+
+### 6. Print output
+
+```
+Plugin                            Version   Last Tag   Ahead  Status         Core Req
+claude-code-hermit                1.0.22    1.0.21     2      awaiting-tag   —
+claude-code-dev-hermit            0.2.2     0.2.1      2      awaiting-tag   >=1.0.22 ✓
+claude-code-homeassistant-hermit  0.0.6     0.0.6      0      up-to-date     >=1.0.21 ⚠ stale (core: 1.0.22)
+claude-code-fitness-hermit        —         —          —      unstructured (skip)
+```
+
+After the table:
+
+- List any **ERROR** items with a one-line explanation.
+- End with one of:
+  - `Nothing ready to ship.` — no plugin is `awaiting-tag` or `prep-needed`
+  - `Ready to ship: <slug>, <slug>` — plugins where status is `awaiting-tag` or `prep-needed`

--- a/.claude/skills/release-status/trigger-evals.json
+++ b/.claude/skills/release-status/trigger-evals.json
@@ -1,0 +1,22 @@
+[
+  {"query": "what's ready to ship?", "should_trigger": true},
+  {"query": "before we start releasing, can you check where everything stands", "should_trigger": true},
+  {"query": "show me release status for all plugins", "should_trigger": true},
+  {"query": "which plugins have unreleased changes right now", "should_trigger": true},
+  {"query": "is ha-hermit's required_core_version still in sync with core?", "should_trigger": true},
+  {"query": "we're about to do a release session — give me the pipeline overview", "should_trigger": true},
+  {"query": "are there any plugins that are awaiting tag", "should_trigger": true},
+  {"query": "quick check — any [Unreleased] sections I should know about", "should_trigger": true},
+  {"query": "does anything need to ship before I open the PR", "should_trigger": true},
+  {"query": "give me a snapshot of where the release pipeline is at", "should_trigger": true},
+  {"query": "release claude-code-dev-hermit", "should_trigger": false},
+  {"query": "open a PR for this branch", "should_trigger": false},
+  {"query": "what changed in the last commit", "should_trigger": false},
+  {"query": "run the test suite for core", "should_trigger": false},
+  {"query": "bump the version for claude-code-hermit", "should_trigger": false},
+  {"query": "do a fleet release for core and dev-hermit", "should_trigger": false},
+  {"query": "commit these changelog updates", "should_trigger": false},
+  {"query": "is the required_core_version bumped to 1.0.22 in my local edit", "should_trigger": false},
+  {"query": "what plugins are installed on this hermit", "should_trigger": false},
+  {"query": "show me git log since the last tag for dev-hermit", "should_trigger": false}
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Always launch Claude Code from this repo's root, not from inside a plugin dir. A
 - **Use `/commit` for every commit in this repo.** It detects which plugin's scope the diff belongs to, routes the CHANGELOG entry to that plugin's `CHANGELOG.md`, path-scopes staging (never `git add -A`), and runs `/simplify` on every diff (including markdown-only). The skill enforces "one plugin per commit" — cross-plugin changes are split into separate `/commit` runs.
 - Root-scope edits (CI, root README, `.claude/`, `.claude-plugin/marketplace.json`) skip the CHANGELOG step entirely — they don't ship to operators. `/commit` handles that automatically.
 - Releases still go through `/release <slug>`, which promotes a plugin's `[Unreleased]` section to a real version. `/commit` accumulates those entries during day-to-day work.
-- **Where these skills live**: `/commit`, `/release`, `/create-pr`, `/test-run` are repo-internal skills under `.claude/skills/` — they're not shipped to operators, only used during monorepo dev.
+- **Where these skills live**: `/commit`, `/release`, `/create-pr`, `/release-status`, `/fleet-release`, `/test-run` are repo-internal skills under `.claude/skills/` — they're not shipped to operators, only used during monorepo dev. Use `/release-status` for a read-only pipeline snapshot before any release session; use `/fleet-release` when multiple plugins change together on one branch (handles dep ordering and `required_core_version` sync automatically).
 
 ## Branching
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,11 @@ See [Testing](docs/testing.md) for hook test details, fixtures, manual testing, 
 ## PR Workflow
 
 1. Create a feature branch
-2. Make changes
-3. Run `( cd plugins/claude-code-hermit && bash tests/run-all.sh )` locally (and the HA pytest suite if HA code changed)
-4. Push — CI runs the same tests
-5. Keep commits focused — one concern per PR
+2. Run `/release-status` for a read-only pipeline snapshot (flags stale `required_core_version`, shows what's awaiting tag)
+3. Make changes
+4. Run `( cd plugins/claude-code-hermit && bash tests/run-all.sh )` locally (and the HA pytest suite if HA code changed)
+5. Push — CI runs the same tests
+6. Keep commits focused — one concern per PR
 
 ## Adding a New Hermit
 
@@ -78,6 +79,8 @@ Every plugin in this fleet that depends on the core hermit declares three versio
 ```
 
 `required_core_version` is the canonical fleet contract. It is read by the core plugin's `hermit-doctor` (the `dependencies` check), `smoke-test`, and `hermit-evolve`, and by external/third-party hermits that live outside this monorepo. The parallel `requires.claude-code-hermit` field mirrors it — the two must agree, and `tests/run-hooks.sh` enforces this on every CI run (test `sibling manifests: required_core_version vs requires consistency`). When you bump one, bump all three.
+
+When releasing core and a domain plugin together, use `/fleet-release` — it updates all three fields automatically after the core prep commit, before the domain plugin's release runs.
 
 ## Per-Plugin Test Runner Pattern
 


### PR DESCRIPTION
## Summary

- **`/release-status`** — read-only pipeline snapshot across all plugins:
  version, last tag, commits ahead, `[Unreleased]` presence, and
  `required_core_version` staleness/satisfaction check. The "git status for
  the release pipeline."

- **`/fleet-release`** — multi-plugin release orchestrator: detects which
  plugins changed on the branch, releases in dependency order (core first),
  and automatically updates `required_core_version` in each domain plugin's
  `hermit-meta.json` after the core prep commit — the manual sync step that
  was previously error-prone.

- **`/create-pr` fix** — after `/release` prep runs, `[Unreleased]` is
  promoted to `[X.Y.Z]`. The old body logic read `[Unreleased]` and found
  nothing. Fixed to parse release commits from `git log` and extract the
  versioned CHANGELOG sections; handles multi-plugin branches by
  concatenating all sections (core first).

- **CLAUDE.md + CONTRIBUTING.md** — surface the new skills in the two
  places contributors look: the skills list in CLAUDE.md and the
  `required_core_version` + PR workflow sections in CONTRIBUTING.md.

- **`trigger-evals.json`** co-located with each skill for description
  re-optimization if needed.

## Test plan

- [x] Run `/release-status` — verify table shows correct version, last tag,
  ahead count, and `⚠ stale` flag for `claude-code-homeassistant-hermit`
  (its `required_core_version` is `>=1.0.21`, core is now `1.0.22`)
- [x] On a release branch with multiple plugin changes, run
  `/fleet-release --dry-run` — verify it proposes core-first order and
  shows the `required_core_version` sync step
- [x] On `dev-hermit/v0.2.2` after merging, run `/create-pr` from main —
  verify the PR body pulls from the versioned `[1.0.22]` / `[0.2.2]`
  CHANGELOG sections, not an empty `[Unreleased]`