### PR TITLE
release(claude-code-dev-hermit): v0.3.1

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`/dev-quality` skill (`skills/dev-quality/SKILL.md`)** — re-introduces a `/dev-quality` skill (removed in v0.3.0 as "workflow ceremony") in leaner form as a mechanical pre-wrap quality gate: runs `/simplify` on the working-tree diff, re-runs `commands.test`, and reports results. On test regression, surfaces the failure and stops — no auto-rollback. If `/code-review:code-review` (`code-review@claude-plugins-official`) is in the agent's available slash-command list, the skill tells the agent to suggest it to the operator (never invokes it autonomously). No state file, no cross-skill contract.
+
+### Changed
+
+- **`state-templates/CLAUDE-APPEND.md`** — adds step 4 to §Implementation Flow pointing to `/dev-quality`; rewrites §Tests Before PR to reference `/dev-quality` as the `/simplify`+re-run owner (with a note to re-run `commands.test` after committing, before `/dev-pr`, until the `last-test.json` tree-equality fix ships). Operators must re-run `/claude-code-dev-hermit:hatch` to refresh their project's CLAUDE.md.
+
 ## [0.3.0] - 2026-04-28
 
 **v0.3.0 — language-agnostic safety layer.** Mass cleanup: dropped ~6,000 lines (~70% of the plugin) to reframe dev-hermit as a thin safety layer instead of a stack-aware orchestrator. The plugin now ships 2 skills (`hatch`, `dev-pr`), 1 hook (`git-push-guard`), and a CLAUDE-APPEND template that injects safety rules into the project's CLAUDE.md. No built-in implementer agent — operators use the native `Agent` tool, `feature-dev`'s research/architect agents, or custom subagents, all governed by the injected rules. Three audits (value / complexity / native-delegation) and a series of design-iteration conversations led to this redesign; full rationale in the v0.3.0 plan (`/home/d0m/.claude/plans/cryptic-weaving-dolphin.md`).

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Added
 
-- **`/dev-quality` skill (`skills/dev-quality/SKILL.md`)** — re-introduces a `/dev-quality` skill (removed in v0.3.0 as "workflow ceremony") in leaner form as a mechanical pre-wrap quality gate: runs `/simplify` on the working-tree diff, re-runs `commands.test`, and reports results. On test regression, surfaces the failure and stops — no auto-rollback. If `/code-review:code-review` (`code-review@claude-plugins-official`) is in the agent's available slash-command list, the skill tells the agent to suggest it to the operator (never invokes it autonomously). No state file, no cross-skill contract.
+- **`/dev-test` skill (`skills/dev-test/SKILL.md`)** — run the configured test suite and record the result to `last-test.json`. Useful for mid-task verification and warming the `/dev-pr` test cache. Internally calls `record-test-result.js run`.
+- **`/dev-quality` skill (`skills/dev-quality/SKILL.md`)** — re-introduces a `/dev-quality` skill (removed in v0.3.0 as "workflow ceremony") in leaner form as a mechanical pre-wrap quality gate: runs `/simplify` on the working-tree diff, re-runs `commands.test` if set, and reports results. On test regression, surfaces the failure and stops — no auto-rollback. If `/code-review:code-review` (`code-review@claude-plugins-official`) is in the agent's available slash-command list, the skill tells the agent to suggest it to the operator (never invokes it autonomously).
 
 ### Changed
 
-- **`state-templates/CLAUDE-APPEND.md`** — adds step 4 to §Implementation Flow pointing to `/dev-quality`; rewrites §Tests Before PR to reference `/dev-quality` as the `/simplify`+re-run owner (with a note to re-run `commands.test` after committing, before `/dev-pr`, until the `last-test.json` tree-equality fix ships). Operators must re-run `/claude-code-dev-hermit:hatch` to refresh their project's CLAUDE.md.
+- **`/dev-pr` Gate 0 tests check** — now runs tests automatically on cache miss instead of blocking with "run the test command yourself". A fresh `status:"pass"` record at the current HEAD is a cache hit (instant); anything else triggers `record-test-result.js run`. Fixes #12 (hook couldn't observe exit codes; gate previously refused all PRs).
+- **`scripts/record-test-result.js`** — adds `run` subcommand (executes `commands.test`, records real exit code + duration) and `write <exit_code> <duration_ms>` subcommand (for direct callers and CI). Hook path now silently skips on missing exit code instead of writing `status:"unknown"`. Interrupted runs (`tool_response.interrupted === true`) are skipped.
+- **`/dev-quality`** — test step now calls `record-test-result.js run` instead of `$COMMANDS_TEST`, so the result is recorded to `last-test.json` (note: SHA is pre-commit; `/dev-pr` will still re-run after commit).
+- **`state-templates/CLAUDE-APPEND.md`** — adds step 4 to §Implementation Flow pointing to `/dev-quality`; rewrites §Tests Before PR to reference `/dev-quality` as the `/simplify`+re-run owner. Operators must re-run `/claude-code-dev-hermit:hatch` to refresh their project's CLAUDE.md.
 
 ## [0.3.0] - 2026-04-28
 

