### PR TITLE
feat: convert hook commands to exec form fleet-wide (PROP-011)

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Hooks: converted `git-push-guard` and `record-test-result` to exec form.** Aligns with core's exec-form sweep. Fixes path-with-spaces fragility on installs whose plugin dir contains a space.
+
+### Upgrade Instructions
+
+- **Requires Claude Code 2.1.139 or newer.** The `args: []` exec form was introduced in CC 2.1.139. Update Claude Code before pulling this release, or hooks will fail to register.
+
 ## [0.3.5] - 2026-05-07
 
 ### Removed

--- a/plugins/claude-code-dev-hermit/hooks/hooks.json
+++ b/plugins/claude-code-dev-hermit/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/git-push-guard.js"
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/git-push-guard.js"]
           }
         ],
         "description": "Block direct git push to protected branches, --no-verify, force-push (strict profile)"
@@ -18,7 +19,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.js"
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.js"]
           }
         ],
         "description": "Record exit code + duration of the configured test command to state/last-test.json (consumed by /dev-pr)"

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 - **Hooks: converted shell-form commands to exec form (`args: []`).** All 8 convertible hook entries (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart, Stop) now use exec form. The dev-mode contract runner stays in shell form (uses stdin/jq/pipes); its `description` explains why. Fixes path-with-spaces fragility: installs at paths containing a space previously broke because `${CLAUDE_PLUGIN_ROOT}` expanded unquoted in shell form.
-- Added `tests/test-hook-registration-form.sh` contract test — guards against future regressions to naked shell-form interpolation across the plugin fleet.
+- Added `tests/test-hook-registration-form.sh` contract test — guards against future regressions to naked shell-form interpolation across the plugin fleet. Also fails loudly when the path-resolution glob returns zero hook entries, so a future refactor that breaks `MONOREPO_ROOT` resolution cannot silently pass the test vacuously.
 
 ### Fixed
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Hooks: converted shell-form commands to exec form (`args: []`).** All 8 convertible hook entries (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart, Stop) now use exec form. The dev-mode contract runner stays in shell form (uses stdin/jq/pipes); its `description` explains why. Fixes path-with-spaces fragility: installs at paths containing a space previously broke because `${CLAUDE_PLUGIN_ROOT}` expanded unquoted in shell form.
+- Added `tests/test-hook-registration-form.sh` contract test — guards against future regressions to naked shell-form interpolation across the plugin fleet.
+
+### Upgrade Instructions
+
+- **Requires Claude Code 2.1.139 or newer.** The `args: []` exec form was introduced in CC 2.1.139. Update Claude Code before pulling this release, or hooks will fail to register.
+
 ## [1.0.37] - 2026-05-11
 
 ### Added

--- a/plugins/claude-code-hermit/hooks/hooks.json
+++ b/plugins/claude-code-hermit/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/enforce-deny-patterns.js",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/enforce-deny-patterns.js"],
             "timeout": 3
           }
         ],
@@ -17,7 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/cache-edit-guard.js",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/cache-edit-guard.js"],
             "timeout": 3
           }
         ],
@@ -30,7 +32,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/channel-hook.js",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/channel-hook.js"],
             "timeout": 5
           }
         ],
@@ -45,14 +48,15 @@
             "timeout": 30
           }
         ],
-        "description": "Run contract tests after script/hook edits (dev mode only: set HERMIT_DEV_MODE=1)"
+        "description": "Run contract tests after script/hook edits (dev mode only: set HERMIT_DEV_MODE=1). Stays in shell form: uses stdin/jq/pipes; convert by porting to Node, not by switching to args:[]."
       },
       {
         "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/validate-config.js",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/validate-config.js"],
             "timeout": 5
           }
         ],
@@ -63,7 +67,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/generate-summary.js",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/generate-summary.js"],
             "timeout": 5
           }
         ],
@@ -76,7 +81,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/prompt-context.js"
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/prompt-context.js"]
           }
         ],
         "description": "Inject current local time before every prompt so the model never anchors to a stale 'now'"
@@ -88,7 +94,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/startup-context.js"
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/startup-context.js"]
           }
         ],
         "description": "Load session context on startup"
@@ -100,7 +107,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/stop-pipeline.js",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/stop-pipeline.js"],
             "timeout": 15
           }
         ],

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -14,4 +14,5 @@ bash "$SCRIPT_DIR/cron-tz-shift.test.sh"      || rc=$?
 bash "$SCRIPT_DIR/test-docker-security-templates.sh" || rc=$?
 bash "$SCRIPT_DIR/test-template-skill-sync.sh"       || rc=$?
 bash "$SCRIPT_DIR/test-archive-shell.sh"             || rc=$?
+bash "$SCRIPT_DIR/test-hook-registration-form.sh"   || rc=$?
 exit $rc

--- a/plugins/claude-code-hermit/tests/test-hook-registration-form.sh
+++ b/plugins/claude-code-hermit/tests/test-hook-registration-form.sh
@@ -19,11 +19,13 @@ cat > "$_form_check" <<'PYEOF'
 import json, sys, glob, os
 monorepo = os.environ["MONOREPO_ROOT"]
 ok = True
