### PR TITLE
feat(claude-code-fitness-hermit): RPE capture via channel after strava-sync

### DIFF
--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -8,11 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **capture-activity-rpe**: new fleet-owned skill that auto-triggers when the operator replies to a `strava-sync` channel notification with an RPE rating. Binds the RPE to the most-recently synced activity and persists to `state/activity-notes.json`. Channel-agnostic (Discord, Telegram, iMessage). Duplicates `channel-responder`'s `allowed_users` auth check since it auto-triggers outside that gate.
+- **capture-activity-rpe**: new fleet-owned skill that captures RPE when the operator replies to a `strava-sync` channel notification. Self-triggers via skill description match (intentionally more specific than `claude-code-hermit:channel-responder`) while `state/strava-pending-rpe.json` is fresh. Re-checks `allowed_users` itself rather than relying on `channel-responder`'s gate. Binds the RPE to the most-recently synced activity and persists to `state/activity-notes.json`. Channel-agnostic (Discord, Telegram, iMessage).
 - **set-rpe**: new slash command for manual and retroactive RPE entry (`/claude-code-fitness-hermit:set-rpe <id|latest> <rpe> [notes]`). Primary escape hatch for non-latest activities, backfilling, and corrections.
 - **strava-sync**: appends an RPE prompt to the daily channel summary. After a successful send, writes `state/strava-pending-rpe.json` with the latest synced activity for `capture-activity-rpe` to consume.
 - **activity-deep-dive**: reads `state/activity-notes.json` for the analyzed activity (after ID resolution) and surfaces `Subjective: RPE N/10 — <notes>` in the output and compiled-artifact frontmatter when present.
 - **weekly-load-review**: reads `state/activity-notes.json` for this week's activities and appends `💬 Avg RPE: X.X/10 (N=<count>)` to the channel summary when 2 or more entries exist.
+- **knowledge-schema.md**: documents the JSON shape of `activity-notes.json` and `strava-pending-rpe.json`, including the invariant that `notes` is always present (`null` when empty, never missing). Cross-skill consumers (`activity-deep-dive`, `weekly-load-review`) can rely on this.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **capture-activity-rpe**: new fleet-owned skill that auto-triggers when the operator replies to a `strava-sync` channel notification with an RPE rating. Binds the RPE to the most-recently synced activity and persists to `state/activity-notes.json`. Channel-agnostic (Discord, Telegram, iMessage). Duplicates `channel-responder`'s `allowed_users` auth check since it auto-triggers outside that gate.
+- **set-rpe**: new slash command for manual and retroactive RPE entry (`/claude-code-fitness-hermit:set-rpe <id|latest> <rpe> [notes]`). Primary escape hatch for non-latest activities, backfilling, and corrections.
+- **strava-sync**: appends an RPE prompt to the daily channel summary. After a successful send, writes `state/strava-pending-rpe.json` with the latest synced activity for `capture-activity-rpe` to consume.
+- **activity-deep-dive**: reads `state/activity-notes.json` for the analyzed activity (after ID resolution) and surfaces `Subjective: RPE N/10 — <notes>` in the output and compiled-artifact frontmatter when present.
+- **weekly-load-review**: reads `state/activity-notes.json` for this week's activities and appends `💬 Avg RPE: X.X/10 (N=<count>)` to the channel summary when 2 or more entries exist.
+
+### Upgrade Instructions
+
+1. Overwrite `.claude-code-hermit/compiled/routine-strava-sync.md` and `.claude-code-hermit/compiled/routine-weekly-load-review.md` from this plugin's `state-templates/compiled/`. These are bot-owned routine prompts; it is safe to overwrite them.
+2. Create `.claude-code-hermit/state/activity-notes.json` as `{}` if the file does not exist. (`strava-pending-rpe.json` is created on the next routine run — no manual seeding needed.)
+3. In the `Fitness Workflow` block of the project's `CLAUDE.md` (between the `<!-- claude-code-fitness-hermit: Fitness Workflow -->` markers), append these two lines to the Conventions section:
+   - `Subjective notes: state/activity-notes.json (written by capture-activity-rpe + set-rpe, read by activity-deep-dive + weekly-load-review)`
+   - `Pending RPE: state/strava-pending-rpe.json (written by strava-sync after a successful channel send, read and deleted by capture-activity-rpe)`
+
+---
+
 ## [0.0.2] - 2026-05-03
 
 ### Changed

