### PR TITLE
release(claude-code-dev-hermit): v0.3.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
       "name": "claude-code-dev-hermit",
       "source": "./plugins/claude-code-dev-hermit",
       "description": "Language-agnostic safety layer + dev conventions for any agent your hermit uses to write code",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "category": "development",
       "author": {
         "name": "gtapps"

--- a/plugins/claude-code-dev-hermit/.claude-plugin/hermit-meta.json
+++ b/plugins/claude-code-dev-hermit/.claude-plugin/hermit-meta.json
@@ -1,4 +1,4 @@
 {
-  "required_core_version": ">=1.0.31",
-  "requires": { "claude-code-hermit": ">=1.0.31" }
+  "required_core_version": ">=1.0.32",
+  "requires": { "claude-code-hermit": ">=1.0.32" }
 }

--- a/plugins/claude-code-dev-hermit/.claude-plugin/hermit-meta.json
+++ b/plugins/claude-code-dev-hermit/.claude-plugin/hermit-meta.json
@@ -1,4 +1,4 @@
 {
-  "required_core_version": ">=1.0.26",
-  "requires": { "claude-code-hermit": ">=1.0.26" }
+  "required_core_version": ">=1.0.31",
+  "requires": { "claude-code-hermit": ">=1.0.31" }
 }

--- a/plugins/claude-code-dev-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-dev-hermit/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "dependencies": [
     {
       "name": "claude-code-hermit",
-      "version": "^1.0.31"
+      "version": "^1.0.32"
     }
   ],
   "description": "Language-agnostic safety layer + dev conventions for any agent your hermit uses to write code",

--- a/plugins/claude-code-dev-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-dev-hermit/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "dependencies": [
     {
       "name": "claude-code-hermit",
-      "version": "^1.0.26"
+      "version": "^1.0.31"
     }
   ],
   "description": "Language-agnostic safety layer + dev conventions for any agent your hermit uses to write code",

--- a/plugins/claude-code-dev-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-dev-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-dev-hermit",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "dependencies": [
     {
       "name": "claude-code-hermit",

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Added
 
 - **`scripts/git-commit-quality-gate.js`** — new `PreToolUse` Bash hook that fires on `git commit`. In `standard` profile, injects an `additionalContext` reminder to run `/dev-quality` first. In `strict` profile, hard-blocks the commit (exit 2). Tokenizer-based argv parsing handles `git -C <path> commit`, env-var prefixes, and chained commands; avoids false positives on `git log --grep="commit"` and `git config commit.template`. Resolves [#30](https://github.com/gtapps/claude-code-hermit/issues/30).
+- **`--cwd <path>` argument on `/dev-quality`, `/dev-test`, `/dev-pr`** — scopes the entire flow at a nested git working tree (submodule, path workspace, vendored dep) while letting the operator stay in the parent CWD. Git ops use `git -C "<path>"`, the test command spawns from `<path>`, `last-test.json` records the child's HEAD SHA (so `/dev-pr`'s SHA-only cache check correctly discriminates parent-scope from child-scope records), `/simplify` is scoped to files under `<path>`, and `gh`/`glab` runs from `<path>` so the PR opens against the child's remote. Hermit state still lives under the parent's `.claude-code-hermit/`. Resolves [#32](https://github.com/gtapps/claude-code-hermit/issues/32).
+- **`record-test-result.js` `--cwd <path>` flag** on `run` and `write` subcommands. Validates the path exists and is a git working tree, spawns the test command from `<path>`, captures `<path>`'s HEAD SHA. The PostToolUse hook entry-point is unchanged — it still captures `process.cwd()`'s SHA and cannot reliably parse `cd <path> && testcmd` chains; the `--cwd`-driven flow (via `run --cwd`) is the supported nested-repo entry point.
+
+### Changed
+
+- **`/dev-quality` Gate 0 clean-tree FAIL** — adds a `hint:` line pointing operators at `--cwd <path>` for nested-repo workflows. Hint suppressed when `--cwd` was already passed.
 
 ### Files affected
 
@@ -13,10 +19,16 @@
 | `scripts/git-commit-quality-gate.js` | New profile-gated PreToolUse hook script |
 | `scripts/git-commit-quality-gate.test.js` | Unit tests (tokenizer, both profile branches, false-positive cases) |
 | `hooks/hooks.json` | Second `PreToolUse` Bash entry registered |
+| `scripts/record-test-result.js` | `--cwd <path>` parsing on `run` and `write` |
+| `scripts/record-test-result.test.js` | New `--cwd` cases (child-SHA capture, validation failures) |
+| `skills/dev-quality/SKILL.md` | Argument section, target-aware gates, hint in Gate 0 FAIL |
+| `skills/dev-test/SKILL.md` | Argument section + passthrough |
+| `skills/dev-pr/SKILL.md` | Argument section + child-remote warning, target-aware gates |
+| `state-templates/CLAUDE-APPEND.md` | Nested-repo reminders in §Implementation Flow, §Tests Before PR, §Dev Quick Reference |
 
 ### Upgrade Instructions
 
-Run `/claude-code-hermit:hermit-evolve`. The evolve skill picks up the new hook automatically via plugin update — no `config.json` changes and no `/hatch` re-run required.
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill picks up the new hook and skill prose automatically via plugin update — no `config.json` changes and no `/hatch` re-run required.
 
 ## [0.3.3] - 2026-05-03
 

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- **Minimum core version bumped to `>=1.0.32`** — aligns `required_core_version`, `requires`, and `dependencies` with the upcoming core release.
 - **`/dev-quality` Gate 0 clean-tree FAIL** — adds a `hint:` line pointing operators at `--cwd <path>` for nested-repo workflows. Hint suppressed when `--cwd` was already passed.
 
 ### Files affected

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`scripts/git-commit-quality-gate.js`** — new `PreToolUse` Bash hook that fires on `git commit`. In `standard` profile, injects an `additionalContext` reminder to run `/dev-quality` first. In `strict` profile, hard-blocks the commit (exit 2). Tokenizer-based argv parsing handles `git -C <path> commit`, env-var prefixes, and chained commands; avoids false positives on `git log --grep="commit"` and `git config commit.template`. Resolves [#30](https://github.com/gtapps/claude-code-hermit/issues/30).
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `scripts/git-commit-quality-gate.js` | New profile-gated PreToolUse hook script |
+| `scripts/git-commit-quality-gate.test.js` | Unit tests (tokenizer, both profile branches, false-positive cases) |
+| `hooks/hooks.json` | Second `PreToolUse` Bash entry registered |
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill picks up the new hook automatically via plugin update — no `config.json` changes and no `/hatch` re-run required.
+
 ## [0.3.3] - 2026-05-03
 
 ### Added

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.3.4] - 2026-05-07
 
 ### Added
 

--- a/plugins/claude-code-dev-hermit/CLAUDE.md
+++ b/plugins/claude-code-dev-hermit/CLAUDE.md
@@ -9,7 +9,8 @@ Language-agnostic safety layer for any agent doing dev work in a hermit project.
 - `skills/dev-quality/` — pre-wrap quality gate: runs `/simplify` on the working-tree diff and re-runs `commands.test` if configured. Surfaces failures; suggests `/code-review:code-review` when installed.
 - `skills/dev-test/` — run the configured test suite and record the result to `state/last-test.json`. Useful for mid-task verification and warming the `/dev-pr` test cache.
 - `scripts/git-push-guard.js` — strict-profile-only `PreToolUse` hook for Bash. Blocks `--no-verify`, force-push (incl. `--force-with-lease`), `--mirror`/`--all`, and direct push to any branch in `claude-code-dev-hermit.protected_branches`.
-- `hooks/hooks.json` — registers `git-push-guard.js`.
+- `scripts/git-commit-quality-gate.js` — `PreToolUse` hook for Bash. Fires on `git commit`. Standard profile: injects `additionalContext` nudge to run `/dev-quality` first. Strict profile: hard-blocks (exit 2). Handles `git -C <path> commit`, env-var prefixes, and chained commands.
+- `hooks/hooks.json` — registers `git-push-guard.js` and `git-commit-quality-gate.js`.
 - `state-templates/CLAUDE-APPEND.md` — full (standard mode) template. Sections: §Git Safety, §Branch Discipline, §Implementation Flow, §Tests Before PR, §Technical Constraints, §Before Archiving a Task, §Dev Session Hygiene, §Dev Knowledge, §Dev Proposal Categories, §Dev Quick Reference. Injected by `/hatch` into the target project's `CLAUDE.md` when `hatch_mode = "standard"`.
 - `state-templates/CLAUDE-APPEND-SAFETY.md` — safety mode template. Subset: §Git Safety, §Branch Discipline, §Technical Constraints, §Before Archiving a Task, §Dev Session Hygiene, §Dev Knowledge, §Dev Proposal Categories, trimmed §Dev Quick Reference. No §Implementation Flow, §Tests Before PR, or `/dev-pr`/`/dev-quality`/`/dev-test` references. Injected by `/hatch` when `hatch_mode = "safety"` (recommended for projects that already have their own commit/PR/release skills).
 - `tests/` — `run-all.sh` central runner + `skill-structure.test.js` structural lint.
@@ -23,7 +24,7 @@ Language-agnostic safety layer for any agent doing dev work in a hermit project.
 
 ## Hook Profiles
 
-The `git-push-guard` hook activates at **strict** profile only (`AGENT_HOOK_PROFILE=strict`). `/hatch` defaults to installing strict and offers an explicit opt-out; once strict, `/hatch` re-runs never silently downgrade. See `docs/GIT-SAFETY.md` for the full profile model.
+`git-push-guard` activates at **strict** profile only. `git-commit-quality-gate` activates at **all** profiles — nudge (`additionalContext`) in `standard`/unset, hard-block (exit 2) in `strict`. `/hatch` defaults to installing strict and offers an explicit opt-out; once strict, `/hatch` re-runs never silently downgrade. See `docs/GIT-SAFETY.md` for the full profile model.
 
 ## Depends On
 

--- a/plugins/claude-code-dev-hermit/README.md
+++ b/plugins/claude-code-dev-hermit/README.md
@@ -41,7 +41,7 @@ Three steps to a hermit that won't push to main:
 
 **2. A working agreement for any code-writing agent.** The CLAUDE-APPEND.md template, injected into your project's CLAUDE.md, gives every agent the same rules: clean tree before starting, branch from `protected_branches[0]`, name as `<prefix>/<slug>`, run the configured test command before declaring done, re-run after `/simplify`, revert on regression. Whether you spawn the native `Agent` tool, `feature-dev:code-architect`, or your own subagent — they all read the same rules.
 
-**3. `/dev-pr` to close the loop.** Pushes the current feature branch and opens a PR with a body assembled inline from your commits, last test result, screenshots, and an optional project PR template. Refuses on protected branches, dirty trees, or zero commits ahead. Calls `gh pr create` (or `glab pr create` if `git remote` points at GitLab).
+**3. `/dev-pr` to close the loop.** Pushes the current feature branch and opens a PR with a body assembled inline from your commits, last test result, screenshots, and an optional project PR template. Refuses on protected branches, dirty trees, or zero commits ahead. Calls `gh pr create` (GitHub), `glab mr create` (GitLab), or a custom command configured at `/hatch`. Bitbucket and other forges require a custom wrapper — `/hatch` prompts for it.
 
 That's it. Three things, ~500 lines of plugin. Whatever you don't need from the dev-server lifecycle, the watchdog, the worktree dance, the implementer agent — gone. Operators bring their own `tmux`, `npm run dev`, `tail -f`, and however they like to spawn agents.
 
@@ -49,7 +49,7 @@ That's it. Three things, ~500 lines of plugin. Whatever you don't need from the 
 
 ## Quick Start
 
-> **Prerequisites:** [Claude Code](https://code.claude.com) v2.1.110+, a Claude plan (Pro, Max, Teams, or Enterprise), Node.js 24+ (for the `git-push-guard` hook at strict profile), `gh` (or `glab`) for `/dev-pr`.
+> **Prerequisites:** [Claude Code](https://code.claude.com) v2.1.110+, a Claude plan (Pro, Max, Teams, or Enterprise), Node.js 24+ (for the `git-push-guard` hook at strict profile), `gh` (GitHub) or `glab` (GitLab) for `/dev-pr`; see `/hatch` for Bitbucket and other forge setup.
 
 ### 1. Install
 

--- a/plugins/claude-code-dev-hermit/README.md
+++ b/plugins/claude-code-dev-hermit/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.3.3-green.svg" alt="Version 0.3.3" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.3.4-green.svg" alt="Version 0.3.4" /></a>
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
 </p>
 

--- a/plugins/claude-code-dev-hermit/docs/HOW-TO-USE.md
+++ b/plugins/claude-code-dev-hermit/docs/HOW-TO-USE.md
@@ -5,7 +5,7 @@
 - [Claude Code](https://code.claude.com) v2.1.110+
 - [claude-code-hermit](https://github.com/gtapps/claude-code-hermit) v1.0.26+ (installed and hatched)
 - Node.js 24+ (for the `git-push-guard` hook at strict profile)
-- `gh` (or `glab`) for `/dev-pr`
+- `gh` (GitHub) or `glab` (GitLab) for `/dev-pr`; Bitbucket and other forges need `commands.pr_create` set via `/hatch`
 
 ---
 

--- a/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
+++ b/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
@@ -67,13 +67,13 @@ Operator (or the agent on the operator's behalf) runs:
 
 `/dev-pr` runs five gates (Gate 0 through Gate 4):
 
-- **Gate 0 — preconditions**: protected-branch refusal, clean-tree refusal, commits-ahead refusal. No `--force` flag exists; the only escape is to fix the failing condition.
+- **Gate 0 — preconditions**: forge/tool sanity (`commands.pr_create` set and matching origin host), protected-branch refusal, clean-tree refusal, commits-ahead refusal. No `--force` flag exists; the only escape is to fix the failing condition.
 - **Gate 1 — push**: regular push if upstream missing or you're ahead. If `BEHIND > 0`, refuses with "git pull --rebase first" (no force-push).
-- **Gate 2 — assemble title and body**: title from binding (e.g. `PROJ-123:`) + first commit subject (conventional-prefix-stripped). Body sections in order: Summary (deduped commit subjects), Context (binding link), Verification (last test result), Screenshots (from `raw/screenshots/<binding-id>/manifest.json` if any), Notes (operator-supplied). Project PR template (`pr_template_path` or `.github/PULL_REQUEST_TEMPLATE.md`) appended verbatim if found.
-- **Gate 3 — create**: writes the body to a temp file, calls `gh pr create --title ... --body-file ... --base ...` (or the configured `commands.pr_create`, e.g. `glab pr create` for GitLab).
+- **Gate 2 — assemble title and body**: title from binding (e.g. `PROJ-123:`) + first commit subject (conventional-prefix-stripped). Body sections in order: Summary (deduped commit subjects), Context (binding link), Verification (last test result), Screenshots (from `raw/screenshots/<binding-id>/manifest.json` if any), Notes (operator-supplied). Project PR template (`pr_template_path` or forge-specific path) appended verbatim if found.
+- **Gate 3 — create**: writes the body to a temp file, calls `gh pr create` (GitHub), `glab mr create` (GitLab), or the configured `commands.pr_create`. Flag layout is forge-aware: glab uses `--description "$(cat ...)"` and `--target-branch`; custom commands receive gh-style flags and should wrap if needed.
 - **Gate 4 — record**: writes `state/bindings.json` with the PR URL, appends to SHELL.md.
 
-Native session→PR auto-link: calling `gh pr create` via Bash preserves Claude Code's session linking. The operator can resume this session later with `claude --from-pr <number>`.
+Native session→PR auto-link: when using `gh pr create` on GitHub, Claude Code preserves session linking. The operator can resume this session later with `claude --from-pr <number>`. This feature is GitHub-specific.
 
 ### Step 7 — Reflect
 

--- a/plugins/claude-code-dev-hermit/hooks/hooks.json
+++ b/plugins/claude-code-dev-hermit/hooks/hooks.json
@@ -10,6 +10,16 @@
           }
         ],
         "description": "Block direct git push to protected branches, --no-verify, force-push (strict profile)"
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/git-commit-quality-gate.js"
+          }
+        ],
+        "description": "Nudge Claude to run /dev-quality before git commit (additionalContext in standard; hard-block in strict)"
       }
     ],
     "PostToolUse": [

--- a/plugins/claude-code-dev-hermit/scripts/git-commit-quality-gate.js
+++ b/plugins/claude-code-dev-hermit/scripts/git-commit-quality-gate.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// PreToolUse hook: fires on every Bash call and checks if a git commit is
+// being attempted. Standard profile: injects additionalContext nudge. Strict
+// profile: hard-blocks (exit 2).
+// Adapted from git-push-guard.js — same stdin/profile/tokenizer pattern.
+
+const MAX_STDIN = 1024 * 1024;
+
+function isGitCommitCmd(cmd) {
+  for (const subcmd of cmd.split(/(?:&&|\|\||;|\|)/)) {
+    const tokens = subcmd.trim().split(/\s+/);
+    let i = 0;
+    // Skip leading shell env assignments (e.g. LANG=en git commit)
+    while (i < tokens.length && /^\w+=/.test(tokens[i])) i++;
+    if (tokens[i] !== 'git') continue;
+    i++;
+    // Skip global git options that consume the next token as their value
+    while (i < tokens.length) {
+      const t = tokens[i];
+      if (t === '-C' || t === '-c' || t === '--exec-path' ||
+          t === '--git-dir' || t === '--work-tree' || t === '--namespace') {
+        i += 2;
+      } else if (t.startsWith('-')) {
+        i++;
+      } else {
+        break;
+      }
+    }
+    if (tokens[i] === 'commit') return true;
+  }
+  return false;
+}
+
+async function main() {
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of process.stdin) {
+    total += chunk.length;
+    if (total > MAX_STDIN) process.exit(0);
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf-8').trim();
+  if (!raw) process.exit(0);
+
+  let command;
+  try {
+    const data = JSON.parse(raw);
+    command = (data.tool_input || data.input || {}).command || '';
+  } catch { process.exit(0); }
+  if (!command) process.exit(0);
+
+  if (!isGitCommitCmd(command)) process.exit(0);
+
+  const profile = (process.env.AGENT_HOOK_PROFILE || 'standard').trim().toLowerCase();
+  if (profile === 'strict') {
+    console.error('[git-commit-quality-gate] BLOCKED: Run /dev-quality first. Order: /dev-quality → git commit → /dev-pr.');
+    process.exit(2);
+  }
+
+  process.stdout.write(JSON.stringify({
+    additionalContext: 'REMINDER: Run /dev-quality on the working tree BEFORE this commit. Order: /dev-quality → git commit → /dev-pr. If you already ran it and the tree is unchanged, proceed.',
+  }));
+  process.exit(0);
+}
+
+main();

--- a/plugins/claude-code-dev-hermit/scripts/git-commit-quality-gate.test.js
+++ b/plugins/claude-code-dev-hermit/scripts/git-commit-quality-gate.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+// Tests for git-commit-quality-gate.js
+// Run with: node scripts/git-commit-quality-gate.test.js
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+const GATE = path.join(__dirname, 'git-commit-quality-gate.js');
+
+let passed = 0;
+let failed = 0;
+
+function makeInput(command) {
+  return JSON.stringify({ tool_input: { command } });
+}
+
+function run(command, env = {}) {
+  return runRaw(makeInput(command), env);
+}
+
+function runRaw(rawInput, env = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cqg-test-'));
+  try {
+    return spawnSync(process.execPath, [GATE], {
+      input: rawInput,
+      env: { ...process.env, ...env },
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function assert(description, cond, detail) {
+  if (cond) { console.log(`  ✓ ${description}`); passed++; }
+  else { console.error(`  ✗ ${description}${detail ? ' — ' + detail : ''}`); failed++; }
+}
+
+// --- Standard profile: nudge on commit, silence on everything else ---
+console.log('\nStandard profile:');
+{
+  const r = run('git commit -m "x"', { AGENT_HOOK_PROFILE: 'standard' });
+  assert('git commit: exits 0', r.status === 0);
+  assert('git commit: stdout contains additionalContext', r.stdout.includes('"additionalContext"'));
+}
+{
+  delete process.env.AGENT_HOOK_PROFILE;
+  const r = run('git commit -m "x"');
+  assert('unset profile treated as standard: exits 0', r.status === 0);
+  assert('unset profile: stdout contains additionalContext', r.stdout.includes('"additionalContext"'));
+}
+
+// --- Strict profile: hard-block ---
+console.log('\nStrict profile:');
+{
+  const r = run('git commit -m "x"', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git commit: exits 2', r.status === 2);
+  assert('git commit: stderr contains BLOCKED', r.stderr.includes('BLOCKED'));
+  assert('git commit: no additionalContext on stdout', !r.stdout.includes('"additionalContext"'));
+}
+
+// --- Tokenizer: handles git -C prefix ---
+console.log('\nTokenizer — git -C:');
+{
+  const r = run('git -C modules/foo commit -m "msg"', { AGENT_HOOK_PROFILE: 'standard' });
+  assert('git -C path commit: fires correctly', r.stdout.includes('"additionalContext"'));
+}
+{
+  const r = run('git -C modules/foo commit -m "msg"', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git -C path commit: blocks in strict', r.status === 2);
+}
+
+// --- Tokenizer: handles -c key=val prefix ---
+console.log('\nTokenizer — git -c:');
+{
+  const r = run('git -c user.email=x@y.com commit -m "msg"', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git -c key=val commit: blocks in strict', r.status === 2);
+}
+
+// --- Tokenizer: env var prefix ---
+console.log('\nTokenizer — env prefix:');
+{
+  const r = run('LANG=en git commit -m "msg"', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('LANG=en git commit: blocks in strict', r.status === 2);
+}
+
+// --- False positives: non-commit git commands ---
+console.log('\nFalse positive checks:');
+{
+  const r = run('git log --grep="commit message"', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git log --grep="commit ...": no false positive', r.status === 0 && !r.stdout.includes('"additionalContext"'));
+}
+{
+  const r = run('git config commit.template ~/.gitmessage', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git config commit.template: no false positive', r.status === 0 && !r.stdout.includes('"additionalContext"'));
+}
+{
+  const r = run('git status', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git status: silent', r.status === 0 && r.stdout === '');
+}
+{
+  const r = run('git push origin main', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git push: silent', r.status === 0 && r.stdout === '');
+}
+{
+  const r = run('git commit-tree abc123', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git commit-tree: no false positive', r.status === 0 && !r.stdout.includes('"additionalContext"'));
+}
+{
+  const r = run('npm test', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('non-git command: silent', r.status === 0 && r.stdout === '');
+}
+
+// --- Chained commands ---
+console.log('\nChained commands:');
+{
+  const r = run('git add . && git commit -m "x"', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('git add && git commit: blocks in strict', r.status === 2);
+}
+{
+  const r = run('git add . && git commit -m "x"', { AGENT_HOOK_PROFILE: 'standard' });
+  assert('git add && git commit: nudges in standard', r.stdout.includes('"additionalContext"'));
+}
+
+// --- Edge cases ---
+console.log('\nEdge cases:');
+{
+  const r = runRaw('', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('empty stdin: exits 0', r.status === 0);
+}
+{
+  const r = runRaw('not-json', { AGENT_HOOK_PROFILE: 'strict' });
+  assert('malformed JSON: exits 0', r.status === 0);
+}
+{
+  const r = runRaw(JSON.stringify({}), { AGENT_HOOK_PROFILE: 'strict' });
+  assert('no command field: exits 0', r.status === 0);
+}
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/plugins/claude-code-dev-hermit/scripts/record-test-result.js
+++ b/plugins/claude-code-dev-hermit/scripts/record-test-result.js
@@ -48,8 +48,8 @@ function atomicWrite(filePath, content) {
   fs.renameSync(tmp, filePath);
 }
 
-function writeRecord(hermitDir, command, exitCode, durationMs) {
-  const sha = gitHead(process.cwd());
+function writeRecord(hermitDir, command, exitCode, durationMs, targetDir) {
+  const sha = gitHead(targetDir || process.cwd());
   if (!sha) return;
   const record = {
     command,
@@ -75,15 +75,35 @@ function writeRecord(hermitDir, command, exitCode, durationMs) {
 
 const argv = process.argv;
 
+function parseCwdFlag(args) {
+  const i = args.indexOf('--cwd');
+  if (i === -1) return null;
+  const val = args[i + 1];
+  if (!val || val.startsWith('--')) {
+    console.error('--cwd: missing path argument');
+    process.exit(1);
+  }
+  try {
+    execSync('git rev-parse --git-dir', { cwd: val, stdio: ['ignore', 'ignore', 'ignore'] });
+  } catch (_) {
+    console.error(`--cwd: not a git working tree: ${val}`);
+    process.exit(1);
+  }
+  return val;
+}
+
 // run subcommand: execute commands.test and record the result
 if (argv[2] === 'run') {
+  const targetDir = parseCwdFlag(argv.slice(3));
   const hermitDir = findHermitDir(process.cwd());
   if (!hermitDir) { console.error('No .claude-code-hermit/ found'); process.exit(1); }
   const testCmd = loadTestCommand(hermitDir);
   if (!testCmd) { console.error('commands.test not configured'); process.exit(1); }
   const start = Date.now();
-  const r = spawnSync('bash', ['-c', testCmd], { stdio: 'inherit' });
-  writeRecord(hermitDir, testCmd, r.status ?? 1, Date.now() - start);
+  const spawnOpts = { stdio: 'inherit' };
+  if (targetDir) spawnOpts.cwd = targetDir;
+  const r = spawnSync('bash', ['-c', testCmd], spawnOpts);
+  writeRecord(hermitDir, testCmd, r.status ?? 1, Date.now() - start, targetDir);
   process.exit(r.status ?? 1);
 }
 
@@ -92,10 +112,11 @@ if (argv[2] === 'write') {
   const ecArg = argv[3];
   const durArg = argv[4];
   if (!/^-?\d+$/.test(ecArg) || !/^-?\d+$/.test(durArg)) process.exit(0);
+  const targetDir = parseCwdFlag(argv.slice(5));
   const hermitDir = findHermitDir(process.cwd());
   if (!hermitDir) process.exit(0);
   const testCmd = loadTestCommand(hermitDir) || '';
-  writeRecord(hermitDir, testCmd, parseInt(ecArg, 10), parseInt(durArg, 10));
+  writeRecord(hermitDir, testCmd, parseInt(ecArg, 10), parseInt(durArg, 10), targetDir);
   process.exit(0);
 }
 

--- a/plugins/claude-code-dev-hermit/scripts/record-test-result.test.js
+++ b/plugins/claude-code-dev-hermit/scripts/record-test-result.test.js
@@ -191,5 +191,37 @@ s = readState(proj);
 assert('likely_cause: absent on generic exit 1', s !== null && !('likely_cause' in s));
 cleanup(proj);
 
+// --cwd: parent repo with a nested child repo. Verify the captured SHA
+// is the child's HEAD, not the parent's.
+proj = setupProject('exit 0');
+const child = path.join(proj, 'packages', 'foo');
+fs.mkdirSync(child, { recursive: true });
+const gitEnv = { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' };
+execSync('git init -q && git commit -q --allow-empty -m child-init', { cwd: child, env: gitEnv, stdio: 'ignore' });
+const parentSha = execSync('git rev-parse HEAD', { cwd: proj, encoding: 'utf-8' }).trim();
+const childSha = execSync('git rev-parse HEAD', { cwd: child, encoding: 'utf-8' }).trim();
+assert('--cwd test setup: parent and child SHAs differ', parentSha !== childSha);
+const cwdRun = spawnSync(process.execPath, [HOOK, 'run', '--cwd', child], { cwd: proj, encoding: 'utf-8' });
+s = readState(proj);
+assert('run --cwd: exits 0 on passing test command', cwdRun.status === 0);
+assert('run --cwd: captures child HEAD sha (not parent)', s !== null && s.sha === childSha);
+cleanup(proj);
+
+// --cwd: bogus path fails fast
+proj = setupProject('exit 0');
+const cwdBogus = spawnSync(process.execPath, [HOOK, 'run', '--cwd', '/nonexistent/path/xyz'], { cwd: proj, encoding: 'utf-8' });
+assert('run --cwd: exits non-zero on missing path', cwdBogus.status !== 0);
+assert('run --cwd: does not write last-test.json on missing path', readState(proj) === null);
+cleanup(proj);
+
+// `git rev-parse --git-dir` walks up, so the dir must be outside any git repo.
+proj = setupProject('exit 0');
+const notGit = fs.mkdtempSync(path.join(os.tmpdir(), 'rec-test-notgit-'));
+const cwdNotGit = spawnSync(process.execPath, [HOOK, 'run', '--cwd', notGit], { cwd: proj, encoding: 'utf-8' });
+assert('run --cwd: exits non-zero on non-git dir', cwdNotGit.status !== 0);
+assert('run --cwd: does not write last-test.json on non-git dir', readState(proj) === null);
+fs.rmSync(notGit, { recursive: true, force: true });
+cleanup(proj);
+
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -5,18 +5,54 @@ description: Open a PR from the current feature branch with a body assembled inl
 
 # /dev-pr
 
-Push the current branch and open a PR with a structured body. Reads commit history, the test results you just ran (per `state-templates/CLAUDE-APPEND.md` §Tests Before PR), any screenshots in `raw/screenshots/`, and an optional project PR template — assembles them into title + body — then calls `gh pr create` (or the configured equivalent).
+Push the current branch and open a PR with a structured body. Reads commit history, the test results you just ran (per `state-templates/CLAUDE-APPEND.md` §Tests Before PR), any screenshots in `raw/screenshots/`, and an optional project PR template — assembles them into title + body — then calls the forge-appropriate CLI.
+
+## Configuration
+
+`commands.pr_create` — the shell command used to open the PR. Set by `/claude-code-dev-hermit:hatch` from the detected forge. **If unset, Gate 0 refuses immediately** with a pointer to run `/hatch`.
+
+- **GitHub**: `gh pr create` — flags: `--body-file <path>`, `--base <branch>`.
+- **GitLab**: `glab mr create` — flags: `--description "$(cat <path>)"`, `--target-branch <branch>`.
+- **Bitbucket / custom / other**: operator-supplied. Gate 3 passes `--title "$TITLE" --body-file "$PR_BODY_TMP" --base "$BASE"` to custom commands — wrap your CLI in a script that accepts those flags if the native CLI uses different ones.
+
+The command must print the PR URL on a line matching `^https?://`.
 
 ## Prerequisites
 
 - Verify `.claude-code-hermit/sessions/` exists. If not: tell the operator to run `/claude-code-hermit:hatch` and `/claude-code-dev-hermit:hatch` first.
-- Read `.claude-code-hermit/config.json` once. Cache `claude-code-dev-hermit.protected_branches` (defaults to `["main", "master"]`), `commands.pr_create` (defaults to `gh pr create`), `pr_base_branch`, `pr_template_path`.
+- Read `.claude-code-hermit/config.json` once. Cache `claude-code-dev-hermit.protected_branches` (defaults to `["main", "master"]`), `commands.pr_create` (no default — if unset, Gate 0 fails with a pointer to run `/claude-code-dev-hermit:hatch`), `pr_base_branch`, `pr_template_path`.
+
+## Argument
+
+Optional `--cwd <path>`. When set, the entire flow targets the nested git repo at `<path>` end-to-end: Gate 0 checks (forge, branch, clean tree, tests, commits-ahead), Gate 1 push, Gate 2 title/body assembly, and Gate 3 `commands.pr_create` invocation all run against `<path>`. **The PR opens against `<path>`'s remote, not the parent's** — that's intentional (the child repo is the unit being PR'd) but the operator must understand it. Use this for nested-repo workflows (see CLAUDE-APPEND §Implementation Flow).
+
+State (`bindings.json`, `last-test.json`, `SHELL.md`) still resolves under the parent's `.claude-code-hermit/` — there's a single store. The `last-test.json` cache check stays SHA-only — `record.sha === git -C "$TARGET" rev-parse HEAD` already discriminates parent records from child records (different repos, different histories, different SHAs).
 
 ## Plan
 
+In every gate below, when `--cwd <path>` is set, prefix all `git ...` invocations with `-C "<path>"` (e.g. `git -C "<path>" status --porcelain`) and run the configured `commands.pr_create` via Bash with `cwd: "<path>"` so the forge CLI reads the child's `.git/config`. When `--cwd` is omitted, run as today (against `$PWD`). Below, `$TARGET` stands for `<path>` when set or `$PWD` otherwise; the bash blocks show the no-`--cwd` form.
+
 ### Gate 0 — preconditions
 
-Run all four checks in order. FAIL on the first failure, name it, give the exact command to fix it.
+Run all checks in order. FAIL on the first failure, name it, give the exact command to fix it.
+
+**0. Forge / tool sanity.** Two sub-checks, both cheap and run before anything else:
+
+*0a. `commands.pr_create` configured?* If the cached value is absent or empty: FAIL `"commands.pr_create not configured — run /claude-code-dev-hermit:hatch to set it"`.
+
+*0b. Forge/tool coherence.* Derive the tool discriminator: `TOOL=$(basename $(echo "$PR_CREATE" | awk '{print $1}'))`. Classify `git remote get-url origin 2>/dev/null` using the same map as hatch:
+- `github.com` or `github.` → `FORGE=github`
+- `gitlab.com` or `gitlab.` → `FORGE=gitlab`
+- `bitbucket.org` → `FORGE=bitbucket`
+- anything else → `FORGE=custom`
+
+Fail **only** when both forge and tool are in the recognized set and they form a known-bad pairing:
+- `FORGE=github` AND `TOOL != gh` → FAIL
+- `FORGE=gitlab` AND `TOOL != glab` → FAIL
+
+All other combinations (FORGE=bitbucket, FORGE=custom, TOOL not in {gh,glab}, no remote) → warn-and-proceed (custom wrappers on known hosts must not be blocked).
+
+Fail message: `"commands.pr_create ('<configured>') doesn't match origin host (<forge>) — re-run /claude-code-dev-hermit:hatch or update commands.pr_create in .claude-code-hermit/config.json"`.
 
 **1. Protected-branch check.** Materialize the cached `protected_branches` config value as a bash array, then compare the current branch against each pattern using bash glob semantics:
 
@@ -41,16 +77,16 @@ done
 
 Otherwise, read `.claude-code-hermit/state/last-test.json`:
 
-- If the file exists **and** `sha === current HEAD` **and** `status === "pass"`: cache hit — skip test run and proceed.
+- If the file exists **and** `sha === git -C "$TARGET" rev-parse HEAD` **and** `status === "pass"`: cache hit — skip test run and proceed.
 - Anything else (file missing, stale SHA, or `status !== "pass"`): run tests now:
 
   ```bash
   node "${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.js" run
   ```
 
-  Use `timeout: 600000`. If exit non-zero: read the just-written `state/last-test.json` and include `likely_cause` in the message if present (`tests failed (exit 137, likely OOM) — fix and re-run /dev-pr`); otherwise FAIL `"tests failed (exit N) — fix and re-run /dev-pr"`. If exit 0: proceed.
+  Append `--cwd "<path>"` when the operator passed `--cwd`. Use `timeout: 600000`. If exit non-zero: read the just-written `state/last-test.json` and include `likely_cause` in the message if present (`tests failed (exit 137, likely OOM) — fix and re-run /dev-pr`); otherwise FAIL `"tests failed (exit N) — fix and re-run /dev-pr"`. If exit 0: proceed.
 
-  For suites longer than 10 min: run tests in a terminal, record with `node <PLUGIN_ROOT>/scripts/record-test-result.js write <exit_code> <duration_ms>`, then re-run `/dev-pr`.
+  For suites longer than 10 min: run tests in a terminal, record with `node <PLUGIN_ROOT>/scripts/record-test-result.js write <exit_code> <duration_ms>` (append `--cwd "<path>"` when relevant), then re-run `/dev-pr`.
 
 This is the gate that enforces CLAUDE-APPEND §Tests Before PR mechanically rather than relying on the agent's self-report.
 
@@ -119,24 +155,39 @@ Build the title and body inline, no helper script.
 
 5. **Notes** — optional. Skip unless the operator passed in qualitative concerns through Gate 2 (out-of-scope follow-ups, known limitations) — there is no automatic source for this section.
 
-**Project PR template.** If `pr_template_path` is set in config, OR `.github/PULL_REQUEST_TEMPLATE.md` exists, OR `docs/pull_request_template.md` exists — load the first one found and append it after the assembled body, separated by `\n\n---\n\n`. Do not attempt to merge headings or substitute sections — the project's template appears verbatim below ours.
+**Project PR template.** Check in priority order: `pr_template_path` from config (operator override), then `.github/PULL_REQUEST_TEMPLATE.md`, then `.gitlab/merge_request_templates/Default.md`, then `.bitbucket/pull_request_template.md`, then `docs/pull_request_template.md`. Load the first one found and append it after the assembled body, separated by `\n\n---\n\n`. Do not attempt to merge headings or substitute sections — the project's template appears verbatim below ours.
 
 ### Gate 3 — create the PR
 
-Write the body to a temp file (avoids shell-quoting issues with multi-line markdown). Use the `Write` tool with `file_path: $PR_BODY_TMP` (capture the path from `mktemp` via Bash first) and `content: <assembled body>`. Then:
+Write the body to a temp file (avoids shell-quoting issues with multi-line markdown). Use the `Write` tool with `file_path: $PR_BODY_TMP` (capture the path from `mktemp` via Bash first) and `content: <assembled body>`. Then dispatch based on `$TOOL` (derived in Gate 0 step 0b):
 
 ```bash
 PR_BODY_TMP=$(mktemp)
 # (Write tool wrote the body to $PR_BODY_TMP)
-gh pr create --title "$TITLE" --body-file "$PR_BODY_TMP" --base "$BASE"
-# or the configured commands.pr_create
+
+case "$TOOL" in
+  gh)
+    $PR_CREATE --title "$TITLE" --body-file "$PR_BODY_TMP" --base "$BASE"
+    ;;
+  glab)
+    # glab mr create uses --description (string) and --target-branch, not --body-file/--base
+    $PR_CREATE --title "$TITLE" --description "$(cat "$PR_BODY_TMP")" --target-branch "$BASE"
+    ;;
+  *)
+    # Custom command: Gate 3 passes gh-style flags.
+    # Wrap your CLI in a script that accepts --title --body-file --base if it uses different flags.
+    $PR_CREATE --title "$TITLE" --body-file "$PR_BODY_TMP" --base "$BASE"
+    ;;
+esac
+
 rm -f "$PR_BODY_TMP"
 ```
 
 - Capture stdout; extract the first line matching `^https?://` as the PR URL.
-- If stdout/stderr contains `pull request already exists`: ask the operator (`AskUserQuestion`: `Update existing PR body` / `Cancel`). On Update, run `gh pr edit <number> --body-file "$PR_BODY_TMP"`.
-- On `gh auth` error in stderr: FAIL `"not authenticated — run: gh auth login"`.
-- On any non-zero exit: FAIL with stderr tail + exit code.
+- On any non-zero exit: print stderr tail and a tool-aware recovery hint:
+  - `$TOOL == gh` → `"recovery: gh auth login"`
+  - `$TOOL == glab` → `"recovery: glab auth login"`
+  - `*` → `"recovery: check authentication for your forge CLI"`
 
 ### Gate 4 — record
 
@@ -181,4 +232,4 @@ On Gate 3 FAIL: show the host-tool exit message + a one-line recovery hint.
 - **No screenshot creation.** Reads from `raw/screenshots/<binding-id>/manifest.json`. Producing screenshots is a stack-specific plugin's job.
 - **No merge.** Opening the PR is the terminal step; merging is a separate operator decision.
 - **Never force-push.** Even on divergence — surface the conflict, let the operator resolve. The `git-push-guard` hook blocks force-push at strict profile; this skill respects the same rule unconditionally.
-- **Session→PR auto-link.** Calling `gh pr create` via Bash preserves Claude Code's native session→PR linking. The operator can resume this session later with `claude --from-pr <number>`.
+- **Session→PR auto-link.** When `$TOOL == gh`, calling `gh pr create` via Bash preserves Claude Code's native session→PR linking. The operator can resume later with `claude --from-pr <number>`. This feature is GitHub-specific and does not apply for other forge tools.

--- a/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
@@ -14,17 +14,23 @@ Run a quality pass on the working-tree diff before declaring the task done. Invo
 
 ## Plan
 
+### Argument
+
+Optional `--cwd <path>`. When set, all git operations and the test re-run target `<path>` instead of `$PWD`. `<path>` must be a git working tree. Use this for nested-repo workflows (see CLAUDE-APPEND §Implementation Flow). State (`last-test.json`, hermit dir) still resolves from `$PWD`.
+
+In the gates below, use `git -C "<path>"` for every git invocation when `--cwd` is set, otherwise omit the `-C` and run against `$PWD` as today. Below this is written as `git -C "$TARGET"` with `$TARGET` standing for either form.
+
 ### Gate 0 — preconditions
 
 ```bash
-git diff --quiet && git diff --cached --quiet
+git -C "$TARGET" diff --quiet && git -C "$TARGET" diff --cached --quiet
 ```
 
 If both are empty: working tree is clean. Before failing, check whether HEAD has commits ahead of the base:
 
 1. Resolve `BASE_NAME` using the same priority order as `/dev-pr` Gate 0 step 4 (`pr_base_branch` → first non-glob `protected_branches` → `origin/HEAD` → `main`/`master`).
-2. Resolve `BASE_REF`: try `git rev-parse --verify "$BASE_NAME" 2>/dev/null`; on failure try `git rev-parse --verify "origin/$BASE_NAME" 2>/dev/null`; if neither resolves, skip the NOTICE.
-3. If `git rev-list --count "$BASE_REF..HEAD"` > 0, emit before failing:
+2. Resolve `BASE_REF`: try `git -C "$TARGET" rev-parse --verify "$BASE_NAME" 2>/dev/null`; on failure try `git -C "$TARGET" rev-parse --verify "origin/$BASE_NAME" 2>/dev/null`; if neither resolves, skip the NOTICE.
+3. If `git -C "$TARGET" rev-list --count "$BASE_REF..HEAD"` > 0, emit before failing:
 
    ```
    NOTICE: working tree is clean but HEAD has N commits ahead of <BASE_NAME>.
@@ -33,11 +39,13 @@ If both are empty: working tree is clean. Before failing, check whether HEAD has
            To verify the committed state passes tests, run /dev-test instead.
    ```
 
-Then FAIL `"no working-tree diff — nothing to simplify"`.
+Then FAIL `"no working-tree diff — nothing to simplify"`. Append the hint `hint: if edits are in a nested git repo, re-run with --cwd <path>` unless `--cwd` was already passed.
 
 ### Gate 1 — run `/simplify`
 
 Invoke `/simplify` on the current diff. Wait for it to complete. If `/simplify` reports no changes, note `simplify: no changes` and continue to Gate 2 anyway.
+
+When `--cwd <path>` is set, scope `/simplify` to files under `<path>` — list them via `git -C "<path>" diff --name-only` and pass that file set as the focus. Don't simplify outside `<path>`.
 
 ### Gate 2 — re-run tests
 
@@ -46,6 +54,8 @@ If `commands.test` is unset: skip this gate, record `tests: skipped`, and procee
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.js" run
 ```
+
+When `--cwd <path>` is set, append `--cwd "<path>"` to the invocation. The script runs the test command from `<path>` and records `<path>`'s HEAD SHA into `last-test.json` (so `/dev-pr` cache checks against the right commit).
 
 Use `timeout: 600000`. Records the result to `last-test.json`.
 
@@ -73,6 +83,17 @@ dev-quality
   simplify: applied
   tests:    pass (12.3s)
   next:     suggest operator run /code-review:code-review (installed)
+  status:   ok
+```
+
+When invoked with `--cwd <path>`, prepend a `target:` line:
+
+```
+dev-quality
+  target:   packages/foo
+  diff:     3 files modified
+  simplify: applied
+  tests:    pass (4.1s)
   status:   ok
 ```
 
@@ -113,7 +134,10 @@ On Gate 0 failure (clean tree, no commits ahead or base unresolvable):
 ```
 dev-quality
   FAIL (Gate 0): no working-tree diff — nothing to simplify
+                 hint: if edits are in a nested git repo, re-run with --cwd <path>
 ```
+
+(The `hint:` line is omitted when `--cwd` was already passed.)
 
 ## Rules
 

--- a/plugins/claude-code-dev-hermit/skills/dev-test/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-test/SKILL.md
@@ -7,9 +7,13 @@ description: Run the configured test suite and record the result to .claude-code
 
 Run the project's configured test command and record the result.
 
+## Argument
+
+Optional `--cwd <path>`. When set, the test command runs from `<path>` and `last-test.json` records `<path>`'s HEAD SHA. Use this for nested-repo workflows (see CLAUDE-APPEND §Implementation Flow). `<path>` must be a git working tree.
+
 ## Plan
 
-Run the following Bash command. Use `timeout: 600000` (10-min ceiling).
+Run the following Bash command. Use `timeout: 600000` (10-min ceiling). Append `--cwd "<path>"` when the operator passed `--cwd`.
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.js" run

--- a/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
@@ -23,9 +23,13 @@ Check if `.claude-code-hermit/` exists in the current project.
 Run all detection in a single parallel turn:
 
 **Bash:**
-- Existing PR template: `ls .github/PULL_REQUEST_TEMPLATE.md docs/pull_request_template.md 2>/dev/null | head -1`.
+- Existing PR template: `ls .github/PULL_REQUEST_TEMPLATE.md .gitlab/merge_request_templates/Default.md .bitbucket/pull_request_template.md docs/pull_request_template.md 2>/dev/null | head -1`.
 - Installed plugins: `claude plugin list 2>/dev/null` or read `.claude/settings.json`.
-- Remote host (for `commands.pr_create` default): `git remote get-url origin 2>/dev/null` — if the URL contains `gitlab`, default `pr_create` to `glab pr create`; else default to `gh pr create`.
+- Remote forge (for `commands.pr_create`): `git remote get-url origin 2>/dev/null` — classify by substring:
+  - `github.com` or `github.` → `FORGE=github`, `DEFAULT_PR_CREATE="gh pr create"`
+  - `gitlab.com` or `gitlab.` → `FORGE=gitlab`, `DEFAULT_PR_CREATE="glab mr create"`
+  - `bitbucket.org` → `FORGE=bitbucket`, `DEFAULT_PR_CREATE=""` (no universal CLI — operator must supply)
+  - anything else or no remote → `FORGE=custom`, `DEFAULT_PR_CREATE=""`
 - Capability scan: `ls .claude/skills/ 2>/dev/null` — list skill directory names. Match if any of the following dir names are present: `commit`, `create-pr`, `pr`, `pull-request`, `release`, `git-commit`. Record the matched names.
 - Base-branch detection: `git branch -r --format='%(refname:short)' 2>/dev/null | sed 's|^origin/||'` — collect remote branch names. Record which of the following are present: `main`, `master`, `develop`, `development`, `dev`, `trunk`. Call this set `CANDIDATE_BASES`.
 
@@ -154,6 +158,20 @@ questions: [
     ]
   },
   {
+    header: "PR cmd",   // standard mode only (see below)
+    question: "How should /dev-pr open the PR? (Invoked with --title, a body flag, and a base flag per the detected forge.)",
+    options: [
+      { label: "Keep current (<value>)", description: "Already configured" },          // re-run only
+      { label: "gh pr create (recommended)", description: "Detected GitHub remote" },  // FORGE=github only
+      { label: "glab mr create (recommended)", description: "Detected GitLab remote — uses --description and --target-branch" }, // FORGE=gitlab only
+      // For FORGE=bitbucket:
+      { label: "Skip — I'll configure later", description: "Bitbucket detected. No universally-available CLI exists — see docs/WORKFLOW.md for custom wrapper guidance. /dev-pr will fail until commands.pr_create is set in .claude-code-hermit/config.json." },
+      // For FORGE=custom:
+      { label: "Skip — I'll configure later", description: "/dev-pr will fail until commands.pr_create is set in .claude-code-hermit/config.json." },
+      { label: "Other", description: "Type a custom command or wrapper script. Must print the PR URL on a line starting with https://. Gate 3 passes --title, --body-file, --base — wrap your CLI if it uses different flags." }
+    ]
+  },
+  {
     header: "PR template",   // standard mode only (see below)
     question: "PR template path? (auto-detected: `<detected or 'none'>`)",
     options: [
@@ -185,7 +203,7 @@ questions: [
 ]
 ```
 
-In `safety` mode, skip the `PR template` and `Base branch` questions; do not write `pr_template_path` or `pr_base_branch` to config (these feed `/dev-pr` which is not prescribed in safety mode). Keep `Hook` and `Plugins`.
+In `safety` mode, skip the `PR cmd`, `PR template`, and `Base branch` questions; do not write `commands.pr_create`, `pr_template_path`, or `pr_base_branch` to config (these feed `/dev-pr` which is not prescribed in safety mode). Keep `Hook` and `Plugins`.
 
 Filter the Plugins `options` array to only those NOT already installed (per the `claude plugin list` detection above). If the filtered list is empty, skip the Plugins question entirely.
 
@@ -207,7 +225,7 @@ In `standard` mode only, also write:
 - `claude-code-dev-hermit.commands.test` — required, from Round 1.
 - `claude-code-dev-hermit.commands.lint` — optional.
 - `claude-code-dev-hermit.commands.format` — optional.
-- `claude-code-dev-hermit.commands.pr_create` — from the remote-host detection above (`gh pr create` / `glab pr create`); preserve any existing operator override.
+- `claude-code-dev-hermit.commands.pr_create` — from the Round 2 `PR cmd` answer. If the operator chose `Skip`, leave the key absent (do not write null or empty string). Preserve any existing operator override on re-run.
 - `claude-code-dev-hermit.pr_template_path` — optional, from Round 2.
 - `claude-code-dev-hermit.pr_base_branch` — write only if the chosen branch (from the Round 2 `Base branch` question, or `AUTO_BASE` from the single-match case) differs from `FALLBACK_BASE`. If equal or not set, leave the key absent so `/dev-pr`'s fallback chain operates undisturbed.
 
@@ -232,6 +250,7 @@ Commands:  [standard mode only]
   Test:   <cmd>
   Lint:   <cmd or 'skipped'>
   Format: <cmd or 'skipped'>
+  PR cmd: <commands.pr_create or 'unset — /dev-pr will fail until configured via /hatch'>
 
 Updated:
   CLAUDE.md — dev block [appended / updated to vX.Y.Z / already current]
@@ -278,4 +297,5 @@ Read by `/claude-code-hermit:docker-security` when the operator enables LAN cont
 - **Single source of truth.** The selected template (`CLAUDE-APPEND.md` or `CLAUDE-APPEND-SAFETY.md`) is the source for the project's dev conventions. Step 3 always overwrites the marked block when versions differ or mode changes; do not preserve operator edits to that block (operators who want overrides put them elsewhere in their CLAUDE.md).
 - **Never downgrade hook profile.** If the operator chooses "No — leave at standard" but `env.AGENT_HOOK_PROFILE` is already `strict`, preserve `strict`. The opt-out only applies on first install.
 - **No stack detection magic.** Detection seeds defaults for prompts; operators always confirm. Never write `commands.test` from detection alone — it must be operator-confirmed.
-- **Safety mode skips workflow prompts.** In `safety` mode, do not prompt for `commands.test`, `commands.lint`, `commands.format`, `commands.pr_create`, or `pr_template_path`. These keys feed workflow sections that safety mode does not inject.
+- **Safety mode skips workflow prompts.** In `safety` mode, do not prompt for `commands.test`, `commands.lint`, `commands.format`, `commands.pr_create`, `pr_template_path`, or `pr_base_branch`. These keys feed workflow sections that safety mode does not inject.
+- **PR cmd question options are built dynamically.** The `PR cmd` question options array is constructed at runtime: include `Keep current` only on re-run; include the forge-recommended option only when `FORGE` is `github` or `gitlab`; include the forge-specific `Skip` message for `FORGE=bitbucket` or a generic `Skip` for `FORGE=custom`; always include `Other`. Never show more than 4 options at once — omit `Keep current` on first run.

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -45,16 +45,16 @@ After making code changes:
 1. Run the configured test command (`claude-code-dev-hermit.commands.test`, set via `/claude-code-dev-hermit:hatch`). If unset, ask the operator for the command and offer to save it via `hatch`.
 2. If tests fail, fix the failures or surface them in the response — **do not declare the task done with broken tests**.
 3. If the task is non-trivial and `/feature-dev:feature-dev` is installed, run it first when the code path is unfamiliar (framework lifecycle hooks, ORM internals, build-tool plugins, auth middleware). The trigger is **unfamiliarity, not urgency**. Skip for: doc/prompt/config edits, single-line fixes, code paths you've already read end-to-end.
-4. Before declaring the task done: run `/claude-code-dev-hermit:dev-quality`. It runs `/simplify` on the diff and re-runs `commands.test` if configured. If tests regress, investigate before committing. If `/code-review:code-review` is installed (`code-review@claude-plugins-official`), the skill will tell you to suggest it to the operator — do not invoke that skill autonomously.
+4. Before declaring the task done: run `/claude-code-dev-hermit:dev-quality`. It runs `/simplify` on the diff and re-runs `commands.test` if configured. If tests regress, investigate before committing. If `/code-review:code-review` is installed (`code-review@claude-plugins-official`), the skill will tell you to suggest it to the operator — do not invoke that skill autonomously. **Nested git repo?** If your work is happening inside a nested git repo (true submodule, Composer path package, npm/pnpm path workspace, vendored dep edited in place), pass `--cwd <relative/path>` so `/dev-quality` scopes git ops, `/simplify`, and the test re-run to that repo. State still lives under the parent's `.claude-code-hermit/`, but the captured SHA is the child's HEAD.
 
 ## Tests Before PR
 
 If the project defines its own pre-PR validation (e.g. a custom test runner, CI gate, or PR-creation skill that handles testing internally), follow that. The steps below are the fallback.
 
-1. Run `/claude-code-dev-hermit:dev-quality` — handles `/simplify` + test re-run (see §Implementation Flow step 4).
+1. Run `/claude-code-dev-hermit:dev-quality` — handles `/simplify` + test re-run (see §Implementation Flow step 4). For nested-repo workflows, pass `--cwd <path>`.
 2. Commit.
 3. If you committed after `/dev-quality` ran and `commands.test` is configured, re-run it once — `/dev-pr` Gate 0 checks `last-test.json` against the current HEAD sha.
-4. Run `/claude-code-dev-hermit:dev-pr`. Gate 0 reads `last-test.json` and refuses if missing, on a stale sha, or with a non-pass status.
+4. Run `/claude-code-dev-hermit:dev-pr`. Gate 0 reads `last-test.json` and refuses if missing, on a stale sha, or with a non-pass status. Pass `--cwd <path>` if you used it for `/dev-quality` — the PR opens against the child repo's remote.
 
 ## Technical Constraints
 
@@ -97,9 +97,9 @@ Tier mapping:
 ## Dev Quick Reference
 
 - One-time setup / re-config: `/claude-code-dev-hermit:hatch`
-- Mid-task test run + cache warm: `/claude-code-dev-hermit:dev-test`
-- Pre-wrap quality gate: `/claude-code-dev-hermit:dev-quality`
-- Open the PR: `/claude-code-dev-hermit:dev-pr`
+- Mid-task test run + cache warm: `/claude-code-dev-hermit:dev-test` (supports `--cwd <path>`)
+- Pre-wrap quality gate: `/claude-code-dev-hermit:dev-quality` (supports `--cwd <path>`)
+- Open the PR: `/claude-code-dev-hermit:dev-pr` (supports `--cwd <path>`)
 - Cleanup: `/simplify` (built-in)
 - Parallel changes across many files: `/batch` (built-in)
 - Diagnostics: `/debug` (built-in)

--- a/plugins/claude-code-dev-hermit/tests/forge-awareness.test.js
+++ b/plugins/claude-code-dev-hermit/tests/forge-awareness.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+// Structural lint for forge-aware /dev-pr and /hatch (issue #33).
+// Asserts exact flag snippets per tool, rejects old wrong defaults, and
+// checks that stale-doc strings have been removed from docs.
+
+const fs = require('fs');
+const path = require('path');
+const { makeReporter } = require('./test-utils');
+
+const PLUGIN_ROOT = path.join(__dirname, '..');
+const HATCH_SKILL  = path.join(PLUGIN_ROOT, 'skills', 'hatch', 'SKILL.md');
+const DEV_PR_SKILL = path.join(PLUGIN_ROOT, 'skills', 'dev-pr', 'SKILL.md');
+const README       = path.join(PLUGIN_ROOT, 'README.md');
+const WORKFLOW     = path.join(PLUGIN_ROOT, 'docs', 'WORKFLOW.md');
+const HOW_TO_USE   = path.join(PLUGIN_ROOT, 'docs', 'HOW-TO-USE.md');
+
+const { ok, summary } = makeReporter();
+
+// ── Load files ──────────────────────────────────────────────────────────────
+
+function load(p) {
+  ok(`${path.relative(PLUGIN_ROOT, p)} exists`, fs.existsSync(p), p);
+  return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '';
+}
+
+const hatch  = load(HATCH_SKILL);
+const devPr  = load(DEV_PR_SKILL);
+const readme = load(README);
+const wf     = load(WORKFLOW);
+const htu    = load(HOW_TO_USE);
+
+// ── Regression: old wrong defaults must not appear anywhere ─────────────────
+
+console.log('\nRegression — glab pr create (wrong command) not present:');
+
+ok('hatch SKILL.md',   !hatch.includes('glab pr create'));
+ok('dev-pr SKILL.md',  !devPr.includes('glab pr create'));
+ok('README.md',        !readme.includes('glab pr create'));
+ok('WORKFLOW.md',      !wf.includes('glab pr create'));
+ok('HOW-TO-USE.md',    !htu.includes('glab pr create'));
+
+// ── Regression: glab --description-file does not exist ──────────────────────
+
+console.log('\nRegression — glab --description-file (invalid flag) not present:');
+
+ok('dev-pr SKILL.md',  !devPr.includes('--description-file'));
+ok('hatch SKILL.md',   !hatch.includes('--description-file'));
+
+// ── Regression: gh pr edit auto-update branch dropped ───────────────────────
+
+console.log('\nRegression — auto-edit gh pr edit --body-file dropped:');
+
+ok('dev-pr SKILL.md no gh pr edit --body-file', !devPr.includes('gh pr edit --body-file'));
+
+// ── Hatch — forge classification ────────────────────────────────────────────
+
+console.log('\nHatch SKILL.md — forge classification:');
+
+ok('classifies github',   hatch.includes('FORGE=github'));
+ok('classifies gitlab',   hatch.includes('FORGE=gitlab'));
+ok('classifies bitbucket', hatch.includes('FORGE=bitbucket'));
+ok('classifies custom',   hatch.includes('FORGE=custom'));
+
+// ── Hatch — correct canonical commands ──────────────────────────────────────
+
+console.log('\nHatch SKILL.md — canonical command heads:');
+
+ok('gh pr create present',   hatch.includes('gh pr create'));
+ok('glab mr create present', hatch.includes('glab mr create'));
+
+// ── Hatch — PR cmd question in Round 2 ──────────────────────────────────────
+
+console.log('\nHatch SKILL.md — PR cmd question:');
+
+ok('PR cmd header present', hatch.includes('"PR cmd"'));
+ok('Skip option present',   hatch.includes("Skip — I'll configure later"));
+ok('step 6 shows PR cmd:',  hatch.includes('PR cmd:'));
+
+// ── Hatch — gitlab template path in ls ──────────────────────────────────────
+
+console.log('\nHatch SKILL.md — extended template detection:');
+
+ok('gitlab template path in ls',
+   hatch.includes('.gitlab/merge_request_templates/Default.md'));
+ok('bitbucket template path in ls',
+   hatch.includes('.bitbucket/pull_request_template.md'));
+
+// ── dev-pr — Configuration section ──────────────────────────────────────────
+
+console.log('\ndev-pr SKILL.md — Configuration section:');
+
+ok('## Configuration present', devPr.includes('## Configuration'));
+ok('gh pr create documented',   devPr.includes('gh pr create'));
+ok('glab mr create documented', devPr.includes('glab mr create'));
+
+// ── dev-pr — Gate 0 forge/tool sanity check ─────────────────────────────────
+
+console.log('\ndev-pr SKILL.md — Gate 0 forge sanity check:');
+
+ok('not configured message present', devPr.includes('not configured'));
+ok('FORGE=github check present',     devPr.includes('FORGE=github'));
+ok('FORGE=gitlab check present',     devPr.includes('FORGE=gitlab'));
+
+// ── dev-pr — Gate 3 exact flag assertions ───────────────────────────────────
+
+console.log('\ndev-pr SKILL.md — Gate 3 tool-aware dispatch flags:');
+
+ok('gh arm: --body-file present',          devPr.includes('--body-file "$PR_BODY_TMP"'));
+ok('gh arm: --base present',               devPr.includes('--base "$BASE"'));
+ok('glab arm: --description "$(cat ...")', devPr.includes('--description "$(cat "$PR_BODY_TMP")'));
+ok('glab arm: --target-branch present',    devPr.includes('--target-branch "$BASE"'));
+ok('case block has *) arm',                devPr.includes('  *)\n'));
+ok('no bb) arm in case block',            !devPr.includes('  bb)\n'));
+
+// ── dev-pr — template chain ──────────────────────────────────────────────────
+
+console.log('\ndev-pr SKILL.md — extended PR template chain:');
+
+ok('gitlab template path in chain',
+   devPr.includes('.gitlab/merge_request_templates/Default.md'));
+ok('bitbucket template path in chain',
+   devPr.includes('.bitbucket/pull_request_template.md'));
+
+// ── Docs updated ─────────────────────────────────────────────────────────────
+
+console.log('\nDocs — stale references removed:');
+
+ok('README mentions glab mr create',   readme.includes('glab mr create'));
+ok('WORKFLOW mentions glab mr create', wf.includes('glab mr create'));
+ok('HOW-TO-USE updated',               htu.includes('glab') && !htu.includes('glab pr create'));
+
+process.exit(summary() === 0 ? 0 : 1);

--- a/plugins/claude-code-dev-hermit/tests/run-all.sh
+++ b/plugins/claude-code-dev-hermit/tests/run-all.sh
@@ -8,6 +8,7 @@ rc=0
 
 node "$SCRIPT_DIR/skill-structure.test.js" || rc=$?
 node "$SCRIPT_DIR/hatch-mode.test.js" || rc=$?
+node "$SCRIPT_DIR/forge-awareness.test.js" || rc=$?
 
 while IFS= read -r f; do
   node "$f" || rc=$?


### PR DESCRIPTION
### Added

- **`scripts/git-commit-quality-gate.js`** — new `PreToolUse` Bash hook that fires on `git commit`. In `standard` profile, injects an `additionalContext` reminder to run `/dev-quality` first. In `strict` profile, hard-blocks the commit (exit 2). Tokenizer-based argv parsing handles `git -C <path> commit`, env-var prefixes, and chained commands; avoids false positives on `git log --grep="commit"` and `git config commit.template`. Resolves #30.
- **`--cwd <path>` argument on `/dev-quality`, `/dev-test`, `/dev-pr`** — scopes the entire flow at a nested git working tree (submodule, path workspace, vendored dep) while letting the operator stay in the parent CWD. Git ops use `git -C "<path>"`, the test command spawns from `<path>`, `last-test.json` records the child's HEAD SHA (so `/dev-pr`'s SHA-only cache check correctly discriminates parent-scope from child-scope records), `/simplify` is scoped to files under `<path>`, and `gh`/`glab` runs from `<path>` so the PR opens against the child's remote. Hermit state still lives under the parent's `.claude-code-hermit/`. Resolves #32.
- **`record-test-result.js` `--cwd <path>` flag** on `run` and `write` subcommands. Validates the path exists and is a git working tree, spawns the test command from `<path>`, captures `<path>`'s HEAD SHA. The PostToolUse hook entry-point is unchanged — it still captures `process.cwd()`'s SHA and cannot reliably parse `cd <path> && testcmd` chains; the `--cwd`-driven flow (via `run --cwd`) is the supported nested-repo entry point.

### Changed

- **Minimum core version bumped to `>=1.0.32`** — aligns `required_core_version`, `requires`, and `dependencies` with the upcoming core release.
- **`/dev-quality` Gate 0 clean-tree FAIL** — adds a `hint:` line pointing operators at `--cwd <path>` for nested-repo workflows. Hint suppressed when `--cwd` was already passed.

### Files affected

| File | Change |
|------|--------|
| `scripts/git-commit-quality-gate.js` | New profile-gated PreToolUse hook script |
| `scripts/git-commit-quality-gate.test.js` | Unit tests (tokenizer, both profile branches, false-positive cases) |
| `hooks/hooks.json` | Second `PreToolUse` Bash entry registered |
| `scripts/record-test-result.js` | `--cwd <path>` parsing on `run` and `write` |
| `scripts/record-test-result.test.js` | New `--cwd` cases (child-SHA capture, validation failures) |
| `skills/dev-quality/SKILL.md` | Argument section, target-aware gates, hint in Gate 0 FAIL |
| `skills/dev-test/SKILL.md` | Argument section + passthrough |
| `skills/dev-pr/SKILL.md` | Argument section + child-remote warning, target-aware gates |
| `state-templates/CLAUDE-APPEND.md` | Nested-repo reminders in §Implementation Flow, §Tests Before PR, §Dev Quick Reference |

### Upgrade Instructions

Run `/claude-code-hermit:hermit-evolve`. The evolve skill picks up the new hook and skill prose automatically via plugin update — no `config.json` changes and no `/hatch` re-run required.

Closes #30
Closes #32

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the
> SHA and strands the release tag on an orphan commit. After merging, run
> `/release claude-code-dev-hermit` from `main` to tag.