### PR TITLE
release(claude-code-hermit): v1.0.33

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "claude-code-hermit",
       "source": "./plugins/claude-code-hermit",
       "description": "Core hermit - memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "category": "productivity",
       "author": {
         "name": "gtapps"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="plugins/claude-code-hermit/CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.32-green.svg" alt="Version 1.0.32" /></a>
+  <a href="plugins/claude-code-hermit/CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.33-green.svg" alt="Version 1.0.33" /></a>
   <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/gtapps/claude-code-hermit/_gh_traffic_stats/.github/badges/clones.json" alt="Downloads" />
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
   <a href="plugins/claude-code-hermit/docs/obsidian-setup.md"><img src="https://img.shields.io/badge/obsidian-active-7c3aed.svg" alt="Obsidian Integration" /></a>
@@ -18,11 +18,11 @@ Turn Claude Code into an Always-on Personal AI assistant that lives in your proj
 Three steps to a running 24/7 hermit:
 
 ```
-# Boot claude code and install
-/plugin marketplace add gtapps/claude-code-hermit
-/plugin install claude-code-hermit@claude-code-hermit --scope project
+# Install
+claude plugin marketplace add gtapps/claude-code-hermit
+claude plugin install claude-code-hermit@claude-code-hermit --scope project
 
-# Setup Wizard
+# Boot Claude Code and run the setup wizard
 /claude-code-hermit:hatch
 
 # Go always-on

--- a/plugins/claude-code-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-hermit",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "A personal assistant that lives in your project — memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
   "author": {
     "name": "gtapps"

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.0.33] - 2026-05-07
+
+### Changed
+
+- **`/session-close` no longer invokes `reflect` inline.** Step 5 of session-close (the explicit `reflect` call) is removed; close now goes straight from "create proposals if needed" to "format Tasks table → archive via session-mgr". Reflect continues to run on its established cadence: daily cron (`0 9 * * *`), idle/task-boundary triggers in the `session` skill (4-hour debounce), and heartbeat-path idle behaviors. Closeout time drops from minutes to seconds; no coverage is lost (at worst one reflect cycle is delayed up to 4h until the next idle/cron fire).
+- **Right-sized thinking budgets across `reflect`, `reflection-judge`, and `proposal-create`.** `agents/reflection-judge.md` drops the `ultrathink` keyword — the frontmatter `effort: medium` is now the sole, coherent control surface for that agent. `skills/reflect/SKILL.md` downgrades `ultrathink` to `think hard` (~10K vs ~32K token budget), appropriate for cross-session synthesis. `skills/proposal-create/SKILL.md` drops the keyword entirely from the body-writing step (structured drafting, no escalation needed) and downgrades to `think hard` for the capability-plan branch (designing new agents/skills). Reduces routine-path cost without compromising gating or synthesis quality.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `skills/session-close/SKILL.md` | Removes step 5 (inline reflect call); renumbers steps 6→5, 7→6 |
+| `agents/reflection-judge.md` | Replaces `ultrathink` line with plain "reason carefully" instruction |
+| `skills/reflect/SKILL.md` | Downgrades `ultrathink` to `think hard` |
+| `skills/proposal-create/SKILL.md` | Drops `ultrathink` from body-writing step; downgrades to `think hard` for capability-plan branch |
+
+### Upgrade Instructions
+
+No upgrade actions required. Skill and agent text changes propagate via plugin update — no `config.json`, `runtime.json`, `state-templates/`, or operator-editable file changes.
+
 ## [1.0.32] - 2026-05-07
 
 ### Added

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,14 +4,12 @@
 
 ### Changed
 
-- **`/session-close` no longer invokes `reflect` inline.** Step 5 of session-close (the explicit `reflect` call) is removed; close now goes straight from "create proposals if needed" to "format Tasks table → archive via session-mgr". Reflect continues to run on its established cadence: daily cron (`0 9 * * *`), idle/task-boundary triggers in the `session` skill (4-hour debounce), and heartbeat-path idle behaviors. Closeout time drops from minutes to seconds; no coverage is lost (at worst one reflect cycle is delayed up to 4h until the next idle/cron fire).
 - **Right-sized thinking budgets across `reflect`, `reflection-judge`, and `proposal-create`.** `agents/reflection-judge.md` drops the `ultrathink` keyword — the frontmatter `effort: medium` is now the sole, coherent control surface for that agent. `skills/reflect/SKILL.md` downgrades `ultrathink` to `think hard` (~10K vs ~32K token budget), appropriate for cross-session synthesis. `skills/proposal-create/SKILL.md` drops the keyword entirely from the body-writing step (structured drafting, no escalation needed) and downgrades to `think hard` for the capability-plan branch (designing new agents/skills). Reduces routine-path cost without compromising gating or synthesis quality.
 
 ### Files affected
 
 | File | Change |
 |------|--------|
-| `skills/session-close/SKILL.md` | Removes step 5 (inline reflect call); renumbers steps 6→5, 7→6 |
 | `agents/reflection-judge.md` | Replaces `ultrathink` line with plain "reason carefully" instruction |
 | `skills/reflect/SKILL.md` | Downgrades `ultrathink` to `think hard` |
 | `skills/proposal-create/SKILL.md` | Drops `ultrathink` from body-writing step; downgrades to `think hard` for capability-plan branch |

--- a/plugins/claude-code-hermit/agents/reflection-judge.md
+++ b/plugins/claude-code-hermit/agents/reflection-judge.md
@@ -34,7 +34,7 @@ Multiple candidates may be passed in one invocation.
 
 ## For Each Candidate
 
-ultrathink — this batch gates what reaches the proposal pipeline. Reason carefully about each candidate's evidence and tier before emitting its verdict.
+Reason carefully about each candidate's evidence and tier before emitting its verdict — this batch gates what reaches the proposal pipeline.
 
 ### 0. Evidence Source dispatch
 

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -69,7 +69,7 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js \
      - `title`: short proposal title (same text used in the H1 heading after the dash)
      - `resolved_date`: `null` (set later by reflect when pattern is confirmed gone)
    - Fill in the title in the H1 heading
-   - ultrathink while writing the body: write a clear Context, Problem, Proposed Solution, and Impact
+   - while writing the body: write a clear Context, Problem, Proposed Solution, and Impact
    - Leave "Operator Decision" blank — the operator fills that in
    - Do NOT write bullet-point metadata (`- **Created:**`, etc.) — all metadata lives in frontmatter only
 
@@ -98,7 +98,7 @@ If the proposal affects security boundaries — permissions, network access, cre
 
 When your operational scope changes (new API, new local service, new publishing channel), create a PROP recommending deny pattern additions or networking changes. Never modify `deny-patterns.json` or Docker config directly. The operator implements security changes.
 
-When the proposed solution involves creating a new agent, skill, heartbeat item, or OPERATOR.md change, ultrathink and make the Suggested Plan self-contained:
+When the proposed solution involves creating a new agent, skill, heartbeat item, or OPERATOR.md change, think hard and make the Suggested Plan self-contained:
 
 **For a new sub-agent:**
 1. Create `.claude/agents/<name>.md` with:

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -62,7 +62,7 @@ This skill is **silent by default**. Only notify the operator (per the channel p
       If the pattern is absent but the elapsed guard is not yet met (frequent: < 14d, sparse: < 2×cadence), skip and revisit next cycle.
    f. Note the last PROP-NNN checked (or null if batch was empty). Include as `last_resolution_check` in the final state write in the State Update section below — do NOT write `reflection-state.json` here.
 
-Now reflect — ultrathink — using your memory and the context above:
+Now reflect — think hard — using your memory and the context above:
 - Is anything recurring that shouldn't be?
 - Have you been working around something that deserves a real fix?
 - Is spending proportional to the work being done?

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -30,9 +30,8 @@ Use this when the operator wants to end everything (via `hermit-stop` or explici
 2. Ensure all native Tasks reflect their correct status (`completed`, `pending`)
 3. Confirm the "Next Start Point" is clear enough for a fresh session to resume without questions
 4. If any high-leverage improvements were discovered during work, create proposals via the `claude-code-hermit:proposal-create` skill
-5. Invoke the `claude-code-hermit:reflect` skill to reflect on accumulated experience. Reflect no longer requires archived reports — it uses memory. This runs before archiving so any findings are included in the archived report.
-6. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for completed tasks only — pending/in_progress tasks persist for next session.
-7. Archive the session via `claude-code-hermit:session-mgr` (full close — finalize SHELL.md and replace with fresh template in one operation). Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
+5. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for completed tasks only — pending/in_progress tasks persist for next session.
+6. Archive the session via `claude-code-hermit:session-mgr` (full close — finalize SHELL.md and replace with fresh template in one operation). Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
    ```
    Status: <completed|partial|blocked>
    Blockers: <one line each, or none>

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -30,8 +30,9 @@ Use this when the operator wants to end everything (via `hermit-stop` or explici
 2. Ensure all native Tasks reflect their correct status (`completed`, `pending`)
 3. Confirm the "Next Start Point" is clear enough for a fresh session to resume without questions
 4. If any high-leverage improvements were discovered during work, create proposals via the `claude-code-hermit:proposal-create` skill
-5. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for completed tasks only — pending/in_progress tasks persist for next session.
-6. Archive the session via `claude-code-hermit:session-mgr` (full close — finalize SHELL.md and replace with fresh template in one operation). Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
+5. Invoke the `claude-code-hermit:reflect` skill to reflect on accumulated experience. Reflect no longer requires archived reports — it uses memory. This runs before archiving so any findings are included in the archived report.
+6. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for completed tasks only — pending/in_progress tasks persist for next session.
+7. Archive the session via `claude-code-hermit:session-mgr` (full close — finalize SHELL.md and replace with fresh template in one operation). Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
    ```
    Status: <completed|partial|blocked>
    Blockers: <one line each, or none>


### PR DESCRIPTION
### Changed

- **Right-sized thinking budgets across `reflect`, `reflection-judge`, and `proposal-create`.** `agents/reflection-judge.md` drops the `ultrathink` keyword — the frontmatter `effort: medium` is now the sole, coherent control surface for that agent. `skills/reflect/SKILL.md` downgrades `ultrathink` to `think hard` (~10K vs ~32K token budget), appropriate for cross-session synthesis. `skills/proposal-create/SKILL.md` drops the keyword entirely from the body-writing step (structured drafting, no escalation needed) and downgrades to `think hard` for the capability-plan branch (designing new agents/skills). Reduces routine-path cost without compromising gating or synthesis quality.

### Files affected

| File | Change |
|------|--------|
| `agents/reflection-judge.md` | Replaces `ultrathink` line with plain "reason carefully" instruction |
| `skills/reflect/SKILL.md` | Downgrades `ultrathink` to `think hard` |
| `skills/proposal-create/SKILL.md` | Drops `ultrathink` from body-writing step; downgrades to `think hard` for capability-plan branch |

### Upgrade Instructions

No upgrade actions required. Skill and agent text changes propagate via plugin update — no `config.json`, `runtime.json`, `state-templates/`, or operator-editable file changes.

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the SHA and strands the release tag on an orphan commit. After merging, run `/release claude-code-hermit` from `main` to tag.