--- a/plugins/claude-code-fitness-hermit/CLAUDE.md
+++ b/plugins/claude-code-fitness-hermit/CLAUDE.md
@@ -17,6 +17,8 @@ After install, run `/claude-code-fitness-hermit:hatch` in the target project. Th
 
 - `skills/hatch/` — one-time setup wizard namespaced as `/claude-code-fitness-hermit:hatch`
 - `skills/activity-deep-dive/` — per-activity coaching analysis (`/claude-code-fitness-hermit:activity-deep-dive`)
+- `skills/capture-activity-rpe/` — auto-triggered RPE capture from channel replies (`/claude-code-fitness-hermit:capture-activity-rpe`)
+- `skills/set-rpe/` — manual RPE entry for any activity (`/claude-code-fitness-hermit:set-rpe`)
 - `agents/strava-data-cruncher.md` — Haiku bulk-aggregation subagent (`@claude-code-fitness-hermit:strava-data-cruncher`)
 - `state-templates/compiled/routine-*.md` — four routine prompt files dropped into the consumer's `.claude-code-hermit/compiled/` by `hatch`
 - `state-templates/CLAUDE-APPEND.md` — Fitness Workflow block injected into the consumer's `CLAUDE.md` by `hatch`
@@ -52,6 +54,8 @@ If you add or modify routine prompts, the corresponding `config.json.routines` e
 - `.claude-code-hermit/compiled/` — durable outputs (weekly plans, weekly summaries, activity notes). Injected at session start within `compiled_budget_chars`.
 - `.claude-code-hermit/state/strava-last-activity-id.txt` — rolling cursor written by `strava-sync` routine.
 - `.claude-code-hermit/state/strava-weekly-baselines.json` — rolling load baselines written by `weekly-load-review` and read by `monday-planning`.
+- `.claude-code-hermit/state/activity-notes.json` — subjective RPE and notes keyed by Strava activity ID. Written by `capture-activity-rpe` and `set-rpe`; read by `activity-deep-dive` and `weekly-load-review`. Retained indefinitely (covers multi-year lookback).
+- `.claude-code-hermit/state/strava-pending-rpe.json` — single-record file written by `strava-sync` after a successful channel send. Holds the latest synced activity for RPE binding. Deleted by `capture-activity-rpe` on capture; freshness-gated (24h) not pruned.
 
 Do NOT create subdirectories inside `.claude-code-hermit/raw/` or `.claude-code-hermit/compiled/`. All artifacts are flat per the base hermit's storage contract (`docs/plugin-hermit-storage.md`).
 

--- a/plugins/claude-code-fitness-hermit/docs/knowledge-schema.md
+++ b/plugins/claude-code-fitness-hermit/docs/knowledge-schema.md
@@ -50,6 +50,33 @@ Machine-written state files produced by routines. Not compiled artifacts — not
 | `activity-notes.json` | capture-activity-rpe skill, set-rpe skill | activity-deep-dive skill, weekly-load-review routine | permanent |
 | `strava-pending-rpe.json` | strava-sync routine (after successful send) | capture-activity-rpe skill (deleted on success) | 24h TTL (freshness-gated, not pruned) |
 
+### activity-notes.json shape
+
+Keyed by Strava activity ID. The `notes` field is always present: `null` when no notes were captured, never a missing key. Readers (`activity-deep-dive`, `weekly-load-review`) can rely on this invariant.
+
+```json
+{
+  "<activity_id>": {
+    "rpe": <int 1-10>,
+    "notes": <string|null>,
+    "recorded_at": "<ISO 8601 with offset>"
+  }
+}
+```
+
+### strava-pending-rpe.json shape
+
+Single record overwritten on each successful `strava-sync` channel send.
+
+```json
+{
+  "activity_id": <int>,
+  "name": "<string>",
+  "sport": "<Run|Ride|WeightTraining|…>",
+  "synced_at": "<ISO 8601 with offset>"
+}
+```
+
 ## Retention
 
 - `activity-fetch`: 3 days (superseded by next sync)

