### PR TITLE
release(claude-code-hermit): v1.0.23

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased]
+
+### Removed
+
+- **hermit-start: agent worktree setup** — deleted `setup_agent_worktree()` and the `HERMIT_AGENT_WORKTREE` env-file export from `scripts/hermit-start.py`. The function was added in v1.0.22 to give dev-hermit's always-on worktree topology a persistent `.claude/worktrees/agent/` checkout to operate in; dev-hermit v0.3.0 dropped that topology entirely (no more `$HERMIT_AGENT_WORKTREE` consumers anywhere in the fleet). The setup ran on every boot, made up to 3 git subprocess calls (15s timeout each → up to 45s worst-case), and produced a stale `.claude/worktrees/agent/` directory that nothing reads. Removing it speeds up boot and shrinks the per-session tmux env file by one variable.
+
+### Changed
+
+- **`docs/architecture.md`: agent layer description** — the line claiming dev-hermit "adds repo-mapper, implementer, reviewer" was always wrong (dev-hermit historically shipped only an `implementer`; v0.3.0 ships zero agents). Replaced with a generic statement pointing operators at each plugin's CLAUDE.md for its actual agent set.
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
+
+1. **Remove the stale agent worktree** if it exists. Run `git -C "$PROJECT_ROOT" worktree list --porcelain` to detect a registered worktree at `.claude/worktrees/agent/`. If present, run `git -C "$PROJECT_ROOT" worktree remove --force .claude/worktrees/agent`. If absent from `git worktree list` but the directory still exists on disk, `rm -r .claude/worktrees/agent` (no `-f` per repo rules) and `git worktree prune` to clear any stale ref. Best-effort: do not block the upgrade if the operation fails — print a one-line warning telling the operator to clean up manually.
+2. **Note the env-var removal.** Tell the operator: "v1.0.23 removes the `HERMIT_AGENT_WORKTREE` env var from the per-session tmux env file. Any custom skill or script you wrote that reads this var (none ship in the official hermit fleet) will see it as unset — adjust to either drop the dependency or read project root from `Path.cwd()` instead."
+
+The `.claude/worktrees/` line in `state-templates/GITIGNORE-APPEND.txt` and `GITIGNORE-APPEND-PROJECT.txt` is intentionally preserved — it covers Claude Code's native `isolation: worktree` agent feature (used by other plugins), not just the deleted hermit-managed subpath.
+
+No `config.json` changes required.
+
 ## [1.0.22] - 2026-04-28
 
 ### Added

--- a/plugins/claude-code-hermit/docs/architecture.md
+++ b/plugins/claude-code-hermit/docs/architecture.md
@@ -85,7 +85,7 @@ SHELL.md tasks,  status,   S-NNN-REPORT.md,
 
 Tools: Read, Write, Edit, Bash, Glob, Grep. No web access. Uses `memory: project` for accumulated knowledge across sessions.
 
-Hermits extend this layer with specialized agents (e.g., `claude-code-dev-hermit` adds repo-mapper, implementer, reviewer).
+Hermits extend this layer with specialized agents when they ship them; the active set varies per hermit and is documented in each plugin's `CLAUDE.md`.
 
 ---
 

--- a/plugins/claude-code-hermit/scripts/hermit-start.py
+++ b/plugins/claude-code-hermit/scripts/hermit-start.py
@@ -161,66 +161,6 @@ def is_container():
     )
 
 
-def setup_agent_worktree():
-    """Ensure the persistent agent worktree at .claude/worktrees/agent/ exists.
-
-    Three-way idempotent:
-      - absent on disk → create (--detach avoids "branch already checked out" error)
-      - dir exists but unlisted in git → prune stale refs, then re-add
-      - dir exists and listed → leave alone; do NOT re-detach HEAD (the worktree
-        may already be on a feature branch from the prior session — resetting
-        would destroy that context)
-
-    Fails open: prints a warning and returns the expected path even on git error
-    so skills can handle the situation gracefully via /dev-doctor.
-
-    Returns the absolute path string.
-    """
-    project_dir = Path.cwd().resolve()
-    worktree_abs = project_dir / '.claude' / 'worktrees' / 'agent'
-
-    try:
-        result = subprocess.run(
-            ['git', 'worktree', 'list', '--porcelain'],
-            capture_output=True, text=True, cwd=str(project_dir), timeout=15,
-        )
-        listed = result.returncode == 0 and str(worktree_abs) in result.stdout
-    except subprocess.TimeoutExpired:
-        print('[hermit] WARNING: git worktree list timed out — skipping worktree setup.')
-        return str(worktree_abs)
-
-    if worktree_abs.is_dir() and listed:
-        return str(worktree_abs)
-
-    if worktree_abs.is_dir() and not listed:
-        try:
-            subprocess.run(
-                ['git', 'worktree', 'prune'], cwd=str(project_dir),
-                capture_output=True, timeout=15,
-            )
-        except subprocess.TimeoutExpired:
-            pass  # prune is best-effort; proceed to add regardless
-
-    try:
-        # --force allows re-registering a directory that already exists on disk
-        # after a stale ref was pruned (prune removes the ref, not the directory).
-        result = subprocess.run(
-            ['git', 'worktree', 'add', '--detach', '--force', str(worktree_abs)],
-            capture_output=True, text=True, cwd=str(project_dir), timeout=15,
-        )
-    except subprocess.TimeoutExpired:
-        print('[hermit] WARNING: git worktree add timed out — skipping worktree setup.')
-        return str(worktree_abs)
-
-    if result.returncode != 0:
-        print(f'[hermit] WARNING: agent worktree setup failed — {result.stderr.strip()}')
-        print('[hermit]   Continuing without worktree isolation. Run /dev-doctor to diagnose.')
-    else:
-        print(f'[hermit] Agent worktree: .claude/worktrees/agent')
-
-    return str(worktree_abs)
-
-
 def write_runtime_json(data):
     """Atomic write to state/runtime.json."""
     STATE_DIR.mkdir(parents=True, exist_ok=True)
