### PR TITLE
cache-edit-guard: warn (or block) Edit/Write to marketplace cache copies

### DIFF
--- a/plugins/claude-code-hermit/hooks/hooks.json
+++ b/plugins/claude-code-hermit/hooks/hooks.json
@@ -11,6 +11,17 @@
           }
         ],
         "description": "Enforce deny-patterns (always_on incl. OPERATOR.md only when AGENT_HOOK_PROFILE=strict), warn on template edits"
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/cache-edit-guard.js",
+            "timeout": 3
+          }
+        ],
+        "description": "Warn (or block, with HERMIT_CACHE_GUARD=block) when editing a marketplace cache copy whose runtime source is canonical"
       }
     ],
     "PostToolUse": [

--- a/plugins/claude-code-hermit/scripts/cache-edit-guard.js
+++ b/plugins/claude-code-hermit/scripts/cache-edit-guard.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * PreToolUse hook — warn (or block) when Edit/Write targets a marketplace cache copy.
+ *
+ * Project-local marketplaces declare `"source": "<relative-path>"` in marketplace.json
+ * and the runtime loads plugin code from the source. The directory under
+ * `.claude/plugins/cache/<marketplace>/<plugin>/<version>/` is a stale snapshot —
+ * silent edits to the cache produce no-ops at runtime and waste debugging time.
+ *
+ * On a cache-path target, this hook prints the canonical source path to stderr
+ * and exits 0 (warn, don't block) so debugging workflows still work. Set
+ * `HERMIT_CACHE_GUARD=block` to upgrade the warning into a hard block (exit 2).
+ *
+ * Non-cache paths, non-Edit/Write tool calls, or remote-source plugins → silent
+ * passthrough (exit 0). Failures to parse stdin or marketplace.json fail open.
+ */
+
+const MAX_STDIN = 64 * 1024;
+const CACHE_RE = /(?:^|\/)\.claude\/plugins\/cache\/([^/]+)\/([^/]+)\/([^/]+)\/(.*)$/;
+
+function readEvent(callback) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    raw += chunk;
+    if (raw.length > MAX_STDIN) process.exit(0);
+  });
+  process.stdin.on('end', () => {
+    try {
+      callback(JSON.parse(raw));
+    } catch (_e) {
+      process.exit(0);
+    }
+  });
+  process.stdin.on('error', () => process.exit(0));
+}
+
+function findProjectMarketplace(start) {
+  let dir = path.resolve(start);
+  while (true) {
+    const candidate = path.join(dir, '.claude-plugin', 'marketplace.json');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function resolveSourceRoot(marketplaceFile, marketplaceName, pluginName) {
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(marketplaceFile, 'utf8'));
+  } catch (_e) {
+    return null;
+  }
+  if (manifest.name !== marketplaceName) return null;
+  const plugins = Array.isArray(manifest.plugins) ? manifest.plugins : [];
+  const entry = plugins.find(p => p && p.name === pluginName);
+  if (!entry) return null;
+  const src = entry.source;
+  if (typeof src !== 'string') return null; // remote git refs are objects — skip
+  const projectRoot = path.dirname(path.dirname(marketplaceFile));
+  return path.resolve(projectRoot, src);
+}
+
+function main() {
+  readEvent(event => {
+    const name = event && event.tool_name;
+    if (name !== 'Edit' && name !== 'Write') process.exit(0);
+
+    const input = (event && event.tool_input) || {};
+    const filePath = input.file_path || input.path || '';
+    if (!filePath) process.exit(0);
+
+    const m = filePath.match(CACHE_RE);
+    if (!m) process.exit(0);
+
+    const [, marketplaceName, pluginName, , relInsideVersion] = m;
+
+    const marketplaceFile = findProjectMarketplace(process.cwd());
+    if (!marketplaceFile) process.exit(0);
+
+    const sourceRoot = resolveSourceRoot(marketplaceFile, marketplaceName, pluginName);
+    if (!sourceRoot) process.exit(0);
+
+    const canonical = path.join(sourceRoot, relInsideVersion);
+    const blockMode = process.env.HERMIT_CACHE_GUARD === 'block';
+    const verb = blockMode ? 'BLOCKED' : 'WARNING';
+
+    process.stderr.write(
+      `[hermit] ${verb}: ${name} target is a marketplace cache copy.\n` +
+      `[hermit]   path:   ${filePath}\n` +
+      `[hermit]   source: ${canonical}\n` +
+      `[hermit]   Runtime loads from the source path; cache edits are lost on next plugin install.\n` +
+      `[hermit]   ${blockMode ? 'Unset HERMIT_CACHE_GUARD or set it to "warn" to allow.' : 'Set HERMIT_CACHE_GUARD=block to make this a hard error.'}\n`
+    );
+    process.exit(blockMode ? 2 : 0);
+  });
+}
+
+main();

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -378,6 +378,123 @@ class TestHookOutputs(_TempDirTest):
 
 
 # ============================================================
