### PR TITLE
release(claude-code-dev-hermit): v0.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
       "name": "claude-code-dev-hermit",
       "source": "./plugins/claude-code-dev-hermit",
       "description": "Language-agnostic safety layer + dev conventions for any agent your hermit uses to write code",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "category": "development",
       "author": {
         "name": "gtapps"

--- a/plugins/claude-code-dev-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-dev-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-dev-hermit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "dependencies": [
     {
       "name": "claude-code-hermit",

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -22,6 +22,7 @@
 | `state-templates/CLAUDE-APPEND-SAFETY.md` | New safety-mode template |
 | `skills/hatch/SKILL.md` | Capability scan, mode question, conditional prompts, mode-aware template selection, `hatch_mode` persistence |
 | `.claude-plugin/plugin.json` | Version bump to 0.3.2 |
+| `.claude-plugin/marketplace.json` | Version synced to 0.3.2 |
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.3.2] - 2026-04-29
+
+### Added
+
+- **`claude-code-dev-hermit.hatch_mode` config key** — `"safety"` | `"standard"`. Persists the operator's hatch mode across re-runs and is used by `/hatch` to select the right CLAUDE-APPEND template.
+- **`state-templates/CLAUDE-APPEND-SAFETY.md`** — a subset template for `safety` mode containing only mode-independent sections: §Git Safety, §Branch Discipline, §Technical Constraints, §Before Archiving a Task, §Dev Session Hygiene, §Dev Knowledge, §Dev Proposal Categories, and a trimmed §Dev Quick Reference. Does not include §Implementation Flow, §Tests Before PR, or `/dev-test`/`/dev-quality`/`/dev-pr` references.
+
+### Changed
+
+- **`state-templates/CLAUDE-APPEND.md`** — adds a one-sentence "project conventions take precedence" preamble to §Branch Discipline, §Implementation Flow, and §Tests Before PR. Makes `standard`-mode installs non-destructive in projects that already have their own commit/PR/release skills.
+- **`/hatch` capability scan** — at hatch time, scans `.claude/skills/` for dirs named `commit`, `create-pr`, `pr`, `pull-request`, `release`, or `git-commit`. If matched, defaults the mode prompt to `safety` and surfaces the detected skill names. Else defaults to `standard`.
+- **`/hatch` mode-conditional prompts** — in `safety` mode, skips prompts for `commands.test`, `commands.lint`, `commands.format`, `commands.pr_create`, and `pr_template_path` (workflow keys that feed sections not injected). Only asks `Protected` branches, `Hook` profile, and companion `Plugins`. In `standard` mode, behavior is unchanged from v0.3.1.
+- **`/hatch` template selection** — injects `CLAUDE-APPEND-SAFETY.md` in safety mode, `CLAUDE-APPEND.md` in standard mode.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `state-templates/CLAUDE-APPEND.md` | Precedence preambles added to §Branch Discipline, §Implementation Flow, §Tests Before PR |
+| `state-templates/CLAUDE-APPEND-SAFETY.md` | New safety-mode template |
+| `skills/hatch/SKILL.md` | Capability scan, mode question, conditional prompts, mode-aware template selection, `hatch_mode` persistence |
+| `.claude-plugin/plugin.json` | Version bump to 0.3.2 |
+
+### Upgrade Instructions
+
+1. Ask the operator (`AskUserQuestion`): "Does this project already have its own `/commit`, `/create-pr`, or `/release` skills? Choose `safety` to keep dev-hermit's workflow sections out of CLAUDE.md, or `standard` for the full workflow (recommended for greenfield projects)." Options: `safety` / `standard`.
+2. Write the chosen value to `.claude-code-hermit/config.json` under `claude-code-dev-hermit.hatch_mode`.
+3. Tell the operator: "After this evolve completes, re-run `/claude-code-dev-hermit:hatch` to refresh your CLAUDE.md with the chosen mode. (hermit-evolve's CLAUDE-APPEND sync writes the standard template at the end of this run — that's expected; one `/hatch` re-run resolves it.)"
+
 ## [0.3.1] - 2026-04-29
 
 ### Added

--- a/plugins/claude-code-dev-hermit/CLAUDE.md
+++ b/plugins/claude-code-dev-hermit/CLAUDE.md
@@ -10,7 +10,8 @@ Language-agnostic safety layer for any agent doing dev work in a hermit project.
 - `skills/dev-test/` — run the configured test suite and record the result to `state/last-test.json`. Useful for mid-task verification and warming the `/dev-pr` test cache.
 - `scripts/git-push-guard.js` — strict-profile-only `PreToolUse` hook for Bash. Blocks `--no-verify`, force-push (incl. `--force-with-lease`), `--mirror`/`--all`, and direct push to any branch in `claude-code-dev-hermit.protected_branches`.
 - `hooks/hooks.json` — registers `git-push-guard.js`.
-- `state-templates/CLAUDE-APPEND.md` — the rules-of-the-road for any agent doing dev work in this project. Sections: §Git Safety, §Branch Discipline, §Implementation Flow, §Tests Before PR, §Technical Constraints, §Before Archiving a Task, §Dev Session Hygiene, §Dev Knowledge, §Dev Proposal Categories, §Dev Quick Reference. Injected by `/hatch` into the target project's `CLAUDE.md`.
+- `state-templates/CLAUDE-APPEND.md` — full (standard mode) template. Sections: §Git Safety, §Branch Discipline, §Implementation Flow, §Tests Before PR, §Technical Constraints, §Before Archiving a Task, §Dev Session Hygiene, §Dev Knowledge, §Dev Proposal Categories, §Dev Quick Reference. Injected by `/hatch` into the target project's `CLAUDE.md` when `hatch_mode = "standard"`.
+- `state-templates/CLAUDE-APPEND-SAFETY.md` — safety mode template. Subset: §Git Safety, §Branch Discipline, §Technical Constraints, §Before Archiving a Task, §Dev Session Hygiene, §Dev Knowledge, §Dev Proposal Categories, trimmed §Dev Quick Reference. No §Implementation Flow, §Tests Before PR, or `/dev-pr`/`/dev-quality`/`/dev-test` references. Injected by `/hatch` when `hatch_mode = "safety"` (recommended for projects that already have their own commit/PR/release skills).
 - `tests/` — `run-all.sh` central runner + `skill-structure.test.js` structural lint.
 - `docs/` — `GIT-SAFETY.md` (what the hook blocks), `HOW-TO-USE.md` (workflow), `RECOMMENDED-PLUGINS.md` (companion suggestions). `WORKFLOW.md` describes the end-to-end mechanics.
 - `.claude-plugin/plugin.json` — plugin manifest.
@@ -31,7 +32,7 @@ The `git-push-guard` hook activates at **strict** profile only (`AGENT_HOOK_PROF
 ## Core Contracts
 
 1. **Profile-gating**: `AGENT_HOOK_PROFILE` values are `minimal`/`standard`/`strict`. The `git-push-guard` hook self-gates on this and exits 0 immediately if the profile is not `strict`.
-2. **Safety rules live in CLAUDE-APPEND.md**: the plugin no longer ships its own implementer agent. The rules in `state-templates/CLAUDE-APPEND.md` apply to whatever agent the operator uses (native `Agent` tool, `feature-dev`'s research/architect agents, custom subagents). The `git-push-guard` hook backs §Git Safety at strict profile.
+2. **Safety rules live in the selected CLAUDE-APPEND template**: the plugin no longer ships its own implementer agent. The rules in the chosen template (CLAUDE-APPEND.md for standard mode, CLAUDE-APPEND-SAFETY.md for safety mode) apply to whatever agent the operator uses. The `git-push-guard` hook backs §Git Safety at strict profile.
 3. **Session state**: `.claude-code-hermit/state/runtime.json` is authoritative for session lifecycle. SHELL.md `Status:` is cosmetic only — never read it for programmatic state checks.
 4. **Learning loop**: `reflect` runs at every task boundary (per core hermit's contract).
-5. **Proposal gate**: the three-condition rule and tier mapping live in `state-templates/CLAUDE-APPEND.md` §Dev Proposal Categories.
+5. **Proposal gate**: the three-condition rule and tier mapping live in both CLAUDE-APPEND templates' §Dev Proposal Categories section.

--- a/plugins/claude-code-dev-hermit/README.md
+++ b/plugins/claude-code-dev-hermit/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.3.1-green.svg" alt="Version 0.3.1" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.3.2-green.svg" alt="Version 0.3.2" /></a>
   <img src="https://img.shields.io/badge/Claude-Pro%20%7C%20Max-blueviolet.svg" alt="Claude Pro/Max Compatible" />
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
 </p>
@@ -15,6 +15,8 @@
 </p>
 
 Ships a `git-push-guard` hook (strict-by-default), a test-result recorder, a `/hatch` setup wizard, a `/dev-pr` skill, and a CLAUDE-APPEND template that injects safety rules into your project's `CLAUDE.md`. No built-in implementer — operators use the native `Agent` tool, `feature-dev`'s research/architect agents, or their own subagents. The rules apply to whichever agent runs; the `git-push-guard` hook backs them at strict profile; the test-result recorder closes the loop so `/dev-pr` only opens PRs after tests actually pass on the current commit.
+
+**Using a project that already has its own `/commit`, `/create-pr`, or `/release` skills?** Run `/hatch` — it detects those skills and defaults to `safety` mode, which installs the git safety layer and branch discipline without prescribing dev-hermit's own workflow on top of yours.
 
 Three steps to a hermit that won't push to main:
 

--- a/plugins/claude-code-dev-hermit/docs/HOW-TO-USE.md
+++ b/plugins/claude-code-dev-hermit/docs/HOW-TO-USE.md
@@ -17,7 +17,10 @@ claude plugin install claude-code-dev-hermit@claude-code-hermit --scope project
 /claude-code-dev-hermit:hatch
 ```
 
-The wizard captures your test/lint/format commands, protected branches, and PR template path; installs `git-push-guard` at strict profile (with an explicit opt-out); and offers companion plugins. Run it once per project.
+The wizard installs `git-push-guard` at strict profile (with an explicit opt-out) and offers companion plugins. It scans the project for existing `/commit`, `/create-pr`, or `/release` skills and chooses a mode:
+
+- **`safety` mode** (default when existing skills are detected) — injects only §Git Safety, §Branch Discipline, and supporting sections. Does not inject §Implementation Flow, §Tests Before PR, or `/dev-pr`/`/dev-quality`/`/dev-test` references. Use this when the project already has its own dev workflow.
+- **`standard` mode** (default for greenfield) — injects the full workflow and prompts for `commands.test`, lint, format, and PR template. Behavior unchanged from v0.3.1.
 
 **Already set up?** Re-run `/claude-code-dev-hermit:hatch` any time. Every key offers `Keep current (<value>)` as the recommended option, so you can sweep through with Enter-presses to fast-confirm — or change individual values.
 

--- a/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
+++ b/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
@@ -4,7 +4,9 @@ End-to-end mechanics of a ticket from branch → PR. Read this once to understan
 
 The plugin's contribution to the workflow is two-part:
 
-1. **`state-templates/CLAUDE-APPEND.md`** is injected into the project's `CLAUDE.md` by `/hatch`. Every code-writing agent in the project — native `Agent`, `feature-dev:code-architect`, custom subagent, the main session — reads it and follows the rules.
+1. **A CLAUDE-APPEND template** is injected into the project's `CLAUDE.md` by `/hatch`. The template chosen depends on `hatch_mode`:
+   - **`standard`** (`state-templates/CLAUDE-APPEND.md`): full workflow — §Git Safety, §Branch Discipline, §Implementation Flow, §Tests Before PR, and supporting sections. For greenfield projects without existing dev skills.
+   - **`safety`** (`state-templates/CLAUDE-APPEND-SAFETY.md`): git safety and branch discipline only. No §Implementation Flow or §Tests Before PR. For projects that already have their own `/commit`, `/create-pr`, or `/release` skills — dev-hermit's safety layer without the prescriptive workflow.
 2. **`/dev-pr`** is the operator-invoked terminal step that pushes the branch and opens the PR.
 
 Everything between (planning, branch creation, code, tests, simplify) is the agent following the injected rules. There's no "dev-hermit pipeline" — the rules ARE the pipeline.

--- a/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: hatch
-description: Activate the dev hermit in the current project. Appends the dev safety rules to CLAUDE.md, captures test/lint/format/PR-template commands, installs the git-push-guard hook at strict profile by default, and offers companion plugins. Run once per project after /claude-code-hermit:hatch; re-run to update individual settings.
+description: Activate the dev hermit in the current project. Appends the dev safety rules to CLAUDE.md, installs the git-push-guard hook at strict profile by default, and offers companion plugins. Run once per project after /claude-code-hermit:hatch; re-run to update individual settings.
 ---
 
 # Activate Dev Hermit
 
 Set up the language-agnostic safety layer for this project. Requires `claude-code-hermit` core to be initialized first.
 
-The plugin's identity in v0.3.0+: a thin wrapper around (a) `git-push-guard` strict-profile hook, (b) `state-templates/CLAUDE-APPEND.md` rules injected into the project's CLAUDE.md, (c) `/dev-pr` to push and open the PR. There is no built-in implementer agent — operators use the native `Agent` tool, `feature-dev`, or custom subagents, all governed by the injected rules.
+The plugin's identity in v0.3.0+: a thin wrapper around (a) `git-push-guard` strict-profile hook, (b) a CLAUDE-APPEND template (safety or standard) injected into the project's CLAUDE.md, (c) dev workflow skills (`/dev-pr`, `/dev-quality`, `/dev-test`) available but only prescribed in standard mode. There is no built-in implementer agent — operators use the native `Agent` tool, `feature-dev`, or custom subagents, all governed by the injected rules.
 
 ## Plan
 
@@ -18,38 +18,70 @@ Check if `.claude-code-hermit/` exists in the current project.
 - Missing: ask the operator (`AskUserQuestion`) "Core hermit isn't set up yet. Run `/claude-code-hermit:hatch` now?" with options `Yes — run now` / `No — I'll do it later`. If yes, invoke `/claude-code-hermit:hatch`, then continue. If no, stop.
 - Present: read `.claude-code-hermit/config.json` and the plugin's `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/hermit-meta.json`. Verify `_hermit_versions["claude-code-hermit"]` from config satisfies `required_core_version` from hermit-meta (e.g. `">=1.0.22"`). If absent or below the floor, ask whether to run `/claude-code-hermit:hermit-evolve` first; allow opt-out with a warning. (Reading the floor from hermit-meta — never hardcoding it in skill prose — keeps this skill in sync with the plugin's declared requirement.)
 
-### 2. Update CLAUDE.md dev block
+### 2. Capability scan + choose mode
 
-Read the cached `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md` and `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`.
-
-Look for the marker comment `<!-- claude-code-dev-hermit: Development Workflow -->` in the project's `CLAUDE.md`.
-
-- Marker absent: append the cached template to `CLAUDE.md`.
-- Marker present, stamped version differs from the plugin version: silently replace the existing block with the cached template.
-- Marker present, versions match: skip — block is current.
-
-The template is the source of truth. No operator prompt is needed for this step.
-
-### 3. Detect, then ask
-
-This skill is **idempotent**. Every config key shown below is ALWAYS prompted; for keys already set in `config.json`, the prompt offers `Keep current (<value>)` as the first (recommended) option so the operator can sweep through Enter-presses to fast-confirm. There is no `--reset` mode — re-running and pressing Enter for every key is the equivalent.
-
-**Placeholder convention.** Strings in angle brackets in the question definitions below (e.g. `<value>`, `<detected default>`, `<detected path>`) are templating placeholders. Substitute them with concrete runtime values before passing to `AskUserQuestion`. Never pass the literal angle-bracket string.
-
-Run all detection in a single parallel turn before asking anything:
+Run all detection in a single parallel turn:
 
 **Bash:**
 - Existing PR template: `ls .github/PULL_REQUEST_TEMPLATE.md docs/pull_request_template.md 2>/dev/null | head -1`.
 - Installed plugins: `claude plugin list 2>/dev/null` or read `.claude/settings.json`.
 - Remote host (for `commands.pr_create` default): `git remote get-url origin 2>/dev/null` — if the URL contains `gitlab`, default `pr_create` to `glab pr create`; else default to `gh pr create`.
+- Capability scan: `ls .claude/skills/ 2>/dev/null` — list skill directory names. Match if any of the following dir names are present: `commit`, `create-pr`, `pr`, `pull-request`, `release`, `git-commit`. Record the matched names.
 
 **File reads:**
 - `OPERATOR.md` if present (check for `## Development Conventions` section).
-- The project's main config files for stack hints — `package.json`, `Cargo.toml`, `pyproject.toml`, `Gemfile`, `pom.xml`, `go.mod`. Use these only to seed reasonable defaults for the test command prompt; never assume them.
+- The project's main config files for stack hints — `package.json`, `Cargo.toml`, `pyproject.toml`, `Gemfile`, `pom.xml`, `go.mod`. Use these only to seed reasonable defaults for the test command prompt in standard mode; never assume them.
 
-#### Round 1 — commands and safety
+**Mode question:**
 
-Single `AskUserQuestion` call with up to 4 questions. ALWAYS include all four; for keys already in `config.json`, prepend `Keep current (<value>)` as the first option (and recommend it).
+Ask the operator a single `AskUserQuestion`:
+
+```
+questions: [
+  {
+    header: "Mode",
+    question: "Which hatch mode? 'safety' injects only the git-safety and branch-discipline sections (recommended when this project already has its own /commit, /create-pr, or /release skills). 'standard' injects the full dev workflow.",
+    options: [
+      { label: "Keep current (<value>)", description: "Already configured" },        // only on re-run when hatch_mode already in config
+      { label: "safety (recommended)", description: "Detected existing skills: <matched names> — skip /dev-quality, /dev-pr, /dev-test workflow sections." },   // when capability scan matched
+      { label: "safety", description: "Inject only §Git Safety, §Branch Discipline, §Technical Constraints, and supporting sections." },   // when no match but operator chooses
+      { label: "standard", description: "Inject the full workflow including §Implementation Flow, §Tests Before PR, §Dev Quick Reference." }
+    ]
+  }
+]
+```
+
+**Placeholder convention.** Strings in angle brackets (e.g. `<value>`, `<matched names>`) are templating placeholders — substitute concrete runtime values before passing to `AskUserQuestion`. Never pass the literal angle-bracket string.
+
+When building the options array at runtime:
+- If `hatch_mode` is already set in `config.json`, prepend `Keep current (<value>)` as the first (recommended) option.
+- If the capability scan matched one or more skill dirs, surface `safety (recommended)` with the detected names; present `standard` as the alternative.
+- If no scan match, present `standard` first (no existing project skills detected) and `safety` as the alternative.
+
+### 3. Update CLAUDE.md dev block
+
+Read the plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`.
+
+Based on the mode chosen in step 2:
+- `safety` → read `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND-SAFETY.md`
+- `standard` → read `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md`
+
+Look for the marker comment `<!-- claude-code-dev-hermit: Development Workflow -->` in the project's `CLAUDE.md`.
+
+- Marker absent: append the selected template to `CLAUDE.md`.
+- Marker present, stamped version differs from the plugin version: silently replace the existing block with the selected template.
+- Marker present, versions match AND mode is unchanged from config: skip — block is current.
+- Marker present, versions match but mode changed: replace — operator switched modes.
+
+The template is the source of truth. No operator prompt is needed for this step.
+
+### 4. Ask about remaining settings
+
+#### Round 1 — commands and safety (standard mode only)
+
+In `safety` mode, skip this round entirely — do not prompt for `commands.test`, `commands.lint`, `commands.format`, or `commands.pr_create`. These keys feed workflow sections that are not injected. The dev-hermit skills (`/dev-test`, `/dev-quality`, `/dev-pr`) remain available; if invoked, they will prompt for `commands.test` on first use.
+
+In `standard` mode, ask a single `AskUserQuestion` with up to 4 questions. ALWAYS include all four; for keys already in `config.json`, prepend `Keep current (<value>)` as the first option (and recommend it).
 
 ```
 questions: [
@@ -94,6 +126,8 @@ questions: [
 ]
 ```
 
+In `safety` mode, ask only the `Protected` question (single `AskUserQuestion` call with one question).
+
 #### Round 2 — hook profile and companions
 
 `git-push-guard` defaults to **strict**. The wizard does not ask which profile to use; it installs strict and offers an opt-out.
@@ -133,40 +167,49 @@ questions: [
 ]
 ```
 
+In `safety` mode, skip the `PR template` question and do not write `pr_template_path` to config (it feeds `/dev-pr` which is not prescribed in safety mode). Keep `Hook` and `Plugins`.
+
 Filter the Plugins `options` array to only those NOT already installed (per the `claude plugin list` detection above). If the filtered list is empty, skip the Plugins question entirely.
 
 If `OPERATOR.md` exists and does NOT contain a `## Development Conventions` section, append the answers under that heading.
 
-### 4. Write config and stamp version
+### 5. Write config and stamp version
 
 Single atomic config.json write:
 
-- `claude-code-dev-hermit.commands.test` — required, from Round 1.
-- `claude-code-dev-hermit.commands.lint` — optional.
-- `claude-code-dev-hermit.commands.format` — optional.
-- `claude-code-dev-hermit.commands.pr_create` — from the remote-host detection above (`gh pr create` / `glab pr create`); preserve any existing operator override.
-- `claude-code-dev-hermit.protected_branches` — array. The Round 1 prompt accepts a comma-separated string; split on `,`, trim each entry, drop empties before writing.
-- `claude-code-dev-hermit.pr_template_path` — optional, from Round 2.
+- `claude-code-dev-hermit.hatch_mode` — `"safety"` or `"standard"`, from step 2.
+- `claude-code-dev-hermit.protected_branches` — array. The prompt accepts a comma-separated string; split on `,`, trim each entry, drop empties before writing.
 - `env.AGENT_HOOK_PROFILE`:
   - If the operator accepted strict in Round 2 → write `"strict"`.
   - Else if the existing value is already `"strict"` → preserve it (never silently downgrade).
   - Else → write `"standard"` explicitly. Do not leave the key unset; an explicit value makes the operator's choice durable across `hermit-evolve` runs and prevents silent re-prompting.
-- `_hermit_versions["claude-code-dev-hermit"]` — set to the plugin version cached in step 2.
+- `_hermit_versions["claude-code-dev-hermit"]` — set to the plugin version cached in step 3.
+
+In `standard` mode only, also write:
+- `claude-code-dev-hermit.commands.test` — required, from Round 1.
+- `claude-code-dev-hermit.commands.lint` — optional.
+- `claude-code-dev-hermit.commands.format` — optional.
+- `claude-code-dev-hermit.commands.pr_create` — from the remote-host detection above (`gh pr create` / `glab pr create`); preserve any existing operator override.
+- `claude-code-dev-hermit.pr_template_path` — optional, from Round 2.
 
 For each selected companion plugin: `claude plugin install <plugin>@claude-plugins-official --scope project`.
 
-### 5. Report results
+### 6. Report results
 
 Print a summary that reflects what actually happened:
 
 ```
 Dev hermit activated (claude-code-dev-hermit vX.Y.Z).
 
+Mode: safety  [or: standard]
+  Injected: §Git Safety, §Branch Discipline, §Technical Constraints  [safety]
+  Injected: §Git Safety, §Branch Discipline, §Implementation Flow, §Tests Before PR, §Technical Constraints  [standard]
+
 Git safety:
   Hook profile: strict (git-push-guard active)  [or: standard — no hook enforcement]
   Protected branches: main, master  [or whatever was set]
 
-Commands:
+Commands:  [standard mode only]
   Test:   <cmd>
   Lint:   <cmd or 'skipped'>
   Format: <cmd or 'skipped'>
@@ -174,7 +217,7 @@ Commands:
 Updated:
   CLAUDE.md — dev block [appended / updated to vX.Y.Z / already current]
   OPERATOR.md — dev conventions [added / already present / skipped]
-  PR template: <path or 'none'>
+  PR template: <path or 'none'>  [standard mode only]
 
 Companion plugins:
   [installed: code-review, feature-dev, context7  /  partial  /  none]
@@ -182,17 +225,20 @@ Companion plugins:
 Available skills:
   /claude-code-dev-hermit:hatch    — re-run to update settings (idempotent)
   /claude-code-dev-hermit:dev-pr   — push the current branch and open a PR
+  /claude-code-dev-hermit:dev-test — run the configured test suite and warm test cache
+  /claude-code-dev-hermit:dev-quality — pre-wrap quality gate (simplify + test re-run)
 
+Conventions are in CLAUDE.md (§Git Safety, §Branch Discipline). [safety]
 Conventions are in CLAUDE.md (§Git Safety, §Branch Discipline,
-§Implementation Flow, §Tests Before PR). Any agent doing dev
-work in this project — native Agent, feature-dev, custom — must
-follow them.
+§Implementation Flow, §Tests Before PR). [standard]
+Any agent doing dev work in this project — native Agent, feature-dev, custom — must follow them.
 ```
 
 ## Rules
 
 - **Strict-by-default.** The wizard defaults to installing `git-push-guard` at strict. Do not ask "which profile?" — ask "yes or opt out?".
 - **Idempotent.** Re-running detects existing `config.json` values and offers `Keep current (<value>)` as the first option per key, so operators can fast-confirm with Enter presses.
-- **Single source of truth.** `state-templates/CLAUDE-APPEND.md` is the source for the project's dev conventions. Step 2 always overwrites the marked block when versions differ; do not preserve operator edits to that block (operators who want overrides put them elsewhere in their CLAUDE.md).
+- **Single source of truth.** The selected template (`CLAUDE-APPEND.md` or `CLAUDE-APPEND-SAFETY.md`) is the source for the project's dev conventions. Step 3 always overwrites the marked block when versions differ or mode changes; do not preserve operator edits to that block (operators who want overrides put them elsewhere in their CLAUDE.md).
 - **Never downgrade hook profile.** If the operator chooses "No — leave at standard" but `env.AGENT_HOOK_PROFILE` is already `strict`, preserve `strict`. The opt-out only applies on first install.
 - **No stack detection magic.** Detection seeds defaults for prompts; operators always confirm. Never write `commands.test` from detection alone — it must be operator-confirmed.
+- **Safety mode skips workflow prompts.** In `safety` mode, do not prompt for `commands.test`, `commands.lint`, `commands.format`, `commands.pr_create`, or `pr_template_path`. These keys feed workflow sections that safety mode does not inject.

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -1,4 +1,3 @@
-
 ---
 <!-- claude-code-dev-hermit: Development Workflow -->
 

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -36,26 +36,6 @@ Before starting code changes:
 
 Examples: `PROJ-123 add auth flow` → `feature/proj-123-add-auth-flow`. `Fix login redirect (urgent!)` → `fix/login-redirect-urgent`. `feature/foo/bar` → `feature/foo-bar`.
 
-## Implementation Flow
-
-If the project's own CLAUDE.md or skills define an implementation flow (e.g. its own commit/test/PR sequence), follow that. The steps below are the fallback for projects without one.
-
-After making code changes:
-
-1. Run the configured test command (`claude-code-dev-hermit.commands.test`, set via `/claude-code-dev-hermit:hatch`). If unset, ask the operator for the command and offer to save it via `hatch`.
-2. If tests fail, fix the failures or surface them in the response — **do not declare the task done with broken tests**.
-3. If the task is non-trivial and `/feature-dev:feature-dev` is installed, run it first when the code path is unfamiliar (framework lifecycle hooks, ORM internals, build-tool plugins, auth middleware). The trigger is **unfamiliarity, not urgency**. Skip for: doc/prompt/config edits, single-line fixes, code paths you've already read end-to-end.
-4. Before declaring the task done: run `/claude-code-dev-hermit:dev-quality`. It runs `/simplify` on the diff and re-runs `commands.test` if configured. If tests regress, investigate before committing. If `/code-review:code-review` is installed (`code-review@claude-plugins-official`), the skill will tell you to suggest it to the operator — do not invoke that skill autonomously.
-
-## Tests Before PR
-
-If the project defines its own pre-PR validation (e.g. a custom test runner, CI gate, or PR-creation skill that handles testing internally), follow that. The steps below are the fallback.
-
-1. Run `/claude-code-dev-hermit:dev-quality` — handles `/simplify` + test re-run (see §Implementation Flow step 4).
-2. Commit.
-3. If you committed after `/dev-quality` ran and `commands.test` is configured, re-run it once — `/dev-pr` Gate 0 checks `last-test.json` against the current HEAD sha.
-4. Run `/claude-code-dev-hermit:dev-pr`. Gate 0 reads `last-test.json` and refuses if missing, on a stale sha, or with a non-pass status.
-
 ## Technical Constraints
 
 Subagents cannot invoke skills (`/simplify`, `/batch`, etc.) — those must run in the main session only.
@@ -66,7 +46,7 @@ Core rules (artifact frontmatter, tag discipline, proposals) apply to all dev wo
 
 ## Before Archiving a Task
 
-- `/claude-code-dev-hermit:dev-pr` run, or PR opened via other means — URL recorded in `state/bindings.json`.
+- PR opened.
 - Feature branch committed, no uncommitted changes.
 - If partial: Session Summary describes what remains.
 
@@ -97,9 +77,6 @@ Tier mapping:
 ## Dev Quick Reference
 
 - One-time setup / re-config: `/claude-code-dev-hermit:hatch`
-- Mid-task test run + cache warm: `/claude-code-dev-hermit:dev-test`
-- Pre-wrap quality gate: `/claude-code-dev-hermit:dev-quality`
-- Open the PR: `/claude-code-dev-hermit:dev-pr`
 - Cleanup: `/simplify` (built-in)
 - Parallel changes across many files: `/batch` (built-in)
 - Diagnostics: `/debug` (built-in)

--- a/plugins/claude-code-dev-hermit/tests/hatch-mode.test.js
+++ b/plugins/claude-code-dev-hermit/tests/hatch-mode.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+// Structural lint for the hatch-mode feature (v0.3.2).
+// Verifies template shape, preamble presence, and skill references.
+// These are grep-level checks — no runtime skill execution.
+
+const fs = require('fs');
+const path = require('path');
+const { makeReporter } = require('./test-utils');
+
+const PLUGIN_ROOT = path.join(__dirname, '..');
+const TEMPLATES = path.join(PLUGIN_ROOT, 'state-templates');
+const STANDARD = path.join(TEMPLATES, 'CLAUDE-APPEND.md');
+const SAFETY = path.join(TEMPLATES, 'CLAUDE-APPEND-SAFETY.md');
+const HATCH_SKILL = path.join(PLUGIN_ROOT, 'skills', 'hatch', 'SKILL.md');
+
+const { ok, summary } = makeReporter();
+
+// ── Safety template shape ────────────────────────────────────────────────────
+
+console.log('\nCLAUDE-APPEND-SAFETY.md shape:');
+
+ok('file exists', fs.existsSync(SAFETY), SAFETY);
+
+if (fs.existsSync(SAFETY)) {
+  const text = fs.readFileSync(SAFETY, 'utf-8');
+  const marker = '<!-- claude-code-dev-hermit: Development Workflow -->';
+
+  ok('marker present', text.includes(marker));
+  ok('marker is near top (within first 10 lines)',
+    text.split('\n').slice(0, 10).some(l => l.includes(marker)));
+
+  // Workflow-specific content must NOT appear in the safety template.
+  ok('no /dev-pr reference', !text.includes('/dev-pr'));
+  ok('no /dev-quality reference', !text.includes('/dev-quality'));
+  ok('no /dev-test reference', !text.includes('/dev-test'));
+  ok('no commands.test reference', !text.includes('commands.test'));
+  ok('no §Implementation Flow section', !text.includes('## Implementation Flow'));
+  ok('no §Tests Before PR section', !text.includes('## Tests Before PR'));
+
+  // Mode-independent sections MUST appear.
+  ok('§Git Safety present', text.includes('## Git Safety'));
+  ok('§Branch Discipline present', text.includes('## Branch Discipline'));
+  ok('§Technical Constraints present', text.includes('## Technical Constraints'));
+  ok('§Dev Proposal Categories present', text.includes('## Dev Proposal Categories'));
+}
+
+// ── Standard template preambles + required sections ─────────────────────────
+
+console.log('\nCLAUDE-APPEND.md preambles and sections:');
+
+ok('file exists', fs.existsSync(STANDARD), STANDARD);
+
+if (fs.existsSync(STANDARD)) {
+  const text = fs.readFileSync(STANDARD, 'utf-8');
+
+  // Mode-independent sections must be present in the standard template too.
+  ok('§Git Safety present', text.includes('## Git Safety'));
+  ok('§Branch Discipline present', text.includes('## Branch Discipline'));
+  ok('§Technical Constraints present', text.includes('## Technical Constraints'));
+  ok('§Dev Proposal Categories present', text.includes('## Dev Proposal Categories'));
+
+  // Each preamble ends with "fallback for projects without one" or "fallback."
+  const branchSection = text.match(/## Branch Discipline[\s\S]*?## Implementation Flow/);
+  ok('§Branch Discipline has precedence preamble',
+    branchSection !== null && branchSection[0].includes('fallback for projects without one'));
+
+  const implSection = text.match(/## Implementation Flow[\s\S]*?## Tests Before PR/);
+  ok('§Implementation Flow has precedence preamble',
+    implSection !== null && implSection[0].includes('fallback for projects without one'));
+
+  const prSection = text.match(/## Tests Before PR[\s\S]*?## Technical Constraints/);
+  ok('§Tests Before PR has precedence preamble',
+    prSection !== null && prSection[0].includes('fallback'));
+}
+
+// ── Hatch SKILL.md references ────────────────────────────────────────────────
+
+console.log('\nskills/hatch/SKILL.md mode references:');
+
+ok('file exists', fs.existsSync(HATCH_SKILL), HATCH_SKILL);
+
+if (fs.existsSync(HATCH_SKILL)) {
+  const text = fs.readFileSync(HATCH_SKILL, 'utf-8');
+
+  ok('references hatch_mode', text.includes('hatch_mode'));
+  ok('references safety mode', text.includes('"safety"') || text.includes("'safety'") || text.includes('`safety`'));
+  ok('references standard mode', text.includes('"standard"') || text.includes("'standard'") || text.includes('`standard`'));
+  ok('references CLAUDE-APPEND-SAFETY.md', text.includes('CLAUDE-APPEND-SAFETY.md'));
+  ok('references capability scan slugs', text.includes('create-pr') && text.includes('release'));
+}
+
+process.exit(summary() === 0 ? 0 : 1);

--- a/plugins/claude-code-dev-hermit/tests/run-all.sh
+++ b/plugins/claude-code-dev-hermit/tests/run-all.sh
@@ -7,6 +7,7 @@ PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 rc=0
 
 node "$SCRIPT_DIR/skill-structure.test.js" || rc=$?
+node "$SCRIPT_DIR/hatch-mode.test.js" || rc=$?
 
 while IFS= read -r f; do
   node "$f" || rc=$?

--- a/plugins/claude-code-dev-hermit/tests/skill-structure.test.js
+++ b/plugins/claude-code-dev-hermit/tests/skill-structure.test.js
@@ -13,7 +13,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { parseFrontmatter } = require('./test-utils');
+const { parseFrontmatter, makeReporter } = require('./test-utils');
 
 const SKILL_DIR = path.join(__dirname, '..', 'skills');
 
@@ -23,18 +23,7 @@ const SKILLS = [
   { name: 'dev-pr', gates: 5 },         // Gate 0..4
 ];
 
-let passed = 0;
-let failed = 0;
-
-function ok(name, cond, detail) {
-  if (cond) {
-    console.log(`  ✓ ${name}`);
-    passed += 1;
-  } else {
-    console.error(`  ✗ ${name}${detail ? ' — ' + detail : ''}`);
-    failed += 1;
-  }
-}
+const { ok, summary } = makeReporter();
 
 for (const { name, gates } of SKILLS) {
   console.log(`\n${name}/SKILL.md:`);
@@ -84,5 +73,4 @@ for (const { name, gates } of SKILLS) {
   ok(`internal links resolve (${linksChecked} checked)`, linksBad === 0, `${linksBad} bad`);
 }
 
-console.log(`\nResults: ${passed} passed, ${failed} failed`);
-process.exit(failed === 0 ? 0 : 1);
+process.exit(summary() === 0 ? 0 : 1);

--- a/plugins/claude-code-dev-hermit/tests/test-utils.js
+++ b/plugins/claude-code-dev-hermit/tests/test-utils.js
@@ -11,4 +11,23 @@ function parseFrontmatter(text) {
   return { raw: m[1], fields, body: text.slice(m[0].length) };
 }
 
-module.exports = { parseFrontmatter };
+function makeReporter() {
+  let passed = 0;
+  let failed = 0;
+  function ok(name, cond, detail) {
+    if (cond) {
+      console.log(`  ✓ ${name}`);
+      passed += 1;
+    } else {
+      console.error(`  ✗ ${name}${detail ? ' — ' + detail : ''}`);
+      failed += 1;
+    }
+  }
+  function summary() {
+    console.log(`\nResults: ${passed} passed, ${failed} failed`);
+    return failed;
+  }
+  return { ok, summary };
+}
+
+module.exports = { parseFrontmatter, makeReporter };


### PR DESCRIPTION
### Added

- **`claude-code-dev-hermit.hatch_mode` config key** — `"safety"` | `"standard"`. Persists the operator's hatch mode across re-runs and is used by `/hatch` to select the right CLAUDE-APPEND template.
- **`state-templates/CLAUDE-APPEND-SAFETY.md`** — a subset template for `safety` mode containing only mode-independent sections: §Git Safety, §Branch Discipline, §Technical Constraints, §Before Archiving a Task, §Dev Session Hygiene, §Dev Knowledge, §Dev Proposal Categories, and a trimmed §Dev Quick Reference. Does not include §Implementation Flow, §Tests Before PR, or `/dev-test`/`/dev-quality`/`/dev-pr` references.

### Changed

- **`state-templates/CLAUDE-APPEND.md`** — adds a one-sentence "project conventions take precedence" preamble to §Branch Discipline, §Implementation Flow, and §Tests Before PR. Makes `standard`-mode installs non-destructive in projects that already have their own commit/PR/release skills.
- **`/hatch` capability scan** — at hatch time, scans `.claude/skills/` for dirs named `commit`, `create-pr`, `pr`, `pull-request`, `release`, or `git-commit`. If matched, defaults the mode prompt to `safety` and surfaces the detected skill names. Else defaults to `standard`.
- **`/hatch` mode-conditional prompts** — in `safety` mode, skips prompts for `commands.test`, `commands.lint`, `commands.format`, `commands.pr_create`, and `pr_template_path`. Only asks Protected branches, Hook profile, and companion Plugins. In `standard` mode, behavior is unchanged from v0.3.1.
- **`/hatch` template selection** — injects `CLAUDE-APPEND-SAFETY.md` in safety mode, `CLAUDE-APPEND.md` in standard mode.

### Files affected

| File | Change |
|------|--------|
| `state-templates/CLAUDE-APPEND.md` | Precedence preambles added to §Branch Discipline, §Implementation Flow, §Tests Before PR |
| `state-templates/CLAUDE-APPEND-SAFETY.md` | New safety-mode template |
| `skills/hatch/SKILL.md` | Capability scan, mode question, conditional prompts, mode-aware template selection, `hatch_mode` persistence |
| `.claude-plugin/plugin.json` | Version bump to 0.3.2 |
| `.claude-plugin/marketplace.json` | Version synced to 0.3.2 |

### Upgrade Instructions

1. Ask the operator: "Does this project already have its own `/commit`, `/create-pr`, or `/release` skills? Choose `safety` to keep dev-hermit's workflow sections out of CLAUDE.md, or `standard` for the full workflow." Options: `safety` / `standard`.
2. Write the chosen value to `.claude-code-hermit/config.json` under `claude-code-dev-hermit.hatch_mode`.
3. Tell the operator: "Re-run `/claude-code-dev-hermit:hatch` to refresh your CLAUDE.md with the chosen mode."

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the SHA and strands the release tag on an orphan commit. After merging, run `/release claude-code-dev-hermit` from `main` to tag.