--- a/plugins/claude-code-fitness-hermit/docs/knowledge-schema.md
+++ b/plugins/claude-code-fitness-hermit/docs/knowledge-schema.md
@@ -43,10 +43,12 @@ Durable outputs. Injected into session context at startup within `compiled_budge
 
 Machine-written state files produced by routines. Not compiled artifacts — not loaded into session context.
 
-| File | Written by | Read by |
-|---|---|---|
-| `strava-last-activity-id.txt` | strava-sync routine | strava-sync routine (dedup cursor) |
-| `strava-weekly-baselines.json` | weekly-load-review routine | monday-planning routine |
+| File | Written by | Read by | Retention |
+|---|---|---|---|
+| `strava-last-activity-id.txt` | strava-sync routine | strava-sync routine (dedup cursor) | permanent |
+| `strava-weekly-baselines.json` | weekly-load-review routine | monday-planning routine | rolling 8 weeks |
+| `activity-notes.json` | capture-activity-rpe skill, set-rpe skill | activity-deep-dive skill, weekly-load-review routine | permanent |
+| `strava-pending-rpe.json` | strava-sync routine (after successful send) | capture-activity-rpe skill (deleted on success) | 24h TTL (freshness-gated, not pruned) |
 
 ## Retention
 

--- a/plugins/claude-code-fitness-hermit/skills/activity-deep-dive/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/activity-deep-dive/SKILL.md
@@ -30,6 +30,9 @@ Produces a standardised per-activity coaching note: zone breakdown, pace/HR effi
 3. Resolve activity:
    - If `"latest"`: call `mcp__strava__get-recent-activities` with limit 1, extract the activity ID.
    - Otherwise: use the provided activity ID directly.
+
+3b. Read `.claude-code-hermit/state/activity-notes.json`. If the file exists and contains an entry for the resolved activity ID, hold `rpe` and `notes` in context for steps 6 and 7.
+
 4. Issue all four calls in a single turn so they execute concurrently:
    - `mcp__strava__get-activity-details` — name, type, date, distance, duration, avg/max HR, avg pace, elevation
    - `mcp__strava__get-activity-laps` — lap splits
@@ -60,6 +63,7 @@ Zones: Z1 N% / Z2 N% / Z3 N% / Z4 N% / Z5 N%
 Pace/HR efficiency: X.XX min·km⁻¹·bpm⁻¹ (vs prior 4: ±X%)
 Cardiac drift: +N bpm (flag if > 10 bpm)
 Recovery: N/5 — recommended rest: Xh
+Subjective: RPE N/10 — <notes>          ← include only when RPE data exists from step 3b
 Coaching: <2–3 sentences>
 ```
 
@@ -74,8 +78,10 @@ source: manual
 tags: [activity-analysis]
 activity_id: <id>
 sport_type: <Run|Ride|WeightTraining|…>
