### PR TITLE
feat(claude-code-hermit): add "Start implementing now" to accept flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Always launch Claude Code from this repo's root, not from inside a plugin dir. A
 - Root-scope edits (CI, root README, `.claude/`, `.claude-plugin/marketplace.json`) skip the CHANGELOG step entirely — they don't ship to operators. `/commit` handles that automatically.
 - Releases still go through `/release <slug>`, which promotes a plugin's `[Unreleased]` section to a real version. `/commit` accumulates those entries during day-to-day work.
 - **Where these skills live**: `/commit`, `/release`, `/create-pr`, `/release-status`, `/fleet-release`, `/test-run` are repo-internal skills under `.claude/skills/` — they're not shipped to operators, only used during monorepo dev. Use `/release-status` for a read-only pipeline snapshot before any release session; use `/fleet-release` when multiple plugins change together on one branch (handles dep ordering and `required_core_version` sync automatically).
+- **`/release` is operator-initiated — don't auto-suggest it.** Don't propose `/release <slug>` or `/fleet-release` in plans, summaries, or "next steps." Wait for an explicit ship/release/version request. `/create-pr` is the normal end of feature/fix flow and is welcome to suggest. `/release-status` is read-only and fine to suggest when checking pipeline state.
 
 ## Branching
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **"Create a session task" branch preserves an existing `NEXT-TASK.md` rather than overwriting it.** If one is already pending, the branch skips the write, marks the proposal `accepted`, and tells the operator to consume the existing task first via `/session-start`.
 - **Resolve Flow drops the hardcoded "Pattern confirmed absent" suffix.** `Resolved on <date>.` is now the default append. Reflect's auto-resolve path may still add the pattern-absence note in SHELL.md Findings (unchanged); the proposal file itself stays generic.
 - **`HEARTBEAT.md.template`: scope proposal review to `status: proposed`.** Accepted proposals were re-surfaced as actionable by the LLM-evaluated checklist item. New wording explicitly skips accepted, resolved, deferred, and dismissed.
+- **Accept-flow wording tightened (review pass).** Step 3a now explicitly reads both `session_id` and `session_state` so step 4(a)'s back-reference is real. Step 4(a) clarifies the read is used "to branch". Waiting branch reads "without asking, then notify" instead of the contradictory "silently; notify". The NEXT-TASK collision notify now points at a concrete recovery path (`/session-start` to consume, then re-run `/proposal-act accept PROP-NNN`) instead of the impossible "re-accept".
 
 ### Files affected
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Accept flow adds "Start implementing now" as the default third option.** When chosen, the hermit handles session lifecycle (idle: delegates to `session-mgr` to go `in_progress`; in_progress: confirms task switch with operator; waiting: falls back silently to queue) then reads the proposal body and executes the Proposed Solution in the current turn. On completion it runs `/proposal-act resolve` and notifies the operator with a one-line summary. The option is marked as the default/typical answer to guide Discord replies.
+- **"Create a session task" branch preserves an existing `NEXT-TASK.md` rather than overwriting it.** If one is already pending, the branch skips the write, marks the proposal `accepted`, and tells the operator to consume the existing task first via `/session-start`.
+- **Resolve Flow drops the hardcoded "Pattern confirmed absent" suffix.** `Resolved on <date>.` is now the default append. Reflect's auto-resolve path may still add the pattern-absence note in SHELL.md Findings (unchanged); the proposal file itself stays generic.
+- **`HEARTBEAT.md.template`: scope proposal review to `status: proposed`.** Accepted proposals were re-surfaced as actionable by the LLM-evaluated checklist item. New wording explicitly skips accepted, resolved, deferred, and dismissed.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `skills/proposal-act/SKILL.md` | Three-option accept step 4; resolve wording; description string |
+| `state-templates/HEARTBEAT.md.template` | Scope proposal review to `status: proposed` |
+| `tests/test-proposal-act-accept-flow.sh` | New regression test |
+| `tests/run-all.sh` | Register new test |
+
+### Upgrade Instructions
+
+**HEARTBEAT.md**: existing hermits have an on-disk `HEARTBEAT.md` that template updates won't touch. Check line 5 of `.claude-code-hermit/HEARTBEAT.md`. If it still reads exactly:
+
+```
+- Review proposals/ for any needing attention
+```
+
+replace it with:
+
+```
+- Review `proposals/` for any with `status: proposed` needing operator review. Skip `accepted` (operator-owned, implementation underway), `resolved`, `deferred`, and `dismissed`.
+```
+
+If you have customised this line, skip and update manually.
+
+### Known Limitations
+
+- **"Create a session task" does not queue multiple proposals.** `session-start` always deletes `NEXT-TASK.md` after presenting it, so appending would lose unselected items. The preserve-and-notify guard is the safe minimum. Making `session-start` understand a queue of suggested tasks is a separate follow-up.
+
 ## [1.0.38] - 2026-05-12
 
 ### Added

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -60,7 +60,7 @@ When the operator accepts a proposal:
    Accepted on 2026-04-06T14:30:00+01:00.
    ```
 
-3a. **Session tracking:** Read `state/runtime.json`. If `session_id` is non-null, set `accepted_in_session` to that session ID in the proposal's YAML frontmatter. If no session is active (`session_id` is null), leave `accepted_in_session: null`.
+3a. **Session tracking:** Read `state/runtime.json` for `session_id` and `session_state` (both are used below). If `session_id` is non-null, set `accepted_in_session` to that session ID in the proposal's YAML frontmatter. If no session is active (`session_id` is null), leave `accepted_in_session: null`.
 
 3b. **Routine proposals.** If the proposal metadata contains `Type: routine` and a `## Config` section with a JSON block:
     - Parse the JSON block. Validate: must have `id`, `schedule`, `skill`, `enabled` fields.
