### PR TITLE
feat(hermit-scribe): harden filing flow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,7 @@
   },
   "enabledPlugins": {
     "claude-code-hermit@claude-code-hermit": true,
-    "feature-dev@claude-plugins-official": true
+    "feature-dev@claude-plugins-official": true,
+    "hermit-scribe@claude-code-hermit": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ Always launch Claude Code from this repo's root, not from inside a plugin dir. A
 
 ## Environment quirks
 
+- **Secrets:** env vars → `.env` (gitignored); secret files (`.pem` etc.) → `.claude.local/` (gitignored). Never `.claude/` — it's checked in.
+- **Docker paths mirror the host** (`${PWD}:${PWD}` mount) — absolute paths are identical inside the container despite the container user being `claude`.
 - **`rm -rf` is blocked** by the `enforce-deny-patterns` hook. Use `rm -r` (no `-f`) for scratch cleanup.
 - **Subtree imports are unsquashed**: `git log --first-parent` for the monorepo-only view; full upstream commits live under each subtree merge.
 - **CI is not path-filtered yet**: every plugin's tests run on every PR. Don't assume a HA-test failure on a core-only PR is your fault.

--- a/plugins/hermit-scribe/CHANGELOG.md
+++ b/plugins/hermit-scribe/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `HERMIT_GH_APP_KEY_FILE` path errors now surface a labeled message (`HERMIT_GH_APP_KEY_FILE='<path>' does not exist (cwd=<x>) — check .env`) instead of a raw `ENOENT` from deep in the JWT signing path.
+
+### Added
+
+- `--check <proposal-id>` flag on `file-issue.js`: queries open `hermit-filed` issues and matches on the `proposal={id}` footer. Exits 0 with the URL if found, 2 with "no match" if not. The skill runs this automatically before filing and surfaces the result to the operator.
+- `issue-sanitizer` subagent: strips anything personal or specific to the operator's machine and project unless it's clearly part of an upstream hermit plugin. Always strips secrets, `.env` content, connection strings, internal hostnames/IPs, and non-public URLs even when they look technical. Single `<redacted>` placeholder; one principle the LLM applies rather than an exhaustive rule list. Operator un-redacts during the preview step if needed. Configured with `model: haiku`, `effort: low`, `maxTurns: 2` to cap cost.
+- Operator preview gate: before invoking the script, the skill shows the sanitized title + body and asks the operator to confirm, edit, or cancel.
+- Proposal frontmatter back-write: on successful file, the skill inserts `gh_issue: <url>` into the proposal's YAML frontmatter so `/proposal-list` and cortex views can show the linked issue without re-querying GitHub.
+
 ---
 
 ## [0.0.1] - 2026-05-13

--- a/plugins/hermit-scribe/CLAUDE.md
+++ b/plugins/hermit-scribe/CLAUDE.md
@@ -13,8 +13,9 @@ claude plugin install hermit-scribe@claude-code-hermit --scope project
 
 ## Plugin Structure
 
+- `agents/issue-sanitizer.md`: subagent that sanitizes draft issue content before filing — strips anything personal or specific to the operator's machine and project unless it's clearly part of an upstream hermit plugin. Tools: none (pure text transform).
 - `skills/hermit-scribe/SKILL.md`: the skill, namespaced as `/hermit-scribe:hermit-scribe`
-- `skills/hermit-scribe/file-issue.js`: Node stdlib script that signs the JWT, gets an install token, and POSTs the issue
+- `skills/hermit-scribe/file-issue.js`: Node stdlib script that signs the JWT, gets an install token, and POSTs the issue. Supports `--check <proposal-id>` to query existing issues before filing.
 - `.claude-plugin/plugin.json`: plugin manifest
 
 ## Required env vars
@@ -28,7 +29,7 @@ Set these in your project `.env` (loaded by Docker hermit via `env_file:`) or in
 | `HERMIT_GH_APP_KEY_FILE` | Absolute path to the `.pem` private key file |
 | `HERMIT_GH_REPO` | Optional override; target `owner/repo` (default: `gtapps/claude-code-hermit`) |
 
-Place the private key at `.claude/secrets/hermit-scribe-key.pem` (gitignored via `*.pem`).
+Place the private key at `.claude.local/hermit-scribe-key.pem` (`.claude.local/` is gitignored).
 
 ## Manual smoke test
 

--- a/plugins/hermit-scribe/README.md
+++ b/plugins/hermit-scribe/README.md
@@ -30,8 +30,7 @@ The plugin requires a GitHub App with `Issues: Read & write` permission installe
 Store the key in a gitignored location:
 
 ```bash
-mkdir -p .claude/secrets
-mv ~/Downloads/<your-app>.*.pem .claude/secrets/hermit-scribe-key.pem
+mv ~/Downloads/<your-app>.*.pem .claude.local/hermit-scribe-key.pem
 ```
 
 ## Env vars
@@ -58,13 +57,27 @@ For proposal-backed issues: the skill globs `.claude-code-hermit/proposals/PROP-
 
 For ad-hoc: supply title and body directly.
 
-All issues get the `hermit-filed` label. No dedup; running twice creates two issues.
+All issues get the `hermit-filed` label.
+
+### Dedup
+
+Before filing, the skill runs `--check {id}` automatically. If a matching issue already exists (matched by `proposal={id}` in the footer), the skill shows the existing URL and asks whether to skip or proceed. Re-filing after overriding writes the new URL into the proposal's `gh_issue:` field (latest wins).
+
+### Privacy sanitization
+
+Before showing the preview, the skill passes the draft through the `issue-sanitizer` subagent. It strips anything personal or specific to the operator's machine and project unless it's clearly part of an upstream hermit plugin (`claude-code-hermit`, `claude-code-dev-hermit`, `claude-code-homeassistant-hermit`, `claude-code-fitness-hermit`, `hermit-scribe`) or the hermit state tree (`.claude-code-hermit/...`). Secrets, `.env` content, connection strings, internal hostnames/IPs, and non-public URLs are always stripped even when they look technical. Stripped content is replaced with `<redacted>`.
+
+The operator can un-redact specific items during the preview step if a particular value is load-bearing for the issue.
+
+### Operator preview
+
+The cleaned title and body are shown to the operator before filing. The operator can confirm, edit, or cancel.
 
 ## Errors
 
 | Error | Cause |
 |-------|-------|
-| `ENOENT` | Key file path wrong or missing |
+| `HERMIT_GH_APP_KEY_FILE='...' does not exist` | Key file path wrong or missing — check `.env` |
 | `GH 401: Bad credentials` | Wrong App ID, install ID, or key file |
 | `GH 404` | App not installed on target repo, or repo name typo |
 | `GH 422` | Empty title or GitHub validation error |
@@ -80,9 +93,11 @@ All issues get the `hermit-filed` label. No dedup; running twice creates two iss
 
 ```
 hermit-scribe/
+  ├── agents/
+  │     └── issue-sanitizer.md  redacts non-hermit content from draft body
   └── skills/hermit-scribe/
-        ├── SKILL.md        trigger phrases + filing instructions
-        └── file-issue.js   stdlib: JWT → install token → POST /issues
+        ├── SKILL.md            trigger phrases + filing flow
+        └── file-issue.js       stdlib: JWT → install token → POST /issues; --check flag
 ```
 
 `file-issue.js` is a single-shot Node script: signs an RS256 JWT from the App private key, exchanges it for an installation access token at `POST /app/installations/{id}/access_tokens`, then `POST /repos/{owner}/{repo}/issues` with the `hermit-filed` label. Two HTTPS round-trips per invocation. Node is required (Claude Code already provides it).

--- a/plugins/hermit-scribe/agents/issue-sanitizer.md
+++ b/plugins/hermit-scribe/agents/issue-sanitizer.md
@@ -1,0 +1,53 @@
+---
+name: issue-sanitizer
+description: Sanitizes a draft GitHub issue (title + body) before it's filed publicly. Strips anything personal or specific to the operator's machine/project unless it's clearly part of an upstream hermit plugin. Invoked by hermit-scribe:hermit-scribe.
+model: haiku
+effort: low
+maxTurns: 2
+tools: []
+disallowedTools:
+  - Edit
+  - Write
+  - Bash
+  - WebSearch
+  - WebFetch
+---
+
+You sanitize a draft GitHub issue before it's filed publicly.
+
+## Input
+
+The caller's message contains:
+
+```
+DRAFT_TITLE: <title>
+DRAFT_BODY:
+<body markdown>
+```
+
+## Output
+
+Return only:
+
+```
+TITLE: <sanitized title>
+<<<HERMIT_SCRIBE_BODY>>>
+<sanitized body markdown>
+```
+
+Do not emit the `<<<HERMIT_SCRIBE_BODY>>>` sentinel anywhere else.
+
+## What to redact
+
+Strip anything personal or specific to the operator's machine and project, unless it's clearly part of the upstream `claude-code-hermit` plugin or one of its sibling hermit plugins (`claude-code-dev-hermit`, `claude-code-homeassistant-hermit`, `claude-code-fitness-hermit`, `hermit-scribe`). The hermit state tree (`.claude-code-hermit/...`) is fine to keep.
+
+**Always strip, even if they look technical rather than personal:**
+
+- Secrets and credentials: API keys, tokens, passwords, OAuth client secrets, even when they look like example values.
+- `.env` file content: entire snippets, not just the values.
+- Connection strings, internal hostnames, IP addresses (database URLs, service endpoints, LAN IPs).
+- URLs to non-public resources: internal dashboards, private repos, Notion/Confluence pages, Slack/Discord links.
+
+Replace stripped content with `<redacted>`. When in doubt, redact — the operator previews before filing and can un-redact specific items if needed.
+
+Redaction only. Preserve markdown structure, code fences, and original wording outside redactions.

--- a/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
+++ b/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
@@ -22,9 +22,9 @@ Activate when the operator says:
 If the operator named a proposal (`PROP-NNN`):
 1. Glob `.claude-code-hermit/proposals/PROP-NNN-*.md` to find the file.
 2. Read frontmatter: `id`, `title`, `category`, `session`.
-3. Read body sections verbatim: `## Context`, `## Problem`, `## Proposed Solution`, `## Impact`.
-4. Issue title: `[hermit/{category}] {title}`.
-5. Append to body:
+3. Read body sections: `## Context`, `## Problem`, `## Proposed Solution`, `## Impact`.
+4. Construct draft title: `[hermit/{category}] {title}`.
+5. Construct draft body with the four body sections, then append:
    ```
    ---
    *Filed via hermit-scribe · proposal={id} · session={session}*
@@ -32,19 +32,55 @@ If the operator named a proposal (`PROP-NNN`):
 
 For ad-hoc issues (no proposal): use the title and body the operator provides.
 
-**Step 2: write title and body to temp files.**
+**Step 2: dedup check.** (proposal-backed only — skip for ad-hoc issues)
+
+Run:
+```bash
+node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" --check {id}
+```
+
+- Exit 0 + URL printed → an issue already exists for this proposal. Show the URL to the operator and ask whether to skip filing or proceed anyway.
+- Exit 2 → no existing issue. Continue.
+
+**Step 3: sanitize.**
+
+Pass the draft title and body to the `hermit-scribe:issue-sanitizer` subagent:
+
+```
+DRAFT_TITLE: {draft title}
+DRAFT_BODY:
+{draft body}
+```
+
+Parse the response: split on the `<<<HERMIT_SCRIBE_BODY>>>` line. Everything before it (after stripping `TITLE: `) is the cleaned title; everything after is the cleaned body.
+
+**Step 4: operator preview.**
+
+Print the cleaned title and body to the operator:
+
+```
+--- PREVIEW ---
+Title: {cleaned title}
+
+{cleaned body}
+--- END PREVIEW ---
+
+File this issue? (yes / edit / cancel)
+```
+
+Wait for the operator's response. On "edit": apply any requested changes to title or body. On "cancel": abort. Proceed only on "yes" or after applying edits.
+
+**Step 5: write title and body to temp files.**
 
 Run `mktemp -d` and capture the path it prints to stdout (something like `/tmp/tmp.AbCdEf`). Shell state does not persist between Bash tool calls, so record the exact path from the output before using the Write tool.
 
-Use the Write tool to create two files inside that directory. If the mktemp path was `/tmp/tmp.AbCdEf`, the files are:
-- `/tmp/tmp.AbCdEf/title` containing the issue title only (single line, no markdown formatting).
-- `/tmp/tmp.AbCdEf/body.md` containing the issue body markdown.
+Use the Write tool to create two files inside that directory:
+- `/tmp/tmp.AbCdEf/title` — the cleaned issue title (single line, no markdown formatting).
+- `/tmp/tmp.AbCdEf/body.md` — the cleaned issue body markdown.
 
-Passing both as files avoids any shell-quoting issues with title content.
+**Step 6: run the script.**
 
-**Step 3: run the script.**
-
-Substitute the same path from step 2. If the mktemp path was `/tmp/tmp.AbCdEf`:
+Substitute the same path from step 5:
 
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /tmp/tmp.AbCdEf/title /tmp/tmp.AbCdEf/body.md
@@ -52,12 +88,14 @@ node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /tmp/tmp.AbCdEf/ti
 
 Capture stdout: it is the issue URL on success. Stderr has any error message.
 
-**Step 4: report.**
+**Step 7: back-write and report.**
 
-On success: output `Filed: {url}`.
+On success:
+1. Use the Edit tool to insert `gh_issue: {url}` into the proposal's YAML frontmatter, on a new line directly after the `id:` field. Skip this step for ad-hoc issues (no proposal file).
+2. Output `Filed: {url}`.
 
 On error, surface the stderr. Common causes:
-- `ENOENT` → `HERMIT_GH_APP_KEY_FILE` path is wrong or file is missing.
+- `HERMIT_GH_APP_KEY_FILE='...' does not exist` → key file path is wrong or file is missing — check `.env`.
 - `GH 401: Bad credentials` → wrong App ID, install ID, or key file.
 - `GH 404` → App not installed on target repo, or repo name typo.
 - `GH 422` → empty title or GH validation error.
@@ -65,5 +103,5 @@ On error, surface the stderr. Common causes:
 ## Notes
 
 - `HERMIT_GH_REPO` overrides the default target (`gtapps/claude-code-hermit`).
-- Running the skill twice on the same PROP-NNN creates two issues; no dedup. Operator's call.
-- This skill does not write back to the proposal file.
+- If the operator overrides the dedup check and re-files the same proposal, `gh_issue` in the frontmatter is overwritten with the new URL (latest wins).
+- The `issue-sanitizer` subagent strips anything personal or specific to the operator's machine and project unless it's clearly part of an upstream hermit plugin. It does not edit for style or clarity — only for privacy.

--- a/plugins/hermit-scribe/skills/hermit-scribe/file-issue.js
+++ b/plugins/hermit-scribe/skills/hermit-scribe/file-issue.js
@@ -52,13 +52,7 @@ function ghRequest(method, path, auth, body) {
   });
 }
 
-async function main() {
-  const [, , titleFile, bodyFile] = process.argv;
-  if (!titleFile || !bodyFile) {
-    process.stderr.write("Usage: node file-issue.js <title-file> <body-file>\n");
-    process.exit(1);
-  }
-
+function loadEnv() {
   const {
     HERMIT_GH_APP_ID,
     HERMIT_GH_APP_INSTALL_ID,
@@ -82,22 +76,85 @@ async function main() {
     process.stderr.write(`HERMIT_GH_REPO must be "owner/repo", got: ${HERMIT_GH_REPO}\n`);
     process.exit(1);
   }
-  const [owner, repo] = repoParts;
 
-  const pem = readFileSync(HERMIT_GH_APP_KEY_FILE, "utf8");
+  const [owner, repo] = repoParts;
+  return { HERMIT_GH_APP_ID, HERMIT_GH_APP_INSTALL_ID, HERMIT_GH_APP_KEY_FILE, owner, repo };
+}
+
+async function getInstallToken({ HERMIT_GH_APP_ID, HERMIT_GH_APP_INSTALL_ID, HERMIT_GH_APP_KEY_FILE }) {
+  let pem;
+  try {
+    pem = readFileSync(HERMIT_GH_APP_KEY_FILE, "utf8");
+  } catch {
+    process.stderr.write(
+      `HERMIT_GH_APP_KEY_FILE='${HERMIT_GH_APP_KEY_FILE}' does not exist (cwd=${process.cwd()}) — check .env\n`
+    );
+    process.exit(1);
+  }
+  const jwt = makeJWT(HERMIT_GH_APP_ID, pem);
+  const { token } = await ghRequest(
+    "POST",
+    `/app/installations/${HERMIT_GH_APP_INSTALL_ID}/access_tokens`,
+    `Bearer ${jwt}`
+  );
+  return token;
+}
+
+async function checkMode() {
+  const proposalId = process.argv[3];
+  if (!proposalId) {
+    process.stderr.write("Usage: node file-issue.js --check <proposal-id>\n");
+    process.exit(1);
+  }
+
+  const env = loadEnv();
+  const token = await getInstallToken(env);
+  const { owner, repo } = env;
+
+  let page = 1;
+  while (true) {
+    const issues = await ghRequest(
+      "GET",
+      `/repos/${owner}/${repo}/issues?labels=hermit-filed&state=open&per_page=100&page=${page}`,
+      `Bearer ${token}`
+    );
+    if (!Array.isArray(issues) || issues.length === 0) break;
+    const match = issues.find((i) => i.body && i.body.includes(`proposal=${proposalId}`));
+    if (match) {
+      process.stdout.write(match.html_url + "\n");
+      process.exit(0);
+    }
+    if (issues.length < 100) break;
+    page++;
+  }
+
+  process.stderr.write(`no match for ${proposalId}\n`);
+  process.exit(2);
+}
+
+async function main() {
+  if (process.argv[2] === "--check") {
+    await checkMode();
+    return;
+  }
+
+  const [, , titleFile, bodyFile] = process.argv;
+  if (!titleFile || !bodyFile) {
+    process.stderr.write("Usage: node file-issue.js <title-file> <body-file>\n");
+    process.exit(1);
+  }
+
+  const env = loadEnv();
+
   const title = readFileSync(titleFile, "utf8").trim();
   const issueBody = readFileSync(bodyFile, "utf8");
   if (!title) {
     process.stderr.write(`Title file is empty: ${titleFile}\n`);
     process.exit(1);
   }
-  const jwt = makeJWT(HERMIT_GH_APP_ID, pem);
 
-  const { token } = await ghRequest(
-    "POST",
-    `/app/installations/${HERMIT_GH_APP_INSTALL_ID}/access_tokens`,
-    `Bearer ${jwt}`
-  );
+  const token = await getInstallToken(env);
+  const { owner, repo } = env;
 
   const issue = await ghRequest(
     "POST",

--- a/plugins/hermit-scribe/tests/cli.test.js
+++ b/plugins/hermit-scribe/tests/cli.test.js
@@ -115,13 +115,43 @@ test("HERMIT_GH_REPO with no slash is rejected", () => {
   );
 });
 
-test("missing key file produces ENOENT", () => {
+test("missing key file shows labeled error with var name and path", () => {
   assertFails(
     { ...fullEnv, HERMIT_GH_APP_KEY_FILE: "/nonexistent/key.pem" },
     [titleFile, bodyFile],
-    /ENOENT/
+    /HERMIT_GH_APP_KEY_FILE=.*does not exist/
   );
 });
+
+test("--check with no proposal id prints usage and exits 1", () => {
+  assertFails({}, ["--check"], /Usage: node file-issue\.js --check/);
+});
+
+test("--check with missing env var reports the var name", () => {
+  assertFails({}, ["--check", "PROP-001"], /Missing env var: HERMIT_GH_APP_ID/);
+});
+
+test("--check with missing key file shows labeled error", () => {
+  assertFails(
+    { ...fullEnv, HERMIT_GH_APP_KEY_FILE: "/nonexistent/key.pem" },
+    ["--check", "PROP-001"],
+    /HERMIT_GH_APP_KEY_FILE=.*does not exist/
+  );
+});
+
+// Requires real GitHub App credentials. Set HERMIT_GH_CHECK_LIVE=1 to run.
+if (process.env.HERMIT_GH_CHECK_LIVE) {
+  test("--check with unknown proposal id exits 2 with no match message", () => {
+    const liveEnv = {
+      HERMIT_GH_APP_ID: process.env.HERMIT_GH_APP_ID,
+      HERMIT_GH_APP_INSTALL_ID: process.env.HERMIT_GH_APP_INSTALL_ID,
+      HERMIT_GH_APP_KEY_FILE: process.env.HERMIT_GH_APP_KEY_FILE,
+    };
+    const r = run(liveEnv, ["--check", "PROP-NOTREAL-99999"]);
+    assertEqual(r.status, 2, "exit code");
+    assertMatch(r.stderr, /no match/, "stderr");
+  });
+}
 
 test("empty title file is rejected", () => {
   assertFails(fullEnv, [emptyTitleFile, bodyFile], /Title file is empty/);


### PR DESCRIPTION
## Summary

- **`file-issue.js`**: raw `ENOENT` on bad key path replaced with a labeled error (`HERMIT_GH_APP_KEY_FILE='<path>' does not exist — check .env`). New `--check <proposal-id>` flag queries open `hermit-filed` issues by footer match before filing. Shared `loadEnv` + `getInstallToken` helpers extracted; `accessSync` TOCTOU anti-pattern removed.
- **`issue-sanitizer` agent** (new): strips anything personal or specific to the operator's machine/project unless it's clearly part of an upstream hermit plugin. Generic principle — not an enumerated rule list. Always strips secrets, `.env` content, connection strings, internal URLs. Single `<redacted>` placeholder. `<<<HERMIT_SCRIBE_BODY>>>` sentinel avoids `---` parsing collisions with markdown bodies. Configured with `model: haiku`, `effort: low`, `maxTurns: 2`.
- **`SKILL.md`**: 4-step flow expanded to 7 — dedup check (`--check`), sanitizer subagent, operator preview gate (confirm/edit/cancel), then `gh_issue: <url>` written back to proposal frontmatter on success.
- **Tests**: updated keyfile test to assert labeled error; 3 new `--check` tests (usage, env validation, keyfile error). Live dedup test gated behind `HERMIT_GH_CHECK_LIVE=1`. 13/13 pass.
- **Root `CLAUDE.md`**: two env-quirk notes added (`.env`/`.claude.local` secrets placement, Docker `${PWD}:${PWD}` path identity).

## Test plan

- [x] `cd plugins/hermit-scribe && node tests/cli.test.js` → 13/13 pass
- [x] Smoke-test labeled keyfile error: `HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent node skills/hermit-scribe/file-issue.js /dev/null /dev/null`
- [x] Live `--check` dedup: `HERMIT_GH_CHECK_LIVE=1 node tests/cli.test.js` with real credentials
- [x] End-to-end: file a proposal as an issue against a test repo, verify sanitizer preview, confirm `gh_issue:` written to frontmatter