+rpe: <int>                               # include only when RPE data exists from step 3b
+subjective_notes: "<string>"             # include only when notes exist from step 3b
 ---
 ```
-Body: the full 8–10 line output above.
+Body: the full output above.
 
 8. Return the formatted output to the caller.

--- a/plugins/claude-code-fitness-hermit/skills/capture-activity-rpe/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/capture-activity-rpe/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: capture-activity-rpe
+description: Captures RPE (1-10) and subjective notes when the operator replies to a strava-sync notification on any configured channel. Triggers on inbound channel messages matching RPE grammar while state/strava-pending-rpe.json has a sync from the last 24h. Channel-agnostic.
+---
+
+# Capture Activity RPE
+
+Records the operator's perceived effort and subjective notes for the most recent synced activity.
+
+## Steps
+
+1. Read `.claude-code-hermit/state/strava-pending-rpe.json`. If the file is absent: exit silently. If `synced_at` is more than 24 hours ago: delete the file and exit silently — the reply window has closed.
+
+2. **Authorization.** Read `.claude-code-hermit/config.json` → `channels.<channel>.allowed_users` for the inbound channel (extract the channel name from the inbound message metadata):
+   - If `allowed_users` exists and the sender's platform user ID is **not** in it: exit silently. No response, no log, no state write.
+   - If `allowed_users` is absent: accept (backwards-compatible).
+   - If `allowed_users` is `[]`: reject all — exit silently.
+
+3. Parse the inbound message body (case-insensitive, leading/trailing whitespace stripped):
+
+   ```
+   ^(?:RPE\s*:?\s*)?(\d{1,2})(?:\s*/\s*10)?(?:[\s,:]+(.+))?$
+   ```
+
+   This matches: `7`, `7/10`, `RPE 7`, `RPE: 7`, `RPE:7`, `7 heavy legs`, `RPE 7, heavy legs`, `RPE: 7 heavy legs`.
+
+   - Extract `rpe` (group 1) and `notes` (group 2, may be absent).
+   - Validate `rpe` is an integer from 1 to 10 inclusive.
+   - **Exclude bare `yes`, `no`, `y`, `n`** — those belong to the micro-approval branch in core's channel-responder.
+   - If parse fails or validation fails: exit silently.
+
+4. Read `.claude-code-hermit/state/activity-notes.json`, or use `{}` if absent. Write the entry:
+   ```json
+   {
+     "<pending.activity_id>": {
+       "rpe": <int>,
+       "notes": <string or null>,
+       "recorded_at": "<ISO 8601 with offset>"
+     }
+   }
+   ```
+   If an entry already exists for this activity_id, overwrite it silently.
+
+5. Delete `.claude-code-hermit/state/strava-pending-rpe.json` so the same sync cannot bind twice.
+
+6. Reply via the channel's `reply` tool with `{chat_id, text}`:
+   ```
+   Got it — RPE <rpe>/10 saved for <pending.name>.
+   ```

--- a/plugins/claude-code-fitness-hermit/skills/capture-activity-rpe/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/capture-activity-rpe/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: capture-activity-rpe
 description: Captures RPE (1-10) and subjective notes when the operator replies to a strava-sync notification on any configured channel. Triggers on inbound channel messages matching RPE grammar while state/strava-pending-rpe.json has a sync from the last 24h. Channel-agnostic.
+allowed-tools:
+  - Read
+  - Write
+  - Bash(rm .claude-code-hermit/state/strava-pending-rpe.json)
+  - mcp__plugin_discord_discord__reply
 ---
 
 # Capture Activity RPE
 
 Records the operator's perceived effort and subjective notes for the most recent synced activity.
 
+Self-triggers on RPE-shaped replies while `state/strava-pending-rpe.json` is fresh. The skill's `description` is intentionally narrower than `claude-code-hermit:channel-responder`'s so the harness picks it for these specific messages; any non-matching message exits silently and the normal `channel-responder` flow proceeds. Re-checks `allowed_users` itself.
+
 ## Steps
 
-1. Read `.claude-code-hermit/state/strava-pending-rpe.json`. If the file is absent: exit silently. If `synced_at` is more than 24 hours ago: delete the file and exit silently — the reply window has closed.
+1. Read `.claude-code-hermit/state/strava-pending-rpe.json`. If the file is absent: exit silently. If `synced_at` is more than 24 hours ago: run `rm .claude-code-hermit/state/strava-pending-rpe.json` and exit silently (reply window closed).
 
 2. **Authorization.** Read `.claude-code-hermit/config.json` → `channels.<channel>.allowed_users` for the inbound channel (extract the channel name from the inbound message metadata):
    - If `allowed_users` exists and the sender's platform user ID is **not** in it: exit silently. No response, no log, no state write.
@@ -24,26 +31,25 @@ Records the operator's perceived effort and subjective notes for the most recent
 
    This matches: `7`, `7/10`, `RPE 7`, `RPE: 7`, `RPE:7`, `7 heavy legs`, `RPE 7, heavy legs`, `RPE: 7 heavy legs`.
 
-   - Extract `rpe` (group 1) and `notes` (group 2, may be absent).
+   - Extract `rpe` (group 1) and `notes` (group 2). If group 2 is absent or an empty string after trim, treat `notes` as `null`.
    - Validate `rpe` is an integer from 1 to 10 inclusive.
-   - **Exclude bare `yes`, `no`, `y`, `n`** — those belong to the micro-approval branch in core's channel-responder.
-   - If parse fails or validation fails: exit silently.
+   - If parse fails or validation fails: exit silently. (Bare `yes`/`no`/`y`/`n` cannot match `\d{1,2}` so they are naturally excluded; the micro-approval branch in `channel-responder` handles them.)
 
-4. Read `.claude-code-hermit/state/activity-notes.json`, or use `{}` if absent. Write the entry:
+4. Read `.claude-code-hermit/state/activity-notes.json`, or use `{}` if absent. Set the entry for `<pending.activity_id>` (overwrite if it already exists, silently), then write the file back:
    ```json
    {
      "<pending.activity_id>": {
        "rpe": <int>,
-       "notes": <string or null>,
+       "notes": <string|null>,
        "recorded_at": "<ISO 8601 with offset>"
      }
    }
    ```
-   If an entry already exists for this activity_id, overwrite it silently.
+   The `notes` field is always present: `null` when no notes were captured, never missing.
 
-5. Delete `.claude-code-hermit/state/strava-pending-rpe.json` so the same sync cannot bind twice.
+5. Run `rm .claude-code-hermit/state/strava-pending-rpe.json` so the same sync cannot bind twice.
 
-6. Reply via the channel's `reply` tool with `{chat_id, text}`:
+6. Reply via the channel's `reply` tool with `{chat_id, text}`. `allowed-tools` only lists Discord (`mcp__plugin_discord_discord__reply`); on non-Discord channels this step will fail with a permission error, but the RPE is already persisted in step 4. Extend `allowed-tools` when adding Telegram or iMessage.
    ```
    Got it — RPE <rpe>/10 saved for <pending.name>.
    ```

--- a/plugins/claude-code-fitness-hermit/skills/set-rpe/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/set-rpe/SKILL.md
@@ -23,18 +23,18 @@ Records perceived effort and subjective notes for any Strava activity.
 1. Parse arguments:
    - First arg: activity ID (integer) or the literal string `latest`.
    - Second arg: RPE (must be an integer 1–10).
-   - Remaining args: optional free-text notes.
+   - Remaining args: optional free-text notes. If absent or whitespace-only after join, set `notes` to `null`.
    - If `latest`: call `mcp__strava__get-recent-activities` with `perPage: 1` and use the returned activity's `id`.
    - If any required arg is missing or `rpe` is outside 1–10, respond with usage and stop.
 
 2. Read `.claude-code-hermit/state/activity-notes.json`, or use `{}` if absent. Record the previous value for this activity_id if one exists.
 
-3. Write the entry (create or overwrite):
+3. Write the entry (create or overwrite). The `notes` field is always present: `null` when no notes were provided, never missing.
    ```json
    {
      "<activity_id>": {
        "rpe": <int>,
-       "notes": <string or null>,
+       "notes": <string|null>,
        "recorded_at": "<ISO 8601 with offset>"
      }
    }