@@ -554,8 +494,6 @@ def main():
     # Auth vars must be in shell env before claude launches.
     # *_STATE_DIR vars must be OS env because MCP servers (channel plugins)
     # inherit shell env but don't read settings.local.json.
-    agent_worktree = setup_agent_worktree()
-
     forward_vars = ['CLAUDE_CONFIG_DIR', 'ANTHROPIC_API_KEY', 'AGENT_HOOK_PROFILE']
     # *_STATE_DIR vars must reach MCP servers via OS env — see write_settings_env.
     for ch_name, ch_cfg in iter_channel_configs(config):
@@ -567,7 +505,6 @@ def main():
         # set it explicitly so Bash tool calls in skills work in cron-triggered sessions.
         plugin_root = str(Path(__file__).resolve().parent.parent)
         f.write(f'export CLAUDE_PLUGIN_ROOT={shlex.quote(plugin_root)}\n')
-        f.write(f'export HERMIT_AGENT_WORKTREE={shlex.quote(agent_worktree)}\n')
         for var in forward_vars:
             val = os.environ.get(var)
             if val is not None:


### PR DESCRIPTION
### Removed

- **hermit-start: agent worktree setup** — deleted `setup_agent_worktree()` and the `HERMIT_AGENT_WORKTREE` env-file export from `scripts/hermit-start.py`. The function was added in v1.0.22 to give dev-hermit's always-on worktree topology a persistent `.claude/worktrees/agent/` checkout to operate in; dev-hermit v0.3.0 dropped that topology entirely (no more `\$HERMIT_AGENT_WORKTREE` consumers anywhere in the fleet). The setup ran on every boot, made up to 3 git subprocess calls (15s timeout each → up to 45s worst-case), and produced a stale `.claude/worktrees/agent/` directory that nothing reads. Removing it speeds up boot and shrinks the per-session tmux env file by one variable.

### Changed

- **`docs/architecture.md`: agent layer description** — the line claiming dev-hermit "adds repo-mapper, implementer, reviewer" was always wrong (dev-hermit historically shipped only an `implementer`; v0.3.0 ships zero agents). Replaced with a generic statement pointing operators at each plugin's CLAUDE.md for its actual agent set.

### Upgrade Instructions

Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:

1. **Remove the stale agent worktree** if it exists. Run `git -C "\$PROJECT_ROOT" worktree list --porcelain` to detect a registered worktree at `.claude/worktrees/agent/`. If present, run `git -C "\$PROJECT_ROOT" worktree remove --force .claude/worktrees/agent`. If absent from `git worktree list` but the directory still exists on disk, `rm -r .claude/worktrees/agent` (no `-f` per repo rules) and `git worktree prune` to clear any stale ref. Best-effort: do not block the upgrade if the operation fails — print a one-line warning telling the operator to clean up manually.
2. **Note the env-var removal.** Tell the operator: "v1.0.23 removes the `HERMIT_AGENT_WORKTREE` env var from the per-session tmux env file. Any custom skill or script you wrote that reads this var (none ship in the official hermit fleet) will see it as unset — adjust to either drop the dependency or read project root from `Path.cwd()` instead."

The `.claude/worktrees/` line in `state-templates/GITIGNORE-APPEND.txt` and `GITIGNORE-APPEND-PROJECT.txt` is intentionally preserved — it covers Claude Code's native `isolation: worktree` agent feature (used by other plugins), not just the deleted hermit-managed subpath.

No `config.json` changes required.

---

> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the
> SHA and strands the release tag on an orphan commit. After merging, run
> \`/release claude-code-hermit\` from \`main\` to tag.