### PR TITLE
feat(ha-hermit): add ha_safety_mode dial (strict | ask)

### DIFF
--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`ha_safety_mode` two-tier dial** — configurable behaviour for sensitive-domain actuation (`lock`, `alarm_control_panel`, security-related `cover`/`button`/`switch`). Two values:
+  - `strict` (default, existing behaviour) — always block; work goes through a proposal.
+  - `ask` — operator is prompted before any sensitive actuation. `ha-apply-change` uses `AskUserQuestion` before pushing; direct MCP calls emit `permissionDecision: "ask"` so Claude Code's permission system prompts the operator natively (matches the convention already used by `hooks/curl-host-gate.py`). Both paths are harness-enforced, not convention-driven.
+  Set during `hatch` (new §7.5 question) or by editing `ha_safety_mode` in `.claude-code-hermit/config.json` directly. An unknown value (e.g. `permissive`) falls back to `strict`.
+- **`Severity` enum in `policy.py`** (`block` / `ask` / `allow`) — replaces the internal `bool` return from `classify_entity()`. `is_sensitive_entity()` kept as a backward-compatible shim (True for BLOCK or ASK, False for ALLOW). `evaluate_references()` `PolicyDecision` gains a `severity` field alongside the existing `blocked` bool.
+- **`severity` field in `ha policy-check` JSON output** — callers can now distinguish `block`, `ask`, and `allow` without re-implementing the policy logic.
+
+### Design notes
+
+- The dial is deliberately two-tier. A third `permissive` level (no block, no prompt) was considered and rejected — sensitive-domain actuation has no software undo, and a set-and-forget "owner takes the risk" mode is a footgun across long-running sessions. Both surviving tiers route through explicit operator approval.
+- The hook switched from a leaky `exit 0 + stderr warning` convention to harness-enforced `permissionDecision: "ask"` so YAML apply and direct MCP calls have the same enforcement model.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `src/ha_agent_lab/policy.py` | Added `Severity` enum (`block`/`ask`/`allow`), `safety_mode()`, `_load_safety_mode()`; updated `classify_entity()`, `evaluate_references()`, `check_entity()` |
+| `hooks/mcp-safety-gate.py` | Branches on severity: BLOCK → exit 2, ASK → JSON output with `permissionDecision: "ask"`, ALLOW → exit 0 |
+| `src/ha_agent_lab/cli.py` | `policy-check` output includes `severity` field |
+| `skills/hatch/SKILL.md` | Added §7.5 Safety mode question (strict / ask) |
+| `skills/ha-apply-change/SKILL.md` | Step 1 branches on `severity` field from policy-check |
+| `skills/ha-build-automation/SKILL.md` | Step 4 and Safety section updated for mode-awareness |
+| `agents/ha-automation-builder.md` | Safety section updated: mode-conditional drafting |
+| `agents/ha-safety-reviewer.md` | Safety carve-out updated: mode drives finding severity |
+| `SAFETY.md` | Added "Safety Mode" section documenting the dial |
+| `CLAUDE.md` | Core rule updated to reference `ha_safety_mode` |
+| `state-templates/CLAUDE-APPEND.md` | Core rule updated |
+| `tests/test_policy.py` | New mode-related tests, including a regression test asserting `permissive` falls back to `strict` |
+| `tests/test_safety_hook.py` | New hook tests asserting `permissionDecision: "ask"` JSON output under ask mode |
+| `tests/test_config.py` | Updated 3 tests to use `Severity` enum return type |
+| `tests/conftest.py` | New `make_ha_config` factory fixture |
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. After updating the plugin:
+
+1. If `ha_safety_mode` is absent from `.claude-code-hermit/config.json`, merge it in with the default value: `"ha_safety_mode": "strict"`. No behaviour change.
+2. Optional: re-run `/claude-code-homeassistant-hermit:hatch` to step through the new §7.5 question interactively.
+
 ## [0.1.0] - 2026-05-07
 
 ### Changed

