### PR TITLE
release(claude-code-hermit): v1.0.28

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "claude-code-hermit",
       "source": "./plugins/claude-code-hermit",
       "description": "Core hermit - memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "category": "productivity",
       "author": {
         "name": "gtapps"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="plugins/claude-code-hermit/CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.27-green.svg" alt="Version 1.0.27" /></a>
+  <a href="plugins/claude-code-hermit/CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.28-green.svg" alt="Version 1.0.28" /></a>
   <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/gtapps/claude-code-hermit/_stats_badges/.github/badges/clones.json" alt="Downloads" />
   <img src="https://img.shields.io/badge/Claude-Pro%20%7C%20Max-blueviolet.svg" alt="Claude Pro/Max Compatible" />
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />

--- a/plugins/claude-code-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-hermit",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "A personal assistant that lives in your project — memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
   "author": {
     "name": "gtapps"

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.28] - 2026-05-04
 
 ### Fixed
 
@@ -26,6 +26,8 @@
 2. **Re-render the overlay.** Run `/claude-code-hermit:docker-security` and accept the same toggles already enabled — the wizard re-renders the overlay with the corrected `cap_add` list, no `state:/var/log/netguard` bind, and the new healthcheck.
 3. **Rebuild the netguard image.** Run `bin/hermit-docker down && bin/hermit-docker up`. Compose rebuilds `hermit-netguard` because the entrypoint template content changed.
 4. **Verify.** `docker compose -f docker-compose.hermit.yml -f docker-compose.security.yml ps` should show `hermit-netguard` as `healthy` within ~10s.
+
+No `config.json` changes required.
 
 ## [1.0.27] - 2026-05-04
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **docker-security netguard: rootless Docker startup is finally clean.** Four interlocking bugs (the first masking the others) prevented `hermit-netguard` from coming up cleanly under rootless Docker. Operators with the v1.0.27 overlay saw cryptic "dnsmasq failed to stay up" errors even when dnsmasq was alive, plus 30-second startup latency.
+  - **Volume mount.** Removed the `state:/var/log/netguard` bind mount. Under rootless Docker the host UID does not match the container UID, and the host's `state/` directory (mode 0775) is unwritable by the container — so the entrypoint's `tee -a /var/log/netguard/netguard.log` died on first write. The sidecar now logs to stdout only, viewable via `docker compose ... logs hermit-netguard`.
+  - **PID capture.** Replaced `DNSMASQ_PID=$!; kill -0 "$DNSMASQ_PID"` with `pgrep dnsmasq`. After `dnsmasq | tee &`, `$!` returns the PID of `tee`, not `dnsmasq` — so the "stay up" check was inadvertently checking tee. Worse, when bug 1 killed tee on log-open, this check fired a false negative.
+  - **Capability set.** `cap_add: [NET_ADMIN]` was insufficient. Added `NET_BIND_SERVICE` (dnsmasq retains this cap across its post-bind drop), `SETUID`, and `SETGID` (Alpine's dnsmasq drops to UID/GID 100 — needs both). Without these, dnsmasq exited 5 with "failed to set capability vector".
+  - **Healthcheck latency.** Added `start_period: 5s` and lowered `interval` from 30s to 10s. Container now reaches `healthy` in ~10s instead of waiting a full 30s for the first probe.
+- **docker-security netguard entrypoint: dnsmasq queries now reach `docker logs`.** Added `--log-facility=-` to both dnsmasq invocations. Without it, `--log-queries` defaults to syslog, which silently drops in an Alpine container with no syslogd — making log-only mode useless for tuning the allowlist.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `state-templates/docker/security/netguard-entrypoint.sh.template` | Drop tee + file logging + `$!` PID capture; add `--log-facility=-`; replace `kill -0` with `pgrep dnsmasq` |
+| `skills/docker-security/SKILL.md` | cap_add list (4 caps), drop `state:/var/log/netguard` volume, healthcheck `start_period: 5s` + `interval: 10s` |
+| `docs/docker-security.md` | DNS tuning section: stdout instead of `state/dns.log`; correct "blocked-by-policy" wording |
+| `tests/test-docker-security-templates.sh` | New: contract test for entrypoint + SKILL.md regression patterns |
+
+### Upgrade Instructions
+
+1. **Skip if no docker-security overlay.** If `docker-compose.security.yml` does not exist at the project root, this entry is a no-op.
+2. **Re-render the overlay.** Run `/claude-code-hermit:docker-security` and accept the same toggles already enabled — the wizard re-renders the overlay with the corrected `cap_add` list, no `state:/var/log/netguard` bind, and the new healthcheck.
+3. **Rebuild the netguard image.** Run `bin/hermit-docker down && bin/hermit-docker up`. Compose rebuilds `hermit-netguard` because the entrypoint template content changed.
+4. **Verify.** `docker compose -f docker-compose.hermit.yml -f docker-compose.security.yml ps` should show `hermit-netguard` as `healthy` within ~10s.
+
 ## [1.0.27] - 2026-05-04
 
 ### Fixed

--- a/plugins/claude-code-hermit/docs/docker-security.md
+++ b/plugins/claude-code-hermit/docs/docker-security.md
@@ -84,7 +84,14 @@ Or use `/hermit-doctor` — the `docker-security` check flags drift between decl
 
 ## Tuning the DNS allowlist
 
-In **log-only mode**, dnsmasq writes every blocked-by-policy domain to `.claude-code-hermit/state/dns.log`. Read it, decide which domains to allow, then:
+In **log-only mode**, dnsmasq logs every queried domain (allowed or not — log-only does not block) to the container's stdout. Read it via:
+
+```
+docker compose -f docker-compose.hermit.yml \
+               -f docker-compose.security.yml logs hermit-netguard
+```
+
+In **enforce mode**, the same command surfaces NXDOMAIN denials. Decide which domains to allow, then:
 
 1. Edit `.claude-code-hermit/docker/dnsmasq.allowlist`. Add lines like:
    ```
@@ -92,8 +99,8 @@ In **log-only mode**, dnsmasq writes every blocked-by-policy domain to `.claude-
    ```
 2. Restart only the sidecar (faster than a full hermit restart):
    ```
-   .claude-code-hermit/bin/hermit-docker bash  # actually: use the underlying docker compose
-   docker compose -f docker-compose.hermit.yml -f docker-compose.security.yml restart hermit-netguard
+   docker compose -f docker-compose.hermit.yml \
+                  -f docker-compose.security.yml restart hermit-netguard
    ```
 3. When the log goes quiet, re-run `/docker-security` and switch from "Yes — recommended (log-only)" to "Yes — strict (enforce)".
 

--- a/plugins/claude-code-hermit/skills/docker-security/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-security/SKILL.md
@@ -326,7 +326,9 @@ Render `docker-compose.security.yml` from `state-templates/docker/security/docke
       build:
         context: ./.claude-code-hermit/docker
         dockerfile: Dockerfile.hermit-netguard
-      cap_add: [NET_ADMIN]
+      # NET_BIND_SERVICE: dnsmasq retains it post-bind-drop. SETUID+SETGID:
+      # drops to UID/GID 100 (Alpine's `dnsmasq` user).
+      cap_add: [NET_ADMIN, NET_BIND_SERVICE, SETUID, SETGID]
       cap_drop: [ALL]
       security_opt:
         - no-new-privileges:true
@@ -337,7 +339,6 @@ Render `docker-compose.security.yml` from `state-templates/docker/security/docke
       volumes:
         - ./.claude-code-hermit/docker/nftables.conf:/etc/nftables.conf:ro
         - ./.claude-code-hermit/docker/dnsmasq.allowlist:/etc/dnsmasq.allowlist:ro
-        - ./.claude-code-hermit/state:/var/log/netguard
       environment:
         - DNS_LOG_ONLY=<dns_log_only>
       restart: unless-stopped
@@ -345,9 +346,10 @@ Render `docker-compose.security.yml` from `state-templates/docker/security/docke
       {{NETGUARD_PORTS_BLOCK}}
       healthcheck:
         test: ["CMD-SHELL", "nft list ruleset | grep -q 'table inet firewall' && (! [ -f /etc/dnsmasq.allowlist ] || pgrep dnsmasq)"]
-        interval: 30s
+        interval: 10s
         timeout: 5s
         retries: 3
+        start_period: 5s
   ```
   Where `<dns_log_only>` = `"1"` if `dns_mode == "log-only"` else `"0"`. `{{NETGUARD_SYSCTLS}}` is the sysctls block from below if Prompt 3 enabled AND Prompt 1 enabled (sysctls live on netguard, the netns owner).
 

--- a/plugins/claude-code-hermit/state-templates/docker/security/netguard-entrypoint.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/security/netguard-entrypoint.sh.template
@@ -4,6 +4,9 @@
 # `network_mode: "service:hermit-netguard"` in docker-compose.security.yml,
 # so all of hermit's egress passes through these rules.
 #
+# All output goes to stdout/stderr — no on-disk log (rootless Docker
+# bind-mount UID mismatch was the original failure mode in 1.0.27).
+#
 # Fail-safe: on any rule-load or dnsmasq failure, log the error and
 # `tail -f /dev/null` instead of exiting. The alternative is a restart loop
 # that leaves hermit dark with no networking — operator can `docker exec`
@@ -11,14 +14,11 @@
 
 set +e
 
-LOG=/var/log/netguard/netguard.log
-mkdir -p /var/log/netguard
-
-if ! nft -f /etc/nftables.conf 2>>"$LOG"; then
-  echo "[netguard] nftables rule load FAILED — see $LOG. Holding netns open." >&2
+if ! nft -f /etc/nftables.conf 2>&1; then
+  echo "[netguard] nftables rule load FAILED. Holding netns open." >&2
   exec tail -f /dev/null
 fi
-echo "[netguard] nftables rules loaded." | tee -a "$LOG"
+echo "[netguard] nftables rules loaded." >&2
 
 # Start dnsmasq if an allowlist file is mounted. nftables redirects all
 # egress UDP/TCP :53 to here regardless of where hermit tries to send the
@@ -28,28 +28,29 @@ echo "[netguard] nftables rules loaded." | tee -a "$LOG"
 # the redirect via `meta skuid != <DNSMASQ_UID>` in nftables.conf. Without
 # that exemption, dnsmasq's outbound queries loop back to itself and DNS
 # stops working entirely.
+#
+# `--log-facility=-` routes dnsmasq's logs to stderr (default is syslog,
+# which silently drops in an Alpine container with no syslogd).
 if [ -f /etc/dnsmasq.allowlist ]; then
   if [ "${DNS_LOG_ONLY:-0}" = "1" ]; then
     # Log-only mode: don't enforce NXDOMAIN. Allow all queries to upstream
-    # while logging everything for the operator to review and tune the
-    # allowlist before flipping to enforce. Raw `--log-queries` text
-    # (operator greps); structured JSONL emission is deferred to v1.1.
-    dnsmasq -k --log-queries --no-hosts \
+    # while logging every query (allowed or not — log-only does not block)
+    # for the operator to review and tune the allowlist before flipping to
+    # enforce. Raw `--log-queries` text (operator greps); structured JSONL
+    # emission is deferred to v1.1.
+    dnsmasq -k --log-queries --log-facility=- --no-hosts \
       --server=1.1.1.1 \
-      --listen-address=127.0.0.1 \
-      2>&1 | tee -a /var/log/netguard/dns.log &
+      --listen-address=127.0.0.1 2>&1 &
   else
-    dnsmasq -k --conf-file=/etc/dnsmasq.allowlist \
-      --listen-address=127.0.0.1 \
-      2>&1 | tee -a "$LOG" &
+    dnsmasq -k --log-facility=- --conf-file=/etc/dnsmasq.allowlist \
+      --listen-address=127.0.0.1 2>&1 &
   fi
-  DNSMASQ_PID=$!
   sleep 1
-  if ! kill -0 "$DNSMASQ_PID" 2>/dev/null; then
-    echo "[netguard] dnsmasq failed to stay up — see $LOG. Holding netns open." >&2
+  if ! pgrep dnsmasq >/dev/null; then
+    echo "[netguard] dnsmasq failed to stay up. Holding netns open." >&2
     exec tail -f /dev/null
   fi
-  echo "[netguard] dnsmasq started (DNS_LOG_ONLY=${DNS_LOG_ONLY:-0})." | tee -a "$LOG"
+  echo "[netguard] dnsmasq started (DNS_LOG_ONLY=${DNS_LOG_ONLY:-0})." >&2
 fi
 
 # Trap signals for clean shutdown.

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -11,4 +11,5 @@ python3 "$SCRIPT_DIR/run-contracts.py"        || rc=$?
 bash "$SCRIPT_DIR/run-scripts.sh"             || rc=$?
 bash "$SCRIPT_DIR/recurrence-gate-matrix.sh"  || rc=$?
 bash "$SCRIPT_DIR/cron-tz-shift.test.sh"      || rc=$?
+bash "$SCRIPT_DIR/test-docker-security-templates.sh" || rc=$?
 exit $rc

--- a/plugins/claude-code-hermit/tests/test-docker-security-templates.sh
+++ b/plugins/claude-code-hermit/tests/test-docker-security-templates.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Contract tests for the docker-security templates.
+#
+# These bugs (1.0.27 → 1.0.28) escaped because template content has no
+# automated assertions: tee-vs-dnsmasq PID capture, missing capabilities,
+# host bind mount under rootless Docker, slow healthcheck. This suite
+# pattern-matches the templates and SKILL.md to lock those regressions
+# down. No Docker daemon required — pure file inspection.
+#
+# Usage: bash tests/test-docker-security-templates.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "=== docker-security Template Contract Tests ==="
+echo ""
+
+ENTRYPOINT="$REPO_ROOT/state-templates/docker/security/netguard-entrypoint.sh.template"
+SKILL="$REPO_ROOT/skills/docker-security/SKILL.md"
+
+# -------------------------------------------------------
+# Entrypoint: no tee-piping, no DNSMASQ_PID=$! capture
+# -------------------------------------------------------
+run_test "entrypoint: no 'tee -a' (regression: bug #1 + #2 cascade)" bash -c \
+  "! grep -q 'tee -a' '$ENTRYPOINT'"
+
+run_test "entrypoint: no 'DNSMASQ_PID=' assignment (regression: \$! captures tee)" bash -c \
+  "! grep -q 'DNSMASQ_PID=' '$ENTRYPOINT'"
+
+run_test "entrypoint: no '/var/log/netguard' references (regression: rootless bind mount)" bash -c \
+  "! grep -q '/var/log/netguard' '$ENTRYPOINT'"
+
+# -------------------------------------------------------
+# Entrypoint: positive assertions
+# -------------------------------------------------------
+run_test "entrypoint: --log-facility=- on log-only dnsmasq line" bash -c \
+  "grep -E 'dnsmasq -k --log-queries --log-facility=-' '$ENTRYPOINT'"
+
+run_test "entrypoint: --log-facility=- on enforce dnsmasq line" bash -c \
+  "grep -E 'dnsmasq -k --log-facility=- --conf-file' '$ENTRYPOINT'"
+
+run_test "entrypoint: pgrep dnsmasq used for liveness check" bash -c \
+  "grep -q 'pgrep dnsmasq' '$ENTRYPOINT'"
+
+# -------------------------------------------------------
+# SKILL.md: cap_add list (exact match — fails loud if any cap is missing,
+# reordered, or extras are added without test coverage)
+# -------------------------------------------------------
+run_test "SKILL.md: cap_add list is [NET_ADMIN, NET_BIND_SERVICE, SETUID, SETGID]" bash -c \
+  "grep -qF 'cap_add: [NET_ADMIN, NET_BIND_SERVICE, SETUID, SETGID]' '$SKILL'"
+
+# -------------------------------------------------------
+# SKILL.md: healthcheck has start_period
+# -------------------------------------------------------
+run_test "SKILL.md: healthcheck has start_period" bash -c \
+  "grep -q 'start_period:' '$SKILL'"
+
+# -------------------------------------------------------
+# SKILL.md: no rootless-hostile bind mount
+# -------------------------------------------------------
+run_test "SKILL.md: no 'state:/var/log/netguard' bind mount (regression: rootless)" bash -c \
+  "! grep -q 'state:/var/log/netguard' '$SKILL'"
+
+print_results


### PR DESCRIPTION
### Fixed

- **docker-security netguard: rootless Docker startup is finally clean.** Four interlocking bugs (the first masking the others) prevented `hermit-netguard` from coming up cleanly under rootless Docker. Operators with the v1.0.27 overlay saw cryptic "dnsmasq failed to stay up" errors even when dnsmasq was alive, plus 30-second startup latency.
  - **Volume mount.** Removed the `state:/var/log/netguard` bind mount. Under rootless Docker the host UID does not match the container UID, and the host's `state/` directory (mode 0775) is unwritable by the container — so the entrypoint's `tee -a /var/log/netguard/netguard.log` died on first write. The sidecar now logs to stdout only, viewable via `docker compose ... logs hermit-netguard`.
  - **PID capture.** Replaced `DNSMASQ_PID=$!; kill -0 "$DNSMASQ_PID"` with `pgrep dnsmasq`. After `dnsmasq | tee &`, `$!` returns the PID of `tee`, not `dnsmasq` — so the "stay up" check was inadvertently checking tee. Worse, when bug 1 killed tee on log-open, this check fired a false negative.
  - **Capability set.** `cap_add: [NET_ADMIN]` was insufficient. Added `NET_BIND_SERVICE` (dnsmasq retains this cap across its post-bind drop), `SETUID`, and `SETGID` (Alpine's dnsmasq drops to UID/GID 100 — needs both). Without these, dnsmasq exited 5 with "failed to set capability vector".
  - **Healthcheck latency.** Added `start_period: 5s` and lowered `interval` from 30s to 10s. Container now reaches `healthy` in ~10s instead of waiting a full 30s for the first probe.
- **docker-security netguard entrypoint: dnsmasq queries now reach `docker logs`.** Added `--log-facility=-` to both dnsmasq invocations. Without it, `--log-queries` defaults to syslog, which silently drops in an Alpine container with no syslogd — making log-only mode useless for tuning the allowlist.

### Files affected

| File | Change |
|------|--------|
| `state-templates/docker/security/netguard-entrypoint.sh.template` | Drop tee + file logging + `$!` PID capture; add `--log-facility=-`; replace `kill -0` with `pgrep dnsmasq` |
| `skills/docker-security/SKILL.md` | cap_add list (4 caps), drop `state:/var/log/netguard` volume, healthcheck `start_period: 5s` + `interval: 10s` |
| `docs/docker-security.md` | DNS tuning section: stdout instead of `state/dns.log`; correct "blocked-by-policy" wording |
| `tests/test-docker-security-templates.sh` | New: contract test for entrypoint + SKILL.md regression patterns |

### Upgrade Instructions

1. **Skip if no docker-security overlay.** If `docker-compose.security.yml` does not exist at the project root, this entry is a no-op.
2. **Re-render the overlay.** Run `/claude-code-hermit:docker-security` and accept the same toggles already enabled — the wizard re-renders the overlay with the corrected `cap_add` list, no `state:/var/log/netguard` bind, and the new healthcheck.
3. **Rebuild the netguard image.** Run `bin/hermit-docker down && bin/hermit-docker up`. Compose rebuilds `hermit-netguard` because the entrypoint template content changed.
4. **Verify.** `docker compose -f docker-compose.hermit.yml -f docker-compose.security.yml ps` should show `hermit-netguard` as `healthy` within ~10s.

No `config.json` changes required.

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the
> SHA and strands the release tag on an orphan commit. After merging, run
> `/release claude-code-hermit` from `main` to tag.