### PR TITLE
fix(hermit-docker): version-pin CC build arg, fix readiness gate

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`hermit-docker update` now actually updates the Claude Code binary (cache-bust fix).** `docker compose build --pull` only re-pulls the `FROM ubuntu:24.04` base layer; subsequent `RUN` layers — including `RUN npm install -g @anthropic-ai/claude-code` — were content-addressed by command string and silently reused. A running hermit self-updates its binary on the writable container layer; after `hermit-docker update` rebuilt with a cached layer and bounced the container, the new container reverted to the older baked version. Live measurement: `2.1.132 → 2.1.114` (an 18-patch rollback) on a hermit claiming it upgraded to `2.1.139`. Fixed by adding a `CLAUDE_CODE_VERSION` build arg to `Dockerfile.hermit.template` that pins the npm install to a specific version. `hermit-docker update` resolves the desired version via `npm view @anthropic-ai/claude-code version` (already fetched before the build for the plan output) and passes it as `--build-arg CLAUDE_CODE_VERSION=<resolved>`. BuildKit includes the arg value in the `RUN` layer's cache key, so the layer is invalidated exactly when the version changes — fast rebuilds when nothing changed, correct rebuilds when it did. Falls back to `latest` if the registry lookup fails, preserving today's behavior on registry hiccups.
+
+- **`hermit-docker update` no longer reports a false downgrade.** `CC_BEFORE` captured the running container's `claude --version` (the self-updated binary on the writable layer); `CC_AFTER` captured the new container's `claude --version` (the baked image version, before any self-update). The fix sources `CC_AFTER` directly from the resolved build-arg version when known, which is the ground truth — no container query needed.
+
+- **`/reload-plugins` is now gated on the Claude Code prompt being ready.** The previous wait loop only confirmed `tmux has-session` succeeded. In the full update path (container bounced), `tmux has-session` returns true as soon as the session is created by the entrypoint, but `claude` inside the pane needs additional boot time before it reaches its interactive REPL. Keys sent before then went to the bash shell launching claude, not to the Claude Code skill queue. Fixed by polling `tmux capture-pane -p` for the Claude Code input box (detected by the `╭─` / `╰─` box-drawing characters that frame the prompt). Polls up to 60 seconds; if not detected, logs a warning with the manual fallback command and skips the send rather than silently misfiring. The `update-history.jsonl` log field is renamed from `reload_plugins_queued` to `reload_plugins_sent` to reflect the actual outcome.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `state-templates/docker/Dockerfile.hermit.template` | `ARG CLAUDE_CODE_VERSION=latest`; npm install pinned to `@${CLAUDE_CODE_VERSION}` |
+| `state-templates/docker/docker-compose.hermit.yml.template` | `CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-latest}` under `build.args` |
+| `state-templates/bin/hermit-docker` | `update` arm: `--build-arg` pass-through; `CC_AFTER` from pinned value; `_wait_for_claude_prompt` readiness gate; log field renamed |
+
+### Upgrade Instructions
+
+Docker users only. Non-Docker (tmux/local) hermits are unaffected.
+
+The `hermit-docker update` wrapper (`bin/hermit-docker`) is refreshed wholesale by `hermit-evolve` step 5b — no manual wrapper edit needed.
+
+The on-disk `Dockerfile.hermit` and `docker-compose.hermit.yml` in the project root need two surgical patches to pass the build arg through. Apply them idempotently:
+
+1. **Idempotency check for `Dockerfile.hermit`.** If the file does not exist in the project root, skip (Docker not set up). If the file already contains `ARG CLAUDE_CODE_VERSION`, skip this file — already patched.
+
+2. **Patch `Dockerfile.hermit`.** Anchor on the exact line `ARG HOST_UID=1000`. If this line is not found (operator-customized Dockerfile), tell the operator: "Auto-patch skipped for Dockerfile.hermit — anchor `ARG HOST_UID=1000` not found. Add these two lines manually after the HOST_UID ARG: `ARG CLAUDE_CODE_VERSION=latest` and change the npm install line to `RUN npm install -g bun @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}`." Then skip to step 4.
+
+   Use the Edit tool with:
+
+   `old_string`:
+   ```
+   ARG HOST_UID=1000
+   ```
+
+   `new_string`:
+   ```
+   ARG HOST_UID=1000
+   ARG CLAUDE_CODE_VERSION=latest
+   ```
+
+3. **Pin the npm install in `Dockerfile.hermit`.** Anchor on `@anthropic-ai/claude-code` NOT already followed by `@` (i.e. the line doesn't yet have `@${CLAUDE_CODE_VERSION}`). If the npm install line has already been version-pinned, skip.
+
+   Use the Edit tool with:
+
+   `old_string`:
+   ```
+   RUN npm install -g bun @anthropic-ai/claude-code
+   ```
+
+   `new_string`:
+   ```
+   RUN npm install -g bun @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+   ```
+
+   If the old_string is not found (operator added extra packages to the line), tell the operator: "Auto-patch skipped for the npm install line — it has been customized. Update it manually to include `@${CLAUDE_CODE_VERSION}` after `@anthropic-ai/claude-code`."
+
+4. **Idempotency check for `docker-compose.hermit.yml`.** If the file does not exist, skip. If it already contains `CLAUDE_CODE_VERSION:`, skip — already patched.
+
+5. **Patch `docker-compose.hermit.yml`.** Anchor on `HOST_UID: ${UID:-1000}`. If not found, tell the operator: "Auto-patch skipped for docker-compose.hermit.yml — anchor `HOST_UID: ${UID:-1000}` not found. Add `CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-latest}` manually under the `build.args:` block."
+
+   Use the Edit tool with:
+
+   `old_string`:
+   ```
+         HOST_UID: ${UID:-1000}
+   ```
+
+   `new_string`:
+   ```
+         HOST_UID: ${UID:-1000}
+         CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-latest}
+   ```
+
+6. **Rebuild.** Tell the operator: "Run `.claude-code-hermit/bin/hermit-docker update` once to bake the version-pinned image. The first rebuild after this patch will reinstall claude-code (cache is invalidated by the new `RUN` command string); subsequent same-version runs reuse the cache as expected."
+
 ## [1.0.37] - 2026-05-11
 
 ### Added

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -63,6 +63,19 @@ _require_running() {
   fi
 }
 
+# Poll tmux pane for the Claude Code input box (╭─ / ╰─ box-drawing chars).
+# Returns 0 when ready, 1 after 60s timeout.
+_wait_for_claude_prompt() {
+  local i pane
+  for i in $(seq 1 30); do
+    pane=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
+      tmux capture-pane -p -t "$TMUX_SESSION:0.0" 2>/dev/null || true)
+    printf '%s\n' "$pane" | tail -10 | grep -qE '╭─|╰─' && return 0
+    sleep 2
+  done
+  return 1
+}
+
 case "$CMD" in
   up)
     echo "[hermit] Starting Docker container..."