--- a/plugins/claude-code-homeassistant-hermit/CLAUDE.md
+++ b/plugins/claude-code-homeassistant-hermit/CLAUDE.md
@@ -17,7 +17,7 @@ A Home Assistant domain layer for `claude-code-hermit`: skills, subagents, a saf
 
 - `/claude-code-homeassistant-hermit:ha-boot` is the single entry point — starts the hermit session and checks HA connectivity.
 - Never commit real HA URLs, tokens, or device inventories.
-- Never autonomously actuate sensitive domains: `lock`, `alarm_control_panel`, security-related `cover`/`button`/`switch`. These control real-world physical access; an autonomous mistake has no software undo. When in doubt about a new domain (e.g. `garage_door`, `gate`), default to sensitive and require operator approval. See `SAFETY.md` for the full safety model.
+- Actuation of sensitive domains (`lock`, `alarm_control_panel`, security-related `cover`/`button`/`switch`) is gated by `ha_safety_mode` in `.claude-code-hermit/config.json` (absent = `strict`). Under `strict` (default): never autonomously actuate — blocked work becomes a proposal. Under `ask`: the operator is prompted before any sensitive actuation (both YAML apply and direct MCP calls). When in doubt about a new domain, default to sensitive. See `SAFETY.md` for the full safety model.
 - Uncertain entities default to sensitive. Blocked work becomes a proposal.
 - Use the stored language from `MEMORY.md` for all user-facing output.
 - Prefer the Python CLI over ad-hoc reasoning when a helper exists.