@@ -73,12 +73,12 @@ When the operator accepts a proposal:
 4. Ask: **"How should this be implemented?"**
 
    - **"Start implementing now"** (default, typical answer): handle session lifecycle, then execute in this turn.
-     a. Use the `session_state` already read from `state/runtime.json` in step 3a.
+     a. Use the `session_state` already read from `state/runtime.json` in step 3a to branch.
      b. **Idle:** delegate to `claude-code-hermit:session-mgr` to transition to `in_progress` and fill SHELL.md Task as "Implement PROP-NNN: <title>". Proceed to (e).
      c. **In progress:** confirm before switching: "Currently working on: <current task>. Switch to PROP-NNN? Y/N".
         - Yes: append `[HH:MM] switched to PROP-NNN: <title> (prior task: <prior task>)` to SHELL.md `## Progress Log`; overwrite SHELL.md `Task:` field with "Implement PROP-NNN: <title>"; `runtime.json session_state` stays `in_progress`. Proceed to (e).
         - No: fall back to "Create a session task" below.
-     d. **Waiting:** fall back to "Create a session task" silently; notify: "PROP-NNN queued. Session is currently waiting."
+     d. **Waiting:** fall back to "Create a session task" without asking, then notify: "PROP-NNN queued. Session is currently waiting."
      e. Read the proposal body and execute the Proposed Solution as the active task. If the body contains `## Skill Improvement`, use `/skill-creator` for the implementation. If the body is vague, ask the operator for clarification before proceeding.
      f. When verifiably done: run `/proposal-act resolve PROP-NNN`, then notify the operator (or channel in autonomous mode): "PROP-NNN implemented and resolved. Summary: <one-line of what was done>."
 
@@ -97,7 +97,7 @@ When the operator accepts a proposal:
      2. [Step derived from Proposed Solution]
      3. Verify the fix resolves the pattern
      ```
-     If `NEXT-TASK.md` already exists: do **not** write. Status still flips to `accepted`. Notify: "PROP-NNN accepted. NEXT-TASK already pending another proposal. Run /session-start to consume it first, or re-accept and pick 'Start implementing now' or manual."
+     If `NEXT-TASK.md` already exists: do **not** write. Status still flips to `accepted` (operator intent is recorded). Notify: "PROP-NNN accepted. NEXT-TASK is already pending another proposal. Run `/session-start` to consume it first, then re-run `/proposal-act accept PROP-NNN` and pick 'Start implementing now' or manual."
      Otherwise write the file. If the proposal contains `## Skill Improvement` and `/skill-creator` is available, append to the Suggested Plan: "Use `/skill-creator` to build and validate the skill. Run `/skill-creator eval` after creation to verify quality." Confirm: "Task prepared. The next `/session-start` will offer this as the default task."
 
    - **"I'll handle it manually"** → Just mark accepted. Respond: "Marked as accepted. No further action taken."

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: proposal-act
-description: Accept, defer, dismiss, or resolve a proposal. For accepted proposals, asks how to proceed — create a session task or note for manual implementation. Activates on messages like "accept PROP-", "dismiss PROP-", "defer PROP-", "resolve PROP-".
+description: Accept, defer, dismiss, or resolve a proposal. For accepted proposals, asks how to proceed: start implementing now, create a session task, or note for manual implementation. Activates on messages like "accept PROP-", "dismiss PROP-", "defer PROP-", "resolve PROP-".
 ---
 # Proposal Act
 