--- a/plugins/claude-code-fitness-hermit/skills/set-rpe/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/set-rpe/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: set-rpe
+description: Manually record RPE and subjective notes for a specific Strava activity. Use for backfilling, correcting entries, or rating a non-latest activity that the auto-capture skill skipped.
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - mcp__strava__get-recent-activities
+---
+
+# Set RPE
+
+Records perceived effort and subjective notes for any Strava activity.
+
+## Usage
+
+```
+/claude-code-fitness-hermit:set-rpe <activity-id|latest> <rpe> [notes...]
+```
+
+## Steps
+
+1. Parse arguments:
+   - First arg: activity ID (integer) or the literal string `latest`.
+   - Second arg: RPE (must be an integer 1–10).
+   - Remaining args: optional free-text notes.
+   - If `latest`: call `mcp__strava__get-recent-activities` with `perPage: 1` and use the returned activity's `id`.
+   - If any required arg is missing or `rpe` is outside 1–10, respond with usage and stop.
+
+2. Read `.claude-code-hermit/state/activity-notes.json`, or use `{}` if absent. Record the previous value for this activity_id if one exists.
+
+3. Write the entry (create or overwrite):
+   ```json
+   {
+     "<activity_id>": {
+       "rpe": <int>,
+       "notes": <string or null>,
+       "recorded_at": "<ISO 8601 with offset>"
+     }
+   }
+   ```
+
+4. Confirm:
+   - If no prior entry: `"Saved RPE <rpe>/10 for activity <id>."`
+   - If overwriting: `"Updated RPE for activity <id>. (was: RPE <old_rpe>/10 — <old_notes>)"`

