### PR TITLE
release(claude-code-hermit): v1.0.32

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "claude-code-hermit",
       "source": "./plugins/claude-code-hermit",
       "description": "Core hermit - memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "category": "productivity",
       "author": {
         "name": "gtapps"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Always launch Claude Code from this repo's root, not from inside a plugin dir. A
 
 ## Rules
 
+- Always use Context7 when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
 - Don't overengineer.---
 
 <!-- claude-code-hermit: Session Discipline -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Always launch Claude Code from this repo's root, not from inside a plugin dir. A
 
 ## Rules
 
-- Always use Context7 when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
+- Always use Context7 for library/API documentation, code generation, and setup/configuration steps — don't wait for an explicit request.
 - Don't overengineer.---
 
 <!-- claude-code-hermit: Session Discipline -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="plugins/claude-code-hermit/CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.31-green.svg" alt="Version 1.0.31" /></a>
+  <a href="plugins/claude-code-hermit/CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.32-green.svg" alt="Version 1.0.32" /></a>
   <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/gtapps/claude-code-hermit/_gh_traffic_stats/.github/badges/clones.json" alt="Downloads" />
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
   <a href="plugins/claude-code-hermit/docs/obsidian-setup.md"><img src="https://img.shields.io/badge/obsidian-active-7c3aed.svg" alt="Obsidian Integration" /></a>

--- a/plugins/claude-code-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-hermit",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "A personal assistant that lives in your project — memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
   "author": {
     "name": "gtapps"

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.32] - 2026-05-07
 
 ### Added
 
@@ -11,13 +11,21 @@
 - **`agents/proposal-triage.md`** — adds Step 1.5 (Memory cross-reference) between Deduplication and Session cross-reference; SUPPRESS code list extended with `covered-by-memory`; new `memory_ref: <filename>` metadata field emitted alongside that verdict.
 - **`agents/reflection-judge.md`** — adds `### 1.5 Memory cross-check` between Evidence verification and Tier check; canonical suppress codes extended with `covered-by-memory`; reason includes `[memory: <filename>]` breadcrumb so operators can locate the source.
 
+### Files affected
+
+| File | Change |
+|------|--------|
+| `agents/proposal-triage.md` | Adds Step 1.5 memory cross-reference, `covered-by-memory` code, `memory_ref` metadata |
+| `agents/reflection-judge.md` | Adds §1.5 memory cross-check, `covered-by-memory` code, `[memory:]` breadcrumb |
+| `state-templates/CLAUDE-APPEND.md` | Adds Memory-first paragraph in Knowledge Discipline section |
+
 ### Upgrade Instructions
 
 Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes:
 
-1. **CLAUDE-APPEND block sync (automatic).** Step 6 of `hermit-evolve` reads the current `state-templates/CLAUDE-APPEND.md` and replaces the marker→EOF block in the project's `CLAUDE.md`. The new Memory-first paragraph propagates with no version-specific step needed. Idempotent.
+1. **Refresh the CLAUDE-APPEND anchored block.** Step 6 reads `state-templates/CLAUDE-APPEND.md` and replaces the marker→EOF block in the project's `CLAUDE.md`. The new Memory-first paragraph propagates idempotently.
 
-No `config.json` changes. No `runtime.json` changes. No new permissions. Subagent prompt updates ship inside the plugin source and take effect on plugin update — no per-install migration required.
+No `config.json` changes required.
 
 ## [1.0.31] - 2026-05-07
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Memory-first for suggestions.** Suggestion-generating skills (`brief`, `reflect`, `weekly-review`, `proposal-create`, `session-start`) and the `proposal-triage` / `reflection-judge` subagents now consult auto-memory before declaring a finding novel. Convention lives in `state-templates/CLAUDE-APPEND.md` and propagates to existing installs via the standard `/hermit-evolve` Step 6 anchored-block sync. Both subagents gain an explicit Memory cross-reference / cross-check step and a new canonical suppress code, `covered-by-memory`. Acting-on-decided-intent skills (`session-close`, `proposal-act`, `hermit-routines`, `hatch`) are exempt by design.
+
+### Changed
+
+- **`agents/proposal-triage.md`** — adds Step 1.5 (Memory cross-reference) between Deduplication and Session cross-reference; SUPPRESS code list extended with `covered-by-memory`; new `memory_ref: <filename>` metadata field emitted alongside that verdict.
+- **`agents/reflection-judge.md`** — adds `### 1.5 Memory cross-check` between Evidence verification and Tier check; canonical suppress codes extended with `covered-by-memory`; reason includes `[memory: <filename>]` breadcrumb so operators can locate the source.
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes:
+
+1. **CLAUDE-APPEND block sync (automatic).** Step 6 of `hermit-evolve` reads the current `state-templates/CLAUDE-APPEND.md` and replaces the marker→EOF block in the project's `CLAUDE.md`. The new Memory-first paragraph propagates with no version-specific step needed. Idempotent.
+
+No `config.json` changes. No `runtime.json` changes. No new permissions. Subagent prompt updates ship inside the plugin source and take effect on plugin update — no per-install migration required.
+
 ## [1.0.31] - 2026-05-07
 
 ### Fixed

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Changed
 
 - **`agents/proposal-triage.md`** — adds Step 1.5 (Memory cross-reference) between Deduplication and Session cross-reference; SUPPRESS code list extended with `covered-by-memory`; new `memory_ref: <filename>` metadata field emitted alongside that verdict.
-- **`agents/reflection-judge.md`** — adds `### 1.5 Memory cross-check` between Evidence verification and Tier check; canonical suppress codes extended with `covered-by-memory`; reason includes `[memory: <filename>]` breadcrumb so operators can locate the source.
+- **`agents/reflection-judge.md`** — adds `### 1.5 Memory cross-check` between Evidence verification and Tier check; canonical suppress codes extended with `covered-by-memory`; reason includes `[memory: <filename>]` breadcrumb so operators can locate the source. The §0 Evidence-Source dispatch routes `scheduled-check/*` and `operator-request` through §1.5 before §2 Tier check, so the memory cross-check applies to every source — not only `archived-session` / `current-session`.
+- **`agents/proposal-triage.md` Step 5 preamble** — clarifies that the Three-Condition Rule runs only when no duplicate *and* no memory match was found, matching the new Step 1.5 short-circuit.
 
 ### Files affected
 

--- a/plugins/claude-code-hermit/agents/proposal-triage.md
+++ b/plugins/claude-code-hermit/agents/proposal-triage.md
@@ -40,6 +40,13 @@ If a proposal with the same problem already exists (any status, including dismis
 
 Note the nearest near-miss PROP-ID even if no exact duplicate is found — it goes into `closest_prop` metadata.
 
+## Step 1.5 — Memory cross-reference
+
+Read `MEMORY.md` (index of `- [title](file) — description` entries). Read each topic file whose title or description keyword-matches the candidate. Each topic file carries `name`, `description`, body, `Why:`, and `How to apply:` — match against all of them. If memory already records the operator's decision, preference, or pattern that this candidate would propose:
+- Return: `SUPPRESS — covered-by-memory: <one-sentence reason> ("<quoted memory line>")`
+- Emit `memory_ref: <filename>` as metadata so the operator can locate and revise the source if it has gone stale.
+- Stop. Do not evaluate further.
+
 ## Step 2 — Session cross-reference
 
 Glob `.claude-code-hermit/sessions/S-*-REPORT.md`. Sort descending by filename. Read the 3 most recent. Scan for discussion of the candidate's title or problem keywords. If a session contains a relevant decision, deferral, or counter-evidence, capture the session id and a one-line excerpt for the `prior_discussion` metadata field. If nothing relevant, omit.
@@ -70,7 +77,7 @@ Only if no duplicate found, check applicable conditions:
 Return exactly one of these on line 1:
 
 - `CREATE` — applicable conditions pass, no duplicate
-- `SUPPRESS — <code>: <one sentence reason> ("<quoted excerpt from candidate evidence that triggered the call>")` where `<code>` is one of: `weak-recurrence` (failed #1), `weak-consequence` (failed #2), `not-actionable` (failed #3)
+- `SUPPRESS — <code>: <one sentence reason> ("<quoted excerpt from candidate evidence that triggered the call>")` where `<code>` is one of: `weak-recurrence` (failed #1), `weak-consequence` (failed #2), `not-actionable` (failed #3), `covered-by-memory` (matched in Step 1.5)
 - `DUPLICATE:<PROP-ID> — <one-line reason>`
 
 Then optionally one or more metadata lines (one key:value per line, in any order, omit fields that don't apply — never emit null or empty reassurance fields):
@@ -81,6 +88,7 @@ aligned: false
 operator_excerpt: "<quoted line>"
 overlap_compiled: <filename>
 prior_discussion: <S-NNN: "<excerpt>">
+memory_ref: <filename>
 failed_condition: <repeated-pattern|meaningful-consequence|operator-actionable>
 ```
 

--- a/plugins/claude-code-hermit/agents/proposal-triage.md
+++ b/plugins/claude-code-hermit/agents/proposal-triage.md
@@ -61,7 +61,7 @@ Glob `.claude-code-hermit/compiled/*.md`. Read YAML frontmatter (`title`, `type`
 
 ## Step 5 — Three-Condition Rule
 
-Only if no duplicate found, check applicable conditions:
+Only if no duplicate found and no memory match, check applicable conditions:
 
 1. **Repeated pattern** — is the evidence concrete and observed more than once, across sessions?
    - **Skip for `scheduled-check/*`, `operator-request`, and `current-session`** sources:

--- a/plugins/claude-code-hermit/agents/reflection-judge.md
+++ b/plugins/claude-code-hermit/agents/reflection-judge.md
@@ -67,6 +67,10 @@ A session "confirms" the pattern if:
 - The same problem, friction, or observation is described (not just tangentially mentioned)
 - The description is independent — not just a copy of the candidate summary
 
+### 1.5 Memory cross-check
+
+Read `MEMORY.md` (index of `- [title](file) — description` entries). Read each topic file whose title or description keyword-matches the candidate. Match against the file's `name`, `description`, body, `Why:`, and `How to apply:` fields. If memory already records the operator decision, preference, or pattern this candidate would surface, suppress with code `covered-by-memory`, quote the matching memory line in the reason, and include the source filename (e.g. `[memory: feedback_simplify_no_bypass.md]`) so the operator can locate and revise it if stale.
+
 ### 2. Tier check
 
 Given confirmed evidence (or bypassed evidence for scheduled-check/operator-request), is the tier classification correct?
@@ -96,6 +100,7 @@ SUPPRESS (<source>): <title> — <code>: <reason>          # other sources
 **Canonical suppress codes** (use exactly these strings — no others):
 - `no-evidence` — cited sessions don't contain the pattern
 - `no-sessions` — `Sessions: none` with no bypass source
+- `covered-by-memory` — auto-memory already records this decision/preference/pattern
 
 ## Output Format
 

--- a/plugins/claude-code-hermit/agents/reflection-judge.md
+++ b/plugins/claude-code-hermit/agents/reflection-judge.md
@@ -42,7 +42,7 @@ Check `Evidence Source:` first — it overrides the session-based flow.
 
 **If `Evidence Source: scheduled-check/*` or `Evidence Source: operator-request`:**
 - Skip §§ 0.5 and 1 entirely (recurrence is not required for this source type).
-- Go directly to § 2 Tier check.
+- Run § 1.5 (Memory cross-check), then go to § 2 Tier check.
 - Emit the verdict with the appropriate source tag: `(scheduled-check)` or `(operator-request)`.
 
 **Otherwise** (`archived-session` or `current-session`, or field absent): continue to § 0.5.

--- a/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
@@ -68,6 +68,8 @@ When you need to notify the operator proactively:
 
 Auto-memory handles all learning. `compiled/` is for durable domain outputs and records the operator may want surfaced across sessions and in Cortex. Don't duplicate lessons into `compiled/`.
 
+**Memory-first for suggestions.** Before any skill or subagent declares a finding novel — `brief`, `reflect`, `weekly-review`, `proposal-create`, `session-start`, and the `proposal-triage` / `reflection-judge` subagents — consult auto-memory first and suppress the suggestion if memory already covers the same operator decision, preference, or pattern. This applies only to suggestion-generating paths; skills acting on a decided intent (`session-close`, `proposal-act`, `hermit-routines`, `hatch`) are exempt — they execute, not suggest. When memory covers the candidate, suppress with the canonical code `covered-by-memory` and quote the matching memory line.
+
 - Domain inputs go to `raw/<type>-<slug>-<date>.md` with frontmatter (`title`, `type`, `created`, `tags` required).
 - Domain outputs go to `compiled/<type>-<slug>-<date>.md` with frontmatter. Max 150 lines, self-contained. Add `session: S-NNN` when inside a session. Cite source in frontmatter (`source: raw/<type>-<slug>-<date>.md`).
 - **`type` in frontmatter is the discriminator — never a folder.** Do not create subdirectories inside `raw/` or `compiled/`, and do not create new top-level directories inside `.claude-code-hermit/` (e.g. `audits/`, `reports/`, `reviews/`, `memory/`, `tmp/`). Artifacts outside `raw/` and `compiled/` are invisible to session injection and retention.


### PR DESCRIPTION
### Added

- **Memory-first for suggestions.** Suggestion-generating skills (`brief`, `reflect`, `weekly-review`, `proposal-create`, `session-start`) and the `proposal-triage` / `reflection-judge` subagents now consult auto-memory before declaring a finding novel. Convention lives in `state-templates/CLAUDE-APPEND.md` and propagates to existing installs via the standard `/hermit-evolve` Step 6 anchored-block sync. Both subagents gain an explicit Memory cross-reference / cross-check step and a new canonical suppress code, `covered-by-memory`. Acting-on-decided-intent skills (`session-close`, `proposal-act`, `hermit-routines`, `hatch`) are exempt by design.

### Changed

- **`agents/proposal-triage.md`** — adds Step 1.5 (Memory cross-reference) between Deduplication and Session cross-reference; SUPPRESS code list extended with `covered-by-memory`; new `memory_ref: <filename>` metadata field emitted alongside that verdict.
- **`agents/reflection-judge.md`** — adds `### 1.5 Memory cross-check` between Evidence verification and Tier check; canonical suppress codes extended with `covered-by-memory`; reason includes `[memory: <filename>]` breadcrumb so operators can locate the source.

### Files affected

| File | Change |
|------|--------|
| `agents/proposal-triage.md` | Adds Step 1.5 memory cross-reference, `covered-by-memory` code, `memory_ref` metadata |
| `agents/reflection-judge.md` | Adds §1.5 memory cross-check, `covered-by-memory` code, `[memory:]` breadcrumb |
| `state-templates/CLAUDE-APPEND.md` | Adds Memory-first paragraph in Knowledge Discipline section |

### Upgrade Instructions

Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes:

1. **Refresh the CLAUDE-APPEND anchored block.** Step 6 reads `state-templates/CLAUDE-APPEND.md` and replaces the marker→EOF block in the project's `CLAUDE.md`. The new Memory-first paragraph propagates idempotently.

No `config.json` changes required.

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the
> SHA and strands the release tag on an orphan commit. After merging, run
> \`/release claude-code-hermit\` from \`main\` to tag.