@@ -171,7 +184,7 @@ case "$CMD" in
     ;;
 
   update)
-    DRY_RUN=false; CC_ONLY=false; PLUGINS_ONLY=false; ASSUME_YES=false
+    DRY_RUN=false; CC_ONLY=false; PLUGINS_ONLY=false; ASSUME_YES=false; CC_BUILD_VERSION=""; RELOAD_PLUGINS_SENT=false
     while [ $# -gt 0 ]; do
       case "$1" in
         --dry-run) DRY_RUN=true ;;
@@ -208,7 +221,7 @@ case "$CMD" in
       echo "  Marketplaces to refresh:"
       [ -z "$MARKETPLACES" ] && echo "    (none)" || echo "$MARKETPLACES" | sed 's/^/    - /'
       [ "$PLUGINS_ONLY" = true ] && \
-        echo "  Apply method: /reload-plugins sent into tmux (queues if hermit is mid-turn)" || true
+        echo "  Apply method: /reload-plugins sent into tmux once claude prompt is detected" || true
     fi
 
     if [ "$DRY_RUN" = true ]; then
@@ -225,8 +238,12 @@ case "$CMD" in
     # in docker-entrypoint.hermit.sh) — stop_grace_period: 60s in the compose template
     # gives it enough headroom. No need to duplicate that logic here.
     if [ "$PLUGINS_ONLY" = false ]; then