--- a/plugins/claude-code-fitness-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/CLAUDE-APPEND.md
@@ -21,6 +21,8 @@ This project has the `claude-code-fitness-hermit` plugin installed. The rules be
 |-------|---------|
 | `/claude-code-fitness-hermit:hatch` | One-time setup — Strava MCP, routines, CLAUDE.md injection |
 | `/claude-code-fitness-hermit:activity-deep-dive` | Per-activity coaching analysis (zone breakdown, cardiac drift, recovery estimate) |
+| `/claude-code-fitness-hermit:capture-activity-rpe` | Auto-captures RPE from channel replies to strava-sync notifications |
+| `/claude-code-fitness-hermit:set-rpe` | Manually record RPE for any activity (backfill, correction, non-latest activities) |
 
 ### Subagents
 
@@ -65,5 +67,7 @@ Routine prompts are at `.claude-code-hermit/compiled/routine-*.md`.
 - Activity notes: `compiled/activity-<id>-<YYYY-MM-DD>.md` (written by activity-deep-dive)
 - Strava state cursor: `state/strava-last-activity-id.txt` (written by strava-sync)
 - Weekly load baselines: `state/strava-weekly-baselines.json` (written by weekly-load-review, read by monday-planning)
+- Subjective notes: `state/activity-notes.json` (written by capture-activity-rpe + set-rpe, read by activity-deep-dive + weekly-load-review)
+- Pending RPE: `state/strava-pending-rpe.json` (written by strava-sync after a successful channel send, read and deleted by capture-activity-rpe)
 
 <!-- /claude-code-fitness-hermit: Fitness Workflow -->

--- a/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
@@ -26,7 +26,17 @@ Check for new Strava activities uploaded today. Compare against the last known a
    - If it's a **run on a day after a hard session (Z4+ flagged)**: note "recovery day recommended tomorrow".
    - If **no activity today** (0 new): check if yesterday also had 0 new. If 2+ consecutive rest days after a non-rest day, log: "2 consecutive rest days — intentional recovery or missed session?"
 7. Write the highest new activity ID to `state/strava-last-activity-id.txt`.
-8. Send a 2-3 line summary via the configured channel: new activity count, types, any flags. Format: "Daily sync: [X run Xkm, Y ride, Z weights]. [Flag if any]." If no channel is configured, log the summary to SHELL.md Progress Log instead and skip the notification.
+8. Send a summary via the configured channel. Format:
+   ```
+   Daily sync: [X run Xkm, Y ride, Z weights]. [Flag if any]
+   Reply 'RPE 1-10 [notes]' to log perceived effort (e.g. '7, heavy legs').
+   ```
+   If no channel is configured, log the summary (without the RPE prompt) to SHELL.md Progress Log and proceed to step 9.
+   - After a successful send, write `.claude-code-hermit/state/strava-pending-rpe.json` with the activity whose ID matches the cursor from step 7:
+     ```json
+     {"activity_id": <id>, "name": "<name>", "sport": "<Run|Ride|WeightTraining|…>", "synced_at": "<ISO 8601>"}
+     ```
+   - If the send failed or was skipped, do not write this file — a stale pending entry could bind a future RPE reply to unseen activities.
 9. Close session idle.
 
 ## Anomaly Flags