--- a/plugins/claude-code-homeassistant-hermit/SAFETY.md
+++ b/plugins/claude-code-homeassistant-hermit/SAFETY.md
@@ -15,6 +15,21 @@ Every MCP call matching `mcp__homeassistant__Hass*` is pre-screened by `hooks/mc
 
 Blocked operations do not silently fail — they become proposals for human review.
 
+## Safety Mode
+
+The safety gate has a two-tier configurable mode stored in `.claude-code-hermit/config.json` under `ha_safety_mode`. Set during `/claude-code-homeassistant-hermit:hatch` and adjustable afterwards.
+
+| Mode | Behaviour |
+|------|-----------|
+| `strict` (default) | Always blocked — no agent-drafted automation or MCP call can actuate sensitive domains. Blocked work becomes a proposal. |
+| `ask` | Operator is prompted before any actuation of a sensitive entity. The `ha-apply-change` skill requires `AskUserQuestion` confirmation before pushing. Direct MCP calls emit `permissionDecision: "ask"` so Claude Code itself prompts the operator before allowing the call — enforced by the harness, not by agent convention. |
+
+Both tiers enforce confirmation through the runtime; there is no "operator-owns-the-risk" mode by design — actuation of locks and alarms has no software undo.
+
+The mode dial does **not** relax the fail-closed branch: if the hook cannot resolve the target to a concrete `entity_id`, it still blocks regardless of mode. The `HA_SAFE_ENTITIES` per-entity allowlist still takes precedence over both modes — a listed entity is always allowed.
+
+Change the mode by editing `ha_safety_mode` in `.claude-code-hermit/config.json` or re-running `/claude-code-homeassistant-hermit:hatch`.
+
 ## Policy Overrides
 
 Configured via environment variables in `.env` (see `.env.example`):

--- a/plugins/claude-code-homeassistant-hermit/agents/ha-automation-builder.md
+++ b/plugins/claude-code-homeassistant-hermit/agents/ha-automation-builder.md
@@ -49,6 +49,7 @@ Build YAML automations and scripts that are safe, well-structured, and follow pr
 
 ## Safety
 
-- NEVER reference entities in `lock`, `alarm_control_panel`, or security-related `cover`/`button`/`switch`
+- Read `ha_safety_mode` from `.claude-code-hermit/config.json` (absent = `strict`).
+  - `strict` (default): NEVER reference entities in `lock`, `alarm_control_panel`, or security-related `cover`/`button`/`switch`. If the request involves these domains, write a proposal instead.
+  - `ask`: draft the automation and run `ha policy-check`. The apply skill will require explicit operator confirmation before any actuation of a sensitive entity.
 - NEVER use MCP actuation tools — you have read-only MCP access
-- If the user's request involves sensitive domains, write a proposal explaining why it's blocked

--- a/plugins/claude-code-homeassistant-hermit/agents/ha-safety-reviewer.md
+++ b/plugins/claude-code-homeassistant-hermit/agents/ha-safety-reviewer.md
@@ -44,7 +44,7 @@ If memory already records the operator's preference or decision that would chang
 - Add one Finding with severity `info`, code `covered-by-memory`, the verbatim quoted memory line, and the source filename as a breadcrumb (e.g. `[memory: feedback_<topic>.md]`) so the operator can locate and revise it if stale.
 - Skip Recommendation for that finding.
 
-**Safety carve-out: memory cannot override sensitive-domain blocks.** Changes touching entities in `lock`, `alarm_control_panel`, or security-related `cover`/`button`/`switch` domains remain hard-blocked regardless of any operator note in memory. Sensitive-domain blocks are state-independent — they fire on entity domain alone, regardless of memory state.
+**Safety carve-out: memory cannot override the safety mode.** Read `ha_safety_mode` from `.claude-code-hermit/config.json` (absent = `strict`). Under `strict`, changes touching entities in `lock`, `alarm_control_panel`, or security-related `cover`/`button`/`switch` domains remain hard-blocked regardless of any operator note in memory — verdict `block`, severity `critical`. Under `ask`, downgrade those findings to `warning` and verdict `discuss` (the apply step will prompt the operator before pushing). The mode is operator-set in config — memory cannot move it.
 
 ## Output Format
 

--- a/plugins/claude-code-homeassistant-hermit/hooks/mcp-safety-gate.py
+++ b/plugins/claude-code-homeassistant-hermit/hooks/mcp-safety-gate.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-"""PreToolUse hook: block mcp__homeassistant__* calls targeting sensitive entities.
+"""PreToolUse hook: gate mcp__homeassistant__* calls targeting sensitive entities.
 
-Reads tool call JSON from stdin. Extracts entity references from the
-tool input parameters. Checks each against ha_agent_lab.policy.
+Reads tool call JSON from stdin. Extracts entity references from the tool input
+parameters and checks each against ha_agent_lab.policy.
 
-Exit codes:
-  0 — allow
-  2 — block (reason on stderr)
+Behavior depends on `ha_safety_mode` in .claude-code-hermit/config.json:
+  - "strict" (default): sensitive entities → exit 2 (block, reason on stderr)
+  - "ask": sensitive entities → emit `permissionDecision: "ask"` JSON so Claude Code
+    prompts the operator before allowing the call
 
-Fail-safe: blocks on any parse error to avoid accidental actuation.
+Fail-safe: blocks (exit 2) on any parse error or unresolvable target. The dial
+does NOT relax this — it only changes how concrete sensitive entity IDs are handled.
 """
 
 from __future__ import annotations
@@ -16,7 +18,7 @@ from __future__ import annotations
 import json
 import sys
 
-from ha_agent_lab.policy import is_sensitive_entity
+from ha_agent_lab.policy import Severity, classify_entity
 
 
 def extract_entity_ids(tool_input: dict) -> list[str]:
@@ -59,16 +61,35 @@ def main() -> None:
         )
         sys.exit(2)
 
-    blocked = []
+    hits: list[tuple[str, Severity]] = []
     for eid in entity_ids:
-        if is_sensitive_entity(eid):
-            blocked.append(eid)
+        sev, _ = classify_entity(eid)
+        if sev != Severity.ALLOW:
+            hits.append((eid, sev))
 
-    if blocked:
-        reason = f"Blocked sensitive entities: {', '.join(blocked)}. Use a proposal instead."
-        print(reason, file=sys.stderr)
+    if not hits:
+        sys.exit(0)
+
+    # All hits share the same severity under the two-tier model — the current
+    # mode applies uniformly to every sensitive entity in this call.
+    current_sev = hits[0][1]
+    names = ", ".join(e for e, _ in hits)
+
+    if current_sev == Severity.BLOCK:
+        print(f"Blocked sensitive entities: {names}. Use a proposal instead.", file=sys.stderr)
         sys.exit(2)
 
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "ask",
+                    "permissionDecisionReason": f"Sensitive entities: {names}",
+                }
+            }
+        )
+    )
     sys.exit(0)
 
 

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-apply-change/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-apply-change/SKILL.md
@@ -11,8 +11,10 @@ allowed-tools:
 
 ## Steps
 
-1. **Pre-check**: Run `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha policy-check <artifact_path>` to verify safety.
-   - If blocked: stop and explain why. Create a proposal via `/claude-code-hermit:proposal-create`.
+1. **Pre-check**: Run `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha policy-check <artifact_path>` to verify safety. Read the `severity` field in the JSON output:
+   - `"block"` (strict mode): stop and explain why. Create a proposal via `/claude-code-hermit:proposal-create`.
+   - `"ask"` (ask mode): use `AskUserQuestion` to confirm with the operator before proceeding. Show which sensitive entities triggered the prompt and what will be applied.
+   - `"allow"`: proceed to step 2.
 
 2. **Validate and apply**: Run `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <artifact_path> --reload automation` (or `script`).
    - This runs HA config check, **pushes the config to HA via REST**, then reloads the domain.

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-build-automation/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-build-automation/SKILL.md
@@ -32,8 +32,9 @@ allowed-tools:
    - Run `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha policy-check <path>` for a safety assessment.
 
 4. **Handle results**:
-   - If valid and safe: offer to apply via `/claude-code-homeassistant-hermit:ha-apply-change`.
-   - If blocked by policy: explain why and create a proposal using `/claude-code-hermit:proposal-create`.
+   - `severity: "allow"` — valid and safe: offer to apply via `/claude-code-homeassistant-hermit:ha-apply-change`.
+   - `severity: "ask"` (ask mode) — explain which sensitive entities are involved, then offer to apply. The apply step will require explicit operator confirmation.
+   - `severity: "block"` (strict mode) — explain why and create a proposal using `/claude-code-hermit:proposal-create`.
    - If entities are missing: suggest refreshing context first.
 
 ## YAML Conventions
@@ -47,4 +48,4 @@ allowed-tools:
 
 ## Safety
 
-Never draft automations that actuate: `lock`, `alarm_control_panel`, or security-related `cover`/`button`/`switch`. If the user requests this, explain the safety boundary and create a proposal for manual review.
+Under `ha_safety_mode: strict` (the default): never draft automations that actuate `lock`, `alarm_control_panel`, or security-related `cover`/`button`/`switch`. If the user requests this, explain the safety boundary and create a proposal for manual review. Under `ask`: draft and run `ha policy-check` — the severity field in the result drives step 4.

--- a/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
@@ -138,6 +138,17 @@ Check CLAUDE.md for the marker comment `<!-- claude-code-homeassistant-hermit: H
 - Present and version matches current plugin version → skip.
 - Present and version is stale → replace the block between the opening and closing markers with the updated content.
 
