### PR TITLE
release(claude-code-hermit): v1.0.27

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -12,6 +12,9 @@
 - hermit-doctor: `docker-security` check now flags subnet collisions (`warn`) and hermit-side `ports:` blocks that conflict with LAN containment (`fail`). Daemon-unreachable degrades to `warn` rather than `fail`. Existing 8-check structure unchanged.
 - Host-only skills (`docker-setup`, `docker-security`, `hermit-takeover`, `hermit-hand-back`) now refuse to run inside the hermit container — each detects `/.dockerenv` / `/run/.containerenv` at step 0 and prints a tailored redirect (e.g. docker-setup points operators to `/hermit-doctor` for in-container inspection). Prevents partial-success file writes that would corrupt host scaffolding from the wrong vantage point.
 
+### Changed
+- docker-security: moved design rationale, limitations, DNS allowlist tuning, and reversal prose out of the skill and into `docs/docker-security.md` (new `## Design rationale` section). The skill — loaded into model context every time the wizard fires — now carries only operational instructions and a single GitHub URL pointer back to the docs. SKILL.md trimmed from 572 → 552 lines.
+
 ### Upgrade Instructions
 For operators on v1.0.26 with docker-security already configured:
 - Run `/claude-code-hermit:hermit-doctor`. If the docker-security check surfaces a WARN or FAIL, re-run `/claude-code-hermit:docker-security` and accept the defaults — the wizard re-renders the overlay with a fresh subnet and walks any port conflict. Then run `hermit-docker down && hermit-docker up`.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- docker-security: detect operator-added `ports:` on `hermit` and offer to move them to `hermit-netguard` (the netns owner) when LAN containment is enabled. Wizard hard-gates `hermit-docker up` until the operator deletes the base `ports:` block, so a half-applied state cannot reach the daemon. Previously caused `conflicting options: port publishing and the container type network mode`.