+count = 0
 for path in sorted(glob.glob(os.path.join(monorepo, "plugins/*/hooks/hooks.json"))):
     doc = json.load(open(path, encoding="utf-8"))
     for event, entries in doc.get("hooks", {}).items():
         for entry in entries:
             for h in entry.get("hooks", []):
+                count += 1
                 cmd = h.get("command", "")
                 if "args" in h:
                     if " " in cmd or "$" in cmd:
@@ -34,6 +36,9 @@ for path in sorted(glob.glob(os.path.join(monorepo, "plugins/*/hooks/hooks.json"
                 else:
                     print(f"FAIL {path} {event}: naked shell form: {cmd!r}")
                     ok = False
+if count == 0:
+    print(f"FAIL: no hook entries found under {monorepo}/plugins/*/hooks/hooks.json — path resolution likely broken")
+    ok = False
 sys.exit(0 if ok else 1)
 PYEOF
 

--- a/plugins/claude-code-hermit/tests/test-hook-registration-form.sh
+++ b/plugins/claude-code-hermit/tests/test-hook-registration-form.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Contract test: every hooks.json entry fleet-wide uses exec form or the bash -c escape hatch.
+# Guards against regressions to naked shell-form ${CLAUDE_PLUGIN_ROOT} interpolation.
+# Usage: bash tests/test-hook-registration-form.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+MONOREPO_ROOT="$(cd "$REPO_ROOT/../.." && pwd)"
+export MONOREPO_ROOT
+
+echo "=== hook registration form contract ==="
+echo ""
+
+_form_check="$(mktemp)"
+trap "rm -f '$_form_check'" EXIT
+cat > "$_form_check" <<'PYEOF'
+import json, sys, glob, os
+monorepo = os.environ["MONOREPO_ROOT"]
+ok = True
+for path in sorted(glob.glob(os.path.join(monorepo, "plugins/*/hooks/hooks.json"))):
+    doc = json.load(open(path, encoding="utf-8"))
+    for event, entries in doc.get("hooks", {}).items():
+        for entry in entries:
+            for h in entry.get("hooks", []):
+                cmd = h.get("command", "")
+                if "args" in h:
+                    if " " in cmd or "$" in cmd:
+                        print(f"FAIL {path} {event}: exec-form command has shell chars: {cmd!r}")
+                        ok = False
+                elif cmd.startswith("bash -c "):
+                    pass  # documented escape hatch for stdin/jq/pipes work
+                else:
+                    print(f"FAIL {path} {event}: naked shell form: {cmd!r}")
+                    ok = False
+sys.exit(0 if ok else 1)
+PYEOF
+
+run_test "form contract: all hook entries are exec-form or bash -c" \
+  python3 "$_form_check"
+
+print_results

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- **Hooks: converted `mcp-safety-gate` and `curl-host-gate` to exec form.** Aligns with core's exec-form sweep. Fixes path-with-spaces fragility on installs whose plugin dir contains a space.
+
+### Upgrade Instructions
+
+- **Requires Claude Code 2.1.139 or newer.** The `args: []` exec form was introduced in CC 2.1.139. Update Claude Code before pulling this release, or hooks will fail to register.
+
 ## [0.1.1] - 2026-05-11
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/hooks/hooks.json
+++ b/plugins/claude-code-homeassistant-hermit/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/mcp-safety-gate.py"
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/mcp-safety-gate.py"]
           }
         ],
         "description": "Block MCP actuation calls targeting sensitive HA entities. Tool IDs assume the HA MCP Server is registered in Claude Code as 'homeassistant'."
@@ -17,7 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/curl-host-gate.py",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/curl-host-gate.py"],
             "timeout": 5
           }
         ],


### PR DESCRIPTION
## Summary

- Converts 12 of 13 hook entries across `claude-code-hermit`, `claude-code-homeassistant-hermit`, and `claude-code-dev-hermit` from shell form to exec form (`"command": "node"`, `"args": ["${CLAUDE_PLUGIN_ROOT}/script.js"]`).
- The one entry kept in shell form is the dev-mode contract runner (`bash -c` with stdin/jq/pipes); its `description` field now documents why.
- Fixes a path-with-spaces fragility: shell-form entries interpolated `${CLAUDE_PLUGIN_ROOT}` unquoted, breaking hook registration on installs at paths containing a space (e.g. macOS `Library/Application Support/...`).
- Adds `tests/test-hook-registration-form.sh` — a fleet-wide form-contract test that guards against future regressions to naked shell-form interpolation.

## Test plan

- [x] `bash tests/run-all.sh` from `plugins/claude-code-hermit/` — all suites pass including the new `test-hook-registration-form.sh` (1 test: form contract, 13 entries checked)
- [x] Spot-check hook dispatch on a local install to confirm exec-form hooks fire correctly

### Upgrade note

**Requires Claude Code 2.1.139 or newer** — the `args: []` exec form was introduced in that release. Documented in each plugin's `[Unreleased]` CHANGELOG section.