### PR TITLE
release(claude-code-homeassistant-hermit): v0.0.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,7 +50,7 @@
       "name": "claude-code-homeassistant-hermit",
       "source": "./plugins/claude-code-homeassistant-hermit",
       "description": "Home Assistant layer for claude-code-hermit — skills, subagents, safety hook, and Python CLI for an autonomous HA assistant",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "category": "home-automation",
       "author": {
         "name": "gtapps",

--- a/plugins/claude-code-homeassistant-hermit/.claude-plugin/hermit-meta.json
+++ b/plugins/claude-code-homeassistant-hermit/.claude-plugin/hermit-meta.json
@@ -1,6 +1,6 @@
 {
-  "required_core_version": ">=1.0.29",
-  "requires": { "claude-code-hermit": ">=1.0.29" },
+  "required_core_version": ">=1.0.30",
+  "requires": { "claude-code-hermit": ">=1.0.30" },
   "hermit": {
     "boot_skill": "/claude-code-homeassistant-hermit:ha-boot"
   }

--- a/plugins/claude-code-homeassistant-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-homeassistant-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-homeassistant-hermit",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Home Assistant layer for claude-code-hermit — skills, subagents, safety hook, and Python CLI for an autonomous HA assistant",
   "author": {
     "name": "gtapps",

--- a/plugins/claude-code-homeassistant-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-homeassistant-hermit/.claude-plugin/plugin.json
@@ -15,5 +15,5 @@
     "mcp",
     "gtapps"
   ],
-  "dependencies": [{ "name": "claude-code-hermit", "version": "^1.0.29" }]
+  "dependencies": [{ "name": "claude-code-hermit", "version": "^1.0.30" }]
 }

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 ### Fixed
 
 - **Apply flow no longer silently succeeds when HA never received the config** — previous behavior called `automation.reload` with no config push, returning success despite the automation being absent. Now reports `creation_ok: false` with a clear message in the YAML-mode fallback case.
+- **`ha-delete-config` skill**: removed erroneous advice to use `validate-apply` for post-delete reload (it would also push the supplied YAML as a new config). Step 5 now correctly points to HA Developer Tools → Services.
+- **`ha-build-automation` skill**: `id:` field is now required as the first field in generated YAML — without it, `validate-apply` derives a fragile ID from the alias that breaks on rename.
+- **CLI tests**: `_make_config` helper consolidated into a shared `make_mock_config` fixture in `conftest.py`; `test_cli_probe.py` and `test_cli_delete.py` both use it. Renamed `test_delete_automation_missing_id_exits_nonzero` → `test_delete_automation_not_found_exits_nonzero` (the old name conflated a missing CLI argument with a missing HA resource).
 
 ## [0.0.8] - 2026-05-04
 

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
-## [Unreleased]
+## [0.0.9] - 2026-05-05
 
 ### Added
 
@@ -16,6 +16,7 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 
 - **`validate-apply` JSON output** — includes three new fields: `config_id`, `creation_attempted`, `creation_ok`. The `creation_ok` field distinguishes a pushed-and-verified config from a reload-only operation (e.g. YAML mode fallback).
 - **`ApplyResult` dataclass** — extended with `config_id`, `domain`, `creation_attempted`, `creation_ok`.
+- **deps: bump core requirement to `>=1.0.30` / `^1.0.30`** — was `>=1.0.29`; `required_core_version` and `requires.claude-code-hermit` in `hermit-meta.json` and `dependencies[0].version` in `plugin.json` all updated together.
 
 ### Fixed
 
@@ -23,6 +24,31 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 - **`ha-delete-config` skill**: removed erroneous advice to use `validate-apply` for post-delete reload (it would also push the supplied YAML as a new config). Step 5 now correctly points to HA Developer Tools → Services.
 - **`ha-build-automation` skill**: `id:` field is now required as the first field in generated YAML — without it, `validate-apply` derives a fragile ID from the alias that breaks on rename.
 - **CLI tests**: `_make_config` helper consolidated into a shared `make_mock_config` fixture in `conftest.py`; `test_cli_probe.py` and `test_cli_delete.py` both use it. Renamed `test_delete_automation_missing_id_exits_nonzero` → `test_delete_automation_not_found_exits_nonzero` (the old name conflated a missing CLI argument with a missing HA resource).
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `src/ha_agent_lab/apply.py` | REST push (`POST /api/config/{domain}/config/{id}`) added before reload; `ApplyResult` extended with `config_id`, `domain`, `creation_attempted`, `creation_ok` |
+| `src/ha_agent_lab/cli.py` | `list-automations`, `list-scripts`, `delete-automation`, `delete-script` subcommands added |
+| `src/ha_agent_lab/ha_api.py` | `_extract_ha_error_message` helper added; all error responses now surface HA's `{"message":"..."}` field |
+| `skills/ha-apply-change/SKILL.md` | Apply workflow updated to reflect REST push flow and new `creation_ok` output field |
+| `skills/ha-build-automation/SKILL.md` | `id:` field marked required as first field in generated YAML |
+| `skills/ha-delete-config/SKILL.md` | New skill: delete workflow with list → confirm → delete → optional reload |
+| `state-templates/CLAUDE-APPEND.md` | `ha-delete-config` row added to skills table |
+| `CLAUDE.md` | `list-automations`, `list-scripts`, `delete-automation`, `delete-script` CLI commands documented |
+| `.claude-plugin/hermit-meta.json` | `required_core_version` and `requires.claude-code-hermit` bumped `>=1.0.29` → `>=1.0.30` |
+| `.claude-plugin/plugin.json` | `dependencies[0].version` bumped `^1.0.29` → `^1.0.30`; manifest `version` bumped `0.0.8` → `0.0.9` |
+| `CHANGELOG.md` | New `[0.0.9]` entry |
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
+
+1. **Refresh skill files** — replace `skills/ha-apply-change/SKILL.md`, `skills/ha-build-automation/SKILL.md`, and `skills/ha-delete-config/SKILL.md` from this release.
+2. **Add `ha-delete-config` to the injected skills table** — in the operator project's `CLAUDE.md`, find the `### Skills` table under `## Home Assistant Workflow` and append: `| /claude-code-homeassistant-hermit:ha-delete-config | Discover and delete an automation/script config from HA |`
+
+No `config.json` changes required.
 
 ## [0.0.8] - 2026-05-04
 

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 
 - **`ha validate-apply` now pushes config to HA via REST** — `POST /api/config/{domain}/config/{id}` is called before the domain reload, fixing the silent failure where `reload_attempted: true` was returned but the automation never appeared in HA (PROP-005). The automation `id:` field is used as the REST config ID; if absent, it is derived from the alias or filename with a drift warning in the output.
 - **`ha delete-automation <id>` and `ha delete-script <id>`** — remove an automation or script config from HA via `DELETE /api/config/{domain}/config/{id}`. Output includes `ok`, `message`, and a report path.
-- **`ha list-automations` and `ha list-scripts`** — lightweight enumeration of live HA automations/scripts (entity_id, config id, alias, state). Intended as a quick lookup before delete, without the full policy audit of `audit-automations`.
+- **`ha list-automations` and `ha list-scripts`** — lightweight enumeration of live HA automations/scripts (entity_id, config id, friendly_name, state, deletable). Sorted by entity_id. The `deletable: false` flag identifies YAML-packaged automations that lack a numeric `id` and cannot be removed via REST. Intended as a quick lookup before delete, without the full policy audit of `audit-automations`.
 - **`ha-delete-config` skill** — operator-facing workflow for discovering a target automation/script, confirming deletion, and optionally triggering a reload.
 - **Structured HA error messages surfaced verbatim** — all HA error responses carry `{"message":"..."}`. This field is now extracted and included in apply/remove reports, replacing the opaque "Home Assistant request failed (status=400)".
 
@@ -24,6 +24,8 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 - **`ha-delete-config` skill**: removed erroneous advice to use `validate-apply` for post-delete reload (it would also push the supplied YAML as a new config). Step 5 now correctly points to HA Developer Tools → Services.
 - **`ha-build-automation` skill**: `id:` field is now required as the first field in generated YAML — without it, `validate-apply` derives a fragile ID from the alias that breaks on rename.
 - **CLI tests**: `_make_config` helper consolidated into a shared `make_mock_config` fixture in `conftest.py`; `test_cli_probe.py` and `test_cli_delete.py` both use it. Renamed `test_delete_automation_missing_id_exits_nonzero` → `test_delete_automation_not_found_exits_nonzero` (the old name conflated a missing CLI argument with a missing HA resource).
+- **`validate-apply` no longer pushes config when reload domain is disallowed** — the `can_reload_domain` authorization check now runs before the REST POST, not after. Previously the config could be pushed and then the result returned as `reload-blocked`, leaving HA state inconsistent with operator expectations. No-op in practice today (`_CONFIG_DOMAINS` and the reload allowlist are identical sets), but eliminates the latent footgun if those sets ever drift.
+- **`list-automations` / `list-scripts` output shape** — renamed `alias` → `friendly_name` (matches HA's actual `attributes.friendly_name` — HA never exposes the YAML `alias:` field via `/api/states`), added `deletable: bool` flag (`false` for YAML-packaged automations that lack a numeric `id` and cannot be removed via REST), and results are now sorted by `entity_id` for deterministic operator UX. Field rename is contained within this unreleased v0.0.9 — no operator scripting is impacted.
 
 ### Files affected
 
@@ -31,7 +33,7 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 |------|--------|
 | `src/ha_agent_lab/apply.py` | REST push (`POST /api/config/{domain}/config/{id}`) added before reload; `ApplyResult` extended with `config_id`, `domain`, `creation_attempted`, `creation_ok` |
 | `src/ha_agent_lab/cli.py` | `list-automations`, `list-scripts`, `delete-automation`, `delete-script` subcommands added |
-| `src/ha_agent_lab/ha_api.py` | `_extract_ha_error_message` helper added; all error responses now surface HA's `{"message":"..."}` field |
+| `src/ha_agent_lab/ha_api.py` | `extract_ha_error_message` helper added; all error responses now surface HA's `{"message":"..."}` field |
 | `skills/ha-apply-change/SKILL.md` | Apply workflow updated to reflect REST push flow and new `creation_ok` output field |
 | `skills/ha-build-automation/SKILL.md` | `id:` field marked required as first field in generated YAML |
 | `skills/ha-delete-config/SKILL.md` | New skill: delete workflow with list → confirm → delete → optional reload |

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`ha validate-apply` now pushes config to HA via REST** — `POST /api/config/{domain}/config/{id}` is called before the domain reload, fixing the silent failure where `reload_attempted: true` was returned but the automation never appeared in HA (PROP-005). The automation `id:` field is used as the REST config ID; if absent, it is derived from the alias or filename with a drift warning in the output.
+- **`ha delete-automation <id>` and `ha delete-script <id>`** — remove an automation or script config from HA via `DELETE /api/config/{domain}/config/{id}`. Output includes `ok`, `message`, and a report path.
+- **`ha list-automations` and `ha list-scripts`** — lightweight enumeration of live HA automations/scripts (entity_id, config id, alias, state). Intended as a quick lookup before delete, without the full policy audit of `audit-automations`.
+- **`ha-delete-config` skill** — operator-facing workflow for discovering a target automation/script, confirming deletion, and optionally triggering a reload.
+- **Structured HA error messages surfaced verbatim** — all HA error responses carry `{"message":"..."}`. This field is now extracted and included in apply/remove reports, replacing the opaque "Home Assistant request failed (status=400)".
+
+### Changed
+
+- **`validate-apply` JSON output** — includes three new fields: `config_id`, `creation_attempted`, `creation_ok`. The `creation_ok` field distinguishes a pushed-and-verified config from a reload-only operation (e.g. YAML mode fallback).
+- **`ApplyResult` dataclass** — extended with `config_id`, `domain`, `creation_attempted`, `creation_ok`.
+
+### Fixed
+
+- **Apply flow no longer silently succeeds when HA never received the config** — previous behavior called `automation.reload` with no config push, returning success despite the automation being absent. Now reports `creation_ok: false` with a clear message in the YAML-mode fallback case.
+
 ## [0.0.8] - 2026-05-04
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/CLAUDE.md
+++ b/plugins/claude-code-homeassistant-hermit/CLAUDE.md
@@ -48,6 +48,10 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha simulate <artifact>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <artifact> [--reload automation|script]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha policy-check <entity_id_or_yaml>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha audit-automations
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-automations
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-scripts
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-automation <id>
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-script <id>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha probe <path>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab boot status [--probe]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab boot store --language <locale> --url <url> [--token <token>]
@@ -64,6 +68,10 @@ Run `--help` for current flags. Source of truth: `src/ha_agent_lab/cli.py`.
 Before changing HA endpoint usage, verify against upstream (WebFetch or the `find-docs` skill) or probe a live instance with `./bin/ha-agent-lab ha probe <path>`. Do not assume an endpoint exists.
 
 - Automations have no bulk REST listing. Enumerate via `/api/states` (filter `domain=automation`), fetch each config via `/api/config/automation/config/{automation_id}`. YAML-packaged automations lack a numeric `id` and are not retrievable via REST (use WebSocket `config/automation/list` for full coverage).
+- `POST /api/config/{automation|script}/config/{id}` — create/update (upsert). URL `id` is sufficient; body `id` field is ignored by HA. Returns `{"result":"ok"}` on success. Returns 403 if HA is in YAML config mode (REST config API unavailable).
+- `DELETE /api/config/{automation|script}/config/{id}` — remove config. **A missing id returns 400** (not 404) with `{"message":"Resource not found"}` — do not special-case 404. All HA error responses carry `{"message":"..."}` — surface it verbatim.
+- After `POST`, `GET` reflects the change synchronously (verified against HA 2026.x). No retry or delay needed for verify calls.
+- `--reload {automation|script}` in `ha validate-apply` is overloaded: it controls both the REST push endpoint and the reload service call. There is no push-only mode; add `--no-reload` if that use case arises.
 
 ## Development constraints
 

--- a/plugins/claude-code-homeassistant-hermit/README.md
+++ b/plugins/claude-code-homeassistant-hermit/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.0.8-green.svg" alt="Version 0.0.8" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.0.9-green.svg" alt="Version 0.0.9" /></a>
 </p>
 
 # claude-code-homeassistant-hermit

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-apply-change/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-apply-change/SKILL.md
@@ -15,16 +15,19 @@ allowed-tools:
    - If blocked: stop and explain why. Create a proposal via `/claude-code-hermit:proposal-create`.
 
 2. **Validate and apply**: Run `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <artifact_path> --reload automation` (or `script`).
-   - This runs HA config check, then reloads the domain.
+   - This runs HA config check, **pushes the config to HA via REST**, then reloads the domain.
+   - The artifact must include `id:` at the top level — if missing, the CLI derives an ID from the alias or filename and warns in the output. A derived ID drifts if the alias is renamed, creating a duplicate.
 
 3. **Confirm with operator**: Always ask before executing the apply. Show:
    - The artifact being applied
    - Policy check result
    - What domain will be reloaded
 
-4. **Post-apply**: Read the apply report from `.claude-code-hermit/raw/audit-ha-apply-latest.md`.
-   - If successful: update `MEMORY.md` Automation Insights if this is a new pattern.
-   - If failed: explain the error and suggest fixes.
+4. **Post-apply**: Check the JSON output for `creation_ok` and read `.claude-code-hermit/raw/audit-ha-apply-latest.md`.
+   - `creation_ok: true` — config was pushed and verified via REST. Reload picks it up immediately.
+   - `creation_ok: false` + message contains "YAML mode" — HA is in YAML config mode (403). Tell the operator to place the generated YAML in their HA config directory and reload manually.
+   - `creation_ok: false` + other message — push failed with a validation error from HA. Show the error message and suggest fixing the YAML.
+   - If overall successful: update `MEMORY.md` Automation Insights if this is a new pattern.
 
 ## Safety
 

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-build-automation/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-build-automation/SKILL.md
@@ -22,7 +22,7 @@ allowed-tools:
    - Optionally call `GetLiveContext` via MCP for current state.
 
 2. **Draft the YAML**:
-   - Use stable, language-neutral IDs (e.g., `kitchen_motion_after_sunset_notification`).
+   - **Always include `id:` as the first field**, using a stable, language-neutral snake_case value (e.g., `kitchen_motion_after_sunset_notification`). The `validate-apply` command uses this as the REST config ID — omitting it causes a derived, fragile ID that breaks on alias rename.
    - Use the stored locale for `alias` and `description`.
    - Set `mode` explicitly where concurrency matters.
    - Write to `.claude-code-hermit/raw/automation-<automation_id>.yaml`.

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-delete-config/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-delete-config/SKILL.md
@@ -27,8 +27,9 @@ Removes an automation or script from Home Assistant via `DELETE /api/config/{dom
    - `ok: false, message: "Resource not found"` — the ID doesn't exist in HA (note: HA returns 400, not 404).
    - `ok: false` + other message — surface the error to the operator.
 
-5. **Reload (optional)**: Offer to reload the domain so the entity disappears from the registry:
-   - `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <any-yaml> --reload automation` — or remind the operator to run `automation.reload` from HA Developer Tools.
+5. **Reload (optional)**: After deletion the entity stays in the registry until the next reload. Offer to trigger one:
+   - Tell the operator to go to **HA Developer Tools → Services → `automation.reload`** (or `script.reload`).
+   - Do **not** use `validate-apply` for this — it would also push the supplied YAML as a new config.
 
 ## Safety
 

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-delete-config/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-delete-config/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: ha-delete-config
+description: Delete an automation or script from Home Assistant via REST API with operator confirmation. Use when the operator asks to remove, delete, or disable a specific automation or script.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Delete HA Config
+
+Removes an automation or script from Home Assistant via `DELETE /api/config/{domain}/config/{id}`.
+
+## Steps
+
+1. **Identify the target**: Ask the operator which automation or script to delete (name or ID).
+   - If unknown, list options: `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-automations` or `ha list-scripts`.
+   - The `id` column is the config ID needed for deletion. The `alias` column shows the friendly name.
+
+2. **Confirm with operator**: Show the target details (entity_id, id, alias, state) and ask for explicit confirmation before proceeding. This action cannot be undone via CLI.
+
+3. **Delete**: Run the appropriate command:
+   - `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-automation <id>` for automations.
+   - `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-script <id>` for scripts.
+
+4. **Check result**: Read the JSON output.
+   - `ok: true` — config deleted. The entity stays in the registry until the next reload.
+   - `ok: false, message: "Resource not found"` — the ID doesn't exist in HA (note: HA returns 400, not 404).
+   - `ok: false` + other message — surface the error to the operator.
+
+5. **Reload (optional)**: Offer to reload the domain so the entity disappears from the registry:
+   - `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <any-yaml> --reload automation` — or remind the operator to run `automation.reload` from HA Developer Tools.
+
+## Safety
+
+- Always confirm with the operator before deleting. Deletion is immediate and removes the config from HA storage.
+- Deletion does not check for sensitive entities — the automation is already gone, there is nothing to gate.
+- After deletion, the automation will no longer fire. The entity_id remains in the registry until reload.

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-delete-config/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-delete-config/SKILL.md
@@ -14,9 +14,10 @@ Removes an automation or script from Home Assistant via `DELETE /api/config/{dom
 
 1. **Identify the target**: Ask the operator which automation or script to delete (name or ID).
    - If unknown, list options: `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-automations` or `ha list-scripts`.
-   - The `id` column is the config ID needed for deletion. The `alias` column shows the friendly name.
+   - The `id` column is the config ID needed for deletion. The `friendly_name` column shows the UI display name (this is HA's `friendly_name` attribute, which may differ from the YAML `alias:` field if the operator customized it via the UI).
+   - The `deletable` column is `false` for YAML-packaged automations (no numeric `id`) — these cannot be removed via REST. Tell the operator to delete the YAML block from their config files and reload manually instead.
 
-2. **Confirm with operator**: Show the target details (entity_id, id, alias, state) and ask for explicit confirmation before proceeding. This action cannot be undone via CLI.
+2. **Confirm with operator**: Show the target details (entity_id, id, friendly_name, state) and ask for explicit confirmation before proceeding. This action cannot be undone via CLI.
 
 3. **Delete**: Run the appropriate command:
    - `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-automation <id>` for automations.

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/apply.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/apply.py
@@ -1,20 +1,36 @@
 from __future__ import annotations
 
+import yaml
 from dataclasses import dataclass
 from pathlib import Path
 
 from .artifacts import current_session_id, slugify, standard_metadata, write_markdown_artifact
-from .ha_api import HomeAssistantClient, HomeAssistantError
+from .ha_api import HomeAssistantClient, HomeAssistantError, extract_ha_error_message
 from .policy import can_reload_domain
 from .simulate import SimulationResult, simulate_artifact
+
+_CONFIG_DOMAINS = {"automation", "script"}
 
 
 @dataclass(slots=True)
 class ApplyResult:
     ok: bool
     config_check_ok: bool
+    config_id: str | None
+    domain: str | None
+    creation_attempted: bool
+    creation_ok: bool
     reload_attempted: bool
     reload_domain: str | None
+    message: str
+    report_path: Path
+
+
+@dataclass(slots=True)
+class RemoveResult:
+    ok: bool
+    domain: str
+    config_id: str
     message: str
     report_path: Path
 
@@ -29,68 +45,159 @@ def validate_and_apply(
 
     if not simulation.is_valid:
         report_path = _write_apply_report(
-            root,
-            artifact_path,
-            simulation,
-            False,
-            False,
-            reload_domain,
-            "Simulation failed. See missing entities or blocked reasons.",
+            root, artifact_path, simulation,
+            config_check_ok=False, config_id=None, creation_attempted=False,
+            creation_ok=False, reload_attempted=False, reload_domain=reload_domain,
+            message="Simulation failed. See missing entities or blocked reasons.",
         )
-        return ApplyResult(False, False, False, reload_domain, "simulation-failed", report_path)
+        return ApplyResult(
+            ok=False, config_check_ok=False, config_id=None, domain=reload_domain,
+            creation_attempted=False, creation_ok=False, reload_attempted=False,
+            reload_domain=reload_domain, message="simulation-failed", report_path=report_path,
+        )
 
     try:
         check_result = client.post("/api/config/core/check_config", {})
         config_ok = _is_truthy(check_result)
     except HomeAssistantError as exc:
         report_path = _write_apply_report(
-            root,
-            artifact_path,
-            simulation,
-            False,
-            False,
-            reload_domain,
-            f"Config validation failed: {exc}",
+            root, artifact_path, simulation,
+            config_check_ok=False, config_id=None, creation_attempted=False,
+            creation_ok=False, reload_attempted=False, reload_domain=reload_domain,
+            message=f"Config validation failed: {exc}",
         )
-        return ApplyResult(False, False, False, reload_domain, str(exc), report_path)
+        return ApplyResult(
+            ok=False, config_check_ok=False, config_id=None, domain=reload_domain,
+            creation_attempted=False, creation_ok=False, reload_attempted=False,
+            reload_domain=reload_domain, message=str(exc), report_path=report_path,
+        )
+
+    config_id: str | None = None
+    creation_attempted = False
+    creation_ok = False
+    drift_warning: str | None = None
+    yaml_mode_message: str | None = None
+
+    if reload_domain in _CONFIG_DOMAINS:
+        artifact_config = yaml.safe_load(artifact_path.read_text(encoding="utf-8")) or {}
+        config_id = (
+            str(artifact_config.get("id") or "").strip()
+            or slugify(str(artifact_config.get("alias") or "").strip())
+            or slugify(artifact_path.stem)
+        )
+        if not str(artifact_config.get("id") or "").strip():
+            drift_warning = (
+                f"id '{config_id}' derived from {'alias' if artifact_config.get('alias') else 'filename'} — "
+                f"set id: explicitly in the YAML to prevent drift on rename."
+            )
+
+        try:
+            client.post(f"/api/config/{reload_domain}/config/{config_id}", artifact_config)
+            creation_attempted = True
+            try:
+                verify = client.get(f"/api/config/{reload_domain}/config/{config_id}")
+                creation_ok = verify.get("alias") == artifact_config.get("alias")
+            except HomeAssistantError:
+                creation_ok = False
+        except HomeAssistantError as exc:
+            if exc.status_code == 403:
+                creation_attempted = True
+                yaml_mode_message = (
+                    f"YAML mode: HA rejected REST config push (403). "
+                    f"Place the generated YAML in your HA config directory and reload {reload_domain}."
+                )
+            else:
+                ha_message = extract_ha_error_message(exc)
+                msg = f"Config push failed: {ha_message}"
+                report_path = _write_apply_report(
+                    root, artifact_path, simulation,
+                    config_check_ok=config_ok, config_id=config_id, creation_attempted=True,
+                    creation_ok=False, reload_attempted=False, reload_domain=reload_domain,
+                    message=msg,
+                )
+                return ApplyResult(
+                    ok=False, config_check_ok=config_ok, config_id=config_id, domain=reload_domain,
+                    creation_attempted=True, creation_ok=False, reload_attempted=False,
+                    reload_domain=reload_domain, message=msg, report_path=report_path,
+                )
 
     reload_attempted = False
     if reload_domain:
         if not can_reload_domain(reload_domain):
             report_path = _write_apply_report(
-                root,
-                artifact_path,
-                simulation,
-                False,
-                False,
-                reload_domain,
-                f"Reload domain `{reload_domain}` is not allowed.",
+                root, artifact_path, simulation,
+                config_check_ok=config_ok, config_id=config_id, creation_attempted=creation_attempted,
+                creation_ok=creation_ok, reload_attempted=False, reload_domain=reload_domain,
+                message=f"Reload domain `{reload_domain}` is not allowed.",
             )
-            return ApplyResult(False, config_ok, False, reload_domain, "reload-blocked", report_path)
+            return ApplyResult(
+                ok=False, config_check_ok=config_ok, config_id=config_id, domain=reload_domain,
+                creation_attempted=creation_attempted, creation_ok=creation_ok,
+                reload_attempted=False, reload_domain=reload_domain,
+                message="reload-blocked", report_path=report_path,
+            )
         client.post(f"/api/services/{reload_domain}/reload", {})
         reload_attempted = True
 
-    message = (
-        "Validation succeeded. Apply flow completed. "
-        "Generated YAML must still be present in Home Assistant includes for reload to take effect."
-    )
+    parts = ["Validation succeeded. Apply flow completed."]
+    if creation_attempted and creation_ok:
+        parts.append(f"Config pushed and verified via REST ({reload_domain}/{config_id}).")
+    elif yaml_mode_message:
+        parts.append(yaml_mode_message)
+    else:
+        parts.append(
+            "Generated YAML must still be present in Home Assistant includes for reload to take effect."
+        )
+    if drift_warning:
+        parts.append(drift_warning)
+    message = " ".join(parts)
+
     report_path = _write_apply_report(
-        root,
-        artifact_path,
-        simulation,
-        config_ok,
-        reload_attempted,
-        reload_domain,
-        message,
+        root, artifact_path, simulation,
+        config_check_ok=config_ok, config_id=config_id, creation_attempted=creation_attempted,
+        creation_ok=creation_ok, reload_attempted=reload_attempted, reload_domain=reload_domain,
+        message=message,
     )
-    return ApplyResult(True, config_ok, reload_attempted, reload_domain, message, report_path)
+    return ApplyResult(
+        ok=True, config_check_ok=config_ok, config_id=config_id, domain=reload_domain,
+        creation_attempted=creation_attempted, creation_ok=creation_ok,
+        reload_attempted=reload_attempted, reload_domain=reload_domain,
+        message=message, report_path=report_path,
+    )
+
+
+def remove_config(
+    root: Path,
+    client: HomeAssistantClient,
+    domain: str,
+    config_id: str,
+) -> RemoveResult:
+    if domain not in _CONFIG_DOMAINS:
+        msg = f"Domain '{domain}' is not a configurable domain. Choose from: {', '.join(sorted(_CONFIG_DOMAINS))}."
+        report_path = _write_remove_report(root, domain, config_id, ok=False, message=msg)
+        return RemoveResult(ok=False, domain=domain, config_id=config_id, message=msg, report_path=report_path)
+
+    try:
+        result = client.delete(f"/api/config/{domain}/config/{config_id}")
+        ok = isinstance(result, dict) and result.get("result") == "ok"
+        message = "ok" if ok else f"unexpected response: {result}"
+    except HomeAssistantError as exc:
+        ok = False
+        message = extract_ha_error_message(exc)
+
+    report_path = _write_remove_report(root, domain, config_id, ok=ok, message=message)
+    return RemoveResult(ok=ok, domain=domain, config_id=config_id, message=message, report_path=report_path)
 
 
 def _write_apply_report(
     root: Path,
     artifact_path: Path,
     simulation: SimulationResult,
+    *,
     config_check_ok: bool,
+    config_id: str | None,
+    creation_attempted: bool,
+    creation_ok: bool,
     reload_attempted: bool,
     reload_domain: str | None,
     message: str,
@@ -103,6 +210,9 @@ def _write_apply_report(
         extra={
             "artifact_path": str(artifact_path.relative_to(root)),
             "config_check_ok": config_check_ok,
+            "config_id": config_id,
+            "creation_attempted": creation_attempted,
+            "creation_ok": creation_ok,
             "reload_attempted": reload_attempted,
             "reload_domain": reload_domain,
             "simulation_valid": simulation.is_valid,
@@ -115,6 +225,9 @@ def _write_apply_report(
             "",
             f"- simulation_valid: {str(simulation.is_valid).lower()}",
             f"- config_check_ok: {str(config_check_ok).lower()}",
+            f"- config_id: {config_id or 'none'}",
+            f"- creation_attempted: {str(creation_attempted).lower()}",
+            f"- creation_ok: {str(creation_ok).lower()}",
             f"- reload_attempted: {str(reload_attempted).lower()}",
             f"- reload_domain: {reload_domain or 'none'}",
             "",
@@ -129,6 +242,48 @@ def _write_apply_report(
         metadata,
         body,
         latest_name="audit-ha-apply-latest.md",
+    )
+
+
+def _write_remove_report(
+    root: Path,
+    domain: str,
+    config_id: str,
+    *,
+    ok: bool,
+    message: str,
+) -> Path:
+    metadata = standard_metadata(
+        "remove",
+        f"Remove Report — {domain}/{config_id}",
+        session=current_session_id(root),
+        tags=["ha-remove", f"ha-{domain}"],
+        extra={
+            "domain": domain,
+            "config_id": config_id,
+            "ok": ok,
+            "message": message,
+        },
+    )
+    body = "\n".join(
+        [
+            f"# Remove Report for `{domain}/{config_id}`",
+            "",
+            f"- ok: {str(ok).lower()}",
+            f"- domain: {domain}",
+            f"- config_id: {config_id}",
+            "",
+            f"Message: {message}",
+        ]
+    )
+    slug = f"audit-ha-remove-{domain}-{slugify(config_id)}"
+    return write_markdown_artifact(
+        root,
+        ".claude-code-hermit/raw",
+        slug,
+        metadata,
+        body,
+        latest_name="audit-ha-remove-latest.md",
     )
 
 

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/apply.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/apply.py
@@ -78,6 +78,19 @@ def validate_and_apply(
     drift_warning: str | None = None
     yaml_mode_message: str | None = None
 
+    if reload_domain and not can_reload_domain(reload_domain):
+        report_path = _write_apply_report(
+            root, artifact_path, simulation,
+            config_check_ok=config_ok, config_id=None, creation_attempted=False,
+            creation_ok=False, reload_attempted=False, reload_domain=reload_domain,
+            message=f"Reload domain `{reload_domain}` is not allowed.",
+        )
+        return ApplyResult(
+            ok=False, config_check_ok=config_ok, config_id=None, domain=reload_domain,
+            creation_attempted=False, creation_ok=False, reload_attempted=False,
+            reload_domain=reload_domain, message="reload-blocked", report_path=report_path,
+        )
+
     if reload_domain in _CONFIG_DOMAINS:
         artifact_config = yaml.safe_load(artifact_path.read_text(encoding="utf-8")) or {}
         config_id = (
@@ -91,9 +104,9 @@ def validate_and_apply(
                 f"set id: explicitly in the YAML to prevent drift on rename."
             )
 
+        creation_attempted = True
         try:
             client.post(f"/api/config/{reload_domain}/config/{config_id}", artifact_config)
-            creation_attempted = True
             try:
                 verify = client.get(f"/api/config/{reload_domain}/config/{config_id}")
                 creation_ok = verify.get("alias") == artifact_config.get("alias")
@@ -101,7 +114,6 @@ def validate_and_apply(
                 creation_ok = False
         except HomeAssistantError as exc:
             if exc.status_code == 403:
-                creation_attempted = True
                 yaml_mode_message = (
                     f"YAML mode: HA rejected REST config push (403). "
                     f"Place the generated YAML in your HA config directory and reload {reload_domain}."
@@ -123,19 +135,6 @@ def validate_and_apply(
 
     reload_attempted = False
     if reload_domain:
-        if not can_reload_domain(reload_domain):
-            report_path = _write_apply_report(
-                root, artifact_path, simulation,
-                config_check_ok=config_ok, config_id=config_id, creation_attempted=creation_attempted,
-                creation_ok=creation_ok, reload_attempted=False, reload_domain=reload_domain,
-                message=f"Reload domain `{reload_domain}` is not allowed.",
-            )
-            return ApplyResult(
-                ok=False, config_check_ok=config_ok, config_id=config_id, domain=reload_domain,
-                creation_attempted=creation_attempted, creation_ok=creation_ok,
-                reload_attempted=False, reload_domain=reload_domain,
-                message="reload-blocked", report_path=report_path,
-            )
         client.post(f"/api/services/{reload_domain}/reload", {})
         reload_attempted = True
 

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
@@ -7,7 +7,7 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-from .apply import validate_and_apply
+from .apply import remove_config, validate_and_apply
 from .artifacts import current_session_id, standard_metadata, utc_timestamp, write_json_artifact, write_markdown_artifact
 from .boot import boot_status, save_boot_preferences
 from .config import load_config, normalized_context_path
@@ -59,6 +59,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="GET a raw HA REST path and print the JSON response. Useful for verifying endpoints.",
     )
     probe_parser.add_argument("path", help="HA REST path, e.g. /api/config/automation/config/1234")
+
+    ha_subparsers.add_parser("list-automations", help="List all automation entity IDs and config IDs.")
+    ha_subparsers.add_parser("list-scripts", help="List all script entity IDs and config IDs.")
+
+    delete_automation_parser = ha_subparsers.add_parser("delete-automation", help="Delete an automation config by ID.")
+    delete_automation_parser.add_argument("id", help="Automation config ID (not entity_id).")
+
+    delete_script_parser = ha_subparsers.add_parser("delete-script", help="Delete a script config by ID.")
+    delete_script_parser.add_argument("id", help="Script config ID (not entity_id).")
 
     return parser
 
@@ -167,6 +176,10 @@ def main(argv: list[str] | None = None) -> int:
                 json.dumps(
                     {
                         "ok": result.ok,
+                        "config_id": result.config_id,
+                        "creation_attempted": result.creation_attempted,
+                        "creation_ok": result.creation_ok,
+                        "reload_attempted": result.reload_attempted,
                         "message": result.message,
                         "report_path": str(result.report_path.relative_to(root)),
                         "base_url_source": client.base_url_source,
@@ -179,8 +192,56 @@ def main(argv: list[str] | None = None) -> int:
             print(str(exc))
             return 1
 
+    if args.command == "ha" and args.ha_command in ("list-automations", "list-scripts"):
+        try:
+            client = HomeAssistantClient(config)
+            domain = "automation" if args.ha_command == "list-automations" else "script"
+            items = _list_domain(client, domain)
+            print(json.dumps(items, indent=2, ensure_ascii=False))
+            return 0
+        except HomeAssistantError as exc:
+            print(str(exc))
+            return 1
+
+    if args.command == "ha" and args.ha_command in ("delete-automation", "delete-script"):
+        try:
+            client = HomeAssistantClient(config)
+            domain = "automation" if args.ha_command == "delete-automation" else "script"
+            result = remove_config(root, client, domain, args.id)
+            print(
+                json.dumps(
+                    {
+                        "ok": result.ok,
+                        "domain": result.domain,
+                        "config_id": result.config_id,
+                        "message": result.message,
+                        "report_path": str(result.report_path.relative_to(root)),
+                    },
+                    indent=2,
+                )
+            )
+            return 0 if result.ok else 1
+        except HomeAssistantError as exc:
+            print(str(exc))
+            return 1
+
     parser.error("Unsupported command.")
     return 1
+
+
+def _list_domain(client: HomeAssistantClient, domain: str) -> list[dict[str, Any]]:
+    states = client.get("/api/states")
+    return [
+        {
+            "entity_id": s["entity_id"],
+            "id": (s.get("attributes") or {}).get("id"),
+            "alias": (s.get("attributes") or {}).get("friendly_name"),
+            "state": s.get("state"),
+            "last_changed": s.get("last_changed"),
+        }
+        for s in states
+        if isinstance(s, dict) and s.get("entity_id", "").startswith(f"{domain}.")
+    ]
 
 
 def _print_safety_audit_summary(summary: dict[str, Any]) -> None:

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
@@ -231,17 +231,23 @@ def main(argv: list[str] | None = None) -> int:
 
 def _list_domain(client: HomeAssistantClient, domain: str) -> list[dict[str, Any]]:
     states = client.get("/api/states")
-    return [
-        {
+    prefix = f"{domain}."
+    items: list[dict[str, Any]] = []
+    for s in states:
+        if not (isinstance(s, dict) and s.get("entity_id", "").startswith(prefix)):
+            continue
+        attrs = s.get("attributes") or {}
+        config_id = attrs.get("id")
+        items.append({
             "entity_id": s["entity_id"],
-            "id": (s.get("attributes") or {}).get("id"),
-            "alias": (s.get("attributes") or {}).get("friendly_name"),
+            "id": config_id,
+            "friendly_name": attrs.get("friendly_name"),
             "state": s.get("state"),
             "last_changed": s.get("last_changed"),
-        }
-        for s in states
-        if isinstance(s, dict) and s.get("entity_id", "").startswith(f"{domain}.")
-    ]
+            "deletable": config_id is not None,
+        })
+    items.sort(key=lambda item: item["entity_id"])
+    return items
 
 
 def _print_safety_audit_summary(summary: dict[str, Any]) -> None:

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/ha_api.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/ha_api.py
@@ -44,6 +44,9 @@ class HomeAssistantClient:
     def post(self, path: str, payload: dict[str, Any] | None = None) -> Any:
         return self._request("POST", path, payload)
 
+    def delete(self, path: str) -> Any:
+        return self._request("DELETE", path, None)
+
     def get_states(self) -> list[dict[str, Any]]:
         return self.get("/api/states")
 
@@ -92,10 +95,23 @@ class HomeAssistantClient:
     def _http_error_message(status_code: int) -> str:
         mapping = {
             401: "Unauthorized Home Assistant request.",
+            403: "Forbidden: Home Assistant is in YAML mode (REST config API unavailable).",
             404: "Home Assistant endpoint not found.",
             405: "Home Assistant method not allowed.",
         }
         return mapping.get(status_code, "Home Assistant request failed.")
+
+
+def extract_ha_error_message(exc: HomeAssistantError) -> str:
+    """Pull HA's structured {"message": "..."} body from the error; fall back to str(exc)."""
+    if isinstance(exc.payload, str):
+        try:
+            parsed = json.loads(exc.payload)
+            if isinstance(parsed, dict) and isinstance(parsed.get("message"), str):
+                return parsed["message"]
+        except json.JSONDecodeError:
+            pass
+    return str(exc)
 
 
 def probe_home_assistant_url(base_url: str, token: str, timeout_seconds: int) -> bool:

--- a/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
@@ -33,6 +33,7 @@ This project has the `claude-code-homeassistant-hermit` plugin installed. The ru
 | `/claude-code-homeassistant-hermit:ha-morning-brief` | Morning brief — live status, overnight anomalies, recommendations |
 | `/claude-code-homeassistant-hermit:ha-safety-audit` | Re-audit live automations against the safety policy (weekly scheduled_check) |
 | `/claude-code-homeassistant-hermit:ha-integration-health` | Detect dropped integrations via per-domain unavailable ratios (daily scheduled_check) |
+| `/claude-code-homeassistant-hermit:ha-delete-config` | Discover and delete an automation/script config from HA |
 
 ### Subagents
 

--- a/plugins/claude-code-homeassistant-hermit/tests/conftest.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -23,4 +24,21 @@ def make_ha_root(tmp_path: Path):
         )
         return tmp_path
 
+    return _make
+
+
+@pytest.fixture
+def make_mock_config(tmp_path):
+    """Factory fixture: builds a MagicMock AppConfig for CLI tests."""
+    def _make(url: str = "http://homeassistant.local:8123") -> MagicMock:
+        cfg = MagicMock()
+        cfg.root = tmp_path
+        cfg.missing_ha_configuration_fields.return_value = []
+        cfg.ha_token = "fake-token"
+        cfg.ha_local_url = None
+        cfg.ha_remote_url = None
+        cfg.primary_url.return_value = url
+        cfg.retry_count = 0
+        cfg.timeout_seconds = 5
+        return cfg
     return _make

--- a/plugins/claude-code-homeassistant-hermit/tests/test_apply.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_apply.py
@@ -1,13 +1,22 @@
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
-from ha_agent_lab.apply import validate_and_apply
-from ha_agent_lab.ha_api import HomeAssistantError
+from ha_agent_lab.apply import remove_config, validate_and_apply
+from ha_agent_lab.ha_api import HomeAssistantError, extract_ha_error_message
 from helpers import write_artifact
 
 SAFE_YAML = """
+alias: Safe automation
+actions:
+  - service: light.turn_on
+    target:
+      entity_id: light.living_room
+""".strip()
+
+SAFE_YAML_WITH_ID = """
+id: my_automation
 alias: Safe automation
 actions:
   - service: light.turn_on
@@ -23,11 +32,20 @@ actions:
       entity_id: lock.front_door
 """.strip()
 
+SCRIPT_YAML = """
+id: my_script
+alias: Safe script
+sequence:
+  - delay: "00:00:01"
+""".strip()
+
 
 @pytest.fixture
 def safe_root(make_ha_root):
     return make_ha_root()
 
+
+# --- existing tests (updated) ---
 
 def test_sensitive_yaml_is_blocked_before_network_call(make_ha_root):
     root = make_ha_root(inventory={
@@ -59,6 +77,7 @@ def test_valid_yaml_with_reload_calls_reload(safe_root: Path):
     artifact = write_artifact(safe_root, SAFE_YAML)
     client = MagicMock()
     client.post.return_value = {"result": "valid"}
+    client.get.return_value = {"alias": "Safe automation"}
 
     result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
 
@@ -88,3 +107,210 @@ def test_valid_yaml_no_reload(safe_root: Path):
 
     assert result.ok
     assert not result.reload_attempted
+    assert not result.creation_attempted
+
+
+# --- REST push tests ---
+
+def test_pushes_automation_config_via_rest(safe_root: Path):
+    artifact = write_artifact(safe_root, SAFE_YAML_WITH_ID)
+    client = MagicMock()
+    client.post.return_value = {"result": "valid"}
+    client.get.return_value = {"alias": "Safe automation"}
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
+
+    assert result.ok
+    assert result.creation_attempted
+    client.post.assert_any_call(
+        "/api/config/automation/config/my_automation",
+        {"id": "my_automation", "alias": "Safe automation", "actions": [{"service": "light.turn_on", "target": {"entity_id": "light.living_room"}}]},
+    )
+
+
+def test_pushes_script_config_via_rest(safe_root: Path):
+    artifact = write_artifact(safe_root, SCRIPT_YAML)
+    client = MagicMock()
+    client.post.return_value = {"result": "valid"}
+    client.get.return_value = {"alias": "Safe script"}
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="script")
+
+    assert result.ok
+    assert result.creation_attempted
+    client.post.assert_any_call(
+        "/api/config/script/config/my_script",
+        {"id": "my_script", "alias": "Safe script", "sequence": [{"delay": "00:00:01"}]},
+    )
+
+
+def test_id_extracted_from_yaml_id_field(safe_root: Path):
+    artifact = write_artifact(safe_root, SAFE_YAML_WITH_ID)
+    client = MagicMock()
+    client.post.return_value = {"result": "valid"}
+    client.get.return_value = {"alias": "Safe automation"}
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
+
+    assert result.config_id == "my_automation"
+    assert result.creation_ok
+
+
+def test_id_generated_from_alias_when_no_id(safe_root: Path):
+    artifact = write_artifact(safe_root, SAFE_YAML)
+    client = MagicMock()
+    client.post.return_value = {"result": "valid"}
+    client.get.return_value = {"alias": "Safe automation"}
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
+
+    assert result.config_id == "Safe_automation"
+    assert "derived from alias" in result.message
+
+
+def test_id_generated_from_stem_when_no_id_no_alias(safe_root: Path):
+    yaml_content = "actions:\n  - service: light.turn_on\n    target:\n      entity_id: light.living_room"
+    artifact = write_artifact(safe_root, yaml_content, name="my_rule.yaml")
+    client = MagicMock()
+    client.post.return_value = {"result": "valid"}
+    client.get.return_value = {}
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
+
+    assert result.config_id == "my_rule"
+    assert "derived from filename" in result.message
+
+
+def test_skip_push_when_no_reload_domain(safe_root: Path):
+    artifact = write_artifact(safe_root, SAFE_YAML_WITH_ID)
+    client = MagicMock()
+    client.post.return_value = True
+
+    result = validate_and_apply(safe_root, client, artifact)
+
+    assert result.ok
+    assert not result.creation_attempted
+    assert result.config_id is None
+    # only the check_config POST, not the config-push POST
+    client.post.assert_called_once_with("/api/config/core/check_config", {})
+
+
+def test_verify_ok_sets_creation_ok_true(safe_root: Path):
+    artifact = write_artifact(safe_root, SAFE_YAML_WITH_ID)
+    client = MagicMock()
+    client.post.return_value = {"result": "valid"}
+    client.get.return_value = {"alias": "Safe automation"}
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
+
+    assert result.creation_ok
+
+
+def test_verify_failure_keeps_overall_ok_true(safe_root: Path):
+    artifact = write_artifact(safe_root, SAFE_YAML_WITH_ID)
+    client = MagicMock()
+    client.post.return_value = {"result": "valid"}
+    client.get.side_effect = HomeAssistantError("GET failed")
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
+
+    assert result.ok
+    assert result.creation_attempted
+    assert not result.creation_ok
+
+
+def test_403_yaml_mode_falls_back_with_clear_message(safe_root: Path):
+    artifact = write_artifact(safe_root, SAFE_YAML_WITH_ID)
+    client = MagicMock()
+    client.post.side_effect = [
+        {"result": "valid"},  # check_config succeeds
+        HomeAssistantError("Forbidden", status_code=403),  # config push fails
+        {"result": "ok"},  # reload succeeds
+    ]
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
+
+    assert result.ok
+    assert result.creation_attempted
+    assert not result.creation_ok
+    assert result.reload_attempted
+    assert "YAML mode" in result.message
+
+
+def test_400_invalid_payload_surfaces_ha_message(safe_root: Path):
+    artifact = write_artifact(safe_root, SAFE_YAML_WITH_ID)
+    client = MagicMock()
+    client.post.side_effect = [
+        {"result": "valid"},  # check_config
+        HomeAssistantError("Bad request", status_code=400, payload='{"message":"Message malformed: required key not provided @ data[\'triggers\']"}'),
+    ]
+
+    result = validate_and_apply(safe_root, client, artifact, reload_domain="automation")
+
+    assert not result.ok
+    assert result.creation_attempted
+    assert not result.creation_ok
+    assert "Message malformed" in result.message
+
+
+# --- remove_config tests ---
+
+def test_remove_automation_ok(safe_root: Path):
+    client = MagicMock()
+    client.delete.return_value = {"result": "ok"}
+
+    result = remove_config(safe_root, client, "automation", "my_automation")
+
+    assert result.ok
+    assert result.message == "ok"
+    client.delete.assert_called_once_with("/api/config/automation/config/my_automation")
+
+
+def test_remove_script_ok(safe_root: Path):
+    client = MagicMock()
+    client.delete.return_value = {"result": "ok"}
+
+    result = remove_config(safe_root, client, "script", "my_script")
+
+    assert result.ok
+    client.delete.assert_called_once_with("/api/config/script/config/my_script")
+
+
+def test_remove_returns_400_with_resource_not_found(safe_root: Path):
+    client = MagicMock()
+    client.delete.side_effect = HomeAssistantError(
+        "Home Assistant request failed.", status_code=400,
+        payload='{"message":"Resource not found"}',
+    )
+
+    result = remove_config(safe_root, client, "automation", "nonexistent_id")
+
+    assert not result.ok
+    assert result.message == "Resource not found"
+
+
+def test_remove_invalid_domain(safe_root: Path):
+    client = MagicMock()
+
+    result = remove_config(safe_root, client, "shell_command", "my_id")
+
+    assert not result.ok
+    assert "not a configurable domain" in result.message
+    client.delete.assert_not_called()
+
+
+# --- extract_ha_error_message tests ---
+
+def test_extract_ha_error_message_pulls_message_field():
+    exc = HomeAssistantError("failed", status_code=400, payload='{"message":"Resource not found"}')
+    assert extract_ha_error_message(exc) == "Resource not found"
+
+
+def test_extract_ha_error_message_falls_back_on_non_json():
+    exc = HomeAssistantError("plain error", status_code=500, payload="Internal Server Error")
+    assert extract_ha_error_message(exc) == str(exc)
+
+
+def test_extract_ha_error_message_falls_back_on_no_payload():
+    exc = HomeAssistantError("connection refused")
+    assert extract_ha_error_message(exc) == str(exc)

--- a/plugins/claude-code-homeassistant-hermit/tests/test_cli_delete.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_cli_delete.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from ha_agent_lab.cli import main
+from ha_agent_lab.ha_api import HomeAssistantError
+
+
+def test_delete_automation_ok(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.delete.return_value = {"result": "ok"}
+        result = main(["ha", "delete-automation", "my_automation"])
+
+    assert result == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["config_id"] == "my_automation"
+    assert out["domain"] == "automation"
+    instance.delete.assert_called_once_with("/api/config/automation/config/my_automation")
+
+
+def test_delete_script_ok(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.delete.return_value = {"result": "ok"}
+        result = main(["ha", "delete-script", "my_script"])
+
+    assert result == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["config_id"] == "my_script"
+    assert out["domain"] == "script"
+    instance.delete.assert_called_once_with("/api/config/script/config/my_script")
+
+
+def test_delete_automation_not_found_exits_nonzero(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.delete.side_effect = HomeAssistantError(
+            "Home Assistant request failed.", status_code=400,
+            payload='{"message":"Resource not found"}',
+        )
+        result = main(["ha", "delete-automation", "nonexistent"])
+
+    assert result == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert out["message"] == "Resource not found"
+
+
+def test_list_automations_ok(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    states = [
+        {"entity_id": "automation.lights_on", "attributes": {"id": "lights_on", "friendly_name": "Lights On"}, "state": "on", "last_changed": "2026-05-05T10:00:00Z"},
+        {"entity_id": "light.living_room", "attributes": {}, "state": "off", "last_changed": "2026-05-05T10:00:00Z"},
+    ]
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get.return_value = states
+        result = main(["ha", "list-automations"])
+
+    assert result == 0
+    items = json.loads(capsys.readouterr().out)
+    assert len(items) == 1
+    assert items[0]["entity_id"] == "automation.lights_on"
+    assert items[0]["id"] == "lights_on"
+    assert items[0]["alias"] == "Lights On"
+
+
+def test_list_scripts_filters_correctly(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    states = [
+        {"entity_id": "script.welcome", "attributes": {"id": "welcome", "friendly_name": "Welcome"}, "state": "off", "last_changed": "2026-05-05T10:00:00Z"},
+        {"entity_id": "automation.lights_on", "attributes": {"id": "lights_on", "friendly_name": "Lights On"}, "state": "on", "last_changed": "2026-05-05T10:00:00Z"},
+    ]
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get.return_value = states
+        result = main(["ha", "list-scripts"])
+
+    assert result == 0
+    items = json.loads(capsys.readouterr().out)
+    assert len(items) == 1
+    assert items[0]["entity_id"] == "script.welcome"

--- a/plugins/claude-code-homeassistant-hermit/tests/test_cli_delete.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_cli_delete.py
@@ -75,7 +75,8 @@ def test_list_automations_ok(capsys, make_mock_config) -> None:
     assert len(items) == 1
     assert items[0]["entity_id"] == "automation.lights_on"
     assert items[0]["id"] == "lights_on"
-    assert items[0]["alias"] == "Lights On"
+    assert items[0]["friendly_name"] == "Lights On"
+    assert items[0]["deletable"] is True
 
 
 def test_list_scripts_filters_correctly(capsys, make_mock_config) -> None:
@@ -94,3 +95,41 @@ def test_list_scripts_filters_correctly(capsys, make_mock_config) -> None:
     items = json.loads(capsys.readouterr().out)
     assert len(items) == 1
     assert items[0]["entity_id"] == "script.welcome"
+
+
+def test_list_automations_marks_yaml_packaged_as_not_deletable(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    states = [
+        {"entity_id": "automation.ui_managed", "attributes": {"id": "ui_managed", "friendly_name": "UI Managed"}, "state": "on", "last_changed": "2026-05-05T10:00:00Z"},
+        {"entity_id": "automation.yaml_packaged", "attributes": {"friendly_name": "YAML Packaged"}, "state": "on", "last_changed": "2026-05-05T10:00:00Z"},
+    ]
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get.return_value = states
+        result = main(["ha", "list-automations"])
+
+    assert result == 0
+    items = json.loads(capsys.readouterr().out)
+    assert len(items) == 2
+    by_entity = {item["entity_id"]: item for item in items}
+    assert by_entity["automation.ui_managed"]["deletable"] is True
+    assert by_entity["automation.yaml_packaged"]["deletable"] is False
+    assert by_entity["automation.yaml_packaged"]["id"] is None
+
+
+def test_list_automations_returns_sorted_by_entity_id(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    states = [
+        {"entity_id": "automation.zebra", "attributes": {"id": "zebra", "friendly_name": "Zebra"}, "state": "on", "last_changed": "2026-05-05T10:00:00Z"},
+        {"entity_id": "automation.alpha", "attributes": {"id": "alpha", "friendly_name": "Alpha"}, "state": "on", "last_changed": "2026-05-05T10:00:00Z"},
+    ]
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get.return_value = states
+        result = main(["ha", "list-automations"])
+
+    assert result == 0
+    items = json.loads(capsys.readouterr().out)
+    assert [item["entity_id"] for item in items] == ["automation.alpha", "automation.zebra"]

--- a/plugins/claude-code-homeassistant-hermit/tests/test_cli_probe.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_cli_probe.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import json
-import sys
-from io import StringIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -11,22 +9,9 @@ from ha_agent_lab.cli import main
 from ha_agent_lab.ha_api import HomeAssistantError
 
 
-def _make_config(url: str = "http://homeassistant.local:8123") -> MagicMock:
-    cfg = MagicMock()
-    cfg.root = MagicMock()
-    cfg.missing_ha_configuration_fields.return_value = []
-    cfg.ha_token = "fake-token"
-    cfg.ha_local_url = None
-    cfg.ha_remote_url = None
-    cfg.primary_url.return_value = url
-    cfg.retry_count = 0
-    cfg.timeout_seconds = 5
-    return cfg
-
-
-def test_probe_success(capsys) -> None:
+def test_probe_success(capsys, make_mock_config) -> None:
     response = {"id": "123", "alias": "Test automation", "trigger": []}
-    cfg = _make_config()
+    cfg = make_mock_config()
 
     with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
          patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
@@ -40,8 +25,8 @@ def test_probe_success(capsys) -> None:
     instance.get.assert_called_once_with("/api/config/automation/config/123")
 
 
-def test_probe_404_exits_nonzero(capsys) -> None:
-    cfg = _make_config()
+def test_probe_404_exits_nonzero(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
 
     with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
          patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:


### PR DESCRIPTION
### Added

- **`ha validate-apply` now pushes config to HA via REST** — `POST /api/config/{domain}/config/{id}` is called before the domain reload, fixing the silent failure where `reload_attempted: true` was returned but the automation never appeared in HA (PROP-005). The automation `id:` field is used as the REST config ID; if absent, it is derived from the alias or filename with a drift warning in the output.
- **`ha delete-automation <id>` and `ha delete-script <id>`** — remove an automation or script config from HA via `DELETE /api/config/{domain}/config/{id}`. Output includes `ok`, `message`, and a report path.
- **`ha list-automations` and `ha list-scripts`** — lightweight enumeration of live HA automations/scripts (entity_id, config id, alias, state). Intended as a quick lookup before delete, without the full policy audit of `audit-automations`.
- **`ha-delete-config` skill** — operator-facing workflow for discovering a target automation/script, confirming deletion, and optionally triggering a reload.
- **Structured HA error messages surfaced verbatim** — all HA error responses carry `{"message":"..."}`. This field is now extracted and included in apply/remove reports, replacing the opaque "Home Assistant request failed (status=400)".

### Changed

- **`validate-apply` JSON output** — includes three new fields: `config_id`, `creation_attempted`, `creation_ok`. The `creation_ok` field distinguishes a pushed-and-verified config from a reload-only operation (e.g. YAML mode fallback).
- **`ApplyResult` dataclass** — extended with `config_id`, `domain`, `creation_attempted`, `creation_ok`.
- **deps: bump core requirement to `>=1.0.30` / `^1.0.30`** — was `>=1.0.29`; `required_core_version` and `requires.claude-code-hermit` in `hermit-meta.json` and `dependencies[0].version` in `plugin.json` all updated together.

### Fixed

- **Apply flow no longer silently succeeds when HA never received the config** — previous behavior called `automation.reload` with no config push, returning success despite the automation being absent. Now reports `creation_ok: false` with a clear message in the YAML-mode fallback case.
- **`ha-delete-config` skill**: removed erroneous advice to use `validate-apply` for post-delete reload (it would also push the supplied YAML as a new config). Step 5 now correctly points to HA Developer Tools → Services.
- **`ha-build-automation` skill**: `id:` field is now required as the first field in generated YAML — without it, `validate-apply` derives a fragile ID from the alias that breaks on rename.
- **CLI tests**: `_make_config` helper consolidated into a shared `make_mock_config` fixture in `conftest.py`; test name corrected.

### Files affected

| File | Change |
|------|--------|
| `src/ha_agent_lab/apply.py` | REST push (`POST /api/config/{domain}/config/{id}`) added before reload; `ApplyResult` extended with `config_id`, `domain`, `creation_attempted`, `creation_ok` |
| `src/ha_agent_lab/cli.py` | `list-automations`, `list-scripts`, `delete-automation`, `delete-script` subcommands added |
| `src/ha_agent_lab/ha_api.py` | `_extract_ha_error_message` helper added; all error responses now surface HA's `{"message":"..."}` field |
| `skills/ha-apply-change/SKILL.md` | Apply workflow updated to reflect REST push flow and new `creation_ok` output field |
| `skills/ha-build-automation/SKILL.md` | `id:` field marked required as first field in generated YAML |
| `skills/ha-delete-config/SKILL.md` | New skill: delete workflow with list → confirm → delete → optional reload |
| `state-templates/CLAUDE-APPEND.md` | `ha-delete-config` row added to skills table |
| `CLAUDE.md` | `list-automations`, `list-scripts`, `delete-automation`, `delete-script` CLI commands documented |
| `.claude-plugin/hermit-meta.json` | `required_core_version` and `requires.claude-code-hermit` bumped `>=1.0.29` → `>=1.0.30` |
| `.claude-plugin/plugin.json` | `dependencies[0].version` bumped `^1.0.29` → `^1.0.30`; manifest `version` bumped `0.0.8` → `0.0.9` |
| `CHANGELOG.md` | New `[0.0.9]` entry |

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the SHA and strands the release tag on an orphan commit. After merging, run `/release claude-code-homeassistant-hermit` from `main` to tag.