+- docker-security: auto-pick a free /24 subnet for `hermit-net` instead of hardcoding `172.28.0.0/24`. Scans all host Docker networks (excluding this project's own via Compose labels), walks `172.28-31` then `10.244-247` before prompting. Previously caused `Pool overlaps with other one on this address space` when a second hermit project (or any unrelated network in the same range) ran on the same host.
+- docker-security: `publish_ports` config persists across reruns — operators who deleted the base `ports:` block on a previous run will not lose the netguard publish mapping on the next wizard pass.
+- docker-security: pre-flight Docker daemon check (`docker info`) exits early with a clear message instead of cryptic subprocess errors.
+
+### Added
+- hermit-doctor: `docker-security` check now flags subnet collisions (`warn`) and hermit-side `ports:` blocks that conflict with LAN containment (`fail`). Daemon-unreachable degrades to `warn` rather than `fail`. Existing 8-check structure unchanged.
+
+### Upgrade Instructions
+For operators on v1.0.26 with docker-security already configured:
+- Run `/claude-code-hermit:hermit-doctor`. If the docker-security check surfaces a WARN or FAIL, re-run `/claude-code-hermit:docker-security` and accept the defaults — the wizard re-renders the overlay with a fresh subnet and walks any port conflict. Then run `hermit-docker down && hermit-docker up`.
+- Operators with no overlay or no collision will see no change.
+
 ## [1.0.26] - 2026-05-03
 
 ### Fixed

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Added
 - hermit-doctor: `docker-security` check now flags subnet collisions (`warn`) and hermit-side `ports:` blocks that conflict with LAN containment (`fail`). Daemon-unreachable degrades to `warn` rather than `fail`. Existing 8-check structure unchanged.
+- Host-only skills (`docker-setup`, `docker-security`, `hermit-takeover`, `hermit-hand-back`) now refuse to run inside the hermit container — each detects `/.dockerenv` / `/run/.containerenv` at step 0 and prints a tailored redirect (e.g. docker-setup points operators to `/hermit-doctor` for in-container inspection). Prevents partial-success file writes that would corrupt host scaffolding from the wrong vantage point.
 
 ### Upgrade Instructions
 For operators on v1.0.26 with docker-security already configured:

--- a/plugins/claude-code-hermit/docs/docker-security.md
+++ b/plugins/claude-code-hermit/docs/docker-security.md
@@ -108,6 +108,18 @@ Two ways:
 
 To reverse just one toggle: re-run the wizard, answer Yes to the toggles you still want and No to the one you're disabling.
 
+## Design rationale
+
+A few decisions that operators occasionally ask about:
+
+**Why one combined sidecar.** nftables and dnsmasq share the same network namespace by design — the port-53 redirect rule points to local dnsmasq. Separating them would require careful coordination and provides no operational benefit. Single failure domain, single image to maintain, one health signal.
+
+**Why the dnsmasq UID exemption.** dnsmasq's own upstream queries to `1.1.1.1:53` would otherwise hit the port-53 redirect rule and loop back to itself, breaking all DNS resolution. The `meta skuid != <DNSMASQ_UID>` rule in `nftables.conf` exempts dnsmasq's outbound DNS so it can actually resolve.
+
+**Why the dnsmasq UID is hardcoded.** Alpine's `dnsmasq` package consistently ships `dnsmasq` as uid 100 (its `apk` post-install runs `adduser -u 100 -D -H -s /sbin/nologin dnsmasq`). The wizard renders `100` directly into `nftables.conf` — no probe step. If a future Alpine release ever changes this, the netguard sidecar's fail-safe entrypoint holds the netns open instead of crash-looping (`tail -f /dev/null` after rule-load failure), and the operator can `docker exec hermit-netguard getent passwd dnsmasq` to grep the live UID and update the rendered `nftables.conf` by hand.
+
+**Why a named volume for `.npm-global` under read-only root.** Claude Code self-updates by writing to `/home/claude/.npm-global/bin/claude`. Under `read_only: true`, that path is read-only unless backed by a volume or tmpfs. tmpfs would lose the new version on every restart. The named volume snapshots the image's `.npm-global` on first run, then persists across restarts. To force a downgrade or refresh, use `hermit-docker update` (rebuilds the image and recreates the volume).
+
 ## For plugin authors — declaring network requirements
 
 Fleet plugins can declare their network requirements so `/docker-security` surfaces them as pre-checked additions during Prompt 1's fleet-aware seeding sub-step.

--- a/plugins/claude-code-hermit/docs/docker-security.md
+++ b/plugins/claude-code-hermit/docs/docker-security.md
@@ -128,3 +128,19 @@ In the plugin's `skills/hatch/SKILL.md` or a `DOCKER.md` at the plugin root, add
 Validation: domain regex `^[a-z0-9][a-z0-9.-]+$`; CIDRs validated as IPv4. The token `ASK_OPERATOR_FOR_*_IP` triggers an Other-field prompt for the IP. Plugins without this section contribute nothing — backward compatible.
 
 See [Creating Your Own Hermit](creating-your-own-hermit.md#docker-network-requirements) for the full contract.
+
+## Troubleshooting
+
+### `conflicting options: port publishing and the container type network mode`
+
+Your `docker-compose.hermit.yml` has a `ports:` block on the `hermit` service. With LAN containment on, hermit joins `hermit-netguard`'s network namespace — Docker forbids port publishing on a container that joins another container's netns. Only the netns owner (`hermit-netguard`) can publish ports.
+
+**Fix:** Re-run `/claude-code-hermit:docker-security`. The wizard detects the ports and offers to move them to `hermit-netguard`. When prompted, delete the `ports:` block from `docker-compose.hermit.yml`. The wizard hard-gates `hermit-docker up` until that's done, so a partial state can't reach the daemon.
+
+### `invalid pool request: Pool overlaps with other one on this address space`
+
+The overlay's `hermit-net` subnet (`172.28.0.0/24` by default) collides with another Docker network on the host. This happens most often when a second hermit project (each project gets its own `<proj>_hermit-net` network name, but subnets are host-global) or an unrelated Compose stack already claims that range.
+
+**Fix:** Re-run `/claude-code-hermit:docker-security`. The wizard now scans all Docker networks on the host, excludes this project's own `hermit-net` via Compose labels, and auto-picks the first free /24 from a candidate list (`172.28-31`, then `10.244-247`). If all candidates are taken it prompts for a custom CIDR.
+
+The new `docker.security.network.subnet` field in `config.json` records the chosen subnet. Running `/hermit-doctor` will flag a WARN before the next `hermit-docker up` if the stored subnet has since been claimed by another network.

--- a/plugins/claude-code-hermit/scripts/doctor-check.js
+++ b/plugins/claude-code-hermit/scripts/doctor-check.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 const { globDir, readFrontmatter } = require('./lib/frontmatter');
 const { validate } = require('./validate-config');
@@ -260,17 +261,35 @@ function checkDependencies() {
   }
 }
 
-function checkDockerSecurity() {
-  // Two-state presence check between docker.security.* in config.json and the
-  // rendered docker-compose.security.yml overlay at the project root. No YAML
-  // parsing — Node stdlib has no parser and the plugin's no-deps rule rules
-  // out adding one. Per-key drift detection deferred (would need sentinel
-  // regex; not worth the maintenance for v1).
+// Pure helpers — no subprocess, fully testable in isolation.
+
+/** Returns true if two IPv4 CIDR strings overlap. Fails open (returns false) on any parse error. */
+function cidrOverlap(a, b) {
   try {
-    // Anchor to the project root (parent of the agent dir), not process.cwd(),
-    // so this check is consistent with the rest of doctor-check when invoked
-    // with an explicit agent-dir argv from a different CWD.
-    const overlayPath = path.join(hermitDir, '..', 'docker-compose.security.yml');
+    const parse = s => {
+      const [ip, prefix] = s.split('/');
+      const bits = parseInt(prefix, 10);
+      const parts = ip.split('.').map(Number);
+      const n = (parts[0] << 24 | parts[1] << 16 | parts[2] << 8 | parts[3]) >>> 0;
+      const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+      return { base: n & mask, mask };
+    };
+    const na = parse(a), nb = parse(b);
+    return (na.base & nb.mask) === nb.base || (nb.base & na.mask) === na.base;
+  } catch { return false; }
+}
+
+function checkDockerSecurity() {
+  // Presence check between docker.security.* in config.json and the rendered
+  // docker-compose.security.yml overlay. When both are present, also shells out
+  // to `docker compose config --format json` (timeout 10s) to detect:
+  //   - hermit service ports conflicting with network_mode:service:hermit-netguard (fail)
+  //   - overlay subnet colliding with another Docker network on this host (warn)
+  // All subprocess failures degrade to warn, never fail — daemon-down is transient.
+  try {
+    // Anchor to the project root (parent of the agent dir), not process.cwd().
+    const projectRoot = path.join(hermitDir, '..');
+    const overlayPath = path.join(projectRoot, 'docker-compose.security.yml');
     const overlayPresent = fs.existsSync(overlayPath);
 
     let config = {};
@@ -297,6 +316,88 @@ function checkDockerSecurity() {
         detail: 'overlay present but no posture declared in config — likely a manual edit; re-run /docker-security to reconcile',
       };
     }
+
+    // Both declared and overlay present — run deeper checks via subprocess.
+    const baseCompose = path.join(projectRoot, 'docker-compose.hermit.yml');
+    if (!fs.existsSync(baseCompose)) {
+      return { id: 'docker-security', status: 'ok', detail: 'posture declared and overlay present' };
+    }
+
+    let composeCfg;
+    try {
+      composeCfg = JSON.parse(execFileSync('docker', [
+        'compose', '-f', baseCompose, '-f', overlayPath,
+        'config', '--format', 'json',
+      ], { cwd: projectRoot, timeout: 10_000 }).toString());
+    } catch (e) {
+      return {
+        id: 'docker-security',
+        status: 'warn',
+        detail: `posture declared and overlay present (could not verify via docker compose: ${e.message.slice(0, 80)})`,
+      };
+    }
+
+    // Check 1: hermit service has ports AND network_mode is service:hermit-netguard.
+    const hermitSvc = (composeCfg.services || {}).hermit || {};
+    const hermitPorts = hermitSvc.ports || [];
+    const networkMode = hermitSvc.network_mode || '';
+    if (hermitPorts.length > 0 && networkMode.startsWith('service:')) {
+      return {
+        id: 'docker-security',
+        status: 'fail',
+        detail: 'hermit service has ports: but uses network_mode:service:hermit-netguard — Docker will reject this. Re-run /docker-security → "Move ports to netguard", then delete the ports: block from docker-compose.hermit.yml.',
+      };
+    }
+
+    // Check 2: overlay subnet collides with another Docker network on this host.
+    const lanEnabled = sec && sec.network && sec.network.enabled;
+    if (lanEnabled) {
+      const overlaySubnet = sec.network && sec.network.subnet;
+      if (overlaySubnet) {
+        try {
+          const netNames = execFileSync('docker', ['network', 'ls', '--format', '{{.Name}}'],
+            { timeout: 10_000 }).toString().trim().split('\n').filter(Boolean);
+
+          const projectName = (composeCfg.name || path.basename(projectRoot)).toLowerCase();
+
+          for (const net of netNames) {
+            let inspectOut = '';
+            try {
+              inspectOut = execFileSync('docker', ['network', 'inspect', net,
+                '--format', '{{range .IPAM.Config}}{{.Subnet}}{{end}}|||{{json .Labels}}'],
+                { timeout: 5_000 }).toString().trim();
+            } catch { continue; }
+
+            const [subnetPart, labelsPart] = inspectOut.split('|||');
+            const subnet = (subnetPart || '').trim();
+            if (!subnet || !subnet.includes('/')) continue;
+
+            // Exclude this project's own hermit-net via labels.
+            let labels = {};
+            try { labels = JSON.parse(labelsPart || '{}'); } catch {}
+            const isOwnHermitNet =
+              (labels['com.docker.compose.project'] || '').toLowerCase() === projectName &&
+              labels['com.docker.compose.network'] === 'hermit-net';
+            if (isOwnHermitNet) continue;
+
+            if (cidrOverlap(overlaySubnet, subnet)) {
+              return {
+                id: 'docker-security',
+                status: 'warn',
+                detail: `overlay subnet ${overlaySubnet} overlaps Docker network "${net}" (${subnet}). Re-run /docker-security to auto-pick a fresh subnet.`,
+              };
+            }
+          }
+        } catch (e) {
+          return {
+            id: 'docker-security',
+            status: 'warn',
+            detail: `posture declared and overlay present (subnet collision check failed: ${e.message.slice(0, 80)})`,
+          };
+        }
+      }
+    }
+
     return { id: 'docker-security', status: 'ok', detail: 'posture declared and overlay present' };
   } catch (e) {
     return { id: 'docker-security', status: 'fail', detail: `check failed: ${e.message}` };
@@ -376,7 +477,7 @@ if (require.main === module) {
     checkConfig, checkHooks, checkStateFiles,
     checkCost, checkProposals, checkDependencies, checkPermissions,
     checkDockerSecurity,
-    satisfiesRange,
+    satisfiesRange, cidrOverlap,
     runAllChecks, writeReport,
   };
 }

--- a/plugins/claude-code-hermit/skills/docker-security/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-security/SKILL.md
@@ -25,9 +25,11 @@ Templates live in `${CLAUDE_SKILL_DIR}/../../state-templates/docker/security/`.
 
 1. Read `.claude-code-hermit/config.json`. If missing: "Run `/claude-code-hermit:hatch` first." Stop.
 2. Verify `docker-compose.hermit.yml` exists at the project root. If missing: "Run `/claude-code-hermit:docker-setup` first." Stop.
-3. Read `docker.network_mode` from config (default: `"bridge"`). If `"host"`, set `HOST_NETWORK_MODE=true` and surface to operator: "Detected `network_mode: host` in your config. The LAN containment toggle (Prompt 1) will be skipped — it would replace host mode and break your HA / host-bound service access. Resource bounds (Prompt 3) will not apply network sysctls in host mode either; Docker rejects them and the container would fail to start."
-4. Check whether the container is currently running: `docker compose -f docker-compose.hermit.yml ps --status running --format '{{.Service}}' 2>/dev/null | grep -x hermit`. If absent: tell the operator "Container is not running. The wizard will still write the overlay; you'll see the live verification only after starting the container with `hermit-docker up`."
-5. Read current `docker.security.*` from config.json. Print a "current posture" summary. Example:
+3. **Docker daemon check**: run `timeout 10s docker info >/dev/null 2>&1`. If it fails or times out: tell the operator "Docker daemon is not reachable or timed out. Start Docker before re-running `/docker-security`." Stop.
+4. Read `docker.network_mode` from config (default: `"bridge"`). If `"host"`, set `HOST_NETWORK_MODE=true` and surface to operator: "Detected `network_mode: host` in your config. The LAN containment toggle (Prompt 1) will be skipped — it would replace host mode and break your HA / host-bound service access. Resource bounds (Prompt 3) will not apply network sysctls in host mode either; Docker rejects them and the container would fail to start."
+5. **Detect hermit ports**: run `timeout 10s docker compose -f docker-compose.hermit.yml config --format json 2>/dev/null` and parse `.services.hermit.ports`. Store as in-memory `detected_hermit_ports` (array of long-form Compose port objects: `{target, published, host_ip, protocol, mode}`). If the command fails or returns no JSON, fall back to `grep -n '^\s*ports:' docker-compose.hermit.yml` and set `detected_hermit_ports_unparsed=true` if found. Either way, a non-empty result means ports are present.
+6. Check whether the container is currently running: `docker compose -f docker-compose.hermit.yml ps --status running --format '{{.Service}}' 2>/dev/null | grep -x hermit`. If absent: tell the operator "Container is not running. The wizard will still write the overlay; you'll see the live verification only after starting the container with `hermit-docker up`."
+7. Read current `docker.security.*` from config.json. Print a "current posture" summary. Example:
 
    ```
    Current security posture:
@@ -62,6 +64,27 @@ options:
 ```
 
 Map: `"Yes — recommended"` → `dns_mode: "log-only"`. `"Yes — strict"` → `dns_mode: "enforce"`. `"No"` → skip to step 4.
+
+#### 3-pre. Port conflict handling (only if a "Yes" option was selected above)
+
+If the operator selected a "Yes" option AND `detected_hermit_ports` is non-empty (or `detected_hermit_ports_unparsed=true`), surface a follow-up `AskUserQuestion` (header: `"Port publishing"`) immediately:
+
+```
+Your docker-compose.hermit.yml publishes ports on the hermit service:
+  - "3000:3000"        ← list each port if parsed, or "(port block detected)" if unparsed
+  ...
+
+LAN containment requires hermit to share hermit-netguard's network namespace.
+Docker forbids `ports:` on a container that joins another container's netns —
+only netguard (the netns owner) can publish ports.
+```
+
+Options:
+- `"Move ports to netguard (recommended)"` — render the same `ports:` block on `hermit-netguard` in the overlay. Persist to `docker.security.network.publish_ports`. After overlay is written (step 7), show a diff and prompt the operator to delete the `ports:` block from `docker-compose.hermit.yml` themselves — the wizard does not modify the base file.
+- `"Skip LAN containment (keep ports on hermit)"` — clear the LAN containment selection (treat as if operator answered No above). Set `lan_containment_skipped_due_to_ports=true`. Continue to step 4.
+- `"Cancel"` — print "Re-run /docker-security after deciding how to handle your port publishing. See docs/docker-security.md for guidance." Exit. Write nothing.
+
+**If operator chose "Skip LAN containment"**: proceed to step 4 without any LAN containment config. Step 10 final-report notes: "LAN containment skipped — docker-compose.hermit.yml has a `ports:` block on hermit that is incompatible with `network_mode: service:hermit-netguard`."
 
 #### 3a. Fleet-aware domain seeding
 
@@ -197,7 +220,75 @@ Persist `docker.security.audit.plugin_installs` accordingly.
 
 ### 7. Render overlay
 
-If at least one toggle is enabled, render the overlay. Otherwise (all-off): if `docker-compose.security.yml` exists, delete it; clear `docker.security.*` from config.json; tell the operator "All toggles off — overlay removed (if any) and config cleared." Skip to step 10.
+**Before rendering — preserve `publish_ports` across reruns:**
+Read `docker.security.network.publish_ports` from the existing config.json (if present). Keep this as `persisted_publish_ports`. In the current wizard run:
+- If the operator chose "Move ports to netguard": replace `persisted_publish_ports` with the newly detected ports from step 5 (prerequisites).
+- If no base ports were detected AND the operator did not visit the port-conflict flow: keep `persisted_publish_ports` unchanged (the operator already deleted the base block; do not lose the netguard mapping).
+- If the operator chose "Skip LAN containment (keep ports on hermit)": set `persisted_publish_ports = []` (LAN containment is off; ports stay on hermit in the base file).
+
+**All-off branch — warn before deletion if `publish_ports` was set:**
+Otherwise (all toggles off): before deleting the overlay, check if `persisted_publish_ports` is non-empty. If so, surface:
+
+```
+Heads up: turning all toggles off will remove the overlay, including these
+ports that hermit-netguard currently publishes:
+  - "3000:3000"
+  ...
+
+If you previously deleted the `ports:` block from docker-compose.hermit.yml,
+you'll need to re-add it there before bringing the container back up — the
+overlay won't be there to publish them.
+```
+
+Then `AskUserQuestion` (header: `"Confirm all-off"`):
+- `"Yes — proceed (I'll restore base ports if needed)"`
+- `"No — cancel"`
+
+On Yes: continue to overlay deletion, clear `docker.security.*`, tell the operator "All toggles off — overlay removed and config cleared." Skip to step 10.
+On No: exit wizard, write nothing.
+
+If `persisted_publish_ports` is empty: proceed directly to deletion without the prompt.
+
+**Subnet auto-detection (only if LAN containment is enabled):**
+
+Run the following to enumerate occupied subnets across **all** Docker networks (not filtered to bridge — overlap is address-space-based):
+
+```bash
+timeout 10s docker network ls --format '{{.Name}}' 2>/dev/null | while read net; do
+  timeout 5s docker network inspect "$net" \
+    --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}|||{{json .Labels}}' 2>/dev/null
+done
+```
+
+Parse each output line into a subnet string and a Labels JSON object. Skip lines without IPv4 subnets.
+
+**Exclude** networks belonging to this project's own `hermit-net` from the collision list. Identify these by labels:
+- `com.docker.compose.project == <our project name>` AND `com.docker.compose.network == "hermit-net"`
+
+Derive `<our project name>` from `timeout 10s docker compose -f docker-compose.hermit.yml config --format json 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('name',''))"` — fall back to `basename "$PROJECT_DIR"` if the command fails.
+
+Use Python `ipaddress.ip_network` for overlap checking. Walk candidate /24 subnets in order: `172.28.0.0/24`, `172.29.0.0/24`, `172.30.0.0/24`, `172.31.0.0/24`, `10.244.0.0/24`, `10.245.0.0/24`, `10.246.0.0/24`, `10.247.0.0/24`. Pick the first that doesn't overlap any occupied subnet. Treat parse failures as "subnet unknown, skip."
+
+If all candidates collide, `AskUserQuestion` (header: `"Custom subnet"`) with Other field accepting an IPv4 /24 CIDR (reject if prefix != 24; re-prompt on invalid or still-colliding).
+
+Compute `chosen_gateway = <base>.0.1`, `chosen_netguard_ip = <base>.0.2`. Persist to `docker.security.network`:
+
+```json
+{
+  "enabled": true,
+  "dns_mode": "log-only" | "enforce",
+  "subnet": "172.28.0.0/24",
+  "gateway": "172.28.0.1",
+  "netguard_ip": "172.28.0.2",
+  "lan_allowlist": [...],
+  "additional_domains": [...],
+  "publish_ports": [...]
+}
+```
+
+If LAN containment is not enabled, omit `subnet`, `gateway`, `netguard_ip` from the `docker.security.network` object.
+
+If at least one toggle is enabled, render the overlay. Otherwise (all-off): handled in the all-off branch above.
 
 #### 7a. dnsmasq UID is hardcoded (not probed)
 
@@ -211,17 +302,17 @@ If a future Alpine release ever changes this UID, the netguard sidecar's fail-sa
 
 Render `docker-compose.security.yml` from `state-templates/docker/security/docker-compose.security.yml.template` by substituting the placeholder blocks. The template has placeholders:
 
-- `{{NETWORKS_BLOCK}}` — empty unless Prompt 1 enabled. When enabled:
+- `{{NETWORKS_BLOCK}}` — empty unless Prompt 1 enabled. When enabled, substitute `chosen_subnet` and `chosen_gateway` from the subnet auto-detection step above:
   ```yaml
   networks:
     hermit-net:
       driver: bridge
       ipam:
         config:
-          - subnet: 172.28.0.0/24
-            gateway: 172.28.0.1
+          - subnet: <chosen_subnet>
+            gateway: <chosen_gateway>
   ```
-- `{{HERMIT_NETGUARD_SERVICE}}` — empty unless Prompt 1 enabled. When enabled:
+- `{{HERMIT_NETGUARD_SERVICE}}` — empty unless Prompt 1 enabled. When enabled, substitute `chosen_netguard_ip` and `dns_log_only`. Also render `{{NETGUARD_PORTS_BLOCK}}` (see below):
   ```yaml
     hermit-netguard:
       build:
@@ -234,22 +325,35 @@ Render `docker-compose.security.yml` from `state-templates/docker/security/docke
       pids_limit: 256
       networks:
         hermit-net:
-          ipv4_address: 172.28.0.2
+          ipv4_address: <chosen_netguard_ip>
       volumes:
         - ./.claude-code-hermit/docker/nftables.conf:/etc/nftables.conf:ro
         - ./.claude-code-hermit/docker/dnsmasq.allowlist:/etc/dnsmasq.allowlist:ro
         - ./.claude-code-hermit/state:/var/log/netguard
       environment:
-        - DNS_LOG_ONLY={{DNS_LOG_ONLY}}
+        - DNS_LOG_ONLY=<dns_log_only>
       restart: unless-stopped
       {{NETGUARD_SYSCTLS}}
+      {{NETGUARD_PORTS_BLOCK}}
       healthcheck:
         test: ["CMD-SHELL", "nft list ruleset | grep -q 'table inet firewall' && (! [ -f /etc/dnsmasq.allowlist ] || pgrep dnsmasq)"]
         interval: 30s
         timeout: 5s
         retries: 3
   ```
-  Where `{{DNS_LOG_ONLY}}` = `"1"` if `dns_mode == "log-only"` else `"0"`. `{{NETGUARD_SYSCTLS}}` is the sysctls block from below if Prompt 3 enabled AND Prompt 1 enabled (sysctls live on netguard, the netns owner).
+  Where `<dns_log_only>` = `"1"` if `dns_mode == "log-only"` else `"0"`. `{{NETGUARD_SYSCTLS}}` is the sysctls block from below if Prompt 3 enabled AND Prompt 1 enabled (sysctls live on netguard, the netns owner).
+
+  **`{{NETGUARD_PORTS_BLOCK}}`** — empty unless `persisted_publish_ports` is non-empty AND Prompt 1 is enabled. When non-empty, render as long-form YAML using the parsed port objects (`target`, `published`, `host_ip`, `protocol`, `mode`). Omit `host_ip` if `"0.0.0.0"` (Compose default). Omit `mode` if `"ingress"` (Compose default for non-swarm). Example for two ports:
+  ```yaml
+      ports:
+        - target: 3000
+          published: "3000"
+          protocol: tcp
+        - target: 8080
+          published: "8080"
+          protocol: tcp
+  ```
+  If the ports were detected via grep fallback (`detected_hermit_ports_unparsed=true`) and no parsed shape is available, leave `{{NETGUARD_PORTS_BLOCK}}` empty and tell the operator: "Could not parse port shapes from the compose config — manually add your `ports:` block to `hermit-netguard` in the rendered overlay and delete it from the base file."
 - `{{HERMIT_NETWORK_MODE}}` — empty unless Prompt 1 enabled. When enabled:
   ```yaml
       network_mode: "service:hermit-netguard"
@@ -320,7 +424,19 @@ On `"No — I'll restart manually later"`: skip to step 10 with the note "Overla
 
 ### 8. Restart + smoke test
 
-If operator chose to restart now AND container was running before this skill:
+**Hard gate — re-check base ports before starting:**
+Before running `hermit-docker up`, re-run the step 5 port detection: `timeout 10s docker compose -f docker-compose.hermit.yml config --format json 2>/dev/null | python3 -c "import json,sys; p=json.load(sys.stdin)['services'].get('hermit',{}).get('ports',[]); print(len(p))"`. If the result is non-zero (or the command output from the grep fallback is non-empty) AND `docker.security.network.enabled === true` (LAN containment is on): stop here and print:
+
+```
+Cannot start container — docker-compose.hermit.yml still publishes ports on hermit.
+Those ports are now published by hermit-netguard via the overlay.
+Delete the `ports:` block from docker-compose.hermit.yml, then run:
+  .claude-code-hermit/bin/hermit-docker up
+```
+
+Skip steps 8.1-8.4 entirely. Tell the operator: "Overlay and config have been written — just delete the base `ports:` block first."
+
+If operator chose to restart now AND container was running before this skill (and the hard gate passed):
 
 1. Run `.claude-code-hermit/bin/hermit-docker down`.
 2. Run `.claude-code-hermit/bin/hermit-docker up` (the wrapper now picks up the overlay automatically). The first up will trigger `docker compose build hermit-netguard` if Prompt 1 was enabled — wait for completion (can be 30-60s on first build).

--- a/plugins/claude-code-hermit/skills/docker-security/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-security/SKILL.md
@@ -300,11 +300,9 @@ If LAN containment is not enabled, omit `subnet`, `gateway`, `netguard_ip` from 
 
 If at least one toggle is enabled, render the overlay. Otherwise (all-off): handled in the all-off branch above.
 
-#### 7a. dnsmasq UID is hardcoded (not probed)
+#### 7a. dnsmasq UID is hardcoded
 
-The Alpine `dnsmasq` package consistently ships `dnsmasq` as **uid 100** (its `apk` post-install script runs `adduser -u 100 -D -H -s /sbin/nologin dnsmasq`). The wizard renders `100` directly into `nftables.conf` — no probe step required.
-
-If a future Alpine release ever changes this UID, the netguard sidecar's fail-safe entrypoint will hold the netns open instead of crash-looping (`tail -f /dev/null` after rule-load failure), and the operator can `docker exec hermit-netguard getent passwd dnsmasq` to grep the live UID and update the rendered `nftables.conf` manually. For v1, the simpler hardcoded path is the right tradeoff.
+Render `100` directly into `nftables.conf` as the dnsmasq UID — no probe step. Rationale and recovery path if Alpine ever changes it: see [docs/docker-security.md#design-rationale](https://github.com/gtapps/claude-code-hermit/blob/main/plugins/claude-code-hermit/docs/docker-security.md#design-rationale).
 
 `docker compose build hermit-netguard` runs as part of `hermit-docker up` after the overlay is written — no separate build invocation by the wizard.
 
@@ -551,19 +549,4 @@ Tune DNS allowlist: edit .claude-code-hermit/docker/dnsmasq.allowlist,
 
 ## Notes
 
-**Reversal.** Re-run this skill and answer No to every prompt. The wizard removes `docker-compose.security.yml` and clears `docker.security.*` from config.json. Operators who want to bypass the wizard entirely can `rm docker-compose.security.yml` — the `hermit-docker` wrapper no-ops on its absence.
-
-**Tuning the DNS allowlist.** In log-only mode, blocked domains land in `.claude-code-hermit/state/dns.log`. Read it, decide which to allow, edit `.claude-code-hermit/docker/dnsmasq.allowlist`, then `hermit-docker restart hermit-netguard`. When the log is quiet, re-run `/docker-security` and switch to enforce mode. (The wizard does not auto-promote — manual review keeps the trust boundary at the operator.)
-
-**Documented limitations.** See [docs/docker-security.md](../../docs/docker-security.md). Briefly:
-- Public-IP egress (hardcoded IPs, no DNS) is **not** blocked. v1.1 may add nftset-driven IP allowlisting.
-- Docker's default bridge (172.17.0.0/16) is dropped by the LAN block — operators with adjacent Compose stacks must add carve-outs for the bridge IP.
-- Compose service-name DNS (`db`, etc.) doesn't work through dnsmasq. Add per-service-name lines like `server=/db/127.0.0.11`.
-- mDNS / `.local` (e.g. `homeassistant.local`) doesn't resolve. Use IP-based URLs with LAN carve-outs.
-- Host-bound services unreachable in bridge+containment mode — refactor to bind on the bridge IP if needed.
-
-**Why one combined sidecar.** nftables and dnsmasq share the same network namespace by design (the port-53 redirect points to local dnsmasq). Separating them would require careful coordination and provides no operational benefit. Single failure domain, single image to maintain, one health signal.
-
-**Why the dnsmasq UID exemption.** dnsmasq's own upstream queries to `1.1.1.1:53` would otherwise hit the port-53 redirect rule and loop back to itself, breaking all DNS resolution. The `meta skuid != <DNSMASQ_UID>` rule in `nftables.conf` exempts dnsmasq's outbound DNS so it can actually resolve.
-
-**Why a named volume for `.npm-global` under read-only root.** Claude Code self-updates by writing to `/home/claude/.npm-global/bin/claude`. Under `read_only: true`, that path is read-only unless backed by a volume or tmpfs. tmpfs would lose the new version on every restart. The named volume snapshots the image's `.npm-global` on first run, then persists across restarts. To force a downgrade or refresh, use `hermit-docker update` (rebuilds the image and recreates the volume).
+**Reversal, limitations, DNS allowlist tuning, and design rationale**: see [docs/docker-security.md](https://github.com/gtapps/claude-code-hermit/blob/main/plugins/claude-code-hermit/docs/docker-security.md).

--- a/plugins/claude-code-hermit/skills/docker-security/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-security/SKILL.md
@@ -21,6 +21,16 @@ Templates live in `${CLAUDE_SKILL_DIR}/../../state-templates/docker/security/`.
 
 ## Plan
 
+### 0. Refuse to run inside the hermit container
+
+This skill is host-only — it writes a `docker-compose.security.yml` overlay on the host and recreates the container with stronger isolation.
+
+Run: `[ -f /.dockerenv ] || [ -f /run/.containerenv ] && echo container || echo host`
+
+If the output is `container`, **stop immediately** — do not proceed to step 1. Print:
+
+> This skill writes a `docker-compose.security.yml` overlay on the host and recreates the container with stronger isolation. Run it from your host shell in the project root. To inspect the live security posture *inside* the running container, run `/claude-code-hermit:hermit-doctor` — it includes a `docker-security` check.
+
 ### 1. Prerequisites
 
 1. Read `.claude-code-hermit/config.json`. If missing: "Run `/claude-code-hermit:hatch` first." Stop.

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -14,6 +14,16 @@ Templates live in `${CLAUDE_SKILL_DIR}/../../state-templates/docker/`.
 
 ## Plan
 
+### 0. Refuse to run inside the hermit container
+
+This skill is host-only — it generates Docker scaffolding on the host filesystem and drives `docker compose up`.
+
+Run: `[ -f /.dockerenv ] || [ -f /run/.containerenv ] && echo container || echo host`
+
+If the output is `container`, **stop immediately** — do not proceed to step 1. Print:
+
+> This skill generates host-side Docker scaffolding and then drives `docker compose up`. Run it from your host shell in the project root. To check what's already configured *inside* the running container, run `/claude-code-hermit:hermit-doctor`.
+
 ### 1. Prerequisites
 
 1. Run `docker --version`. If missing: "Docker isn't installed — grab it from https://docs.docker.com/get-docker/ and come back!"

--- a/plugins/claude-code-hermit/skills/hermit-hand-back/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-hand-back/SKILL.md
@@ -8,6 +8,16 @@ Hand control back to the autonomous hermit after an operator takeover session. S
 
 ## Plan
 
+### 0. Refuse to run inside the hermit container
+
+This skill is host-only — hand-back restarts the hermit container after a takeover session.
+
+Run: `[ -f /.dockerenv ] || [ -f /run/.containerenv ] && echo container || echo host`
+
+If the output is `container`, **stop immediately** — do not proceed to step 1. Print:
+
+> Hand-back restarts the hermit container after a takeover session. You're already inside the hermit — there is nothing to hand back to. Run this from your host shell after a takeover session ends.
+
 ### 1. Verify takeover state
 
 Read `.claude-code-hermit/sessions/SHELL.md` and check for the `**Takeover:**` timestamp line.

--- a/plugins/claude-code-hermit/skills/hermit-takeover/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-takeover/SKILL.md
@@ -8,6 +8,16 @@ Stop the autonomous hermit and take the wheel. This skill is for Docker-based al
 
 ## Plan
 
+### 0. Refuse to run inside the hermit container
+
+This skill is host-only — takeover is the operator stopping the container to drive Claude Code interactively from the host.
+
+Run: `[ -f /.dockerenv ] || [ -f /run/.containerenv ] && echo container || echo host`
+
+If the output is `container`, **stop immediately** — do not proceed to step 1. Print:
+
+> Takeover is the operator stopping the hermit container to drive Claude Code interactively from the host. You're already inside the hermit — there is nothing to take over from here. Run this from your host shell when you want to pause autonomous operation.
+
 ### 1. Read config
 
 Read `.claude-code-hermit/config.json` to get:

--- a/plugins/claude-code-hermit/tests/run-hooks.sh
+++ b/plugins/claude-code-hermit/tests/run-hooks.sh
@@ -569,6 +569,131 @@ run_test "checkDependencies (required_core_version in hermit-meta.json sidecar �
 cleanup
 
 # -------------------------------------------------------
+# 54. cidrOverlap pure helper (exported from doctor-check.js)
+# -------------------------------------------------------
+run_test "cidrOverlap pure helper" node -e "
+const { cidrOverlap } = require('$REPO_ROOT/scripts/doctor-check');
+const assert = (cond, msg) => { if (!cond) { console.error('ASSERT:', msg); process.exit(1); } };
+assert(cidrOverlap('172.28.0.0/24', '172.28.0.0/24') === true,  'identical /24 overlaps');
+assert(cidrOverlap('172.28.0.0/16', '172.28.5.0/24') === true,  '/16 contains /24');
+assert(cidrOverlap('172.28.0.0/24', '172.29.0.0/24') === false, 'adjacent /24s disjoint');
+assert(cidrOverlap('10.0.0.0/8',   '172.28.0.0/24') === false,  'different blocks disjoint');
+assert(cidrOverlap('bad-cidr',     '172.28.0.0/24') === false,  'bad input returns false (fail-open)');
+"
+
+# -------------------------------------------------------
+# 55. doctor-check docker-security — docker unavailable → warn (not fail)
+# -------------------------------------------------------
+workdir="$(setup_workdir)"
+cd "$workdir"
+mkdir -p "$workdir/.claude-code-hermit/proposals"
+cat > "$workdir/.claude-code-hermit/config.json" <<'EOF'
+{"agent_name":"t","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true},"routines":[],"docker":{"security":{"network":{"enabled":true,"subnet":"172.28.0.0/24","gateway":"172.28.0.1","netguard_ip":"172.28.0.2"}}}}
+EOF
+# create stub files so both overlay and base compose appear to exist
+touch "$workdir/docker-compose.hermit.yml"
+touch "$workdir/docker-compose.security.yml"
+fake_bin="$(mktemp -d)"
+printf '#!/bin/bash\nexit 1\n' > "$fake_bin/docker"
+chmod +x "$fake_bin/docker"
+run_test "docker-security check (docker unavailable → warn, not fail)" bash -c \
+  "PATH='$fake_bin:$PATH' node '$REPO_ROOT/scripts/doctor-check.js' '$workdir/.claude-code-hermit' >/dev/null && python3 -c \"import json; r=json.load(open('$workdir/.claude-code-hermit/state/doctor-report.json')); d=[c for c in r['checks'] if c['id']=='docker-security'][0]; assert d['status']=='warn', d\""
+rm -rf "$fake_bin"
+cleanup
+
+# -------------------------------------------------------
+# 56. doctor-check docker-security — hermit has ports + network_mode:service → fail
+# -------------------------------------------------------
+workdir="$(setup_workdir)"
+cd "$workdir"
+mkdir -p "$workdir/.claude-code-hermit/proposals"
+cat > "$workdir/.claude-code-hermit/config.json" <<'EOF'
+{"agent_name":"t","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true},"routines":[],"docker":{"security":{"network":{"enabled":true,"subnet":"172.28.0.0/24","gateway":"172.28.0.1","netguard_ip":"172.28.0.2"}}}}
+EOF
+touch "$workdir/docker-compose.hermit.yml"
+touch "$workdir/docker-compose.security.yml"
+# fake docker: compose config returns hermit with ports + network_mode conflict
+fake_bin="$(mktemp -d)"
+cat > "$fake_bin/docker" <<'FAKEEOF'
+#!/bin/bash
+if [[ "$*" == *"config"*"--format"*"json"* ]]; then
+  echo '{"name":"testproj","services":{"hermit":{"ports":[{"target":3000,"published":"3000","protocol":"tcp","mode":"ingress"}],"network_mode":"service:hermit-netguard"}},"networks":{}}'
+  exit 0
+fi
+if [[ "$*" == *"network ls"* ]]; then printf ''; exit 0; fi
+exit 1
+FAKEEOF
+chmod +x "$fake_bin/docker"
+run_test "docker-security check (ports + network_mode:service → fail)" bash -c \
+  "PATH='$fake_bin:$PATH' node '$REPO_ROOT/scripts/doctor-check.js' '$workdir/.claude-code-hermit' >/dev/null && python3 -c \"import json; r=json.load(open('$workdir/.claude-code-hermit/state/doctor-report.json')); d=[c for c in r['checks'] if c['id']=='docker-security'][0]; assert d['status']=='fail' and 'ports' in d['detail'], d\""
+rm -rf "$fake_bin"
+cleanup
+
+# -------------------------------------------------------
+# 57. doctor-check docker-security — subnet collision with other network → warn
+# -------------------------------------------------------
+workdir="$(setup_workdir)"
+cd "$workdir"
+mkdir -p "$workdir/.claude-code-hermit/proposals"
+cat > "$workdir/.claude-code-hermit/config.json" <<'EOF'
+{"agent_name":"t","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true},"routines":[],"docker":{"security":{"network":{"enabled":true,"subnet":"172.28.0.0/24","gateway":"172.28.0.1","netguard_ip":"172.28.0.2"}}}}
+EOF
+touch "$workdir/docker-compose.hermit.yml"
+touch "$workdir/docker-compose.security.yml"
+fake_bin="$(mktemp -d)"
+cat > "$fake_bin/docker" <<'FAKEEOF'
+#!/bin/bash
+# compose config — no ports conflict
+if [[ "$*" == *"config"*"--format"*"json"* ]]; then
+  echo '{"name":"testproj","services":{"hermit":{"ports":[],"network_mode":"service:hermit-netguard"}},"networks":{}}'
+  exit 0
+fi
+if [[ "$*" == *"network ls"* ]]; then printf 'other-net\n'; exit 0; fi
+if [[ "$*" == *"network inspect"* ]]; then
+  # Return subnet that overlaps 172.28.0.0/24, no compose labels
+  printf '172.28.0.0/24|||{}\n'; exit 0
+fi
+exit 0
+FAKEEOF
+chmod +x "$fake_bin/docker"
+run_test "docker-security check (subnet collision with other-net → warn)" bash -c \
+  "PATH='$fake_bin:$PATH' node '$REPO_ROOT/scripts/doctor-check.js' '$workdir/.claude-code-hermit' >/dev/null && python3 -c \"import json; r=json.load(open('$workdir/.claude-code-hermit/state/doctor-report.json')); d=[c for c in r['checks'] if c['id']=='docker-security'][0]; assert d['status']=='warn' and 'overlaps' in d['detail'], d\""
+rm -rf "$fake_bin"
+cleanup
+
+# -------------------------------------------------------
+# 58. doctor-check docker-security — own hermit-net excluded from collision → ok
+# -------------------------------------------------------
+workdir="$(setup_workdir)"
+cd "$workdir"
+mkdir -p "$workdir/.claude-code-hermit/proposals"
+cat > "$workdir/.claude-code-hermit/config.json" <<'EOF'
+{"agent_name":"t","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true},"routines":[],"docker":{"security":{"network":{"enabled":true,"subnet":"172.28.0.0/24","gateway":"172.28.0.1","netguard_ip":"172.28.0.2"}}}}
+EOF
+touch "$workdir/docker-compose.hermit.yml"
+touch "$workdir/docker-compose.security.yml"
+fake_bin="$(mktemp -d)"
+cat > "$fake_bin/docker" <<'FAKEEOF'
+#!/bin/bash
+if [[ "$*" == *"config"*"--format"*"json"* ]]; then
+  echo '{"name":"testproj","services":{"hermit":{"ports":[]}},"networks":{}}'
+  exit 0
+fi
+if [[ "$*" == *"network ls"* ]]; then printf 'testproj_hermit-net\n'; exit 0; fi
+if [[ "$*" == *"network inspect"* ]]; then
+  # Own hermit-net — same subnet but has the compose labels identifying it as ours
+  printf '172.28.0.0/24|||{"com.docker.compose.project":"testproj","com.docker.compose.network":"hermit-net"}\n'
+  exit 0
+fi
+exit 0
+FAKEEOF
+chmod +x "$fake_bin/docker"
+run_test "docker-security check (own hermit-net excluded → ok)" bash -c \
+  "PATH='$fake_bin:$PATH' node '$REPO_ROOT/scripts/doctor-check.js' '$workdir/.claude-code-hermit' >/dev/null && python3 -c \"import json; r=json.load(open('$workdir/.claude-code-hermit/state/doctor-report.json')); d=[c for c in r['checks'] if c['id']=='docker-security'][0]; assert d['status']=='ok', d\""
+rm -rf "$fake_bin"
+cleanup
+
+# -------------------------------------------------------
 # Summary
 # -------------------------------------------------------
 # Clean up any suggest-compact counter files left in /tmp


### PR DESCRIPTION
### Fixed
- docker-security: detect operator-added `ports:` on `hermit` and offer to move them to `hermit-netguard` (the netns owner) when LAN containment is enabled. Wizard hard-gates `hermit-docker up` until the operator deletes the base `ports:` block, so a half-applied state cannot reach the daemon. Previously caused `conflicting options: port publishing and the container type network mode`.
- docker-security: auto-pick a free /24 subnet for `hermit-net` instead of hardcoding `172.28.0.0/24`. Scans all host Docker networks (excluding this project's own via Compose labels), walks `172.28-31` then `10.244-247` before prompting. Previously caused `Pool overlaps with other one on this address space` when a second hermit project (or any unrelated network in the same range) ran on the same host.
- docker-security: `publish_ports` config persists across reruns — operators who deleted the base `ports:` block on a previous run will not lose the netguard publish mapping on the next wizard pass.
- docker-security: pre-flight Docker daemon check (`docker info`) exits early with a clear message instead of cryptic subprocess errors.

### Added
- hermit-doctor: `docker-security` check now flags subnet collisions (`warn`) and hermit-side `ports:` blocks that conflict with LAN containment (`fail`). Daemon-unreachable degrades to `warn` rather than `fail`. Existing 8-check structure unchanged.
- Host-only skills (`docker-setup`, `docker-security`, `hermit-takeover`, `hermit-hand-back`) now refuse to run inside the hermit container — each detects `/.dockerenv` / `/run/.containerenv` at step 0 and prints a tailored redirect (e.g. docker-setup points operators to `/hermit-doctor` for in-container inspection). Prevents partial-success file writes that would corrupt host scaffolding from the wrong vantage point.

### Changed
- docker-security: moved design rationale, limitations, DNS allowlist tuning, and reversal prose out of the skill and into `docs/docker-security.md` (new `## Design rationale` section). The skill — loaded into model context every time the wizard fires — now carries only operational instructions and a single GitHub URL pointer back to the docs. SKILL.md trimmed from 572 → 552 lines.

### Upgrade Instructions
For operators on v1.0.26 with docker-security already configured:
- Run `/claude-code-hermit:hermit-doctor`. If the docker-security check surfaces a WARN or FAIL, re-run `/claude-code-hermit:docker-security` and accept the defaults — the wizard re-renders the overlay with a fresh subnet and walks any port conflict. Then run `hermit-docker down && hermit-docker up`.
- Operators with no overlay or no collision will see no change.

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the
> SHA and strands the release tag on an orphan commit. After merging, run
> `/release claude-code-hermit` from `main` to tag.