### PR TITLE
release(claude-code-hermit): v1.0.34

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "claude-code-hermit",
       "source": "./plugins/claude-code-hermit",
       "description": "Core hermit - memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "category": "productivity",
       "author": {
         "name": "gtapps"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="plugins/claude-code-hermit/CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.33-green.svg" alt="Version 1.0.33" /></a>
+  <a href="plugins/claude-code-hermit/CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.34-green.svg" alt="Version 1.0.34" /></a>
   <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/gtapps/claude-code-hermit/_gh_traffic_stats/.github/badges/clones.json" alt="Downloads" />
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
   <a href="plugins/claude-code-hermit/docs/obsidian-setup.md"><img src="https://img.shields.io/badge/obsidian-active-7c3aed.svg" alt="Obsidian Integration" /></a>

--- a/plugins/claude-code-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-hermit",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "A personal assistant that lives in your project — memory-driven learning, daily rhythm, idle agency, and operational hygiene for Claude Code",
   "author": {
     "name": "gtapps"

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,12 +1,38 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.34] - 2026-05-08
 
 ### Fixed
 
 - **Plugin detection scoped to project/local only across five skills.** `/hatch` Step 1.5, `/docker-setup` Step 7b.1, `/docker-security` Step 3a, `/hermit-evolve` Step 7, and `/channel-setup` Step 3 all enumerated installed plugins without pinning `projectPath` to the current project root. `claude plugin list --json` returns entries for all projects in the operator's config, so a bare `scope == "local"` predicate leaked plugins from sibling repos. All five sites now apply the canonical filter: `enabled == true AND (scope == "project" OR scope == "local") AND projectPath == cwd`. User-scope plugins are explicitly dropped. `/hatch` and `/hermit-evolve` also replace the `${CLAUDE_PLUGIN_ROOT}/../*` disk glob with the JSON list so the install root is read from `installPath` rather than inferred by path proximity. `/hatch`'s `detected_hermits` stash now carries `installPath` so downstream Steps 3, 5a, 6, and Quick Turn 1 read `CLAUDE-APPEND.md`, `plugin.json`, and `OPERATOR-QUESTIONS.md` from the resolved install path instead of re-globbing.
 
-- **`docker.recommended_plugins` now stores both marketplace identifiers.** The entrypoint was deriving the install target and on-disk cache key from `marketplace.split('/')[-1]`, which breaks when the marketplace `name` field differs from the repo basename (e.g. `openai/codex-plugin-cc` → name `openai-codex`). Each entry now carries `marketplace` (`org/repo` for `marketplace add`) and `marketplace_name` (canonical name for install targets and the `~/.claude/plugins/cache/<name>/` key). Official entries switch from the legacy `"claude-plugins-official"` shortcut to `{"marketplace": "anthropics/claude-plugins-official", "marketplace_name": "claude-plugins-official"}`. The entrypoint gains backward-compat fallback paths for legacy configs (org/repo entry → derive name from basename with warning; literal `claude-plugins-official` → normalize to real org/repo with warning; unresolvable no-slash value → skip with warning). The `installed_blob` already-installed check changes from bare substring to `❯ {target}` prefix match, preventing false positives where a short plugin name is a substring of a longer one. Affects `/docker-setup` Step 7b, `/hermit-settings` docker section, docs, and entrypoint.
+- **`docker.recommended_plugins` now stores both marketplace identifiers.** The entrypoint was deriving the install target and on-disk cache key from `marketplace.split('/')[-1]`, which breaks when the marketplace `name` field differs from the repo basename (e.g. `openai/codex-plugin-cc` → name `openai-codex`). Each entry now carries `marketplace` (`org/repo` for `marketplace add`) and `marketplace_name` (canonical name for install targets and the `~/.claude/plugins/cache/<name>/` key). Official entries switch from the legacy `"claude-plugins-official"` shortcut to `{"marketplace": "anthropics/claude-plugins-official", "marketplace_name": "claude-plugins-official"}`. The entrypoint gains backward-compat fallback paths for legacy configs (org/repo entry → derive name from basename with warning; literal `claude-plugins-official` → normalize to real org/repo with warning; unresolvable no-slash value → skip with warning). The already-installed check in the entrypoint switches from bare substring to `❯ {target}` prefix match, preventing false positives where a short plugin name is a substring of a longer entry. Affects `/docker-setup` Step 7b, `/hermit-settings` docker section, docs, and entrypoint.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `skills/hatch/SKILL.md` | Step 1.5 uses `claude plugin list --json` + filter; stash carries `installPath`; downstream steps read from `installPath` |
+| `skills/docker-setup/SKILL.md` | Step 7b.1 filter tightened; dedupe rule added; Step 7b.3/5/10 updated for dual identifiers; backfill section added |
+| `skills/docker-security/SKILL.md` | Step 3a filter tightened; `path` field → `installPath` |
+| `skills/hermit-evolve/SKILL.md` | Step 7 replaces disk glob with `claude plugin list --json` + filter; reads from `installPath` |
+| `skills/channel-setup/SKILL.md` | Step 3 replaces unstructured grep with JSON + filter; adds `marketplace_name` gate; adds explicit `plugin enable` |
+| `skills/hermit-settings/SKILL.md` | Display renders `marketplace_name`; `add` action writes both identifiers with dedupe-by-(plugin, marketplace_name) |
+| `state-templates/docker/docker-entrypoint.hermit.sh.template` | Install loop uses `marketplace_name` for cache-dir check and install target; legacy fallback paths; `❯` prefix match for already-installed guard |
+| `docs/config-reference.md` | `recommended_plugins` schema adds `marketplace_name` row; example entry updated |
+| `docs/recommended-plugins.md` | Config format table adds `marketplace_name` row |
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
+
+1. **Refresh skill spec** — the updated skill text loads on the next invocation of each affected skill. No state files or templates change.
+
+To pick up the entrypoint `marketplace_name` fix in a running Docker container:
+
+2. **Rebuild your container** — run `.claude-code-hermit/bin/hermit-docker update`. This rebuilds the image with the updated entrypoint and refreshes plugin marketplaces. Required only if you use Docker and have non-`gtapps` third-party recommended plugins whose marketplace `name` differs from their repo basename (e.g. `openai-codex` / `openai/codex-plugin-cc`).
+
+**Note:** Existing `docker.recommended_plugins` entries without `marketplace_name` continue to work via the backward-compat fallback (warning printed on boot); run `/docker-setup` to backfill both identifiers cleanly.
 
 ## [1.0.33] - 2026-05-07
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Plugin detection scoped to project/local only across five skills.** `/hatch` Step 1.5, `/docker-setup` Step 7b.1, `/docker-security` Step 3a, `/hermit-evolve` Step 7, and `/channel-setup` Step 3 all enumerated installed plugins without pinning `projectPath` to the current project root. `claude plugin list --json` returns entries for all projects in the operator's config, so a bare `scope == "local"` predicate leaked plugins from sibling repos. All five sites now apply the canonical filter: `enabled == true AND (scope == "project" OR scope == "local") AND projectPath == cwd`. User-scope plugins are explicitly dropped. `/hatch` and `/hermit-evolve` also replace the `${CLAUDE_PLUGIN_ROOT}/../*` disk glob with the JSON list so the install root is read from `installPath` rather than inferred by path proximity. `/hatch`'s `detected_hermits` stash now carries `installPath` so downstream Steps 3, 5a, 6, and Quick Turn 1 read `CLAUDE-APPEND.md`, `plugin.json`, and `OPERATOR-QUESTIONS.md` from the resolved install path instead of re-globbing.
+
+- **`docker.recommended_plugins` now stores both marketplace identifiers.** The entrypoint was deriving the install target and on-disk cache key from `marketplace.split('/')[-1]`, which breaks when the marketplace `name` field differs from the repo basename (e.g. `openai/codex-plugin-cc` → name `openai-codex`). Each entry now carries `marketplace` (`org/repo` for `marketplace add`) and `marketplace_name` (canonical name for install targets and the `~/.claude/plugins/cache/<name>/` key). Official entries switch from the legacy `"claude-plugins-official"` shortcut to `{"marketplace": "anthropics/claude-plugins-official", "marketplace_name": "claude-plugins-official"}`. The entrypoint gains backward-compat fallback paths for legacy configs (org/repo entry → derive name from basename with warning; literal `claude-plugins-official` → normalize to real org/repo with warning; unresolvable no-slash value → skip with warning). The `installed_blob` already-installed check changes from bare substring to `❯ {target}` prefix match, preventing false positives where a short plugin name is a substring of a longer one. Affects `/docker-setup` Step 7b, `/hermit-settings` docker section, docs, and entrypoint.
+
 ## [1.0.33] - 2026-05-07
 
 ### Changed

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -6,21 +6,21 @@
 
 - **Plugin detection scoped to project/local only across five skills.** `/hatch` Step 1.5, `/docker-setup` Step 7b.1, `/docker-security` Step 3a, `/hermit-evolve` Step 7, and `/channel-setup` Step 3 all enumerated installed plugins without pinning `projectPath` to the current project root. `claude plugin list --json` returns entries for all projects in the operator's config, so a bare `scope == "local"` predicate leaked plugins from sibling repos. All five sites now apply the canonical filter: `enabled == true AND (scope == "project" OR scope == "local") AND projectPath == cwd`. User-scope plugins are explicitly dropped. `/hatch` and `/hermit-evolve` also replace the `${CLAUDE_PLUGIN_ROOT}/../*` disk glob with the JSON list so the install root is read from `installPath` rather than inferred by path proximity. `/hatch`'s `detected_hermits` stash now carries `installPath` so downstream Steps 3, 5a, 6, and Quick Turn 1 read `CLAUDE-APPEND.md`, `plugin.json`, and `OPERATOR-QUESTIONS.md` from the resolved install path instead of re-globbing.
 
-- **`docker.recommended_plugins` now stores both marketplace identifiers.** The entrypoint was deriving the install target and on-disk cache key from `marketplace.split('/')[-1]`, which breaks when the marketplace `name` field differs from the repo basename (e.g. `openai/codex-plugin-cc` → name `openai-codex`). Each entry now carries `marketplace` (`org/repo` for `marketplace add`) and `marketplace_name` (canonical name for install targets and the `~/.claude/plugins/cache/<name>/` key). Official entries switch from the legacy `"claude-plugins-official"` shortcut to `{"marketplace": "anthropics/claude-plugins-official", "marketplace_name": "claude-plugins-official"}`. The entrypoint gains backward-compat fallback paths for legacy configs (org/repo entry → derive name from basename with warning; literal `claude-plugins-official` → normalize to real org/repo with warning; unresolvable no-slash value → skip with warning). The already-installed check in the entrypoint switches from bare substring to `❯ {target}` prefix match, preventing false positives where a short plugin name is a substring of a longer entry. Affects `/docker-setup` Step 7b, `/hermit-settings` docker section, docs, and entrypoint.
+- **`docker.recommended_plugins.marketplace` is always `org/repo`; entrypoint resolves the canonical name at boot.** The entrypoint was deriving the install target and on-disk cache key from `marketplace.split('/')[-1]`, which breaks when the marketplace `name` field differs from the repo basename (e.g. `openai/codex-plugin-cc` → name `openai-codex`). Official entries also stored the literal `"claude-plugins-official"` instead of an `org/repo`, mixing identifier types in the same field. The fix normalizes `marketplace` to always be `org/repo` (official is now `anthropics/claude-plugins-official`) and resolves the canonical marketplace name at boot via a single `claude plugin marketplace list --json` lookup — no schema bifurcation, no duplicated source of truth. The `is_safelisted` predicate folds back to a single arg (`marketplace`) since the literal-name shortcut is gone. Pre-v1.0.34 entries whose `marketplace` is not an `org/repo` get one warning at boot and are skipped; re-running `/docker-setup` rebuilds the entries cleanly from the host plugin list. The already-installed check in the entrypoint switches from bare substring to `❯ {target}` prefix match, preventing false positives where a short plugin name is a substring of a longer entry. Affects `/docker-setup` Step 7b, `/hermit-settings` docker section, docs, and entrypoint.
 
 ### Files affected
 
 | File | Change |
 |------|--------|
 | `skills/hatch/SKILL.md` | Step 1.5 uses `claude plugin list --json` + filter; stash carries `installPath`; downstream steps read from `installPath` |
-| `skills/docker-setup/SKILL.md` | Step 7b.1 filter tightened; dedupe rule added; Step 7b.3/5/10 updated for dual identifiers; backfill section added |
+| `skills/docker-setup/SKILL.md` | Step 7b.1 filter tightened; dedupe rule added; Step 7b.3/5/10 updated to write `marketplace` as `org/repo` only |
 | `skills/docker-security/SKILL.md` | Step 3a filter tightened; `path` field → `installPath` |
 | `skills/hermit-evolve/SKILL.md` | Step 7 replaces disk glob with `claude plugin list --json` + filter; reads from `installPath` |
 | `skills/channel-setup/SKILL.md` | Step 3 replaces unstructured grep with JSON + filter; adds `marketplace_name` gate; adds explicit `plugin enable` |
-| `skills/hermit-settings/SKILL.md` | Display renders `marketplace_name`; `add` action writes both identifiers with dedupe-by-(plugin, marketplace_name) |
-| `state-templates/docker/docker-entrypoint.hermit.sh.template` | Install loop uses `marketplace_name` for cache-dir check and install target; legacy fallback paths; `❯` prefix match for already-installed guard |
-| `docs/config-reference.md` | `recommended_plugins` schema adds `marketplace_name` row; example entry updated |
-| `docs/recommended-plugins.md` | Config format table adds `marketplace_name` row |
+| `skills/hermit-settings/SKILL.md` | Display renders `org/repo`; `add` action writes `marketplace` as `org/repo` with dedupe-by-(plugin, marketplace) |
+| `state-templates/docker/docker-entrypoint.hermit.sh.template` | Install loop resolves marketplace name from `claude plugin marketplace list --json` once at start; single warn-and-skip path for pre-v1.0.34 legacy entries; `❯` prefix match for already-installed guard |
+| `docs/config-reference.md` | `recommended_plugins` schema documents `marketplace` as `org/repo` (canonical name resolved at boot); example entry updated |
+| `docs/recommended-plugins.md` | Config format table documents `marketplace` as `org/repo` |
 
 ### Upgrade Instructions
 
@@ -28,11 +28,11 @@ Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
 
 1. **Refresh skill spec** — the updated skill text loads on the next invocation of each affected skill. No state files or templates change.
 
-To pick up the entrypoint `marketplace_name` fix in a running Docker container:
+If you use Docker:
 
-2. **Rebuild your container** — run `.claude-code-hermit/bin/hermit-docker update`. This rebuilds the image with the updated entrypoint and refreshes plugin marketplaces. Required only if you use Docker and have non-`gtapps` third-party recommended plugins whose marketplace `name` differs from their repo basename (e.g. `openai-codex` / `openai/codex-plugin-cc`).
+2. **Rebuild your container** — run `.claude-code-hermit/bin/hermit-docker update`. The new entrypoint resolves marketplace names at boot from the CLI's source of truth (`claude plugin marketplace list --json`) instead of guessing from the repo basename.
 
-**Note:** Existing `docker.recommended_plugins` entries without `marketplace_name` continue to work via the backward-compat fallback (warning printed on boot); run `/docker-setup` to backfill both identifiers cleanly.
+3. **Re-run `/claude-code-hermit:docker-setup` once** — only required if your existing `docker.recommended_plugins` has any entry where `marketplace` is not an `org/repo` (the most common case is pre-v1.0.34 official entries that store the literal `"claude-plugins-official"`). The new entrypoint warns once at boot and skips such entries; re-running `/docker-setup` rebuilds the entries cleanly from the current host plugin list. Skip this step if every `marketplace` value in your config already contains a `/`.
 
 ## [1.0.33] - 2026-05-07
 

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -198,8 +198,9 @@ Modify with `/hermit-settings scheduled-checks`.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `marketplace` | string | `"claude-plugins-official"` | Marketplace name. Use `"claude-plugins-official"` for official plugins, or `"org/repo"` for third-party (e.g. `"obra/superpowers-marketplace"`). |
-| `plugin` | string | _(required)_ | Plugin name to install. |
+| `plugin` | string | _(required)_ | Plugin name to install (substring of `claude plugin list --json` `id` left of `@`). |
+| `marketplace` | string | `"anthropics/claude-plugins-official"` | Marketplace `org/repo`, passed to `claude plugin marketplace add`. |
+| `marketplace_name` | string | `"claude-plugins-official"` | Canonical marketplace name (`name` field from `claude plugin marketplace list --json`; right side of `@` in plugin `id`). Used to build `<plugin>@<marketplace_name>` install targets and key into the `~/.claude/plugins/cache/<marketplace_name>/` directory. |
 | `scope` | string | `"project"` | Install scope: `"project"` or `"local"`. |
 | `enabled` | boolean | `false` | Whether to install on container boot. |
 
@@ -281,7 +282,7 @@ A realistic `config.json` for an always-on Docker hermit with Discord:
   "docker": {
     "packages": ["python3", "python3-pip"],
     "recommended_plugins": [
-      {"marketplace": "claude-plugins-official", "plugin": "claude-code-setup", "scope": "project", "enabled": true}
+      {"plugin": "claude-code-setup", "marketplace": "anthropics/claude-plugins-official", "marketplace_name": "claude-plugins-official", "scope": "project", "enabled": true}
     ]
   },
   "compact": {

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -199,8 +199,7 @@ Modify with `/hermit-settings scheduled-checks`.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `plugin` | string | _(required)_ | Plugin name to install (substring of `claude plugin list --json` `id` left of `@`). |
-| `marketplace` | string | `"anthropics/claude-plugins-official"` | Marketplace `org/repo`, passed to `claude plugin marketplace add`. |
-| `marketplace_name` | string | `"claude-plugins-official"` | Canonical marketplace name (`name` field from `claude plugin marketplace list --json`; right side of `@` in plugin `id`). Used to build `<plugin>@<marketplace_name>` install targets and key into the `~/.claude/plugins/cache/<marketplace_name>/` directory. |
+| `marketplace` | string | `"anthropics/claude-plugins-official"` | Marketplace `org/repo`, passed to `claude plugin marketplace add`. The entrypoint resolves the canonical marketplace name at boot via `claude plugin marketplace list --json` to build `<plugin>@<name>` install targets. |
 | `scope` | string | `"project"` | Install scope: `"project"` or `"local"`. |
 | `enabled` | boolean | `false` | Whether to install on container boot. |
 
@@ -282,7 +281,7 @@ A realistic `config.json` for an always-on Docker hermit with Discord:
   "docker": {
     "packages": ["python3", "python3-pip"],
     "recommended_plugins": [
-      {"plugin": "claude-code-setup", "marketplace": "anthropics/claude-plugins-official", "marketplace_name": "claude-plugins-official", "scope": "project", "enabled": true}
+      {"plugin": "claude-code-setup", "marketplace": "anthropics/claude-plugins-official", "scope": "project", "enabled": true}
     ]
   },
   "compact": {

--- a/plugins/claude-code-hermit/docs/recommended-plugins.md
+++ b/plugins/claude-code-hermit/docs/recommended-plugins.md
@@ -96,8 +96,9 @@ Each entry in `docker.recommended_plugins`:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `marketplace` | string | `"claude-plugins-official"` for official, or `"org/repo"` for third-party |
-| `plugin` | string | Plugin name |
+| `plugin` | string | Plugin name (left side of `@` in `claude plugin list` output) |
+| `marketplace` | string | Marketplace `org/repo`, passed to `claude plugin marketplace add` (e.g. `"anthropics/claude-plugins-official"`, `"obra/superpowers-marketplace"`) |
+| `marketplace_name` | string | Canonical marketplace name — right side of `@` in plugin id, used to build `<plugin>@<marketplace_name>` install targets and key the on-disk cache directory |
 | `scope` | string | `"project"` or `"local"` |
 | `enabled` | boolean | Install on boot when `true` |
 

--- a/plugins/claude-code-hermit/docs/recommended-plugins.md
+++ b/plugins/claude-code-hermit/docs/recommended-plugins.md
@@ -97,8 +97,7 @@ Each entry in `docker.recommended_plugins`:
 | Field | Type | Description |
 |-------|------|-------------|
 | `plugin` | string | Plugin name (left side of `@` in `claude plugin list` output) |
-| `marketplace` | string | Marketplace `org/repo`, passed to `claude plugin marketplace add` (e.g. `"anthropics/claude-plugins-official"`, `"obra/superpowers-marketplace"`) |
-| `marketplace_name` | string | Canonical marketplace name — right side of `@` in plugin id, used to build `<plugin>@<marketplace_name>` install targets and key the on-disk cache directory |
+| `marketplace` | string | Marketplace `org/repo`, passed to `claude plugin marketplace add` (e.g. `"anthropics/claude-plugins-official"`, `"obra/superpowers-marketplace"`). Canonical marketplace name is resolved at boot from `claude plugin marketplace list --json`. |
 | `scope` | string | `"project"` or `"local"` |
 | `enabled` | boolean | Install on boot when `true` |
 

--- a/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
@@ -46,16 +46,27 @@ bun --version 2>/dev/null; uname -s
 
 ### 3. Install plugin
 
-Check if the plugin is already installed:
+Run `claude plugin list --json` and apply the **project-or-local + enabled filter**:
 
-```bash
-claude plugin list 2>/dev/null | grep -i "<channel>@claude-plugins-official"
-```
+- Keep `enabled == true` AND (`scope == "project"` OR `scope == "local"`) AND `projectPath` equals the current project root.
+- Drop user-scope, managed-scope, disabled, and cross-project entries.
 
-- Not installed → `claude plugin install <channel>@claude-plugins-official --scope local`
-- Already installed → skip silently.
+Then check whether the surviving set contains an entry where:
 
-After any install (or if just installed): tell the operator to run `/reload-plugins` in this session to activate the plugin's configure and access commands before pairing.
+- the plugin name (substring of `id` left of `@`) equals `<channel>`, AND
+- the marketplace name (substring of `id` right of `@`) equals `claude-plugins-official`.
+
+(Both clauses matter — `discord@some-other-marketplace` is a different plugin from a different source and must not satisfy this gate.)
+
+- **Found**: skip silently. The official channel plugin is already installed and enabled at project or local scope for this project — the canonical filter guarantees `enabled == true`, and `*_STATE_DIR` (set by `hermit-start` at boot) points at `.claude.local/channels/<channel>/`.
+- **Not found**: run, in order:
+  ```bash
+  claude plugin install <channel>@claude-plugins-official --scope local
+  claude plugin enable  <channel>@claude-plugins-official --scope local
+  ```
+  The explicit `enable` step covers the case where a project- or local-scope copy already exists but is disabled — the canonical filter excluded it (enabled-only), so `install` may no-op as already-installed without re-enabling. A user-scope install elsewhere does not satisfy this gate; channel tokens and access policy are project-local, so the plugin must be installed at project or local scope here too.
+
+After any install (or if already present): tell the operator to run `/reload-plugins` in this session to activate the plugin's configure and access commands before pairing.
 
 ### 4. Token configuration (AskUserQuestion)
 

--- a/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
@@ -64,7 +64,7 @@ Then check whether the surviving set contains an entry where:
   claude plugin install <channel>@claude-plugins-official --scope local
   claude plugin enable  <channel>@claude-plugins-official --scope local
   ```
-  The explicit `enable` step covers the case where a project- or local-scope copy already exists but is disabled — the canonical filter excluded it (enabled-only), so `install` may no-op as already-installed without re-enabling. A user-scope install elsewhere does not satisfy this gate; channel tokens and access policy are project-local, so the plugin must be installed at project or local scope here too.
+  Explicit `enable` covers the disabled-but-installed-at-project/local case — the filter excluded such entries (enabled-only), and `install` is a separate command from `enable` per the CLI surface, so it may no-op without re-enabling. A user-scope install elsewhere does not satisfy this gate; channel tokens and access policy are project-local.
 
 After any install (or if already present): tell the operator to run `/reload-plugins` in this session to activate the plugin's configure and access commands before pairing.
 

--- a/plugins/claude-code-hermit/skills/docker-security/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-security/SKILL.md
@@ -103,9 +103,14 @@ Scan installed fleet plugins. From the host:
 claude plugin list --json 2>/dev/null
 ```
 
-For each entry where `id` matches `*-hermit*` (excluding `claude-code-hermit` itself):
+Apply the **project-or-local + enabled filter**:
 
-1. Locate the plugin's installed root (use `path` field from the JSON).
+- Keep `enabled == true` AND (`scope == "project"` OR `scope == "local"`) AND `projectPath` equals the current project root.
+- Drop user-scope, managed-scope, disabled, and cross-project entries.
+
+For each surviving entry whose plugin name (substring of `id` left of `@`) matches `*-hermit*` and is NOT `claude-code-hermit`:
+
+1. Locate the plugin's installed root using the `installPath` field from the JSON.
 2. Read `<plugin>/skills/hatch/SKILL.md` and look for a `## Docker network requirements` heading. Also check `<plugin>/DOCKER.md`. Stop at the next `##` heading.
 3. Within that section, parse:
    - `### Domains (DNS allowlist)` — bullet entries are domain names. Validate against `^[a-z0-9][a-z0-9.-]+$`. Reject failing entries with a warning.

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -238,7 +238,7 @@ Mirror host-installed plugins into the container so the container starts with th
    The `marketplace_name` value passed to `is_safelisted` is the canonical name from the marketplace JSON; the `marketplace` value is the `org/repo`. Both come from step 7b.3. If you're about to pass `claude-code-homeassistant-hermit` to `is_safelisted` as the marketplace arg, you skipped the lookup — go back to step 3.
 
    Split into two groups:
-   - **SAFE** — `is_safelisted(marketplace)` is `True`. Examples: marketplace `claude-plugins-official`, marketplace `gtapps/claude-code-homeassistant-hermit`.
+   - **SAFE** — `is_safelisted(marketplace, marketplace_name)` is `True`. Examples: `marketplace_name == "claude-plugins-official"` (regardless of `marketplace`), or `marketplace == "gtapps/claude-code-homeassistant-hermit"`.
    - **THIRD-PARTY** — everything else. Examples: `obra/superpowers-marketplace`, any non-`gtapps` `org/repo`, any locally-added marketplace without a GitHub source.
 
    The SAFE group can be accepted as a batch. The THIRD-PARTY group **must be confirmed one-by-one**. Do not bulk-accept third-party plugins for the operator's convenience — the host list is the **candidate** set, not the trusted set.
@@ -280,7 +280,7 @@ Mirror host-installed plugins into the container so the container starts with th
     - Assert `marketplace_name` is non-empty and matches `^[A-Za-z0-9][\w.-]*$`.
     - Assert `marketplace` matches `^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$` (has a slash; is `org/repo`). This is now uniform — official entries store `anthropics/claude-plugins-official`, no more literal-name shortcut.
     - If any entry fails: **stop, do not write config.** Re-derive both identifiers from the `claude plugin marketplace list --json` output (look up `marketplace_name → repo`). If the lookup cannot produce both valid values, prompt the operator (same prompt as step 3). Re-run the assertion. Only proceed to step 7c once every entry passes.
-    - The assertion is uniform across official and third-party entries — every `marketplace` is an `org/repo` after this change, so there is no special case to remember.
+    - The assertion is uniform across official and third-party entries — every `marketplace` written from this skill is an `org/repo`, so there is no special case to remember at write time. Legacy configs at boot are still normalized by the entrypoint backfill paths (see the "Re-run backfill" section below and the entrypoint's per-entry fallback).
 
 11. If the filtered list is **empty** (no extras installed on the host), skip silently — no prompt, no entries written.
 

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -249,7 +249,7 @@ Mirror host-installed plugins into the container so the container starts with th
    Host-installed plugins detected (project + local scope only):
 
    Safelisted (trusted sources):
-     - claude-code-setup @ claude-plugins-official (project)
+     - claude-code-setup @ anthropics/claude-plugins-official (project)
      - claude-code-homeassistant-hermit @ gtapps/claude-code-homeassistant-hermit (project)
 
    Third-party (require individual opt-in):

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -203,16 +203,20 @@ Mirror host-installed plugins into the container so the container starts with th
 
 > **SECURITY-CRITICAL STEP.** Every plugin written here is auto-installed on container boot with `bypassPermissions` (full unrestricted execution). Do not shortcut the safelist, validation, or deselection rules below. If you find yourself about to skip one, stop and re-read this section.
 
-1. Run `claude plugin list --json` to enumerate plugins. Each entry has `id` (in the form `plugin@slug`), `scope`, `enabled`, and `projectPath`. **Keep only entries where:**
-   - `scope == "project"` **and** `projectPath` equals the current project root (the same `id` can appear multiple times for different projects — do not mirror another project's plugins), **OR**
-   - `scope == "local"`.
+1. Run `claude plugin list --json` to enumerate plugins. Each entry includes `id` (form `<plugin>@<marketplace_name>`), `scope`, `enabled`, `projectPath`, and `installPath`. Apply the **project-or-local + enabled filter**:
+   - Keep `enabled == true` AND (`scope == "project"` OR `scope == "local"`) AND `projectPath` equals the current project root.
+   - Drop user-scope, managed-scope, disabled, and cross-project entries entirely.
 
-   Drop `user`-scope entries entirely — those are the host user's personal choices across every project and do not belong in a project-specific container. If the operator wants a user-scope plugin in the container, they can install it at `project` scope on the host first and re-run this skill.
+   `claude plugin list --json` lists across the operator's full config — local-scope plugins from sibling repos carry their own `projectPath` and must be excluded.
+
+   **Dedupe rule.** After filtering, dedupe surviving entries by `(plugin, marketplace_name)`. If both a `project` and a `local` scope entry survive for the same `(plugin, marketplace_name)`, keep the `local` entry only — local is the override scope in Claude Code's overlay model. Different marketplaces remain distinct entries.
+
+   If the operator wants a user-scope plugin in the container, they install it at `project` scope on the host first and re-run this skill.
 2. Filter out additionally:
    - `claude-code-hermit@claude-code-hermit` — the entrypoint already handles it unconditionally.
    - Any channel plugins already picked up via `config.channels` (they flow through the entrypoint's channel branch).
-3. Run `claude plugin marketplace list --json` and build a slug → `repo` map from each entry's `name` (slug) and `repo` (`org/repo`) fields. Split each plugin `id` as `plugin@slug` and look up the slug in the map to get the full `org/repo`. The `marketplace` field written to `docker.recommended_plugins` must be `org/repo` — the entrypoint calls `claude plugin marketplace add <marketplace>` on first boot and a bare slug will fail.
-   - If a marketplace entry has `source != "github"` or no `repo` field (e.g. a locally-added marketplace), ask: "What's the GitHub source for the `<slug>` marketplace? (e.g. `org/repo`)" before presenting the plugin list.
+3. Run `claude plugin marketplace list --json` and build a `marketplace_name → repo` map from each entry's `name` and `repo` fields. Split each plugin `id` as `<plugin>@<marketplace_name>` and look up `marketplace_name` in the map to get the corresponding `org/repo`. Both identifiers are recorded on every entry — the `org/repo` is what the entrypoint passes to `claude plugin marketplace add`, and the `marketplace_name` is what the entrypoint uses to build the install target and locate the on-disk cache directory.
+   - If a marketplace entry has `source != "github"` or no `repo` field (e.g. a locally-added marketplace), ask: "What's the GitHub source for the `<marketplace_name>` marketplace? (e.g. `org/repo`)" before presenting the plugin list.
 
 4. **Validation gate — apply to every `org/repo` before it reaches the plugin list or `config.json`:**
    - Regex: `^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$`
@@ -223,14 +227,15 @@ Mirror host-installed plugins into the container so the container starts with th
 5. **Partition the filtered list using the safelist:**
 
    ```
-   def is_safelisted(marketplace):
-       return (
-           marketplace == "claude-plugins-official"
-           or marketplace.startswith("gtapps/")
-       )
+   def is_safelisted(marketplace, marketplace_name):
+       # Official: identified by canonical marketplace name.
+       if marketplace_name == "claude-plugins-official":
+           return True
+       # gtapps fleet: identified by org prefix on the org/repo.
+       return bool(marketplace) and marketplace.startswith("gtapps/")
    ```
 
-   The `marketplace` value passed to `is_safelisted` is the resolved `org/repo` from step 3 (or the literal string `claude-plugins-official` for official plugins) — **never** the slug from the `plugin@slug` id. If you're about to pass `claude-code-homeassistant-hermit` to `is_safelisted`, you skipped the lookup — go back to step 3.
+   The `marketplace_name` value passed to `is_safelisted` is the canonical name from the marketplace JSON; the `marketplace` value is the `org/repo`. Both come from step 7b.3. If you're about to pass `claude-code-homeassistant-hermit` to `is_safelisted` as the marketplace arg, you skipped the lookup — go back to step 3.
 
    Split into two groups:
    - **SAFE** — `is_safelisted(marketplace)` is `True`. Examples: marketplace `claude-plugins-official`, marketplace `gtapps/claude-code-homeassistant-hermit`.
@@ -272,18 +277,24 @@ Mirror host-installed plugins into the container so the container starts with th
 9. After both groups are processed: any plugin not explicitly confirmed must **not** be written to `docker.recommended_plugins`. Write only confirmed entries with `enabled: true`.
 
 10. **Write-time assertion — run this before handing entries to step 7c.** For each confirmed entry:
-    - If `marketplace == "claude-plugins-official"` → accept.
-    - Else assert `marketplace` matches `^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$` (has a slash; is `org/repo`).
-    - If any entry fails: **stop, do not write config.** Re-derive the failed entry's marketplace from the `claude plugin marketplace list --json` output (look up the slug → `repo`). If the lookup cannot produce a valid `org/repo`, prompt the operator for it (same prompt as step 3). Re-run the assertion. Only proceed to step 7c once every entry passes.
-    - This catches the common failure mode where the slug from `plugin@slug` in `claude plugin list` gets written as the marketplace field verbatim (e.g. `claude-code-homeassistant-hermit` instead of `gtapps/claude-code-homeassistant-hermit`). For `claude-plugins-official` entries both forms are identical, so the bug only surfaces on non-official plugins — don't let the official entries trick you into thinking the set is valid.
+    - Assert `marketplace_name` is non-empty and matches `^[A-Za-z0-9][\w.-]*$`.
+    - Assert `marketplace` matches `^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$` (has a slash; is `org/repo`). This is now uniform — official entries store `anthropics/claude-plugins-official`, no more literal-name shortcut.
+    - If any entry fails: **stop, do not write config.** Re-derive both identifiers from the `claude plugin marketplace list --json` output (look up `marketplace_name → repo`). If the lookup cannot produce both valid values, prompt the operator (same prompt as step 3). Re-run the assertion. Only proceed to step 7c once every entry passes.
+    - The assertion is uniform across official and third-party entries — every `marketplace` is an `org/repo` after this change, so there is no special case to remember.
 
 11. If the filtered list is **empty** (no extras installed on the host), skip silently — no prompt, no entries written.
 
 Record the confirmed selection as `docker.recommended_plugins`. Each entry has:
 ```json
-{"marketplace": "<marketplace-or-org/repo>", "plugin": "<plugin-name>", "scope": "<scope>", "enabled": true}
+{"plugin": "<plugin-name>", "marketplace": "<org/repo>", "marketplace_name": "<marketplace-name>", "scope": "<scope>", "enabled": true}
 ```
 The entrypoint adds the marketplace (if needed) and installs every enabled entry on first boot. See [Recommended Plugins](../../docs/recommended-plugins.md) for the full policy.
+
+**Re-run backfill.** When docker-setup re-runs against an existing config that has `docker.recommended_plugins` entries written before this change (missing `marketplace_name`):
+1. If an entry already has `marketplace_name`, leave it.
+2. If `marketplace` contains `/` (treat as `org/repo`): look it up in `claude plugin marketplace list --json` by `repo`. If found, set `marketplace_name = name`. If not registered, run `claude plugin marketplace add <repo>` once and re-query. If still not found, prompt: "What is the marketplace name for `<repo>`? (e.g. `openai-codex`)"
+3. If `marketplace` has no `/` (legacy literal-name shortcut, almost certainly `claude-plugins-official`): treat it as `marketplace_name`. Look up by `name` in the list to get `repo`. Set `marketplace_name = name` and rewrite `marketplace = repo`. If not found, prompt: "What is the `org/repo` for marketplace `<name>`?"
+4. Re-run the Step 7b.10 assertion. Reject any entry where backfill could not produce both valid fields.
 
 **On container-side `claude plugin marketplace add` / `plugin install` failure (either in entrypoint logs or when re-running the command manually after boot):** if the error mentions SSH auth, HTTPS credentials, `gh` not found, or `.gitconfig` read-only, **stop immediately — do not attempt workarounds inside the container.** The container has no SSH client, no `gh` CLI, and `.gitconfig` is bind-mounted read-only by design. Iterating on `GIT_CONFIG_NOSYSTEM`, `git config --global url...insteadOf`, or similar is guaranteed to fail and wastes the operator's time. Surface the error to the operator verbatim and move on — no retry unless the operator changes something host-side (makes the repo public, mirrors it, etc.) and asks to retry.
 

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -215,7 +215,7 @@ Mirror host-installed plugins into the container so the container starts with th
 2. Filter out additionally:
    - `claude-code-hermit@claude-code-hermit` — the entrypoint already handles it unconditionally.
    - Any channel plugins already picked up via `config.channels` (they flow through the entrypoint's channel branch).
-3. Run `claude plugin marketplace list --json` and build a `marketplace_name → repo` map from each entry's `name` and `repo` fields. Split each plugin `id` as `<plugin>@<marketplace_name>` and look up `marketplace_name` in the map to get the corresponding `org/repo`. Both identifiers are recorded on every entry — the `org/repo` is what the entrypoint passes to `claude plugin marketplace add`, and the `marketplace_name` is what the entrypoint uses to build the install target and locate the on-disk cache directory.
+3. Run `claude plugin marketplace list --json` and build a `marketplace_name → repo` map from each entry's `name` and `repo` fields. Split each plugin `id` as `<plugin>@<marketplace_name>` and look up `marketplace_name` in the map to get the `org/repo`. Only the `org/repo` is recorded on each `docker.recommended_plugins` entry — the entrypoint resolves the canonical marketplace name at boot via the same `marketplace list --json` lookup, so storing it twice would just duplicate the source of truth.
    - If a marketplace entry has `source != "github"` or no `repo` field (e.g. a locally-added marketplace), ask: "What's the GitHub source for the `<marketplace_name>` marketplace? (e.g. `org/repo`)" before presenting the plugin list.
 
 4. **Validation gate — apply to every `org/repo` before it reaches the plugin list or `config.json`:**
@@ -227,18 +227,18 @@ Mirror host-installed plugins into the container so the container starts with th
 5. **Partition the filtered list using the safelist:**
 
    ```
-   def is_safelisted(marketplace, marketplace_name):
-       # Official: identified by canonical marketplace name.
-       if marketplace_name == "claude-plugins-official":
-           return True
-       # gtapps fleet: identified by org prefix on the org/repo.
-       return bool(marketplace) and marketplace.startswith("gtapps/")
+   def is_safelisted(marketplace):
+       # marketplace is always org/repo after the step 7b.3 lookup — no literal-name shortcut.
+       return (
+           marketplace == "anthropics/claude-plugins-official"
+           or marketplace.startswith("gtapps/")
+       )
    ```
 
-   The `marketplace_name` value passed to `is_safelisted` is the canonical name from the marketplace JSON; the `marketplace` value is the `org/repo`. Both come from step 7b.3. If you're about to pass `claude-code-homeassistant-hermit` to `is_safelisted` as the marketplace arg, you skipped the lookup — go back to step 3.
+   The `marketplace` value passed to `is_safelisted` is always the `org/repo` resolved in step 7b.3 — never the marketplace name and never the slug from the `<plugin>@<name>` id. If you're about to pass `claude-code-homeassistant-hermit` (a slug) to `is_safelisted`, you skipped the lookup — go back to step 3.
 
    Split into two groups:
-   - **SAFE** — `is_safelisted(marketplace, marketplace_name)` is `True`. Examples: `marketplace_name == "claude-plugins-official"` (regardless of `marketplace`), or `marketplace == "gtapps/claude-code-homeassistant-hermit"`.
+   - **SAFE** — `is_safelisted(marketplace)` is `True`. Examples: `anthropics/claude-plugins-official`, `gtapps/claude-code-homeassistant-hermit`.
    - **THIRD-PARTY** — everything else. Examples: `obra/superpowers-marketplace`, any non-`gtapps` `org/repo`, any locally-added marketplace without a GitHub source.
 
    The SAFE group can be accepted as a batch. The THIRD-PARTY group **must be confirmed one-by-one**. Do not bulk-accept third-party plugins for the operator's convenience — the host list is the **candidate** set, not the trusted set.
@@ -277,24 +277,18 @@ Mirror host-installed plugins into the container so the container starts with th
 9. After both groups are processed: any plugin not explicitly confirmed must **not** be written to `docker.recommended_plugins`. Write only confirmed entries with `enabled: true`.
 
 10. **Write-time assertion — run this before handing entries to step 7c.** For each confirmed entry:
-    - Assert `marketplace_name` is non-empty and matches `^[A-Za-z0-9][\w.-]*$`.
-    - Assert `marketplace` matches `^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$` (has a slash; is `org/repo`). This is now uniform — official entries store `anthropics/claude-plugins-official`, no more literal-name shortcut.
-    - If any entry fails: **stop, do not write config.** Re-derive both identifiers from the `claude plugin marketplace list --json` output (look up `marketplace_name → repo`). If the lookup cannot produce both valid values, prompt the operator (same prompt as step 3). Re-run the assertion. Only proceed to step 7c once every entry passes.
-    - The assertion is uniform across official and third-party entries — every `marketplace` written from this skill is an `org/repo`, so there is no special case to remember at write time. Legacy configs at boot are still normalized by the entrypoint backfill paths (see the "Re-run backfill" section below and the entrypoint's per-entry fallback).
+    - Assert `marketplace` matches `^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$` (has a slash; is `org/repo`). Uniform across official and third-party entries — official stores `anthropics/claude-plugins-official`, no more literal-name shortcut.
+    - If any entry fails: **stop, do not write config.** Re-derive the failing entry's `org/repo` from the `claude plugin marketplace list --json` output (look up the marketplace name from the plugin's `id` to get the `repo`). If the lookup cannot produce a valid `org/repo`, prompt the operator (same prompt as step 3). Re-run the assertion. Only proceed to step 7c once every entry passes.
 
 11. If the filtered list is **empty** (no extras installed on the host), skip silently — no prompt, no entries written.
 
 Record the confirmed selection as `docker.recommended_plugins`. Each entry has:
 ```json
-{"plugin": "<plugin-name>", "marketplace": "<org/repo>", "marketplace_name": "<marketplace-name>", "scope": "<scope>", "enabled": true}
+{"plugin": "<plugin-name>", "marketplace": "<org/repo>", "scope": "<scope>", "enabled": true}
 ```
-The entrypoint adds the marketplace (if needed) and installs every enabled entry on first boot. See [Recommended Plugins](../../docs/recommended-plugins.md) for the full policy.
+The entrypoint resolves the canonical marketplace name at boot via `claude plugin marketplace list --json` (no need to store it on the entry), adds the marketplace if missing, and installs every enabled entry on first boot. See [Recommended Plugins](../../docs/recommended-plugins.md) for the full policy.
 
-**Re-run backfill.** When docker-setup re-runs against an existing config that has `docker.recommended_plugins` entries written before this change (missing `marketplace_name`):
-1. If an entry already has `marketplace_name`, leave it.
-2. If `marketplace` contains `/` (treat as `org/repo`): look it up in `claude plugin marketplace list --json` by `repo`. If found, set `marketplace_name = name`. If not registered, run `claude plugin marketplace add <repo>` once and re-query. If still not found, prompt: "What is the marketplace name for `<repo>`? (e.g. `openai-codex`)"
-3. If `marketplace` has no `/` (legacy literal-name shortcut, almost certainly `claude-plugins-official`): treat it as `marketplace_name`. Look up by `name` in the list to get `repo`. Set `marketplace_name = name` and rewrite `marketplace = repo`. If not found, prompt: "What is the `org/repo` for marketplace `<name>`?"
-4. Re-run the Step 7b.10 assertion. Reject any entry where backfill could not produce both valid fields.
+**Legacy config note.** Re-running this skill against a pre-v1.0.34 config rebuilds `docker.recommended_plugins` from scratch from the current host plugin list — legacy entries (e.g. `marketplace == "claude-plugins-official"` literal) are replaced cleanly. The entrypoint warns and skips any legacy entry whose `marketplace` is not an `org/repo` until the operator re-runs this skill once.
 
 **On container-side `claude plugin marketplace add` / `plugin install` failure (either in entrypoint logs or when re-running the command manually after boot):** if the error mentions SSH auth, HTTPS credentials, `gh` not found, or `.gitconfig` read-only, **stop immediately — do not attempt workarounds inside the container.** The container has no SSH client, no `gh` CLI, and `.gitconfig` is bind-mounted read-only by design. Iterating on `GIT_CONFIG_NOSYSTEM`, `git config --global url...insteadOf`, or similar is guaranteed to fail and wastes the operator's time. Surface the error to the operator verbatim and move on — no retry unless the operator changes something host-side (makes the repo public, mirrors it, etc.) and asks to retry.
 

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -25,9 +25,13 @@ Before the setup-mode gate or any file writes, gather context silently. Run all 
    - Timezone: `cat /etc/timezone 2>/dev/null || timedatectl show -p Timezone --value 2>/dev/null || date +%Z` (fallback: `UTC`)
 
 2. **Silent hermit detection** (the silent half of Step 3 — split out so it's available before the mode gate without an operator prompt):
-   - Glob: `${CLAUDE_PLUGIN_ROOT}/../*/.claude-plugin/plugin.json`
-   - Read each found `plugin.json` and identify entries where the `name` field contains "hermit" but is NOT "claude-code-hermit"
-   - Stash the candidate list as `detected_hermits` for use later in Step 3 (Advanced) or Quick Turn 1.
+   - Run: `claude plugin list --json`
+   - Apply the **project-or-local + enabled filter**:
+     - Keep `enabled == true` AND (`scope == "project"` OR `scope == "local"`) AND `projectPath` equals the current project root.
+     - Drop user-scope, managed-scope, disabled, and cross-project entries.
+   - For each surviving entry, parse the plugin name from `id` (substring left of `@`). Keep entries whose plugin name contains "hermit" but is NOT "claude-code-hermit".
+   - Stash the resulting list as `detected_hermits`. Each entry must carry: `plugin` (id left of `@`), `id` (full JSON field), `marketplace_name` (id right of `@`), `installPath` (JSON `installPath` field — Step 3 reads `state-templates/CLAUDE-APPEND.md` and `plugin.json` from this path directly).
+   - Note: this is intentionally restrictive. A hermit installed at user scope (a personal default across projects) does NOT auto-detect — operator can install it at project scope and re-run, or activate via `/hermit-settings`.
 
 3. **Print one summary line** so the operator sees what was detected:
 
@@ -135,9 +139,9 @@ Use the `detected_hermits` list cached in Step 1.5 (no re-globbing).
 
 If the list is non-empty:
 - Present the candidates and ask: "Activate a hermit for this project?"
-- If the operator selects one:
-  - Read that hermit's `state-templates/CLAUDE-APPEND.md` and append it to the target project's CLAUDE.md (after the core append in step 5).
-  - Read its `plugin.json`: if it declares a `hermit.boot_skill` field (e.g. `"/claude-code-homeassistant-hermit:ha-boot"`), record it for step 5 to write as `boot_skill` in `config.json`. This replaces the default `/claude-code-hermit:session` bootstrap so the domain hermit's custom boot logic fires on every always-on launch. If the field is absent, leave `boot_skill` unset (core behavior).
+- If the operator selects one: record the full entry from `detected_hermits` as `activated_hermit` (carries `plugin`, `id`, `marketplace_name`, `installPath`).
+  - Read `<activated_hermit.installPath>/state-templates/CLAUDE-APPEND.md` and append it to the target project's CLAUDE.md (after the core append in step 5).
+  - Read `<activated_hermit.installPath>/.claude-plugin/plugin.json`: if it declares a `hermit.boot_skill` field (e.g. `"/claude-code-homeassistant-hermit:ha-boot"`), record it for step 5 to write as `boot_skill` in `config.json`. This replaces the default `/claude-code-hermit:session` bootstrap so the domain hermit's custom boot logic fires on every always-on launch. If the field is absent, leave `boot_skill` unset (core behavior).
 - If the list is empty or the operator declines: skip.
 
 ### 4. Setup wizard
@@ -483,7 +487,7 @@ Tell the operator before Call 1: "I've scanned your project and drafted OPERATOR
 
 All questions use the `AskUserQuestion` structures defined above. Accept short answers or free-text via Other; expand into prose in Phase 4. If the operator selects "Skip", leaves Other blank, or gives a minimal answer, don't include that topic in OPERATOR.md.
 
-**Hermit extension:** If a hermit was activated in step 3 and provides a file at `state-templates/OPERATOR-QUESTIONS.md`, read it and append those questions to Call 2 (or start a Call 3 if Call 2 is already at 4).
+**Hermit extension:** If a hermit was activated in step 3 and provides a file at `<activated_hermit.installPath>/state-templates/OPERATOR-QUESTIONS.md`, read it and append those questions to Call 2 (or start a Call 3 if Call 2 is already at 4).
 
 #### Phase 4 — Write final OPERATOR.md
 
@@ -513,7 +517,7 @@ Tell the operator: "OPERATOR.md is ready. You can review it at `.claude-code-her
   - If no: read `${CLAUDE_SKILL_DIR}/../../state-templates/CLAUDE-APPEND.md` and append its contents to the end of CLAUDE.md
 - If CLAUDE.md doesn't exist: create it with the append block as the initial content
 
-If a hermit was activated in step 3, also append its CLAUDE-APPEND.md here (using the same skip/overwrite logic if its marker already exists).
+If a hermit was activated in step 3, also append `<activated_hermit.installPath>/state-templates/CLAUDE-APPEND.md` here (using the same skip/overwrite logic if its marker already exists).
 
 ### 7. Update .gitignore
 
@@ -653,7 +657,7 @@ Replaces Steps 3-4 with batched turns + confirm; resumes shared Steps 5-9 after 
 
 Only fires if `detected_hermits` from Step 1.5 is non-empty. Same prompt shape as Step 3 of the Advanced branch — uses the cached candidate list, does not re-glob. If multiple hermits detected, list all + Skip. If none, this turn is skipped entirely.
 
-If a hermit is selected: read its `state-templates/CLAUDE-APPEND.md` and stash for Step 6's CLAUDE.md append; read its `plugin.json` for `hermit.boot_skill` and stash for Step 5's config write.
+If a hermit is selected: record the full entry from `detected_hermits` as `activated_hermit` (carries `plugin`, `id`, `marketplace_name`, `installPath`). Read `<activated_hermit.installPath>/state-templates/CLAUDE-APPEND.md` and stash for Step 6's CLAUDE.md append. Read `<activated_hermit.installPath>/.claude-plugin/plugin.json` for the `hermit.boot_skill` field and stash for Step 5's config write.
 
 ### Quick Turn 2 — Identity batch (one `AskUserQuestion`, 3 questions)
 

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -125,17 +125,21 @@ If `.claude-code-hermit/cortex-manifest.json` does not exist:
 
 ### 7. Hermit upgrades
 
-- Detect installed hermits: scan `${CLAUDE_PLUGIN_ROOT}/../*/.claude-plugin/plugin.json` for names containing "hermit" that aren't "claude-code-hermit"
-- **Gate on `_hermit_versions` key existence** — only consider a hermit for upgrade when its name is *already* a key in `_hermit_versions`. The monorepo marketplace cache surfaces every sibling plugin under `${CLAUDE_PLUGIN_ROOT}/../*` regardless of what the operator actually installed; without this gate the skill would execute uninstalled siblings' Upgrade Instructions and append their CLAUDE-APPEND blocks. Initial activation is owned by the hermit's own `hatch` skill, which is what writes the key.
+- Detect installed hermits: run `claude plugin list --json`, then apply the **project-or-local + enabled filter**:
+  - Keep `enabled == true` AND (`scope == "project"` OR `scope == "local"`) AND `projectPath` equals the current project root.
+  - Drop user-scope, managed-scope, disabled, and cross-project entries.
+
+  Then keep entries whose plugin name (substring of `id` left of `@`) contains "hermit" but is NOT "claude-code-hermit". Use `installPath` for each entry as the source of `plugin.json`, `CHANGELOG.md`, and `state-templates/CLAUDE-APPEND.md`.
+- **Gate on `_hermit_versions` key existence** — only consider a hermit for upgrade when its name is *already* a key in `_hermit_versions`. Without this gate the skill would execute uninstalled hermits' Upgrade Instructions and append their CLAUDE-APPEND blocks. Initial activation is owned by the hermit's own `hatch` skill, which is what writes the key.
 - For each gated hermit:
-  - Read the hermit's `plugin.json` version
+  - Read `<installPath>/.claude-plugin/plugin.json` for the current version
   - Compare against `_hermit_versions[hermit_name]`
   - If version gap exists:
-    - Read the hermit's `CHANGELOG.md` if it exists and extract version entries between the config version (exclusive) and the current version (inclusive)
+    - Read `<installPath>/CHANGELOG.md` if it exists and extract version entries between the config version (exclusive) and the current version (inclusive)
     - Present a summary: "{hermit_name}: upgrading from vOLD to vNEW. Here's what changed:" followed by only the relevant changelog sections
     - **Execute migrations in version order** — For each extracted version entry (oldest first), look for a `### Upgrade Instructions` section. If found, execute every instruction in that section — do not skip or merely display them.
     - **Sync hermit's CLAUDE-APPEND block** — Same procedure as step 6, using:
-      - Source template: the hermit's `state-templates/CLAUDE-APPEND.md`. If it doesn't exist, skip.
+      - Source template: `<installPath>/state-templates/CLAUDE-APPEND.md`. If it doesn't exist, skip.
       - Marker: the first HTML comment line in that template (e.g. `<!-- hermit-name: Section Title -->`)
     - Update `_hermit_versions[hermit_name]` to the current hermit version
   - If no gap: skip silently

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -302,16 +302,20 @@ Update `permission_mode` in config.json.
   Recommended Plugins (config.json docker.recommended_plugins)
 
     [enabled]  claude-code-setup (claude-plugins-official) — auto-installed on boot
-    [enabled]  claude-code-homeassistant-hermit (gtapps/claude-code-homeassistant-hermit) — auto-installed on boot
+    [enabled]  claude-code-homeassistant-hermit (claude-code-homeassistant-hermit) — auto-installed on boot
 
   (or "No recommended plugins configured" if empty)
   ```
+  Display each entry as `[enabled/disabled]  <plugin> (<marketplace_name>)` — use `marketplace_name` in the parens, not the full `org/repo` field (reads cleaner; matches the right side of `@` in `claude plugin list` output).
 - Ask: "Enable, disable, add, or remove recommended plugins? (e.g., 'enable claude-code-setup', 'add claude-code-setup', 'add superpowers obra/superpowers-marketplace', 'remove superpowers', or 'done') [done]"
 - Loop until operator says "done", "skip", or presses Enter:
   - `enable <PLUGIN>`: set `enabled: true` on matching entry
   - `disable <PLUGIN>`: set `enabled: false` on matching entry
   - `remove <PLUGIN>`: remove the entry entirely
-  - `add <PLUGIN> [<MARKETPLACE>]`: add new entry with `marketplace` (`"claude-plugins-official"` if omitted), `scope: "project"`, `enabled: true`. Deduplicate by plugin name.
+  - `add <PLUGIN> [<MARKETPLACE>]`: add new entry with `scope: "project"`, `enabled: true`. `<MARKETPLACE>` is an `org/repo` (e.g. `obra/superpowers-marketplace`) or omitted (defaults to official).
+    - If omitted: set `marketplace = "anthropics/claude-plugins-official"` and `marketplace_name = "claude-plugins-official"`.
+    - If `org/repo`: run `claude plugin marketplace list --json` and look up by `repo`. If found, set `marketplace = <repo>` and `marketplace_name = <name>`. If not found, prompt: "Marketplace `<repo>` is not registered locally. Add it with `claude plugin marketplace add <repo>` first, then re-try." Abort the add.
+    - **Dedupe rule**: an entry is a duplicate when an existing entry has the same `(plugin, marketplace_name)` pair — scope is NOT part of the key. If a duplicate is found, refuse: "An entry for `<plugin>@<marketplace_name>` already exists. Use `enable <PLUGIN>` to toggle it, or `remove <PLUGIN>` first to replace it."
   - If input is just a plugin name without a verb: treat as `enable` if it exists, `add` if it doesn't
 - After changes, note: "Restart container to install new plugins: `.claude-code-hermit/bin/hermit-docker restart`"
 

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -306,16 +306,13 @@ Update `permission_mode` in config.json.
 
   (or "No recommended plugins configured" if empty)
   ```
-  Display each entry as `[enabled/disabled]  <plugin> (<marketplace_name>)` — use `marketplace_name` in the parens, not the full `org/repo` field (reads cleaner; matches the right side of `@` in `claude plugin list` output).
+  Display each entry as `[enabled/disabled]  <plugin> (<marketplace>)` — show the `org/repo` (the `marketplace` field) in parens.
 - Ask: "Enable, disable, add, or remove recommended plugins? (e.g., 'enable claude-code-setup', 'add claude-code-setup', 'add superpowers obra/superpowers-marketplace', 'remove superpowers', or 'done') [done]"
 - Loop until operator says "done", "skip", or presses Enter:
   - `enable <PLUGIN>`: set `enabled: true` on matching entry
   - `disable <PLUGIN>`: set `enabled: false` on matching entry
   - `remove <PLUGIN>`: remove the entry entirely
-  - `add <PLUGIN> [<MARKETPLACE>]`: add new entry with `scope: "project"`, `enabled: true`. `<MARKETPLACE>` is an `org/repo` (e.g. `obra/superpowers-marketplace`) or omitted (defaults to official).
-    - If omitted: set `marketplace = "anthropics/claude-plugins-official"` and `marketplace_name = "claude-plugins-official"`.
-    - If `org/repo`: run `claude plugin marketplace list --json` and look up by `repo`. If found, set `marketplace = <repo>` and `marketplace_name = <name>`. If not found, prompt: "Marketplace `<repo>` is not registered locally. Add it with `claude plugin marketplace add <repo>` first, then re-try." Abort the add.
-    - **Dedupe rule**: an entry is a duplicate when an existing entry has the same `(plugin, marketplace_name)` pair — scope is NOT part of the key. If a duplicate is found, refuse: "An entry for `<plugin>@<marketplace_name>` already exists. Use `enable <PLUGIN>` to toggle it, or `remove <PLUGIN>` first to replace it."
+  - `add <PLUGIN> [<MARKETPLACE>]`: add new entry with `scope: "project"`, `enabled: true`. `<MARKETPLACE>` is an `org/repo` (e.g. `obra/superpowers-marketplace`) or omitted (defaults to `anthropics/claude-plugins-official`). If `<MARKETPLACE>` is provided but not registered locally, prompt: "Marketplace `<MARKETPLACE>` is not registered locally. Add it with `claude plugin marketplace add <MARKETPLACE>` first, then re-try." Abort the add. **Dedupe rule:** refuse the add if an existing entry has the same `(plugin, marketplace)` pair (scope is NOT part of the key) — operator should `enable` or `remove` first.
   - If input is just a plugin name without a verb: treat as `enable` if it exists, `add` if it doesn't
 - After changes, note: "Restart container to install new plugins: `.claude-code-hermit/bin/hermit-docker restart`"
 

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -289,7 +289,8 @@ if [ "$NEEDS_OFFICIAL" = true ] && [ -n "$CHANNELS" ]; then
 fi
 
 # Recommended plugins (enabled entries extracted from config.json above)
-# Mirrors the host-installed plugin set confirmed during docker-setup (project + user scope).
+# Mirrors the host-installed plugin set confirmed during docker-setup
+# (project + local scope, both pinned to the host project's projectPath; user-scope is intentionally not mirrored).
 # Each entry may reference any marketplace — the entrypoint adds it on first boot as needed.
 # Operator confirmed these plugins during docker-setup, so no auto-install guard is needed.
 if [ -n "$RECOMMENDED_PLUGINS_JSON" ] && [ "$RECOMMENDED_PLUGINS_JSON" != "[]" ]; then
@@ -301,8 +302,9 @@ if [ -n "$RECOMMENDED_PLUGINS_JSON" ] && [ "$RECOMMENDED_PLUGINS_JSON" != "[]" ]
 import json, os, subprocess, sys, time
 
 plugins = json.loads(sys.argv[1])
-# 'claude plugin list' output is free-form ('  ❯ plugin@slug' plus Version/Scope lines).
-# Substring match against the whole blob is more robust than exact-line set membership.
+# 'claude plugin list' output is free-form: each plugin appears as '  ❯ plugin@slug'.
+# Matching on '❯ {target}' pins the check to the entry line, preventing false positives
+# where a short target (e.g. 'hermit@foo') is a substring of a longer entry.
 installed_blob = sys.argv[2]
 marketplace_dir = sys.argv[3]
 audit_log_path = sys.argv[4] if len(sys.argv) > 4 else ''
@@ -324,12 +326,30 @@ def audit(marketplace, plugin, scope):
 
 for entry in plugins:
     plugin = entry['plugin']
-    marketplace = entry.get('marketplace', 'claude-plugins-official')
+    marketplace = entry.get('marketplace', 'anthropics/claude-plugins-official')
+    marketplace_name = entry.get('marketplace_name')
     scope = entry.get('scope', 'project')
 
-    slug = marketplace.split('/')[-1] if '/' in marketplace else marketplace
+    if not marketplace_name:
+        # Backward-compat for configs written before marketplace_name was tracked.
+        if '/' in marketplace:
+            # Legacy org/repo entry: name happens to equal repo basename for gtapps/*.
+            marketplace_name = marketplace.split('/')[-1]
+            print(f'[docker-entrypoint] Warning: {plugin} entry missing marketplace_name, derived "{marketplace_name}" from repo basename — re-run /docker-setup to backfill', flush=True)
+        elif marketplace == 'claude-plugins-official':
+            # Pre-schema configs stored the bare marketplace name here instead of org/repo.
+            # Normalize marketplace to the real org/repo so the `marketplace add` call succeeds.
+            marketplace_name = 'claude-plugins-official'
+            marketplace = 'anthropics/claude-plugins-official'
+            print(f'[docker-entrypoint] Warning: {plugin} entry uses legacy official literal — normalized to "anthropics/claude-plugins-official"; re-run /docker-setup to backfill', flush=True)
+        else:
+            # Unresolvable: cannot safely guess which GitHub repo this name maps to.
+            # Attempting marketplace add with an unknown value risks cloning the wrong
+            # repo under bypassPermissions. Skip; operator must re-run /docker-setup.
+            print(f'[docker-entrypoint] Warning: {plugin} entry has unresolvable legacy marketplace "{marketplace}" — skipping. Re-run /docker-setup to backfill marketplace_name + marketplace.', flush=True)
+            continue
 
-    if not os.path.isdir(os.path.join(marketplace_dir, slug)):
+    if not os.path.isdir(os.path.join(marketplace_dir, marketplace_name)):
         print(f'[docker-entrypoint] Adding marketplace: {marketplace}', flush=True)
         try:
             result = subprocess.run(['claude', 'plugin', 'marketplace', 'add', marketplace], check=False)
@@ -340,8 +360,8 @@ for entry in plugins:
             print(f'[docker-entrypoint] Warning: failed to add marketplace {marketplace} — skipping {plugin}', flush=True)
             continue
 
-    install_target = f'{plugin}@{slug}'
-    if install_target in installed_blob:
+    install_target = f'{plugin}@{marketplace_name}'
+    if f'❯ {install_target}' in installed_blob:
         continue
     print(f'[docker-entrypoint] Installing recommended plugin: {plugin}', flush=True)
     try:

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -324,32 +324,39 @@ def audit(marketplace, plugin, scope):
     except Exception as e:
         print(f'[docker-entrypoint] Warning: audit log write failed: {e}', flush=True)
 
+# Resolve marketplace canonical names from the CLI's source of truth. We need the
+# 'name' field to build install targets (<plugin>@<name>) and check the on-disk
+# cache dir (which is keyed by name). Storing both name and org/repo in config
+# would just duplicate this lookup; one subprocess call here is cheaper than a
+# permanent schema bifurcation.
+def fetch_marketplace_names():
+    try:
+        result = subprocess.run(['claude', 'plugin', 'marketplace', 'list', '--json'],
+                                capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            return {}
+        return {m.get('repo'): m.get('name') for m in json.loads(result.stdout) if m.get('repo')}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+name_by_repo = fetch_marketplace_names()
+
 for entry in plugins:
     plugin = entry['plugin']
     marketplace = entry.get('marketplace', 'anthropics/claude-plugins-official')
-    marketplace_name = entry.get('marketplace_name')
     scope = entry.get('scope', 'project')
 
-    if not marketplace_name:
-        # Backward-compat for configs written before marketplace_name was tracked.
-        if '/' in marketplace:
-            # Legacy org/repo entry: name happens to equal repo basename for gtapps/*.
-            marketplace_name = marketplace.split('/')[-1]
-            print(f'[docker-entrypoint] Warning: {plugin} entry missing marketplace_name, derived "{marketplace_name}" from repo basename — re-run /docker-setup to backfill', flush=True)
-        elif marketplace == 'claude-plugins-official':
-            # Pre-schema configs stored the bare marketplace name here instead of org/repo.
-            # Normalize marketplace to the real org/repo so the `marketplace add` call succeeds.
-            marketplace_name = 'claude-plugins-official'
-            marketplace = 'anthropics/claude-plugins-official'
-            print(f'[docker-entrypoint] Warning: {plugin} entry uses legacy official literal — normalized to "anthropics/claude-plugins-official"; re-run /docker-setup to backfill', flush=True)
-        else:
-            # Unresolvable: cannot safely guess which GitHub repo this name maps to.
-            # Attempting marketplace add with an unknown value risks cloning the wrong
-            # repo under bypassPermissions. Skip; operator must re-run /docker-setup.
-            print(f'[docker-entrypoint] Warning: {plugin} entry has unresolvable legacy marketplace "{marketplace}" — skipping. Re-run /docker-setup to backfill marketplace_name + marketplace.', flush=True)
-            continue
+    # Schema check: marketplace must be org/repo. Pre-v1.0.34 entries that stored
+    # the literal name (e.g. 'claude-plugins-official' instead of
+    # 'anthropics/claude-plugins-official') hit this path. One warning, skip,
+    # operator re-runs /docker-setup to rebuild config from the current host plugin list.
+    if '/' not in marketplace:
+        print(f'[docker-entrypoint] Warning: {plugin} entry has outdated marketplace \"{marketplace}\" (expected org/repo) — re-run /claude-code-hermit:docker-setup to rebuild config.', flush=True)
+        continue
 
-    if not os.path.isdir(os.path.join(marketplace_dir, marketplace_name)):
+    marketplace_name = name_by_repo.get(marketplace)
+    if not marketplace_name:
+        # Marketplace not yet registered in this container — add it, then re-fetch.
         print(f'[docker-entrypoint] Adding marketplace: {marketplace}', flush=True)
         try:
             result = subprocess.run(['claude', 'plugin', 'marketplace', 'add', marketplace], check=False)
@@ -358,6 +365,11 @@ for entry in plugins:
             continue
         if result.returncode != 0:
             print(f'[docker-entrypoint] Warning: failed to add marketplace {marketplace} — skipping {plugin}', flush=True)
+            continue
+        name_by_repo = fetch_marketplace_names()
+        marketplace_name = name_by_repo.get(marketplace)
+        if not marketplace_name:
+            print(f'[docker-entrypoint] Warning: marketplace {marketplace} added but name not resolvable — skipping {plugin}', flush=True)
             continue
 
     install_target = f'{plugin}@{marketplace_name}'


### PR DESCRIPTION
### Fixed

- **Plugin detection scoped to project/local only across five skills.** `/hatch` Step 1.5, `/docker-setup` Step 7b.1, `/docker-security` Step 3a, `/hermit-evolve` Step 7, and `/channel-setup` Step 3 all enumerated installed plugins without pinning `projectPath` to the current project root. `claude plugin list --json` returns entries for all projects in the operator's config, so a bare `scope == "local"` predicate leaked plugins from sibling repos. All five sites now apply the canonical filter: `enabled == true AND (scope == "project" OR scope == "local") AND projectPath == cwd`. User-scope plugins are explicitly dropped. `/hatch` and `/hermit-evolve` also replace the `${CLAUDE_PLUGIN_ROOT}/../*` disk glob with the JSON list so the install root is read from `installPath` rather than inferred by path proximity. `/hatch`'s `detected_hermits` stash now carries `installPath` so downstream Steps 3, 5a, 6, and Quick Turn 1 read files from the resolved install path.

- **`docker.recommended_plugins` now stores both marketplace identifiers.** The entrypoint was deriving install target and cache-dir key from `marketplace.split('/')[-1]`, which breaks when the marketplace `name` differs from the repo basename (e.g. `openai/codex-plugin-cc` → name `openai-codex`). Each entry now carries `marketplace` (`org/repo` for `marketplace add`) and `marketplace_name` (canonical name for install targets and the `~/.claude/plugins/cache/<name>/` key). Official entries switch from the legacy `"claude-plugins-official"` shortcut to `{"marketplace": "anthropics/claude-plugins-official", "marketplace_name": "claude-plugins-official"}`. Backward-compat fallback paths handle legacy configs. The already-installed check switches from bare substring to `❯ {target}` prefix match, preventing false positives where a short plugin name is a substring of a longer entry.

### Files affected

| File | Change |
|------|--------|
| `skills/hatch/SKILL.md` | Step 1.5 uses `claude plugin list --json` + filter; stash carries `installPath`; downstream steps read from `installPath` |
| `skills/docker-setup/SKILL.md` | Step 7b.1 filter tightened; dedupe rule added; Step 7b.3/5/10 updated for dual identifiers; backfill section added |
| `skills/docker-security/SKILL.md` | Step 3a filter tightened; `path` field → `installPath` |
| `skills/hermit-evolve/SKILL.md` | Step 7 replaces disk glob with `claude plugin list --json` + filter; reads from `installPath` |
| `skills/channel-setup/SKILL.md` | Step 3 replaces unstructured grep with JSON + filter; adds `marketplace_name` gate; adds explicit `plugin enable` |
| `skills/hermit-settings/SKILL.md` | Display renders `marketplace_name`; `add` action writes both identifiers with dedupe-by-(plugin, marketplace_name) |
| `state-templates/docker/docker-entrypoint.hermit.sh.template` | Install loop uses `marketplace_name` for cache-dir check and install target; legacy fallback paths; `❯` prefix match for already-installed guard |
| `docs/config-reference.md` | `recommended_plugins` schema adds `marketplace_name` row; example entry updated |
| `docs/recommended-plugins.md` | Config format table adds `marketplace_name` row |

### Upgrade Instructions

Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:

1. **Refresh skill spec** — the updated skill text loads on the next invocation of each affected skill. No state files or templates change.

To pick up the entrypoint `marketplace_name` fix in a running Docker container:

2. **Rebuild your container** — run `.claude-code-hermit/bin/hermit-docker update`. This rebuilds the image with the updated entrypoint and refreshes plugin marketplaces. Required only if you use Docker and have non-`gtapps` third-party recommended plugins whose marketplace `name` differs from their repo basename.

**Note:** Existing `docker.recommended_plugins` entries without `marketplace_name` continue to work via the backward-compat fallback (warning printed on boot); run `/docker-setup` to backfill both identifiers cleanly.

---
> ⚠️ **Merge as merge commit — not squash or rebase.** Squash changes the SHA and strands the release tag on an orphan commit. After merging, run `/release claude-code-hermit` from `main` to tag.