### PR TITLE
reframe(dev-hermit): lead with git-safety, demote workflow skills to optional

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "claude-code-dev-hermit",
       "source": "./plugins/claude-code-dev-hermit",
-      "description": "Language-agnostic safety layer + dev conventions for any agent your hermit uses to write code",
+      "description": "Strict git-push-guard hook + optional dev conventions for any Claude Code agent — blocks force-push, --no-verify, and direct push to protected branches",
       "version": "0.3.5",
       "category": "development",
       "author": {

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- **README and marketplace reframe: git-safety leads, workflow skills demoted to optional.** `git-push-guard` + CLAUDE-APPEND template are now the headline product. The three workflow skills (`/dev-pr`, `/dev-quality`, `/dev-test`) are consolidated into an "Optional workflow scaffolding" block in the README and grouped under "Optional workflow skills" in What's Included. Marketplace description updated to match. `/hatch`'s no-match default flipped from `standard` first to `safety` first — new installs on greenfield projects with no existing commit/PR/release skills detected now land in safety mode by default.
 - **Hooks: converted `git-push-guard` and `record-test-result` to exec form.** Aligns with core's exec-form sweep. Fixes path-with-spaces fragility on installs whose plugin dir contains a space.
 
 ### Upgrade Instructions

--- a/plugins/claude-code-dev-hermit/README.md
+++ b/plugins/claude-code-dev-hermit/README.md
@@ -7,13 +7,13 @@
 
 # claude-code-dev-hermit
 
-Safety layer for code-writing agents. **Git-safe**, **Agent-agnostic**, **Tests-before-PR**, **Built on `claude-code-hermit`**.
+Strict git-safety hook for any Claude Code agent — blocks force-push, `--no-verify`, and direct push to protected branches. Optional dev workflow skills for greenfield projects.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/gtapps/claude-code-hermit/main/plugins/claude-code-hermit/assets/demo.gif" alt="claude-code-hermit demo (the core hermit — dev-hermit extends it with the safety layer described below)" width="720" />
 </p>
 
-One safety layer for every code-writing agent your hermit spawns — regardless of framework. Ships a `git-push-guard` hook (strict-by-default), `/dev-pr` to close the loop, `/dev-quality` as a pre-wrap quality gate, and a CLAUDE-APPEND template that injects the same rules into your project's `CLAUDE.md`. No built-in implementer — operators bring their own agents (native `Agent` tool, `feature-dev`, custom subagents) and dev-hermit makes sure none of them push to main.
+Installs a `git-push-guard` hook (strict-by-default) and injects git-safety rules into your project's `CLAUDE.md` via a CLAUDE-APPEND template — so every code-writing agent, regardless of framework, can't push to main or bypass hooks. No built-in implementer — bring your own agents. Optional workflow skills (`/dev-pr`, `/dev-quality`, `/dev-test`) are available for greenfield projects that don't already have their own commit/PR/release conventions.
 
 ```
 # Install
@@ -37,13 +37,9 @@ claude plugin install claude-code-dev-hermit@claude-code-hermit --scope project
 
 **Works with any agent.** The CLAUDE-APPEND.md template, injected into your project's `CLAUDE.md`, gives every code-writing agent the same rules: clean tree before starting, branch from `protected_branches[0]`, name as `<prefix>/<slug>`, run the configured test command before declaring done, re-run after `/simplify`, revert on regression. Native `Agent` tool, `feature-dev:code-architect`, your own subagent — they all read the same rules.
 
-**`/dev-pr` to close the loop.** Pushes the current feature branch and opens a PR with a body assembled inline from your commits, last test result, screenshots, and an optional project PR template. Refuses on protected branches, dirty trees, or zero commits ahead. Calls `gh pr create` (GitHub), `glab mr create` (GitLab), or a custom command configured at `/hatch`.
+**Optional workflow scaffolding.** For greenfield projects without their own commit/PR/release conventions: `/dev-pr` pushes the branch and opens a PR assembled from commits + last test result + screenshots (`gh pr create` for GitHub, `glab mr create` for GitLab, or a custom command). `/dev-quality` runs `/simplify` on the diff and re-runs `commands.test` before you commit. `/dev-test` runs the configured suite and records the result so `/dev-pr` only opens PRs after tests pass at the current commit. If your project already has its own `/commit`, `/create-pr`, or `/release` skills, skip these — `/hatch` detects them and defaults to safety mode.
 
-**Pre-wrap quality gate.** `/dev-quality` runs `/simplify` on the diff, re-runs `commands.test`, and reports pass/fail. Suggests `/code-review` if available — never invokes it.
-
-**Mid-task verification.** `/dev-test` runs the configured suite and records the result so `/dev-pr` only opens PRs after tests have actually passed on the current commit.
-
-That's it. Three skills + one hook + one template. Whatever you don't need from a typical dev-server lifecycle (the watchdog, the worktree dance, an implementer agent) — gone. Operators bring their own `tmux`, `npm run dev`, `tail -f`, and however they like to spawn agents.
+That's it. One hook + one template, with optional workflow skills on top. Whatever you don't need — gone.
 
 ---
 
@@ -115,12 +111,15 @@ See [docs/GIT-SAFETY.md](docs/GIT-SAFETY.md) for the full safety model and the t
 
 ## What's Included
 
+- **`git-push-guard` hook** — Strict-profile-only `PreToolUse` Bash hook. Blocks the dangerous git operations listed above.
+- **`state-templates/CLAUDE-APPEND.md`** — Injected into your project's `CLAUDE.md` by `/hatch`. The rules-of-the-road every agent reads when working on this project.
 - **`hatch` skill** — One-time setup wizard. Idempotent and re-runnable. Captures test/lint/format/protected/PR-template/hook-profile. Installs `git-push-guard` at strict by default.
+
+**Optional workflow skills** (for greenfield projects — skip if you already have your own `/commit`, `/create-pr`, or `/release` skills):
+
 - **`dev-pr` skill** — Push the current feature branch and open a PR with body assembled from commits + last test result + screenshots + optional project template. Runs tests automatically on cache miss — fresh HEAD pass hits instantly; anything else triggers the test runner.
 - **`dev-quality` skill** — Pre-wrap quality gate. Runs `/simplify` on the diff, re-runs `commands.test`, and reports pass/fail. Suggests `/code-review` if available — never invokes it.
 - **`dev-test` skill** — Run the configured test suite and record the result to `last-test.json`. Useful for mid-task verification and warming the `/dev-pr` cache.
-- **`git-push-guard` hook** — Strict-profile-only `PreToolUse` Bash hook. Blocks the dangerous git operations listed above.
-- **`state-templates/CLAUDE-APPEND.md`** — Injected into your project's `CLAUDE.md` by `/hatch`. The rules-of-the-road every agent reads when working on this project.
 
 ---
 

--- a/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
@@ -61,7 +61,7 @@ questions: [
 When building the options array at runtime:
 - If `hatch_mode` is already set in `config.json`, prepend `Keep current (<value>)` as the first (recommended) option.
 - If the capability scan matched one or more skill dirs, surface `safety (recommended)` with the detected names; present `standard` as the alternative.
-- If no scan match, present `standard` first (no existing project skills detected) and `safety` as the alternative.
+- If no scan match, present `safety` first and `standard` as the alternative.
 
 ### 3. Update CLAUDE.md dev block
 


### PR DESCRIPTION
## Summary

- README: \`git-push-guard\` hook + CLAUDE-APPEND template now headline the plugin. \`/dev-pr\`, \`/dev-quality\`, \`/dev-test\` consolidated into a single "Optional workflow scaffolding" block in "What you get" and an "Optional workflow skills" group in "What's Included" — makes it clear they're for greenfield projects without existing commit/PR/release skills.
- \`marketplace.json\`: description updated to match the new safety-first pitch.
- \`skills/hatch/SKILL.md\`: \`/hatch\` no-match default flipped from \`standard\` first to \`safety\` first — new installs on greenfield projects (no existing skill dirs detected) land in safety mode instead of getting the full workflow prescription.

## Test plan

- [x] All 165 tests pass (\`bash plugins/claude-code-dev-hermit/tests/run-all.sh\`)
- [x] Read README cold — git-safety appears within the first 20 lines before any workflow skill mention
- [x] Run \`/hatch\` in a scratch project with no \`.claude/skills/\` — confirm \`safety\` appears first in the mode question