+# cache-edit-guard hook
+# ============================================================
+
+class TestCacheEditGuard(_TempDirTest):
+    """cache-edit-guard.js — silent-breakage zone.
+
+    Project-local marketplaces load from `source` at runtime; cache copies are
+    stale. Editing a cache file works *until* the bridge restarts and the source
+    is read instead. The guard must catch this.
+    """
+
+    SCRIPT = REPO / 'scripts' / 'cache-edit-guard.js'
+
+    def _run_guard(self, event, env_extra=None):
+        env = os.environ.copy()
+        env['CLAUDE_PLUGIN_ROOT'] = str(REPO)
+        if env_extra:
+            env.update(env_extra)
+        result = subprocess.run(
+            ['node', str(self.SCRIPT)],
+            input=json.dumps(event), capture_output=True, text=True,
+            cwd=self._tmpdir, env=env, timeout=10,
+        )
+        return result.stdout, result.stderr, result.returncode
+
+    def _seed_marketplace(self, plugin_source):
+        """Write .claude-plugin/marketplace.json + create the plugin source dir."""
+        os.makedirs('.claude-plugin', exist_ok=True)
+        manifest = {
+            'name': 'example-marketplace',
+            'plugins': [{'name': 'sample-plugin', 'source': plugin_source}],
+        }
+        with open('.claude-plugin/marketplace.json', 'w') as f:
+            json.dump(manifest, f)
+        if isinstance(plugin_source, str):
+            os.makedirs(plugin_source.lstrip('./'), exist_ok=True)
+
+    def _cache_path(self, *parts):
+        rel = os.path.join('.claude/plugins/cache/example-marketplace/sample-plugin/0.1.0', *parts)
+        return os.path.join(self._tmpdir, rel)
+
+    def test_cache_edit_warns_with_source_path(self):
+        self._seed_marketplace('./services/sample-plugin')
+        stdout, stderr, code = self._run_guard({
+            'tool_name': 'Edit',
+            'tool_input': {'file_path': self._cache_path('server.ts')},
+        })
+        self.assertEqual(code, 0)
+        self.assertIn('WARNING', stderr)
+        self.assertIn('marketplace cache copy', stderr)
+        self.assertIn('services/sample-plugin/server.ts', stderr)
+
+    def test_block_mode_exits_2(self):
+        self._seed_marketplace('./services/sample-plugin')
+        stdout, stderr, code = self._run_guard(
+            {
+                'tool_name': 'Write',
+                'tool_input': {'file_path': self._cache_path('server.ts')},
+            },
+            env_extra={'HERMIT_CACHE_GUARD': 'block'},
+        )
+        self.assertEqual(code, 2)
+        self.assertIn('BLOCKED', stderr)
+
+    def test_remote_source_skipped(self):
+        # Remote git refs are objects — guard must skip silently.
+        self._seed_marketplace({'source': 'github', 'repo': 'someone/sample-plugin'})
+        stdout, stderr, code = self._run_guard({
+            'tool_name': 'Edit',
+            'tool_input': {'file_path': self._cache_path('server.ts')},
+        })
+        self.assertEqual(code, 0)
+        self.assertEqual(stderr, '')
+
+    def test_non_cache_path_passes_through(self):
+        self._seed_marketplace('./services/sample-plugin')
+        stdout, stderr, code = self._run_guard({
+            'tool_name': 'Edit',
+            'tool_input': {'file_path': os.path.join(self._tmpdir, 'README.md')},
+        })
+        self.assertEqual(code, 0)
+        self.assertEqual(stderr, '')
+
+    def test_non_edit_tool_passes_through(self):
+        self._seed_marketplace('./services/sample-plugin')
+        stdout, stderr, code = self._run_guard({
+            'tool_name': 'Read',
+            'tool_input': {'file_path': self._cache_path('server.ts')},
+        })
+        self.assertEqual(code, 0)
+        self.assertEqual(stderr, '')
+
+    def test_no_marketplace_passes_through(self):
+        # No .claude-plugin/marketplace.json → silent passthrough (foreign repo).
+        stdout, stderr, code = self._run_guard({
+            'tool_name': 'Edit',
+            'tool_input': {'file_path': self._cache_path('server.ts')},
+        })
+        self.assertEqual(code, 0)
+        self.assertEqual(stderr, '')
+
+    def test_unknown_marketplace_passes_through(self):
+        # Cache path names a marketplace not declared in this project's manifest.
+        self._seed_marketplace('./services/sample-plugin')
+        unknown_cache = os.path.join(
+            self._tmpdir,
+            '.claude/plugins/cache/some-other-marketplace/foo/0.1.0/index.js',
+        )
+        stdout, stderr, code = self._run_guard({
+            'tool_name': 'Edit',
+            'tool_input': {'file_path': unknown_cache},
+        })
+        self.assertEqual(code, 0)
+        self.assertEqual(stderr, '')
+
+
+# ============================================================
 # Negative path tests
 # ============================================================
 