-      echo "[hermit] Rebuilding image with latest Claude Code..."
-      if ! (cd "$PROJECT_DIR" && "${DC[@]}" build --pull); then
+      CC_BUILD_VERSION="${CC_LATEST}"
+      if [ -z "$CC_BUILD_VERSION" ] || [ "$CC_BUILD_VERSION" = "unknown" ] || [ "$CC_BUILD_VERSION" = "(skipped)" ]; then
+        CC_BUILD_VERSION="latest"
+      fi
+      echo "[hermit] Rebuilding image with latest Claude Code (${CC_BUILD_VERSION})..."
+      if ! (cd "$PROJECT_DIR" && "${DC[@]}" build --pull --build-arg "CLAUDE_CODE_VERSION=${CC_BUILD_VERSION}"); then
         echo "[hermit] Image build failed — old container still running, no changes applied." >&2
         exit 1
       fi
@@ -269,21 +286,30 @@ case "$CMD" in
         fi
       done <<< "$MARKETPLACES"
 
-      # Split text + Enter into two send-keys calls with sleep 0.5 between them —
-      # Claude Code's TUI treats text+Enter in one burst as bracketed paste and Enter
-      # becomes a literal newline instead of submit. Commands queue in the tmux buffer
-      # if the hermit is mid-turn and apply when idle.
-      echo "[hermit] Sending /reload-plugins to tmux session (queues if hermit is mid-turn)..."
-      cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
-        tmux send-keys -t "$TMUX_SESSION:0.0" "/reload-plugins" 2>/dev/null || \
-        echo "[hermit] Warning: could not reach tmux session — /reload-plugins not sent" >&2
-      sleep 0.5
-      cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
-        tmux send-keys -t "$TMUX_SESSION:0.0" Enter 2>/dev/null || true
+      # Wait for the Claude Code interactive prompt before sending — tmux send-keys
+      # on a pane that hasn't reached the REPL yet goes to bash, not to the skill queue.
+      echo "[hermit] Waiting for Claude Code prompt (up to 60s)..."
+      if _wait_for_claude_prompt; then
+        echo "[hermit] Sending /reload-plugins..."
+        cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
+          tmux send-keys -t "$TMUX_SESSION:0.0" "/reload-plugins" 2>/dev/null || \
+          echo "[hermit] Warning: could not reach tmux session — /reload-plugins not sent" >&2
+        sleep 0.5
+        cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
+          tmux send-keys -t "$TMUX_SESSION:0.0" Enter 2>/dev/null || true
+        RELOAD_PLUGINS_SENT=true
+      else
+        echo "[hermit] Warning: claude prompt not detected after 60s — /reload-plugins was not sent." >&2
+        echo "[hermit]          Run it manually: hermit-docker attach, then type /reload-plugins" >&2
+      fi
     fi
 
-    CC_AFTER=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" claude --version 2>/dev/null \
-      | grep -oP '[\d.]+' | head -1 || echo "unknown")
+    if [ -n "$CC_BUILD_VERSION" ] && [ "$CC_BUILD_VERSION" != "latest" ]; then
+      CC_AFTER="$CC_BUILD_VERSION"
+    else
+      CC_AFTER=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" claude --version 2>/dev/null \
+        | grep -oP '[\d.]+' | head -1 || echo "unknown")
+    fi
     PLUGINS_COUNT_AFTER=0
     [ "$CC_ONLY" = false ] && PLUGINS_COUNT_AFTER=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
       claude plugin list --json 2>/dev/null \
@@ -305,10 +331,10 @@ case "$CMD" in
     fi
     python3 - "$UPDATE_MODE" "$CC_BEFORE" "$CC_AFTER" \
               "$OK_JSON" "$FAIL_JSON" \
-              "$PLUGINS_COUNT_BEFORE" "$PLUGINS_COUNT_AFTER" "$LOG_FILE" <<'PYEOF' || \
+              "$PLUGINS_COUNT_BEFORE" "$PLUGINS_COUNT_AFTER" "$LOG_FILE" "$RELOAD_PLUGINS_SENT" <<'PYEOF' || \
       echo "[hermit] Warning: could not write update log" >&2
 import json, sys, time