--- a/plugins/claude-code-dev-hermit/README.md
+++ b/plugins/claude-code-dev-hermit/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.3.0-green.svg" alt="Version 0.3.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.3.1-green.svg" alt="Version 0.3.1" /></a>
   <img src="https://img.shields.io/badge/Claude-Pro%20%7C%20Max-blueviolet.svg" alt="Claude Pro/Max Compatible" />
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
 </p>
@@ -117,7 +117,9 @@ See [docs/GIT-SAFETY.md](docs/GIT-SAFETY.md) for the full safety model and the t
 | Surface | Role |
 |-------|-------------|
 | `hatch` skill | One-time setup wizard. Idempotent / re-runnable. Captures test/lint/format/protected/PR-template/hook-profile. Installs `git-push-guard` at strict by default. |
-| `dev-pr` skill | Push the current feature branch and open a PR with body assembled from commits + last test result + screenshots + optional project template. |
+| `dev-pr` skill | Push the current feature branch and open a PR with body assembled from commits + last test result + screenshots + optional project template. Runs tests automatically on cache miss — fresh HEAD pass hits instantly; anything else triggers the test runner. |
+| `dev-quality` skill | Pre-wrap quality gate. Runs `/simplify` on the diff, re-runs `commands.test` via `record-test-result.js`, and reports pass/fail. Suggests `/code-review` to the operator if available — never invokes it. |
+| `dev-test` skill | Run the configured test suite and record the result to `last-test.json`. Useful for mid-task verification and warming the `/dev-pr` cache. |
 | `git-push-guard` hook | Strict-profile-only `PreToolUse` Bash hook. Blocks the dangerous git operations listed above. |
 | `state-templates/CLAUDE-APPEND.md` | Injected into your project's `CLAUDE.md` by `/hatch`. The rules-of-the-road every agent reads when working on this project. |
 
@@ -131,7 +133,7 @@ These are Claude Code built-ins — no installation needed:
 - `/batch` — same change across many files in parallel
 - `/debug` — diagnostics when something's stuck
 
-The CLAUDE-APPEND.md `§Tests Before PR` rule wraps `/simplify` with a tests-then-revert-on-regression discipline; this is enforced by the agent reading the rule, not by a separate skill.
+The CLAUDE-APPEND.md `§Implementation Flow` points to `/dev-quality` as the pre-commit quality gate — it runs `/simplify`, re-runs `commands.test`, and records the result so `/dev-pr` can hit the cache at the current HEAD.
 
 ---
 

--- a/plugins/claude-code-dev-hermit/scripts/record-test-result.js
+++ b/plugins/claude-code-dev-hermit/scripts/record-test-result.js
@@ -14,7 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 
 const MAX_STDIN = 1024 * 1024;
 
@@ -48,6 +48,50 @@ function atomicWrite(filePath, content) {
   fs.renameSync(tmp, filePath);
 }
 