### PR DESCRIPTION
## Problem

Project-local marketplaces declare `"source": "<relative-path>"` in `marketplace.json`. Claude Code loads plugin code from the source path at runtime; the directory under `.claude/plugins/cache/<marketplace>/<plugin>/<version>/` is a stale snapshot taken at install time.

When an operator (or an agent) edits a file in the cache directory, the change has no effect at runtime — the bridge / hook / skill is still reading from the source path. The edit looks successful (no error, no warning), and you only notice when something restarts and the source file is loaded instead. This is a particularly nasty kind of silent breakage because the symptom (stale behaviour) shows up minutes after the cause (the wrong-path edit).

## Change

Adds a `PreToolUse` hook on `Edit|Write` that:

1. Detects whether the target path matches `.claude/plugins/cache/<marketplace>/<plugin>/<version>/...`.
2. Walks up from `cwd` to find `.claude-plugin/marketplace.json` and looks up the plugin's `source` field.
3. If `source` is a string (project-local), prints a warning to stderr naming the canonical source path:
   ```
   [hermit] WARNING: Edit target is a marketplace cache copy.
   [hermit]   path:   <cache path>
   [hermit]   source: <canonical source>
   [hermit]   Runtime loads from the source path; cache edits are lost on next plugin install.
   [hermit]   Set HERMIT_CACHE_GUARD=block to make this a hard error.
   ```
4. Exits 0 by default — warn, don't block — so debugging workflows still work.
5. `HERMIT_CACHE_GUARD=block` upgrades the warning to a hard block (exit 2).

### Silent passthrough cases (exit 0, no output):

- Non-cache paths.
- Non-Edit/Write tool calls.
- No `.claude-plugin/marketplace.json` in the project tree.
- Cache path's marketplace name doesn't match the project's marketplace.
- Plugin's `source` is an object (remote git ref) rather than a string.
- stdin or `marketplace.json` fails to parse — fail open.

## Risk

Low.

- **Additive.** New hook, new script, new test class. No existing behaviour changes.
- **Fail-open.** Every error path exits 0. A bug in this guard cannot block legitimate edits.
- **Default warn, not block.** Operators see the message but their tool call still succeeds.
- **Constant-time work per Edit/Write.** Reads one JSON file (marketplace.json) at most; skips silently in the common case where the path isn't under `.claude/plugins/cache/`.
- **All upstream test suites pass.** Hooks 57, scripts 46, recurrence-gate ✓, cron-tz-shift 20, docker-security 18, template-skill 28, archive-shell 36, contract tests 38 (incl. 7 new). Total: 250+ checks, 0 failures.

## Motivating use case

I edited a server.ts in a project-local marketplace's cache directory while iterating on a custom channel plugin. The edits "worked" until the bridge restarted and reloaded from the source path — at which point all my changes vanished and I spent 15 minutes debugging the discrepancy. The guard would have caught it on the first edit with a one-line stderr message naming the source path I should have edited instead.

The same trap exists for anyone iterating on:
- Hermit fleet plugins shipped via in-repo first-party marketplaces.
- Vendored channel plugins (`./external_plugins/<name>` per CONTRIBUTING.md pattern 2).
- Any operator-built plugin with a project-local marketplace.

## Notes

Skipped step 2 of the PR Workflow (`/release-status`) — that skill lives in the maintainer-only `.claude/` of this repo and isn't available to external contributors.