--- a/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-weekly-load-review.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-weekly-load-review.md
@@ -23,18 +23,21 @@ Pull the last 14 days of Strava activities and compute weekly training load summ
    - Bike: total distance (km), session count
    - Strength: session count
    - Total active days
-5. Read `state/strava-weekly-baselines.json`. If it doesn't exist, create it with this week's data as the baseline and note "Baseline initialized — review again next week."
+5. Read `state/strava-weekly-baselines.json` and `state/activity-notes.json` (or `{}` if absent) in the same turn. The baselines file is used in step 6; the activity notes will be used in step 8.
 6. Compare this week's run distance to the 4-week rolling average from the baseline file:
    - >25% above average → 🔴 "Load spike: [X]km vs [avg]km average"
    - >25% below average → 🟡 "Load dip: [X]km vs [avg]km average"
    - Within range → 🟢 "Consistent load"
 7. Update `state/strava-weekly-baselines.json`: append this week's totals. Keep only the last 8 weeks.
-8. Send a message via the configured channel (max 5 lines). If no channel is configured, log the summary to SHELL.md Progress Log instead and skip the notification.
+8. From the activity list fetched in step 2, collect the IDs of this week's activities. Filter the `activity-notes.json` read in step 5 to those IDs. If 2 or more RPE entries exist, compute the average (one decimal place) and prepare the line: `💬 Avg RPE: X.X/10 (N=<count>)`. Otherwise prepare no RPE line.
+
+   Send a message via the configured channel. If no channel is configured, log the summary to SHELL.md Progress Log instead and skip the notification.
    ```
    📅 Weekly review — w/e [date]
    🏃 Run: [X]km ([N] sessions, [E]m elev) [flag]
    🚴 Bike: [X]km ([N] sessions)
    💪 Strength: [N] sessions
+   💬 Avg RPE: X.X/10 (N=3)           ← omit this line if fewer than 2 rated
    Next week: [one-sentence recommendation based on load]
    ```
 9. Write the load summary to `.claude-code-hermit/compiled/weekly-summary-<YYYY-MM-DD>.md` (today's date) with frontmatter:


### PR DESCRIPTION
## Summary

- Adds `capture-activity-rpe` skill: auto-triggers when the operator replies to a `strava-sync` channel notification with an RPE rating (`7`, `RPE: 7`, `7 heavy legs`, etc.). Binds to the most-recently synced activity via `state/strava-pending-rpe.json`. Includes its own `allowed_users` auth check since it fires before `channel-responder`'s gate. Channel-agnostic (Discord, Telegram, iMessage).
- Adds `set-rpe` slash command: manual/retroactive RPE entry for backfilling, corrections, and non-latest activities.
- `strava-sync` appends an RPE prompt to the daily summary and writes `state/strava-pending-rpe.json` only after a successful channel send.
- `activity-deep-dive` surfaces `Subjective: RPE N/10 — notes` in output and adds `rpe`/`subjective_notes` to the compiled artifact frontmatter.
- `weekly-load-review` appends `💬 Avg RPE: X.X/10 (N=count)` to the Sunday summary when ≥2 activities are rated.

Correlation is text-based and channel-agnostic (no dependence on Discord `reply_to`). Pending state is a single-record JSON file, overwritten each sync, deleted on capture, and freshness-gated (24h).

## Test plan

- [ ] Run `strava-sync` with a recent activity; verify `state/strava-pending-rpe.json` written and channel message includes RPE prompt
- [ ] Reply `7 heavy legs` to the sync message; verify `state/activity-notes.json` written and pending file deleted
- [ ] Send `yes`, `no`, `status` with pending present; verify capture skill does not fire
- [ ] `/set-rpe latest 8 felt strong`; verify JSON entry and overwrite-transparency confirmation
- [ ] `activity-deep-dive` on an activity with a note; verify Subjective line in output and frontmatter fields
- [ ] `weekly-load-review` with ≥2 rated activities; verify avg RPE line in summary
- [ ] `strava-sync` with no channel configured; verify `strava-pending-rpe.json` is NOT written
- [ ] Inbound reply from an unauthorized sender; verify capture skill exits silently

Closes #69