+function writeRecord(hermitDir, command, exitCode, durationMs) {
+  const sha = gitHead(process.cwd());
+  if (!sha) return;
+  const record = {
+    command,
+    exit_code: exitCode,
+    duration_ms: durationMs,
+    status: exitCode === 0 ? 'pass' : 'fail',
+    sha,
+    ts: new Date().toISOString(),
+  };
+  const stateDir = path.join(hermitDir, 'state');
+  try {
+    fs.mkdirSync(stateDir, { recursive: true });
+    atomicWrite(path.join(stateDir, 'last-test.json'), JSON.stringify(record, null, 2) + '\n');
+  } catch (_) {}
+}
+
+const argv = process.argv;
+
+// run subcommand: execute commands.test and record the result
+if (argv[2] === 'run') {
+  const hermitDir = findHermitDir(process.cwd());
+  if (!hermitDir) { console.error('No .claude-code-hermit/ found'); process.exit(1); }
+  const testCmd = loadTestCommand(hermitDir);
+  if (!testCmd) { console.error('commands.test not configured'); process.exit(1); }
+  const start = Date.now();
+  const r = spawnSync('bash', ['-c', testCmd], { stdio: 'inherit' });
+  writeRecord(hermitDir, testCmd, r.status ?? 1, Date.now() - start);
+  process.exit(r.status ?? 1);
+}
+
+// write subcommand: record a known exit code (for direct callers / CI)
+if (argv[2] === 'write') {
+  const ecArg = argv[3];
+  const durArg = argv[4];
+  if (!/^-?\d+$/.test(ecArg) || !/^-?\d+$/.test(durArg)) process.exit(0);
+  const hermitDir = findHermitDir(process.cwd());
+  if (!hermitDir) process.exit(0);
+  const testCmd = loadTestCommand(hermitDir) || '';
+  writeRecord(hermitDir, testCmd, parseInt(ecArg, 10), parseInt(durArg, 10));
+  process.exit(0);
+}
+
 async function main() {
   const chunks = [];
   let total = 0;
@@ -61,6 +105,8 @@ async function main() {
 
   let data;
   try { data = JSON.parse(raw); } catch { process.exit(0); }
+
+  if (data.tool_response?.interrupted === true) process.exit(0);
 
   const command = data.tool_input?.command || '';
   if (!command) process.exit(0);
@@ -76,27 +122,9 @@ async function main() {
   const tr = data.tool_response || {};
   const exitCode = typeof tr.exit_code === 'number' ? tr.exit_code
                  : typeof tr.exitCode === 'number' ? tr.exitCode : null;
-  const durationMs = typeof tr.duration_ms === 'number' ? tr.duration_ms
-                   : typeof tr.durationMs === 'number' ? tr.durationMs : null;
+  if (exitCode === null) process.exit(0);
 
-  const sha = gitHead(process.cwd());
-  if (!sha) process.exit(0);
-
-  const record = {
-    command,
-    exit_code: exitCode,
-    duration_ms: durationMs,
-    status: exitCode === 0 ? 'pass' : exitCode === null ? 'unknown' : 'fail',
-    sha,
-    ts: new Date().toISOString(),
-  };
-
-  const stateDir = path.join(hermitDir, 'state');
-  try {
-    fs.mkdirSync(stateDir, { recursive: true });
-    atomicWrite(path.join(stateDir, 'last-test.json'), JSON.stringify(record, null, 2) + '\n');
-  } catch (_) {}
-
+  writeRecord(hermitDir, command, exitCode, null);
   process.exit(0);
 }
 

--- a/plugins/claude-code-dev-hermit/scripts/record-test-result.test.js
+++ b/plugins/claude-code-dev-hermit/scripts/record-test-result.test.js
@@ -16,9 +16,10 @@ function setupProject(testCmd) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rec-test-'));
   const hermit = path.join(tmp, '.claude-code-hermit');
   fs.mkdirSync(hermit, { recursive: true });
-  fs.writeFileSync(path.join(hermit, 'config.json'), JSON.stringify({
-    'claude-code-dev-hermit': { commands: { test: testCmd } },
-  }));
+  const cfg = testCmd !== null
+    ? { 'claude-code-dev-hermit': { commands: { test: testCmd } } }
+    : {};
+  fs.writeFileSync(path.join(hermit, 'config.json'), JSON.stringify(cfg));
   const gitEnv = { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' };
   execSync('git init -q && git commit -q --allow-empty -m init', { cwd: tmp, env: gitEnv, stdio: 'ignore' });
   return tmp;
@@ -54,7 +55,7 @@ let proj = setupProject('npm test');
 runHook(proj, { tool_input: { command: 'npm test' }, tool_response: { exit_code: 0, duration_ms: 1234 } });
 let s = readState(proj);
 assert('records pass with exit_code 0', s !== null && s.status === 'pass' && s.exit_code === 0);
-assert('records duration_ms', s && s.duration_ms === 1234);
+assert('hook path writes duration_ms null (run subcommand provides timing)', s && s.duration_ms === null);
 assert('records command', s && s.command === 'npm test');
 assert('records ts', s && typeof s.ts === 'string' && s.ts.includes('T'));
 cleanup(proj);
@@ -75,7 +76,7 @@ cleanup(proj);
 proj = setupProject('npm test');
 runHook(proj, { tool_input: { command: 'npm test' }, tool_response: {} });
 s = readState(proj);
-assert('records unknown when no exit_code in response', s !== null && s.status === 'unknown' && s.exit_code === null);
+assert('does not write when no exit_code in response', s === null);
 cleanup(proj);
 
 proj = setupProject('npm test');
@@ -104,6 +105,63 @@ const rc2 = runHook(tmp2, { tool_input: { command: 'anything' }, tool_response: 
 assert('exits 0 when commands.test is not configured', rc2 === 0);
 assert('does not write last-test.json without configured command', !fs.existsSync(path.join(tmp2, '.claude-code-hermit', 'state', 'last-test.json')));
 fs.rmSync(tmp2, { recursive: true, force: true });
+
+// interrupted guard
+proj = setupProject('npm test');
+runHook(proj, { tool_input: { command: 'npm test' }, tool_response: { interrupted: true } });
+s = readState(proj);
+assert('does not write when tool_response.interrupted is true', s === null);
+cleanup(proj);
+
+// write subcommand — pass
+proj = setupProject('npm test');
+spawnSync(process.execPath, [HOOK, 'write', '0', '1234'], { cwd: proj });
+s = readState(proj);
+const expectedSha = execSync('git rev-parse HEAD', { cwd: proj, encoding: 'utf-8' }).trim();
+assert('write: records pass with exit_code 0', s !== null && s.exit_code === 0 && s.status === 'pass');
+assert('write: records duration_ms', s !== null && s.duration_ms === 1234);
+assert('write: records git HEAD sha', s !== null && s.sha === expectedSha);
+cleanup(proj);
+
+// write subcommand — fail
+proj = setupProject('npm test');
+spawnSync(process.execPath, [HOOK, 'write', '1', '500'], { cwd: proj });
+s = readState(proj);
+assert('write: records fail with exit_code 1', s !== null && s.exit_code === 1 && s.status === 'fail');
+cleanup(proj);
+
+// write subcommand — invalid args
+proj = setupProject('npm test');
+spawnSync(process.execPath, [HOOK, 'write', '0abc', '1234'], { cwd: proj });
+s = readState(proj);
+assert('write: does not write on invalid exit_code arg', s === null);
+cleanup(proj);
+
+// run subcommand — pass
+proj = setupProject('exit 0');
+const runPass = spawnSync(process.execPath, [HOOK, 'run'], { cwd: proj, encoding: 'utf-8' });
+s = readState(proj);
+const runSha = execSync('git rev-parse HEAD', { cwd: proj, encoding: 'utf-8' }).trim();
+assert('run: exits 0 on passing test command', runPass.status === 0);
+assert('run: records pass', s !== null && s.status === 'pass');
+assert('run: records git HEAD sha', s !== null && s.sha === runSha);
+cleanup(proj);
+
+// run subcommand — fail
+proj = setupProject('exit 1');
+const runFail = spawnSync(process.execPath, [HOOK, 'run'], { cwd: proj, encoding: 'utf-8' });
+s = readState(proj);
+assert('run: exits 1 on failing test command', runFail.status === 1);
+assert('run: records fail', s !== null && s.status === 'fail');
+cleanup(proj);
+
+// run subcommand — no commands.test
+proj = setupProject(null);
+const runNoCmd = spawnSync(process.execPath, [HOOK, 'run'], { cwd: proj, encoding: 'utf-8' });
+s = readState(proj);
+assert('run: exits 1 when commands.test not configured', runNoCmd.status === 1);
+assert('run: does not write when commands.test not configured', s === null);
+cleanup(proj);
 
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -35,11 +35,22 @@ done
 
 **2. Clean-tree check.** `git status --porcelain` must return empty. If non-empty: FAIL with `"commit or stash changes before opening a PR"`.
 
-**3. Tests-ran check.** Read `.claude-code-hermit/state/last-test.json` (written by the `record-test-result` `PostToolUse` hook whenever the configured `commands.test` runs via Bash). Three failure modes:
+**3. Tests check.** Read `commands.test` from `.claude-code-hermit/config.json`.
 
-- File missing: FAIL `"no test result recorded — run the configured test command (commands.test) before /dev-pr; if commands.test is unset, run /claude-code-dev-hermit:hatch to configure it"`.
-- `sha !== current HEAD`: FAIL `"last test run was on <sha>, now at <head> — re-run commands.test"`.
-- `status !== 'pass'`: FAIL `"last test run failed (exit <exit_code>) — fix and re-run commands.test"`.
+- If `commands.test` is **unset**: warn `"No test command configured — test check skipped."` and proceed.
+
+Otherwise, read `.claude-code-hermit/state/last-test.json`:
+
+- If the file exists **and** `sha === current HEAD` **and** `status === "pass"`: cache hit — skip test run and proceed.
+- Anything else (file missing, stale SHA, or `status !== "pass"`): run tests now:
+
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.js" run
+  ```
+
+  Use `timeout: 600000`. If exit non-zero: FAIL `"tests failed (exit N) — fix and re-run /dev-pr"`. If exit 0: proceed.
+
+  For suites longer than 10 min: run tests in a terminal, record with `node <PLUGIN_ROOT>/scripts/record-test-result.js write <exit_code> <duration_ms>`, then re-run `/dev-pr`.
 
 This is the gate that enforces CLAUDE-APPEND §Tests Before PR mechanically rather than relying on the agent's self-report.
 
@@ -160,7 +171,7 @@ On Gate 3 FAIL: show the host-tool exit message + a one-line recovery hint.
 ## Rules
 
 - **Never skips clean-tree or protected-branch checks.** No `--force` flag exists; the only escape is to fix the underlying condition.
-- **No code edits, no test runs.** Run tests yourself (per CLAUDE-APPEND §Tests Before PR) before invoking `/dev-pr`. This skill is a push-and-create operation only.
+- **Runs tests on cache miss.** If no fresh pass exists at HEAD, Gate 0 runs `record-test-result.js run` automatically. First `/dev-pr` after changes may take time; subsequent calls at the same HEAD hit cache instantly.
 - **No screenshot creation.** Reads from `raw/screenshots/<binding-id>/manifest.json`. Producing screenshots is a stack-specific plugin's job.
 - **No merge.** Opening the PR is the terminal step; merging is a separate operator decision.
 - **Never force-push.** Even on divergence — surface the conflict, let the operator resolve. The `git-push-guard` hook blocks force-push at strict profile; this skill respects the same rule unconditionally.

--- a/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dev-quality
+description: Pre-wrap quality gate. Runs /simplify on the working-tree diff, re-runs commands.test, and reports results. Suggests /code-review:code-review when installed. Run this before committing.
+---
+
+# /dev-quality
+
+Run a quality pass on the working-tree diff before declaring the task done. Invokes `/simplify`, re-runs the configured test command, and reports the outcome. Call this at task wrap-up, before committing.
+
+## Prerequisites
+
+- Verify `.claude-code-hermit/sessions/` exists. If not: tell the operator to run `/claude-code-hermit:hatch` and `/claude-code-dev-hermit:hatch` first.
+- Read `commands.test` from `.claude-code-hermit/config.json`. If unset, the test step is skipped — `/simplify` still runs.
+
+## Plan
+
+### Gate 0 — preconditions
+
+```bash
+git diff --quiet && git diff --cached --quiet
+```
+
+If both are empty: FAIL `"no working-tree diff — nothing to simplify"`.
+
+### Gate 1 — run `/simplify`
+
+Invoke `/simplify` on the current diff. Wait for it to complete. If `/simplify` reports no changes, note `simplify: no changes` and continue to Gate 2 anyway.
+
+### Gate 2 — re-run tests
+
+If `commands.test` is unset: skip this gate, record `tests: skipped`, and proceed to Gate 3 pass path.
+
+```bash
+$COMMANDS_TEST
+```
+
+Run `commands.test` via Bash. Capture exit code and wall-clock duration.
+
+### Gate 3 — report
+
+**Tests pass:**
+
+Report the outcome. Then check whether `/code-review:code-review` is in the agent's available slash-command list. If available, append:
+
+```
+next: suggest the operator run /code-review:code-review for a deeper review before commit
+```
+
+Do **not** invoke `/code-review:code-review` autonomously — operator decision only. Skill exits clean; simplified changes remain uncommitted for the operator to commit.
+
+**Tests fail:**
+
+FAIL with `"tests regressed after /simplify (exit <N>) — investigate before committing"` and the last 20 lines of stderr. Leave the working tree as-is (post-simplify state) — the agent or operator decides whether to fix forward or revert the simplify pass manually (`git checkout -- <files>`).
+
+## Output
+
+```
+dev-quality
+  diff:     12 files modified
+  simplify: applied
+  tests:    pass (12.3s)
+  next:     suggest operator run /code-review:code-review (installed)
+  status:   ok
+```
+
+On Gate 3 failure:
+
+```
+dev-quality
+  diff:     12 files modified
+  simplify: applied
+  tests:    FAIL (exit 1, 8.7s)
+  recovery: investigate the regression; fix forward or `git checkout -- <files>` to revert the simplify pass
+  status:   tests-regressed
+```
+
+When `commands.test` is unset:
+
+```
+dev-quality
+  diff:     12 files modified
+  simplify: applied
+  tests:    skipped (commands.test not configured)
+  status:   ok
+```
+
+On Gate 0 failure:
+
+```
+dev-quality
+  FAIL (Gate 0): no working-tree diff — nothing to simplify
+```
+
+## Rules
+
+- **Main session only.** Subagents cannot invoke skills (see CLAUDE-APPEND §Technical Constraints) — `/dev-quality` only fires from the main session.
+- **Never invokes `/code-review:code-review`.** Suggests it to the operator when available; the operator decides.
+- **Never commits.** Leaves the diff uncommitted for the operator.
+- **Never modifies the working tree on test failure.** Surfaces the regression and stops; no rollback.
+- **No state file, no cross-skill contract.** `/dev-pr` is independent — run it separately after committing.

--- a/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
@@ -31,10 +31,10 @@ Invoke `/simplify` on the current diff. Wait for it to complete. If `/simplify` 
 If `commands.test` is unset: skip this gate, record `tests: skipped`, and proceed to Gate 3 pass path.
 
 ```bash
-$COMMANDS_TEST
+node "${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.js" run
 ```
 
-Run `commands.test` via Bash. Capture exit code and wall-clock duration.
+Use `timeout: 600000`. Records the result to `last-test.json`.
 
 ### Gate 3 — report
 
@@ -97,4 +97,4 @@ dev-quality
 - **Never invokes `/code-review:code-review`.** Suggests it to the operator when available; the operator decides.
 - **Never commits.** Leaves the diff uncommitted for the operator.
 - **Never modifies the working tree on test failure.** Surfaces the regression and stops; no rollback.
-- **No state file, no cross-skill contract.** `/dev-pr` is independent — run it separately after committing.
+- **Writes `last-test.json`, but no cross-skill contract.** The record is written at the pre-commit HEAD. After committing, `/dev-pr` sees a stale SHA and re-runs tests — expected behaviour.

--- a/plugins/claude-code-dev-hermit/skills/dev-test/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-test/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: dev-test
+description: Run the configured test suite and record the result to .claude-code-hermit/state/last-test.json. /dev-pr reads this record; a fresh pass at HEAD skips re-running. Use for mid-task verification, debugging a failing test in isolation, or as a building block for /dev-quality.
+---
+
+# /dev-test
+
+Run the project's configured test command and record the result.
+
+## Plan
+
+Run the following Bash command. Use `timeout: 600000` (10-min ceiling).
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.js" run
+```
+
+If exit 0: report `tests: pass`.
+
+If exit 1 and stderr is `"commands.test not configured"`: tell the operator to set `commands.test` in `.claude-code-hermit/config.json` (or re-run `/claude-code-dev-hermit:hatch`).
+
+If exit non-zero for any other reason: report `tests: FAIL (exit N)` with the last 10 lines of output.
+
+## Notes
+
+`/dev-pr` invokes the same machinery on cache miss — running `/dev-test` first is optional but warms the cache (a second `/dev-pr` call at the same HEAD skips the test run entirely).
+
+For suites longer than 10 min (Bash ceiling): run the test command directly in a terminal, then record the result manually:
+
+```bash
+node <CLAUDE_PLUGIN_ROOT>/scripts/record-test-result.js write <exit_code> <duration_ms>
+```
+
+Then re-run `/dev-pr`.

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -41,16 +41,14 @@ After making code changes:
 1. Run the configured test command (`claude-code-dev-hermit.commands.test`, set via `/claude-code-dev-hermit:hatch`). If unset, ask the operator for the command and offer to save it via `hatch`.
 2. If tests fail, fix the failures or surface them in the response — **do not declare the task done with broken tests**.
 3. If the task is non-trivial and `/feature-dev:feature-dev` is installed, run it first when the code path is unfamiliar (framework lifecycle hooks, ORM internals, build-tool plugins, auth middleware). The trigger is **unfamiliarity, not urgency**. Skip for: doc/prompt/config edits, single-line fixes, code paths you've already read end-to-end.
+4. Before declaring the task done: run `/claude-code-dev-hermit:dev-quality`. It runs `/simplify` on the diff and re-runs `commands.test` if configured. If tests regress, investigate before committing. If `/code-review:code-review` is installed (`code-review@claude-plugins-official`), the skill will tell you to suggest it to the operator — do not invoke that skill autonomously.
 
 ## Tests Before PR
 
-After implementation and after `/simplify`:
-
-1. Re-run the test command via Bash. The plugin's `record-test-result` hook captures the exit code, duration, and current HEAD sha into `.claude-code-hermit/state/last-test.json` automatically — you don't write the file, the hook does.
-2. If tests pass, proceed.
-3. If tests fail, run `git checkout -- <changed-files>` to revert the simplify pass and stop. Surface the regression to the operator.
-
-Then run `/claude-code-dev-hermit:dev-pr`. Its Gate 0 reads `last-test.json` and refuses if missing, on a stale sha, or with a non-pass status — closing the loop without trusting the agent's self-report.
+1. Run `/claude-code-dev-hermit:dev-quality` — handles `/simplify` + test re-run (see §Implementation Flow step 4).
+2. Commit.
+3. If you committed after `/dev-quality` ran and `commands.test` is configured, re-run it once — `/dev-pr` Gate 0 checks `last-test.json` against the current HEAD sha.
+4. Run `/claude-code-dev-hermit:dev-pr`. Gate 0 reads `last-test.json` and refuses if missing, on a stale sha, or with a non-pass status.
 
 ## Technical Constraints
 
@@ -93,6 +91,7 @@ Tier mapping:
 ## Dev Quick Reference
 
 - One-time setup / re-config: `/claude-code-dev-hermit:hatch`
+- Pre-wrap quality gate: `/claude-code-dev-hermit:dev-quality`
 - Open the PR: `/claude-code-dev-hermit:dev-pr`
 - Cleanup: `/simplify` (built-in)
 - Parallel changes across many files: `/batch` (built-in)


### PR DESCRIPTION
### Added

- **`/dev-test` skill (`skills/dev-test/SKILL.md`)** — run the configured test suite and record the result to `last-test.json`. Useful for mid-task verification and warming the `/dev-pr` test cache. Internally calls `record-test-result.js run`.
- **`/dev-quality` skill (`skills/dev-quality/SKILL.md`)** — re-introduces a `/dev-quality` skill (removed in v0.3.0 as "workflow ceremony") in leaner form as a mechanical pre-wrap quality gate: runs `/simplify` on the working-tree diff, re-runs `commands.test` if set, and reports results. On test regression, surfaces the failure and stops — no auto-rollback. If `/code-review:code-review` (`code-review@claude-plugins-official`) is in the agent's available slash-command list, the skill tells the agent to suggest it to the operator (never invokes it autonomously).

### Changed

- **`/dev-pr` Gate 0 tests check** — now runs tests automatically on cache miss instead of blocking with "run the test command yourself". A fresh `status:"pass"` record at the current HEAD is a cache hit (instant); anything else triggers `record-test-result.js run`.
- **`scripts/record-test-result.js`** — adds `run` subcommand (executes `commands.test`, records real exit code + duration) and `write <exit_code> <duration_ms>` subcommand (for direct callers and CI). Hook path now silently skips on missing exit code instead of writing `status:"unknown"`. Interrupted runs (`tool_response.interrupted === true`) are skipped.
- **`/dev-quality`** — test step now calls `record-test-result.js run` instead of `$COMMANDS_TEST`, so the result is recorded to `last-test.json` (note: SHA is pre-commit; `/dev-pr` will still re-run after commit).
- **`state-templates/CLAUDE-APPEND.md`** — adds step 4 to §Implementation Flow pointing to `/dev-quality`; rewrites §Tests Before PR to reference `/dev-quality` as the `/simplify`+re-run owner. Operators must re-run `/claude-code-dev-hermit:hatch` to refresh their project's CLAUDE.md.

Closes #12

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the SHA and strands the release tag on an orphan commit. After merging, run `/release claude-code-dev-hermit` from `main` to tag.