+### 7.5 Safety mode
+
+Read `ha_safety_mode` from `.claude-code-hermit/config.json`.
+
+- **If the key is already set**: `AskUserQuestion`: "Current safety mode is `<value>`. Change it?" Yes → re-prompt. No → skip this step.
+- **If absent**: ask the operator which safety mode to use for sensitive domains (`lock`, `alarm_control_panel`, security-related `cover`/`button`/`switch`):
+  - `strict` (recommended) — always block autonomous actuation; work goes through a proposal instead.
+  - `ask` — operator is prompted before any actuation of a sensitive entity. Build/validate normally; both YAML apply and direct MCP calls require an explicit operator confirmation before execution.
+
+Write the chosen value to `config.json` as `ha_safety_mode`. Default to `strict` if the operator skips or is unsure.
+
 ### 8. Stamp version and register routines
 
 Write `_hermit_versions["claude-code-homeassistant-hermit"]` into `.claude-code-hermit/config.json` with the current plugin version.

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
@@ -281,6 +281,7 @@ def _handle_policy_check(target: str) -> int:
                 {
                     "file": str(target_path),
                     "blocked": decision.blocked,
+                    "severity": decision.severity.value,
                     "entities": entities,
                     "services": services,
                     "reasons": decision.reasons,

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/policy.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/policy.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import functools
+import json
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +34,20 @@ SENSITIVE_KEYWORDS = {
 SAFE_RELOAD_DOMAINS = {"automation", "script"}
 
 
+class Severity(str, Enum):
+    BLOCK = "block"
+    ASK = "ask"
+    ALLOW = "allow"  # sentinel for non-sensitive entities; no ha_safety_mode maps to it
+
+
+_MODE_TO_SEVERITY: dict[str, Severity] = {
+    "strict": Severity.BLOCK,
+    "ask": Severity.ASK,
+}
+
+_SEVERITY_ORDER = {Severity.ALLOW: 0, Severity.ASK: 1, Severity.BLOCK: 2}
+
+
 @functools.lru_cache(maxsize=8)
 def _load_policy_overrides(root: Path) -> dict[str, frozenset[str]]:
     from .config import load_env_file
@@ -52,44 +68,71 @@ def _policy_overrides(root: Path | None = None) -> dict[str, frozenset[str]]:
     return _load_policy_overrides((root or Path.cwd()).resolve())
 
 
+@functools.lru_cache(maxsize=8)
+def _load_safety_mode(root: Path) -> str:
+    try:
+        cfg = json.loads((root / ".claude-code-hermit" / "config.json").read_text())
+        mode = cfg.get("ha_safety_mode", "strict")
+        return mode if mode in _MODE_TO_SEVERITY else "strict"
+    except Exception:
+        return "strict"
+
+
+def safety_mode(root: Path | None = None) -> str:
+    """Read ha_safety_mode from .claude-code-hermit/config.json. Fail-closed: returns 'strict'."""
+    return _load_safety_mode((root or Path.cwd()).resolve())
+
+
 @dataclass(slots=True)
 class PolicyDecision:
+    severity: Severity
     blocked: bool
     reasons: list[str]
 
 
-def classify_entity(entity_id: str, root: Path | None = None) -> tuple[bool, list[str]]:
-    """Return (sensitive, reasons) for a single entity."""
-    overrides = _policy_overrides(root)
+def classify_entity(entity_id: str, root: Path | None = None) -> tuple[Severity, list[str]]:
+    """Return (Severity, reasons) for a single entity."""
+    resolved = (root or Path.cwd()).resolve()
+    overrides = _load_policy_overrides(resolved)
     if entity_id in overrides["safe_entities"]:
-        return False, []
+        return Severity.ALLOW, []
     domain = entity_id.split(".", 1)[0]
+    mode_sev = _MODE_TO_SEVERITY[_load_safety_mode(resolved)]
     if domain in SENSITIVE_DOMAINS | overrides["extra_domains"]:
-        return True, [f"Domain '{domain}' is always sensitive"]
+        return mode_sev, [f"Domain '{domain}' is always sensitive"]
     if domain in CONDITIONALLY_SENSITIVE_DOMAINS:
         matched = [kw for kw in SENSITIVE_KEYWORDS | overrides["extra_keywords"] if kw in entity_id.lower()]
         if matched:
-            return True, [f"Domain '{domain}' with keywords: {', '.join(matched)}"]
-    return False, []
+            return mode_sev, [f"Domain '{domain}' with keywords: {', '.join(matched)}"]
+    return Severity.ALLOW, []
 
 
 def is_sensitive_entity(entity_id: str, root: Path | None = None) -> bool:
-    return classify_entity(entity_id, root)[0]
+    sev, _ = classify_entity(entity_id, root)
+    return sev != Severity.ALLOW
 
 
 def is_sensitive_service(service_name: str) -> bool:
-    return classify_entity(service_name)[0]
+    sev, _ = classify_entity(service_name)
+    return sev != Severity.ALLOW
 
 
 def evaluate_references(entity_ids: list[str], services: list[str], root: Path | None = None) -> PolicyDecision:
+    max_sev = Severity.ALLOW
     reasons: list[str] = []
     for entity_id in sorted(set(entity_ids)):
-        if is_sensitive_entity(entity_id, root):
-            reasons.append(f"Sensitive or ambiguous entity blocked: {entity_id}")
+        sev, _ = classify_entity(entity_id, root)
+        if sev != Severity.ALLOW:
+            reasons.append(f"Sensitive or ambiguous entity ({sev.value}): {entity_id}")
+            if _SEVERITY_ORDER[sev] > _SEVERITY_ORDER[max_sev]:
+                max_sev = sev
     for service in sorted(set(services)):
-        if is_sensitive_service(service):
-            reasons.append(f"Sensitive or ambiguous service blocked: {service}")
-    return PolicyDecision(blocked=bool(reasons), reasons=reasons)
+        sev, _ = classify_entity(service, root)
+        if sev != Severity.ALLOW:
+            reasons.append(f"Sensitive or ambiguous service ({sev.value}): {service}")
+            if _SEVERITY_ORDER[sev] > _SEVERITY_ORDER[max_sev]:
+                max_sev = sev
+    return PolicyDecision(severity=max_sev, blocked=(max_sev == Severity.BLOCK), reasons=reasons)
 
 
 def can_reload_domain(domain: str) -> bool:
@@ -98,8 +141,13 @@ def can_reload_domain(domain: str) -> bool:
 
 def check_entity(entity_id: str) -> dict[str, Any]:
     """Return a JSON-friendly policy check for a single entity."""
-    sensitive, reasons = classify_entity(entity_id)
-    return {"entity_id": entity_id, "sensitive": sensitive, "reasons": reasons}
+    sev, reasons = classify_entity(entity_id)
+    return {
+        "entity_id": entity_id,
+        "sensitive": sev != Severity.ALLOW,
+        "severity": sev.value,
+        "reasons": reasons,
+    }
 
 
 def normalize_entity_index(states: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:

--- a/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
@@ -10,7 +10,7 @@ This project has the `claude-code-homeassistant-hermit` plugin installed. The ru
 
 - `/claude-code-homeassistant-hermit:ha-boot` is the single entry point — starts the hermit session and checks HA connectivity.
 - Never commit real HA URLs, tokens, or device inventories.
-- Never autonomously actuate: `lock`, `alarm_control_panel`, security-related `cover`/`button`/`switch`.
+- Actuation of sensitive domains (`lock`, `alarm_control_panel`, security-related `cover`/`button`/`switch`) is gated by `ha_safety_mode` in `.claude-code-hermit/config.json`. Default `strict` = always blocked. `ask` = operator is prompted before actuation (both YAML apply and direct MCP calls). Read the config before deciding whether to draft or block.
 - Uncertain entities default to sensitive. Blocked work becomes a proposal.
 - Use the stored language from `MEMORY.md` for all user-facing output.
 

--- a/plugins/claude-code-homeassistant-hermit/tests/conftest.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/conftest.py
@@ -28,6 +28,17 @@ def make_ha_root(tmp_path: Path):
 
 
 @pytest.fixture
+def make_ha_config(tmp_path: Path):
+    """Factory fixture: writes ha_safety_mode to .claude-code-hermit/config.json."""
+    def _make(mode: str) -> Path:
+        cfg_dir = tmp_path / ".claude-code-hermit"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "config.json").write_text(f'{{"ha_safety_mode": "{mode}"}}')
+        return tmp_path
+    return _make
+
+
+@pytest.fixture
 def make_mock_config(tmp_path):
     """Factory fixture: builds a MagicMock AppConfig for CLI tests."""
     def _make(url: str = "http://homeassistant.local:8123") -> MagicMock:

--- a/plugins/claude-code-homeassistant-hermit/tests/test_config.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from ha_agent_lab.config import load_config, save_env_file
-from ha_agent_lab.policy import _load_policy_overrides, classify_entity
+from ha_agent_lab.policy import Severity, _load_policy_overrides, classify_entity
 
 
 def _write_env(root: Path, **kwargs: str) -> None:
@@ -25,22 +25,22 @@ def test_env_file_fallback_when_env_var_absent(tmp_path: Path, monkeypatch) -> N
 def test_safe_entities_override_bypasses_sensitive_domain(tmp_path: Path) -> None:
     _write_env(tmp_path, HA_SAFE_ENTITIES="cover.garage_door")
     _load_policy_overrides.cache_clear()
-    sensitive, _ = classify_entity("cover.garage_door", tmp_path)
-    assert not sensitive
+    sev, _ = classify_entity("cover.garage_door", tmp_path)
+    assert sev == Severity.ALLOW
     _load_policy_overrides.cache_clear()
 
 
 def test_extra_sensitive_domains_blocks_new_domain(tmp_path: Path) -> None:
     _write_env(tmp_path, HA_EXTRA_SENSITIVE_DOMAINS="vacuum")
     _load_policy_overrides.cache_clear()
-    sensitive, _ = classify_entity("vacuum.roomba", tmp_path)
-    assert sensitive
+    sev, _ = classify_entity("vacuum.roomba", tmp_path)
+    assert sev != Severity.ALLOW
     _load_policy_overrides.cache_clear()
 
 
 def test_extra_sensitive_keywords_blocks_matching_entity(tmp_path: Path) -> None:
     _write_env(tmp_path, HA_EXTRA_SENSITIVE_KEYWORDS="pool")
     _load_policy_overrides.cache_clear()
-    sensitive, _ = classify_entity("switch.pool_pump", tmp_path)
-    assert sensitive
+    sev, _ = classify_entity("switch.pool_pump", tmp_path)
+    assert sev != Severity.ALLOW
     _load_policy_overrides.cache_clear()

--- a/plugins/claude-code-homeassistant-hermit/tests/test_policy.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_policy.py
@@ -3,7 +3,15 @@ from pathlib import Path
 import pytest
 
 from ha_agent_lab.cli import main
-from ha_agent_lab.policy import can_reload_domain, check_entity, evaluate_references, is_sensitive_entity
+from ha_agent_lab.policy import (
+    Severity,
+    can_reload_domain,
+    check_entity,
+    classify_entity,
+    evaluate_references,
+    is_sensitive_entity,
+    safety_mode,
+)
 
 
 def test_sensitive_entity_detection() -> None:
@@ -79,6 +87,67 @@ def test_extra_sensitive_keyword(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.chdir(tmp_path)
     assert is_sensitive_entity("switch.pool_pump")
     assert not is_sensitive_entity("switch.living_room")  # no regression
+
+
+def test_safety_mode_defaults_to_strict(tmp_path: Path) -> None:
+    assert safety_mode(tmp_path) == "strict"
+
+
+def test_safety_mode_reads_ask_from_config(make_ha_config) -> None:
+    root = make_ha_config("ask")
+    assert safety_mode(root) == "ask"
+
+
+def test_safety_mode_invalid_value_defaults_to_strict(make_ha_config) -> None:
+    root = make_ha_config("bogus")
+    assert safety_mode(root) == "strict"
+
+
+def test_safety_mode_permissive_no_longer_valid(make_ha_config) -> None:
+    """`permissive` was removed in favour of two-tier strict/ask. Falls back to strict."""
+    root = make_ha_config("permissive")
+    assert safety_mode(root) == "strict"
+
+
+def test_classify_strict_blocks_sensitive(make_ha_config) -> None:
+    root = make_ha_config("strict")
+    sev, reasons = classify_entity("alarm_control_panel.home", root=root)
+    assert sev == Severity.BLOCK
+    assert reasons
+
+
+def test_classify_ask_returns_ask_severity(make_ha_config) -> None:
+    root = make_ha_config("ask")
+    sev, reasons = classify_entity("alarm_control_panel.home", root=root)
+    assert sev == Severity.ASK
+    assert reasons
+
+
+def test_classify_ask_on_conditional_sensitive(make_ha_config) -> None:
+    root = make_ha_config("ask")
+    sev, _ = classify_entity("cover.garage_door", root=root)
+    assert sev == Severity.ASK
+
+
+def test_safe_entity_allowlist_wins_over_strict(make_ha_config, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = make_ha_config("strict")
+    (root / ".env").write_text("HA_SAFE_ENTITIES=alarm_control_panel.home\n")
+    monkeypatch.chdir(root)
+    sev, _ = classify_entity("alarm_control_panel.home", root=root)
+    assert sev == Severity.ALLOW
+
+
+def test_evaluate_references_severity_field(make_ha_config) -> None:
+    root = make_ha_config("ask")
+    decision = evaluate_references(["alarm_control_panel.home"], [], root=root)
+    assert decision.severity == Severity.ASK
+    assert not decision.blocked
+
+
+def test_check_entity_includes_severity() -> None:
+    result = check_entity("light.kitchen")
+    assert "severity" in result
+    assert result["severity"] == "allow"
 
 
 def test_policy_check_cli_yaml_file(tmp_path: Path, capsys) -> None:

--- a/plugins/claude-code-homeassistant-hermit/tests/test_safety_hook.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_safety_hook.py
@@ -6,13 +6,14 @@ from pathlib import Path
 HOOK = Path(__file__).parent.parent / "hooks" / "mcp-safety-gate.py"
 
 
-def _run(payload: dict | str) -> subprocess.CompletedProcess:
+def _run(payload: dict | str, cwd: Path | None = None) -> subprocess.CompletedProcess:
     data = payload if isinstance(payload, str) else json.dumps(payload)
     return subprocess.run(
         [sys.executable, str(HOOK)],
         input=data,
         capture_output=True,
         text=True,
+        cwd=cwd,
     )
 
 
@@ -64,3 +65,37 @@ def test_missing_tool_input_is_blocked():
     result = _run({})
     assert result.returncode == 2
     assert "Cannot verify target safety" in result.stderr
+
+
+def test_alarm_prompts_operator_in_ask_mode(make_ha_config):
+    root = make_ha_config("ask")
+    result = _run({"tool_input": {"entity_id": "alarm_control_panel.home"}}, cwd=root)
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "alarm_control_panel.home" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_lock_prompts_operator_in_ask_mode(make_ha_config):
+    root = make_ha_config("ask")
+    result = _run({"tool_input": {"entity_id": "lock.front_door"}}, cwd=root)
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "lock.front_door" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_no_entities_blocked_in_ask_mode(make_ha_config):
+    """Fail-closed branch stays exit 2 even in ask mode — dial only relaxes domain checks."""
+    root = make_ha_config("ask")
+    result = _run({"tool_input": {}}, cwd=root)
+    assert result.returncode == 2
+    assert "Cannot verify target safety" in result.stderr
+
+
+def test_safe_entity_in_ask_mode_passes_silently(make_ha_config):
+    """Non-sensitive entities still exit 0 with no stdout output under ask mode."""
+    root = make_ha_config("ask")
+    result = _run({"tool_input": {"entity_id": "light.living_room"}}, cwd=root)
+    assert result.returncode == 0
+    assert result.stdout == ""


### PR DESCRIPTION
## Summary

- Makes the safety gate's hardcoded block on `lock` / `alarm_control_panel` /
  security-related `cover`/`button`/`switch` configurable via a new
  `ha_safety_mode` key in `.claude-code-hermit/config.json`.
- Two tiers:
  - `strict` (default) — existing behaviour; sensitive actuation is always blocked
    and routed through a proposal.
  - `ask` — operator is prompted before sensitive actuation. YAML apply path uses
    `AskUserQuestion`; direct MCP calls emit `permissionDecision:"ask"` so
    Claude Code's permission system prompts the operator natively (matches the
    pattern already used by `hooks/curl-host-gate.py`).
- A third `permissive` tier was considered and rejected — sensitive actuation
  has no software undo, and a set-and-forget "operator owns the risk" mode is
  a footgun across long-running sessions. Both surviving tiers route through
  harness-enforced operator approval.
- `hatch` gains §7.5 to set the mode interactively; existing installs get the
  key merged at default `strict` on next `hermit-evolve`.

## Test plan

- [x] `cd plugins/claude-code-homeassistant-hermit && .venv/bin/pytest tests/ -v` — all 102 pass (14 new cases under `ha_safety_mode`).
- [x] Manual: pipe a payload referencing `alarm_control_panel.casa` to `hooks/mcp-safety-gate.py`:
  - strict config → exit 2, stderr says "Blocked sensitive entities"
  - ask config → exit 0, stdout JSON has `permissionDecision: "ask"`
  - no-config (default) → exit 2 (default is strict)
- [x] Re-run `/claude-code-homeassistant-hermit:hatch` in a scratch project, confirm §7.5 question appears with the two-tier options.
- [x] `bin/ha-agent-lab ha policy-check` against a YAML referencing `alarm_control_panel.*` returns `severity` field with the right value under each mode.