@@ -71,6 +71,17 @@ When the operator accepts a proposal:
     - Skip step 4 — no further implementation needed.
 
 4. Ask: **"How should this be implemented?"**
+
+   - **"Start implementing now"** (default, typical answer): handle session lifecycle, then execute in this turn.
+     a. Use the `session_state` already read from `state/runtime.json` in step 3a.
+     b. **Idle:** delegate to `claude-code-hermit:session-mgr` to transition to `in_progress` and fill SHELL.md Task as "Implement PROP-NNN: <title>". Proceed to (e).
+     c. **In progress:** confirm before switching: "Currently working on: <current task>. Switch to PROP-NNN? Y/N".
+        - Yes: append `[HH:MM] switched to PROP-NNN: <title> (prior task: <prior task>)` to SHELL.md `## Progress Log`; overwrite SHELL.md `Task:` field with "Implement PROP-NNN: <title>"; `runtime.json session_state` stays `in_progress`. Proceed to (e).
+        - No: fall back to "Create a session task" below.
+     d. **Waiting:** fall back to "Create a session task" silently; notify: "PROP-NNN queued. Session is currently waiting."
+     e. Read the proposal body and execute the Proposed Solution as the active task. If the body contains `## Skill Improvement`, use `/skill-creator` for the implementation. If the body is vague, ask the operator for clarification before proceeding.
+     f. When verifiably done: run `/proposal-act resolve PROP-NNN`, then notify the operator (or channel in autonomous mode): "PROP-NNN implemented and resolved. Summary: <one-line of what was done>."
+
    - **"Create a session task"** → Write `.claude-code-hermit/sessions/NEXT-TASK.md`:
      ```markdown
      # Next Task (from PROP-NNN)
@@ -86,18 +97,10 @@ When the operator accepts a proposal:
      2. [Step derived from Proposed Solution]
      3. Verify the fix resolves the pattern
      ```
-     Confirm: "Task prepared. The next `/session-start` will offer this as the default task."
+     If `NEXT-TASK.md` already exists: do **not** write. Status still flips to `accepted`. Notify: "PROP-NNN accepted. NEXT-TASK already pending another proposal. Run /session-start to consume it first, or re-accept and pick 'Start implementing now' or manual."
+     Otherwise write the file. If the proposal contains `## Skill Improvement` and `/skill-creator` is available, append to the Suggested Plan: "Use `/skill-creator` to build and validate the skill. Run `/skill-creator eval` after creation to verify quality." Confirm: "Task prepared. The next `/session-start` will offer this as the default task."
 
    - **"I'll handle it manually"** → Just mark accepted. Respond: "Marked as accepted. No further action taken."
-
-4b. **Skill creation proposals.** If the accepted proposal contains a `## Skill Improvement` section OR the proposal title/body indicates a new skill should be created:
-    - Check if `/skill-creator` is available (plugin installed)
-    - If available AND operator chose "Create a session task":
-      - Append to the NEXT-TASK.md suggested plan: "Use `/skill-creator` to build and validate the skill. Run `/skill-creator eval` after creation to verify quality."
-      - Note in the task context: "This proposal was flagged for skill-creator — use it for structured iteration instead of manual SKILL.md edits."
-    - If `/skill-creator` is not available:
-      - Proceed normally (manual implementation or direct SKILL.md edits)
-      - Note: "skill-creator not installed — skill changes will be applied directly."
 
 5. Notify the operator: "PROP-NNN accepted: [title]"
 
@@ -143,8 +146,9 @@ Used when reflect has surfaced a sparse-cadence proposal as a resolution candida
    ```
 4. Append to the Operator Decision section:
    ```