-mode, cc_before, cc_after, ok_json, fail_json, pb_count, pa_count, log_file = sys.argv[1:]
+mode, cc_before, cc_after, ok_json, fail_json, pb_count, pa_count, log_file, reload_sent = sys.argv[1:]
 entry = {
     'ts': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
     'trigger': 'hermit-docker update',
@@ -318,7 +344,7 @@ entry = {
     'marketplaces_failed': json.loads(fail_json),
     'plugins_before_count': int(pb_count),
     'plugins_after_count': int(pa_count),
-    'reload_plugins_queued': mode in ('full', 'plugins-only'),
+    'reload_plugins_sent': reload_sent == 'true',
 }
 with open(log_file, 'a') as f:
     f.write(json.dumps(entry) + '\n')
@@ -330,7 +356,11 @@ PYEOF
     [ ${#MARKETPLACES_OK[@]} -gt 0 ] && echo "  Marketplaces refreshed: ${MARKETPLACES_OK[*]}" || true
     [ ${#MARKETPLACES_FAIL[@]} -gt 0 ] && echo "  Marketplaces failed:    ${MARKETPLACES_FAIL[*]}" || true
     if [ "$CC_ONLY" = false ]; then
-      echo "  /reload-plugins queued in tmux session — applies when hermit next idles."
+      if [ "$RELOAD_PLUGINS_SENT" = true ]; then
+        echo "  /reload-plugins sent — plugin updates active."
+      else
+        echo "  /reload-plugins not sent — attach and run it manually: hermit-docker attach"
+      fi
     fi
     echo ""
     echo "Verify with:  .claude-code-hermit/bin/hermit-status"

--- a/plugins/claude-code-hermit/state-templates/docker/Dockerfile.hermit.template
+++ b/plugins/claude-code-hermit/state-templates/docker/Dockerfile.hermit.template
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Match host UID for volume permissions. Ubuntu 24.04 ships a default
 # 'ubuntu' user at UID 1000 — remove it first.
 ARG HOST_UID=1000
+ARG CLAUDE_CODE_VERSION=latest
 RUN userdel -r ubuntu 2>/dev/null; \
     useradd -m -s /bin/bash -u ${HOST_UID} claude
 
@@ -24,7 +25,7 @@ RUN mkdir -p /home/claude/.claude
 # Install npm globals as claude user so Claude Code can self-update without sudo
 ENV NPM_CONFIG_PREFIX=/home/claude/.npm-global
 ENV PATH=/home/claude/.npm-global/bin:$PATH
-RUN npm install -g bun @anthropic-ai/claude-code
+RUN npm install -g bun @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
 COPY --chmod=755 --chown=claude:claude docker-entrypoint.hermit.sh /home/claude/docker-entrypoint.sh
 

--- a/plugins/claude-code-hermit/state-templates/docker/docker-compose.hermit.yml.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-compose.hermit.yml.template
@@ -5,6 +5,7 @@ services:
       dockerfile: Dockerfile.hermit
       args:
         HOST_UID: ${UID:-1000}
+        CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-latest}
     volumes:
       - ${PWD}:${PWD}
       # Isolated config volume — container gets its own Claude Code config


### PR DESCRIPTION
## Summary

- `hermit-docker update` was silently a no-op: `docker compose build --pull` only re-pulls the `FROM` base layer; the `npm install -g @anthropic-ai/claude-code` layer was cached by command string. A running hermit had self-updated to v2.1.132; after the bounce it reverted to the baked v2.1.114 — reporting `2.1.132 → 2.1.114` as an "upgrade".
- Fix: add `CLAUDE_CODE_VERSION` build ARG to `Dockerfile.hermit.template` and pass `--build-arg` from the pre-resolved `npm view` version. BuildKit includes the arg in the layer's cache key, invalidating it only when the version changes.
- Fix `CC_AFTER` reporting: was reading the reverted baked version instead of the pinned value.
- Gate `/reload-plugins` send on `tmux capture-pane` detecting the Claude Code input box (`╭─`/`╰─`), preventing keys sent to a bash pane before claude has booted.

## Test plan

- [x] Run `hermit-docker update --cc-only --yes` on a Docker hermit — confirm the `npm install` layer is NOT marked `CACHED` in the build output
- [x] Confirm the summary shows `CC_BEFORE → CC_LATEST` (not a downgrade to the baked image version)
- [x] Run a full `hermit-docker update --yes` and confirm `/reload-plugins` is sent only after the prompt is detected (or the 60s timeout warning fires if something is wrong)
- [x] Re-run `/claude-code-hermit:hermit-evolve` after updating the plugin — confirm the surgical patches to `Dockerfile.hermit` and `docker-compose.hermit.yml` are applied idempotently