### PR TITLE
docs(claude-code-dev-hermit): surface /dev-pr as sanctioned push path in Git Safety rule

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Surface `/dev-pr` as the sanctioned push path in §Git Safety.** Both CLAUDE-APPEND templates and `docs/GIT-SAFETY.md` now end the "Never `git push`" rule with a pointer to `/claude-code-dev-hermit:dev-pr` as the operator-sanctioned alternative, and soften "The operator pushes" to "Stop and ask the operator." Resolves the discoverability gap where downstream LLMs offered manual-push workarounds instead of invoking the skill. `skills/dev-pr/SKILL.md` description updated with the inverse note. `tests/hatch-mode.test.js` drops the "no /dev-pr in safety template" assertion (no longer correct) and adds named positive assertions for both templates. Closes PROP-027.
+
 ## [0.3.6] - 2026-05-13
 
 ### Changed

--- a/plugins/claude-code-dev-hermit/docs/GIT-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/docs/GIT-SAFETY.md
@@ -8,7 +8,7 @@ Two layers of protection: prose rules in `state-templates/CLAUDE-APPEND.md` (alw
 
 Injected into the project's `CLAUDE.md` by `/hatch`. The §Git Safety section reads:
 
-- Never `git push` from agent context. The operator pushes.
+- Never `git push` from agent context. Stop and ask the operator — the sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
 - Never use `--no-verify` on any git command (commit, push, merge, rebase).
 - Never commit to a branch in `claude-code-dev-hermit.protected_branches`. Always work on a feature branch.
 - Never force-push from agent context. No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-pr
-description: Open a PR from the current feature branch with a body assembled inline from commit history, the test command's last output, screenshots, and an optional project PR template. Refuses on protected branches, dirty trees, or zero commits ahead. Run as the final step of a ticket.
+description: "Operator-sanctioned alternative to bare `git push` from agent context. Open a PR from the current feature branch with a body assembled inline from commit history, the test command's last output, screenshots, and an optional project PR template. Refuses on protected branches, dirty trees, or zero commits ahead. Run as the final step of a ticket."
 ---
 
 # /dev-pr

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -5,7 +5,7 @@
 
 These rules apply to every agent doing dev work in this project — the native `Agent` tool, custom subagents, the main session. The `git-push-guard` hook backs them at strict profile.
 
-- **Never `git push`** from agent context. The operator pushes.
+- **Never `git push`** from agent context. Stop and ask the operator — the sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
 - **Never use `--no-verify`** on any git command (commit, push, merge, rebase). Pre-commit hooks exist for a reason.
 - **Never commit to a branch in `claude-code-dev-hermit.protected_branches`** (defaults to `main`/`master` if unset). Always work on a feature branch.
 - **Never force-push from agent context.** No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -6,7 +6,7 @@
 
 These rules apply to every agent doing dev work in this project — the native `Agent` tool, custom subagents, the main session. The `git-push-guard` hook backs them at strict profile.
 
-- **Never `git push`** from agent context. The operator pushes.
+- **Never `git push`** from agent context. Stop and ask the operator — the sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
 - **Never use `--no-verify`** on any git command (commit, push, merge, rebase). Pre-commit hooks exist for a reason.
 - **Never commit to a branch in `claude-code-dev-hermit.protected_branches`** (defaults to `main`/`master` if unset). Always work on a feature branch.
 - **Never force-push from agent context.** No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.

--- a/plugins/claude-code-dev-hermit/tests/hatch-mode.test.js
+++ b/plugins/claude-code-dev-hermit/tests/hatch-mode.test.js
@@ -30,10 +30,12 @@ if (fs.existsSync(SAFETY)) {
   ok('marker is near top (within first 10 lines)',
     text.split('\n').slice(0, 10).some(l => l.includes(marker)));
 
-  // Workflow-specific content must NOT appear in the safety template.
-  ok('no /dev-pr reference', !text.includes('/dev-pr'));
+  // /dev-pr is the universal sanctioned push primitive — allowed in safety template.
+  // Workflow-chain skills (/dev-quality, /dev-test) and workflow sections stay out.
   ok('no /dev-quality reference', !text.includes('/dev-quality'));
   ok('no /dev-test reference', !text.includes('/dev-test'));
+  ok('safety: §Git Safety push rule names /dev-pr',
+    /Never `git push`[\s\S]{0,200}\/claude-code-dev-hermit:dev-pr/.test(text));
   ok('no commands.test reference', !text.includes('commands.test'));
   ok('no §Implementation Flow section', !text.includes('## Implementation Flow'));
   ok('no §Tests Before PR section', !text.includes('## Tests Before PR'));
@@ -59,6 +61,8 @@ if (fs.existsSync(STANDARD)) {
   ok('§Branch Discipline present', text.includes('## Branch Discipline'));
   ok('§Technical Constraints present', text.includes('## Technical Constraints'));
   ok('§Dev Proposal Categories present', text.includes('## Dev Proposal Categories'));
+  ok('standard: §Git Safety push rule names /dev-pr',
+    /Never `git push`[\s\S]{0,200}\/claude-code-dev-hermit:dev-pr/.test(text));
 
   // Each preamble ends with "fallback for projects without one" or "fallback."
   const branchSection = text.match(/## Branch Discipline[\s\S]*?## Implementation Flow/);


### PR DESCRIPTION
## Summary
- The "Never `git push`" rule in both CLAUDE-APPEND templates (standard + safety) and `docs/GIT-SAFETY.md` now points agents at `/claude-code-dev-hermit:dev-pr` as the sanctioned alternative, and softens "The operator pushes" to "Stop and ask the operator." Resolves the discoverability gap where downstream LLMs offered manual-push workarounds instead of invoking the skill (PROP-027).
- `skills/dev-pr/SKILL.md` description gains "Operator-sanctioned alternative to bare `git push` from agent context" closing the loop from the other direction.
- `tests/hatch-mode.test.js` drops the stale "no /dev-pr in safety template" assertion and adds named positive assertions for both templates.

## Test plan
- [x] `bash plugins/claude-code-dev-hermit/tests/run-all.sh` — all green
- [x] Both CLAUDE-APPEND templates §Git Safety push rule reference `/claude-code-dev-hermit:dev-pr`
- [x] Re-read the rule as a fresh LLM: reads as "stop and ask, here's the skill" not "you push manually"