### PR TITLE
marketplace: add matrix channel plugin (remote git ref)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,6 +86,30 @@
         "mcp",
         "gtapps"
       ]
+    },
+    {
+      "name": "matrix",
+      "source": {
+        "source": "github",
+        "repo": "fyrstyk/claude-channel-matrix"
+      },
+      "description": "Matrix channel for Claude Code — bidirectional MCP bridge with media (images, audio, video, files), reactions, edits, typing/presence, optional STT/TTS voice round-trip, and built-in access control. Manage pairing, allowlists, and rooms via /matrix:access.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "author": {
+        "name": "fyrstyk",
+        "url": "https://github.com/fyrstyk"
+      },
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/fyrstyk/claude-channel-matrix",
+      "repository": "https://github.com/fyrstyk/claude-channel-matrix",
+      "keywords": [
+        "matrix",
+        "messaging",
+        "channel",
+        "mcp",
+        "voice"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What this is

Adds a Matrix channel plugin to the marketplace catalog as a Pattern 3 entry (remote git ref). Code lives at https://github.com/fyrstyk/claude-channel-matrix; this PR adds a 24-line entry to `.claude-plugin/marketplace.json` so users can install it via `claude plugin install matrix@claude-code-hermit`.

## Why a Matrix channel

The fleet currently ships Discord, Telegram, and iMessage as built-in channel plugins (`claude-plugins-official`). Matrix is the obvious fourth: federated, self-hostable, encrypted-by-default, and increasingly the default messaging stack for people who don't want to hand their conversation history to a centralised platform. A Matrix channel turns any homeserver-resident user into the same kind of operator-bridge that Telegram/Discord plugins provide.

## What ships in v0.1.0

- Bidirectional text messaging.
- Media in both directions: `m.image`, `m.audio`, `m.file`, `m.video`. Inbound media auto-downloads to the local inbox so Claude can `Read` it directly.
- Reactions (emoji), edits (`m.replace`), typing indicator with rolling 25s renewal so long-running work doesn't time out the indicator.
- Optional STT/TTS voice round-trip via shell-out — engine-agnostic; set `MATRIX_STT_CMD` / `MATRIX_TTS_CMD` to scripts that take an audio path / output `.ogg` path and the bridge handles the rest.
- Built-in access control: pairing for first-DM strangers, allowlist mode, room-scoped policies. State lives in `~/.claude/channels/matrix/access.json`. Two skills (`/matrix:configure` first-time setup, `/matrix:access` for pairings/allowlist/rooms).
- Permission-relay protocol support — the bot can shuttle Claude Code permission prompts to the operator's DM and accept `yes <id>` / `no <id>` replies.

## Compatibility

Apache-2.0. Works against any Matrix homeserver (Synapse, Dendrite, Conduit) — no homeserver-specific assumptions in the wire path. All credentials (homeserver URL, mxid, access token, device id) loaded from `~/.claude/channels/matrix/.env`.

Depends on `matrix-js-sdk` and the MCP SDK; both via `bun install` at boot. No other tooling required.

## Pattern 3 rationale

CONTRIBUTING.md documents three contribution patterns. Going with Pattern 3 (remote git ref) for two reasons:
- Plugin is maintained on its own cadence; no need to couple releases to the gtapps fleet release cycle.
- Bug reports and feature requests land in the plugin's own repo, where they belong, rather than the monorepo's issue tracker.

## Test impact

The catalog entry is data, not code. All upstream test suites pass:
- Hook contracts: 57
- Scripts & static: 46
- Recurrence-gate: ✓
- cron-tz-shift: 20
- docker-security: 18
- Template-skill sync: 28
- archive-shell: 36
- Contract tests: 31

Total: 236 checks, 0 failures. JSON validates with `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"`.

## Notes

Skipped step 2 of the PR Workflow (`/release-status`) — that skill lives in the maintainer-only `.claude/` of this repo and isn't available to external contributors.
