### PR TITLE
feat: add min CLI version gate to hermit-evolve

### DIFF
--- a/plugins/claude-code-hermit/.claude-plugin/hermit-meta.json
+++ b/plugins/claude-code-hermit/.claude-plugin/hermit-meta.json
@@ -1,0 +1,3 @@
+{
+  "min_claude_code_version": ">=2.1.139"
+}

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`min_claude_code_version` gate in `hermit-evolve`.** A new Step 0 reads `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/hermit-meta.json` and checks the running `claude --version` against a `min_claude_code_version` semver range (supports `>=X.Y.Z`). If the CLI is below the declared minimum, the skill aborts with an upgrade message before any config or template writes occur. If the field is absent the gate skips silently (forward-compat). Also adds `.claude-plugin/hermit-meta.json` to the core plugin with `min_claude_code_version: ">=2.1.139"` — the first core-side hermit-meta.json, mirroring the pattern sibling plugins use for `required_core_version`.
+
 ## [1.0.37] - 2026-05-11
 
 ### Added

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -9,6 +9,28 @@ Upgrade the project's hermit configuration after a plugin update.
 
 ## Plan
 
+### 0. Verify Claude Code CLI version
+
+- Read `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/hermit-meta.json`. If the file
+  doesn't exist or `min_claude_code_version` is not set, skip this step.
+- Run `claude --version` and parse the leading semver (format:
+  `X.Y.Z (Claude Code)`). If the command fails or the version cannot be parsed,
+  report: "Could not detect Claude Code CLI version — proceeding anyway." and
+  skip the comparison.
+- Compare the detected version against `min_claude_code_version` (supports
+  `>=X.Y.Z` or bare `X.Y.Z`, treated as `>=`). If the CLI version is below the
+  minimum, report:
+
+  ```
+  This hermit version requires Claude Code >=<min> (you have <detected>).
+
+  Upgrade Claude Code (`claude update` or your package manager) and re-run
+  /claude-code-hermit:hermit-evolve.
+  ```
+
+  Substitute `<min>` with the value from `min_claude_code_version` and
+  `<detected>` with the parsed CLI version. Then stop. Do not prompt to bypass.
+
 ### 1. Read versions
 
 - Read `.claude-code-hermit/config.json`


### PR DESCRIPTION
## Summary

- Adds Step 0 to `hermit-evolve` that reads `.claude-plugin/hermit-meta.json`
  and aborts before any config or template writes if the running `claude` CLI
  is below `min_claude_code_version`. Prevents partial migrations on stale CLIs.
- Gate skips silently when the field is absent (forward-compat for existing installs).
- Adds `.claude-plugin/hermit-meta.json` to the core plugin — the first
  core-side hermit-meta.json, mirroring the pattern siblings use for
  `required_core_version`. Initial floor: `>=2.1.139`.

## Test plan

- [x] Set `min_claude_code_version: ">=99.0.0"` in `hermit-meta.json`, run
  `/hermit-evolve` in a hatched project — expect abort at Step 0, no files touched.
- [x] Set to `>=1.0.0`, run skill — expect gate passes silently, normal flow.
- [x] Remove the field entirely — expect Step 0 silently skips.