### PR TITLE
fix(claude-code-hermit): declare review type in knowledge-schema template (PROP-011)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`knowledge-schema.md.template`: declare `review` as a Work Product type (PROP-011).** The `weekly-review` routine writes compiled artifacts with `type: review`, but the template only declared `note` — so every freshly-hatched hermit running the weekly-review routine reported a permanent `Type \`review\` not declared in knowledge-schema.md ## Work Products` finding from the Knowledge Health checker. Adds a single bullet to the template's `## Work Products` section and provides upgrade instructions for `hermit-evolve` to surgical-patch existing hermits' on-disk schemas.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `state-templates/knowledge-schema.md.template` | Added `- review:` bullet under `## Work Products` |
+
+### Upgrade Instructions
+
+The on-disk `knowledge-schema.md` is operator-editable, so apply this as a surgical, idempotent patch.
+
+1. **File check.** If `.claude-code-hermit/knowledge-schema.md` does not exist, skip — `/hatch` has not been run for this project yet, and the new template already contains the entry for first-time setups.
+
+2. **Idempotency check.** Read `.claude-code-hermit/knowledge-schema.md`. If the `## Work Products` section already contains a bullet starting with `- review:`, skip — patch already applied (or the operator already declared it themselves).
+
+3. **Anchor check.** Confirm the file contains the unmodified `- note:` anchor line:
+
+   ```
+   - note: general-purpose compiled note. location: compiled/note-<slug>-<date>.md
+   ```
+
+   If this line is missing or customized, tell the operator: "Auto-patch failed — anchor not found. The `- note:` bullet in `knowledge-schema.md` has been customized. Add the following bullet manually under `## Work Products`: `- review: weekly review report from the weekly-review routine. location: compiled/review-weekly-<YYYY>-W<NN>.md`"
+
+4. **Propose the patch.** Tell the operator what will be inserted and ask for confirmation:
+
+   > "Patching `.claude-code-hermit/knowledge-schema.md` to declare the `review` type under `## Work Products` (fixes PROP-011 — Knowledge Health false positive after every weekly-review). Apply? [Yes / Skip]"
+
+5. **On Yes — apply.** Use the Edit tool on `.claude-code-hermit/knowledge-schema.md` with:
+
+   `old_string`:
+   ```
+   - note: general-purpose compiled note. location: compiled/note-<slug>-<date>.md
+   ```
+
+   `new_string`:
+   ```
+   - note: general-purpose compiled note. location: compiled/note-<slug>-<date>.md
+   - review: weekly review report from the weekly-review routine. location: compiled/review-weekly-<YYYY>-W<NN>.md
+   ```
+
 ## [1.0.36] - 2026-05-10
 
 ### Added

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -11,6 +11,7 @@
 | File | Change |
 |------|--------|
 | `state-templates/knowledge-schema.md.template` | Added `- review:` bullet under `## Work Products` |
+| `tests/run-scripts.sh` | Extended schema-empty fixture sed to also strip `- review:` starter bullet |
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/state-templates/knowledge-schema.md.template
+++ b/plugins/claude-code-hermit/state-templates/knowledge-schema.md.template
@@ -18,6 +18,7 @@
          location: compiled/briefing-<slug>-<date>.md
 -->
 - note: general-purpose compiled note. location: compiled/note-<slug>-<date>.md
+- review: weekly review report from the weekly-review routine. location: compiled/review-weekly-<YYYY>-W<NN>.md
 
 ## Raw Captures
 <!-- What operational inputs does this hermit collect into raw/?

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -90,7 +90,7 @@ printf -- '---\ntitle: snap\ncreated: 2026-04-22T00:00:00+00:00\n---\ndata' \
 # Copy the real template (all bullets inside HTML comments) so parseSchema returns null
 cp "$REPO_ROOT/state-templates/knowledge-schema.md.template" "$workdir/.claude-code-hermit/knowledge-schema.md"
 # Remove the starter bullets we just added to simulate a pre-upgrade all-comments schema
-sed -i '/^- note:/d; /^- input:/d' "$workdir/.claude-code-hermit/knowledge-schema.md"
+sed -i '/^- note:/d; /^- input:/d; /^- review:/d' "$workdir/.claude-code-hermit/knowledge-schema.md"
 outfile="$(mktemp)"
 node "$REPO_ROOT/scripts/knowledge-lint.js" "$workdir/.claude-code-hermit" > "$outfile" 2>&1 || true
 run_test "knowledge-lint (schema-empty emitted without --verbose)" grep -q 'schema-empty' "$outfile"


### PR DESCRIPTION
## Summary

- The `weekly-review` routine writes compiled artifacts with `type: review`, but `knowledge-schema.md.template` only declared `note` — so every hermit with the weekly-review routine enabled permanently reported `Type 'review' not declared in knowledge-schema.md ## Work Products` from the Knowledge Health checker after each weekly run.
- Adds a single bullet under `## Work Products` in the template. Format matches `knowledge-lint.js`'s parser pattern and the existing `- note:` entry style.
- CHANGELOG includes `### Upgrade Instructions` for `hermit-evolve` to surgical-patch existing hermits' on-disk `knowledge-schema.md` idempotently (file-check → idempotency-check → anchor-check → confirm → edit).

## Test plan

- [x] Run `bash plugins/claude-code-hermit/tests/run-all.sh` from inside the plugin dir — all contracts pass.
- [x] Verify `knowledge-lint.js` parses the updated template without error.
- [x] After `/hermit-evolve` applies the upgrade instructions, re-run Knowledge Health on an existing hermit — `undeclared-type: review` finding should be gone.