### PR TITLE
docs(claude-code-dev-hermit): tighten §Git Safety push rule voice

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **Surface `/dev-pr` as the sanctioned push path in §Git Safety.** Both CLAUDE-APPEND templates and `docs/GIT-SAFETY.md` now end the "Never `git push`" rule with a pointer to `/claude-code-dev-hermit:dev-pr` as the operator-sanctioned alternative, and soften "The operator pushes" to "Stop and ask the operator." Resolves the discoverability gap where downstream LLMs offered manual-push workarounds instead of invoking the skill. `skills/dev-pr/SKILL.md` description updated with the inverse note. `tests/hatch-mode.test.js` drops the "no /dev-pr in safety template" assertion (no longer correct) and adds named positive assertions for both templates. Closes PROP-027.
+- **Surface `/dev-pr` as the sanctioned push path in §Git Safety.** Both CLAUDE-APPEND templates and `docs/GIT-SAFETY.md` now end the "Never `git push`" rule with a pointer to `/claude-code-dev-hermit:dev-pr` as the operator-sanctioned alternative, and soften "The operator pushes" to "Stop and ask the operator." Resolves the discoverability gap where downstream LLMs offered manual-push workarounds instead of invoking the skill. `skills/dev-pr/SKILL.md` description updated with the inverse note. `tests/hatch-mode.test.js` drops the "no /dev-pr in safety template" assertion (no longer correct) and adds named positive assertions for both templates. `docs/WORKFLOW.md` updated to match the new voice. Closes PROP-027.
 
 ## [0.3.6] - 2026-05-13
 

--- a/plugins/claude-code-dev-hermit/docs/GIT-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/docs/GIT-SAFETY.md
@@ -8,7 +8,7 @@ Two layers of protection: prose rules in `state-templates/CLAUDE-APPEND.md` (alw
 
 Injected into the project's `CLAUDE.md` by `/hatch`. The §Git Safety section reads:
 
-- Never `git push` from agent context. Stop and ask the operator — the sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
+- Never `git push` from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
 - Never use `--no-verify` on any git command (commit, push, merge, rebase).
 - Never commit to a branch in `claude-code-dev-hermit.protected_branches`. Always work on a feature branch.
 - Never force-push from agent context. No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.

--- a/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
+++ b/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
@@ -35,7 +35,7 @@ Per `§Branch Discipline`:
 
 Agent writes code on the feature branch. The `§Git Safety` rules apply throughout:
 
-- No `git push` from agent context. The operator pushes (`/dev-pr`).
+- No `git push` from agent context. Stop and ask the operator. The sanctioned answer is `/dev-pr`.
 - No `--no-verify` on any git command.
 - No commits to a branch in `protected_branches`.
 - No force-push (any flavor).

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -5,7 +5,7 @@
 
 These rules apply to every agent doing dev work in this project — the native `Agent` tool, custom subagents, the main session. The `git-push-guard` hook backs them at strict profile.
 
-- **Never `git push`** from agent context. Stop and ask the operator — the sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
+- **Never `git push`** from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
 - **Never use `--no-verify`** on any git command (commit, push, merge, rebase). Pre-commit hooks exist for a reason.
 - **Never commit to a branch in `claude-code-dev-hermit.protected_branches`** (defaults to `main`/`master` if unset). Always work on a feature branch.
 - **Never force-push from agent context.** No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -6,7 +6,7 @@
 
 These rules apply to every agent doing dev work in this project — the native `Agent` tool, custom subagents, the main session. The `git-push-guard` hook backs them at strict profile.
 
-- **Never `git push`** from agent context. Stop and ask the operator — the sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
+- **Never `git push`** from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
 - **Never use `--no-verify`** on any git command (commit, push, merge, rebase). Pre-commit hooks exist for a reason.
 - **Never commit to a branch in `claude-code-dev-hermit.protected_branches`** (defaults to `main`/`master` if unset). Always work on a feature branch.
 - **Never force-push from agent context.** No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.


### PR DESCRIPTION
Polish on the same PROP-027 work:

- Replace em-dash with period in the new "Stop and ask the operator" prose across docs/GIT-SAFETY.md, CLAUDE-APPEND.md, and CLAUDE-APPEND-SAFETY.md. Em-dashes read as an AI tell in operator-facing CLAUDE.md.
- Align docs/WORKFLOW.md to the same voice. It was the only §Git Safety location still saying "The operator pushes (/dev-pr)".
- Extend the existing [Unreleased] CHANGELOG bullet to note the WORKFLOW.md sync.