-   Resolved on 2026-04-06T14:30:00+01:00. Pattern confirmed absent.
+   Resolved on 2026-04-06T14:30:00+01:00.
    ```
+   If the resolve was triggered by reflect's auto-resolve flow (pattern absent from recent sessions), the caller may append "Pattern confirmed absent." but this is no longer the default — resolve also covers implementation completion via the Start-now branch.
 5. Respond: "PROP-NNN resolved."
 
 No first-response tracking on resolve — the proposal was already accepted and that event was already logged.

--- a/plugins/claude-code-hermit/state-templates/HEARTBEAT.md.template
+++ b/plugins/claude-code-hermit/state-templates/HEARTBEAT.md.template
@@ -2,4 +2,4 @@
 <!-- Keep under 10 items. Move periodic checks to routines (/hermit-settings routines). -->
 
 ## Standing Checks
-- Review proposals/ for any needing attention
+- Review `proposals/` for any with `status: proposed` needing operator review. Skip `accepted` (operator-owned, implementation underway), `resolved`, `deferred`, and `dismissed`.

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -15,5 +15,5 @@ bash "$SCRIPT_DIR/test-docker-security-templates.sh" || rc=$?
 bash "$SCRIPT_DIR/test-template-skill-sync.sh"       || rc=$?
 bash "$SCRIPT_DIR/test-archive-shell.sh"             || rc=$?
 bash "$SCRIPT_DIR/test-hook-registration-form.sh"   || rc=$?
-bash "$SCRIPT_DIR/test-proposal-act-accept-flow.sh" || rc=$?
+bash "$SCRIPT_DIR/test-proposal-act-accept-flow.sh"  || rc=$?
 exit $rc

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -15,4 +15,5 @@ bash "$SCRIPT_DIR/test-docker-security-templates.sh" || rc=$?
 bash "$SCRIPT_DIR/test-template-skill-sync.sh"       || rc=$?
 bash "$SCRIPT_DIR/test-archive-shell.sh"             || rc=$?
 bash "$SCRIPT_DIR/test-hook-registration-form.sh"   || rc=$?
+bash "$SCRIPT_DIR/test-proposal-act-accept-flow.sh" || rc=$?
 exit $rc

--- a/plugins/claude-code-hermit/tests/test-proposal-act-accept-flow.sh
+++ b/plugins/claude-code-hermit/tests/test-proposal-act-accept-flow.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Regression: proposal-act Accept Flow lists all three implementation options.
+#
+# Guards against losing any branch or the description tweak in a future edit.
+# Runs from inside plugins/claude-code-hermit/ (REPO_ROOT = that directory).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+echo "=== proposal-act accept flow tests ==="
+echo ""
+
+SKILL="$REPO_ROOT/skills/proposal-act/SKILL.md"
+
+run_test "skill file exists" test -f "$SKILL"
+
+# All three options present in the Accept Flow body.
+run_test "'Start implementing now' option present" \
+  grep -qF "Start implementing now" "$SKILL"
+
+run_test "'Start implementing now' marked as default" \
+  grep -qF "default, typical answer" "$SKILL"
+
+run_test "'Create a session task' option present" \
+  grep -qF "Create a session task" "$SKILL"
+
+run_test "'I'll handle it manually' option present" \
+  grep -qF "I'll handle it manually" "$SKILL"
+
+# Frontmatter description specifically (between the opening --- and the second ---).
+FRONTMATTER="$(awk '/^---$/{c++; next} c==1' "$SKILL")"
+run_test "frontmatter description mentions 'start implementing now'" \
+  bash -c 'echo "$1" | grep -q "^description:.*start implementing now"' -- "$FRONTMATTER"
+
+print_results


### PR DESCRIPTION
## Summary

- Adds a third option to the proposal accept question ("Start implementing now", marked as default) that executes the Proposed Solution in the current turn. Handles all session states: idle delegates to `session-mgr`; in_progress confirms before switching; waiting falls back silently to NEXT-TASK.
- Guards "Create a session task" against silent NEXT-TASK.md overwrites: if one is already pending, preserves it and tells the operator to consume it first.
- Drops the hardcoded "Pattern confirmed absent" suffix from the Resolve Flow — resolve now also covers implementation completion, not only reflect auto-resolves.
- Scopes HEARTBEAT proposal review to `status: proposed` only — accepted proposals were being re-surfaced as actionable even after the operator gave the green light.
- Root: adds CLAUDE.md rule — don't auto-suggest `/release` or `/fleet-release`; wait for explicit operator request.

## Test plan

- [x] `bash tests/run-all.sh` from `plugins/claude-code-hermit/` — all 6 new contract assertions pass alongside existing suite
- [x] Accept a proposal interactively, pick "Start implementing now" — session transitions to in_progress, hermit executes Proposed Solution in-turn
- [x] Accept with "Create a session task" when NEXT-TASK.md already exists — preserves existing file, notifies operator
- [x] Trigger HEARTBEAT with an accepted proposal present — confirm it is no longer surfaced as needing attention
- [x] Discord round-trip: `accept PROP-NNN` → hermit asks three-option question → reply routes back correctly via conversation context