### PR TITLE
feat(claude-code-homeassistant-hermit): add get-automation-config and get-script-config CLI commands

### DIFF
--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`ha get-automation-config <id>` and `ha get-script-config <id>` CLI commands** — read a single automation or script config directly from HA's REST API (`GET /api/config/{domain}/config/{id}`) and print it as JSON. Useful for inspecting what HA holds before deciding whether to patch or delete. Returns exit code 1 with a structured JSON error on failure (including 400 "not found" and 403 YAML-mode responses). New `ReadResult` dataclass and `read_config()` function in `apply.py` back the command; the unsupported-domain error string is now shared via `_unsupported_domain_msg()`. New `tests/test_cli_get_config.py` covers the happy path, not-found, and YAML-mode 403 cases.
+
 ## [0.1.3] - 2026-05-14
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 
 - **`ha get-automation-config <id>` and `ha get-script-config <id>` CLI commands** — read a single automation or script config directly from HA's REST API (`GET /api/config/{domain}/config/{id}`) and print it as JSON. Useful for inspecting what HA holds before deciding whether to patch or delete. Returns exit code 1 with a structured JSON error on failure (including 400 "not found" and 403 YAML-mode responses). New `ReadResult` dataclass and `read_config()` function in `apply.py` back the command; the unsupported-domain error string is now shared via `_unsupported_domain_msg()`. New `tests/test_cli_get_config.py` covers the happy path, not-found, and YAML-mode 403 cases.
 
+### Fixed
+
+- **Backfilled `state-templates/CLAUDE-APPEND.md` with previously shipped CLI commands** (`list-automations`, `list-scripts`, `delete-automation`, `delete-script`, `integration-health`, `fetch-history`, `probe`) plus the two new `get-*-config` commands. Earlier releases added these CLI subcommands but never updated the template injected into target projects by `hatch`. Operators running `hermit-evolve` or fresh `hatch` will see CLAUDE.md grow by these listings on next sync.
+
 ## [0.1.3] - 2026-05-14
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/CLAUDE.md
+++ b/plugins/claude-code-homeassistant-hermit/CLAUDE.md
@@ -53,6 +53,8 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-automations
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-scripts
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-automation <id>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-script <id>
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha get-automation-config <id>
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha get-script-config <id>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha integration-health
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha fetch-history [--window-days N] [--entities <glob> …]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha probe <path>

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/apply.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/apply.py
@@ -12,6 +12,10 @@ from .simulate import SimulationResult, simulate_artifact
 _CONFIG_DOMAINS = {"automation", "script"}
 
 
+def _unsupported_domain_msg(domain: str) -> str:
+    return f"Domain '{domain}' is not a configurable domain. Choose from: {', '.join(sorted(_CONFIG_DOMAINS))}."
+
+
 @dataclass(slots=True)
 class ApplyResult:
     ok: bool
@@ -24,6 +28,15 @@ class ApplyResult:
     reload_domain: str | None
     message: str
     report_path: Path
+
+
+@dataclass(slots=True)
+class ReadResult:
+    ok: bool
+    domain: str
+    config_id: str
+    config: dict
+    message: str
 
 
 @dataclass(slots=True)
@@ -165,6 +178,21 @@ def validate_and_apply(
     )
 
 
+def read_config(
+    client: HomeAssistantClient,
+    domain: str,
+    config_id: str,
+) -> ReadResult:
+    if domain not in _CONFIG_DOMAINS:
+        return ReadResult(ok=False, domain=domain, config_id=config_id, config={}, message=_unsupported_domain_msg(domain))
+
+    try:
+        config = client.get(f"/api/config/{domain}/config/{config_id}")
+        return ReadResult(ok=True, domain=domain, config_id=config_id, config=config, message="ok")
+    except HomeAssistantError as exc:
+        return ReadResult(ok=False, domain=domain, config_id=config_id, config={}, message=extract_ha_error_message(exc))
+
+
 def remove_config(
     root: Path,
     client: HomeAssistantClient,
@@ -172,7 +200,7 @@ def remove_config(
     config_id: str,
 ) -> RemoveResult:
     if domain not in _CONFIG_DOMAINS:
-        msg = f"Domain '{domain}' is not a configurable domain. Choose from: {', '.join(sorted(_CONFIG_DOMAINS))}."
+        msg = _unsupported_domain_msg(domain)
         report_path = _write_remove_report(root, domain, config_id, ok=False, message=msg)
         return RemoveResult(ok=False, domain=domain, config_id=config_id, message=msg, report_path=report_path)
 

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
@@ -7,7 +7,7 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from .apply import remove_config, validate_and_apply
+from .apply import read_config, remove_config, validate_and_apply
 from .artifacts import current_session_id, standard_metadata, utc_timestamp, write_json_artifact, write_markdown_artifact
 from .boot import boot_status, save_boot_preferences
 from .config import load_config, normalized_context_path
@@ -91,6 +91,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     delete_script_parser = ha_subparsers.add_parser("delete-script", help="Delete a script config by ID.")
     delete_script_parser.add_argument("id", help="Script config ID (not entity_id).")
+
+    get_automation_config_parser = ha_subparsers.add_parser("get-automation-config", help="Read an automation's config YAML from HA.")
+    get_automation_config_parser.add_argument("id", help="Automation config ID.")
+
+    get_script_config_parser = ha_subparsers.add_parser("get-script-config", help="Read a script's config YAML from HA.")
+    get_script_config_parser.add_argument("id", help="Script config ID.")
 
     return parser
 
@@ -258,6 +264,29 @@ def main(argv: list[str] | None = None) -> int:
                         "report_path": str(result.report_path.relative_to(root)),
                     },
                     indent=2,
+                )
+            )
+            return 0 if result.ok else 1
+        except HomeAssistantError as exc:
+            print(str(exc))
+            return 1
+
+    if args.command == "ha" and args.ha_command in ("get-automation-config", "get-script-config"):
+        try:
+            client = HomeAssistantClient(config)
+            domain = "automation" if args.ha_command == "get-automation-config" else "script"
+            result = read_config(client, domain, args.id)
+            print(
+                json.dumps(
+                    {
+                        "ok": result.ok,
+                        "domain": result.domain,
+                        "config_id": result.config_id,
+                        "config": result.config,
+                        "message": result.message,
+                    },
+                    indent=2,
+                    ensure_ascii=False,
                 )
             )
             return 0 if result.ok else 1

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
@@ -92,10 +92,10 @@ def build_parser() -> argparse.ArgumentParser:
     delete_script_parser = ha_subparsers.add_parser("delete-script", help="Delete a script config by ID.")
     delete_script_parser.add_argument("id", help="Script config ID (not entity_id).")
 
-    get_automation_config_parser = ha_subparsers.add_parser("get-automation-config", help="Read an automation's config YAML from HA.")
+    get_automation_config_parser = ha_subparsers.add_parser("get-automation-config", help="Read an automation's stored config from HA.")
     get_automation_config_parser.add_argument("id", help="Automation config ID.")
 
-    get_script_config_parser = ha_subparsers.add_parser("get-script-config", help="Read a script's config YAML from HA.")
+    get_script_config_parser = ha_subparsers.add_parser("get-script-config", help="Read a script's stored config from HA.")
     get_script_config_parser.add_argument("id", help="Script config ID.")
 
     return parser

--- a/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
@@ -60,6 +60,15 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <artifact> [--reload au
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha policy-check <entity_id_or_yaml>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha audit-automations
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha audit-scripts
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-automations
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-scripts
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-automation <id>
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-script <id>
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha get-automation-config <id>
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha get-script-config <id>
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha integration-health
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha fetch-history [--window-days N] [--entities <glob> …]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha probe <path>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab boot status [--probe]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab boot store --language <locale> --url <url> [--token <token>]
 ```

--- a/plugins/claude-code-homeassistant-hermit/tests/test_cli_get_config.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_cli_get_config.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from ha_agent_lab.cli import main
+from ha_agent_lab.ha_api import HomeAssistantError
+
+
+def test_get_automation_config_ok(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    config_payload = {"id": "my_automation", "alias": "My Automation", "trigger": [], "action": []}
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get.return_value = config_payload
+        result = main(["ha", "get-automation-config", "my_automation"])
+
+    assert result == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["domain"] == "automation"
+    assert out["config_id"] == "my_automation"
+    assert out["config"] == config_payload
+    instance.get.assert_called_once_with("/api/config/automation/config/my_automation")
+
+
+def test_get_script_config_ok(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    config_payload = {"id": "garage_gate", "alias": "Garage Gate", "sequence": [{"enabled": True}]}
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get.return_value = config_payload
+        result = main(["ha", "get-script-config", "garage_gate"])
+
+    assert result == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["domain"] == "script"
+    assert out["config_id"] == "garage_gate"
+    assert out["config"] == config_payload
+    instance.get.assert_called_once_with("/api/config/script/config/garage_gate")
+
+
+@pytest.mark.parametrize("command", ["get-automation-config", "get-script-config"])
+def test_get_config_not_found_exits_nonzero(command, capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get.side_effect = HomeAssistantError(
+            "Home Assistant request failed.", status_code=400,
+            payload='{"message":"Resource not found"}',
+        )
+        result = main(["ha", command, "nonexistent"])
+
+    assert result == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert out["message"] == "Resource not found"
+
+
+def test_get_automation_config_yaml_mode_403(capsys, make_mock_config) -> None:
+    cfg = make_mock_config()
+    with patch("ha_agent_lab.cli.load_config", return_value=cfg), \
+         patch("ha_agent_lab.cli.HomeAssistantClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get.side_effect = HomeAssistantError(
+            "Forbidden: Home Assistant is in YAML mode (REST config API unavailable).",
+            status_code=403,
+            payload="",
+        )
+        result = main(["ha", "get-automation-config", "my_auto"])
+
+    assert result == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert "403" in out["message"] or "YAML mode" in out["message"] or "Forbidden" in out["message"]

--- a/plugins/claude-code-homeassistant-hermit/tests/test_cli_get_config.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_cli_get_config.py
@@ -78,4 +78,4 @@ def test_get_automation_config_yaml_mode_403(capsys, make_mock_config) -> None:
     assert result == 1
     out = json.loads(capsys.readouterr().out)
     assert out["ok"] is False
-    assert "403" in out["message"] or "YAML mode" in out["message"] or "Forbidden" in out["message"]
+    assert "YAML mode" in out["message"]


### PR DESCRIPTION
## Summary
- Adds `ha get-automation-config <id>` and `ha get-script-config <id>` subcommands to `ha-agent-lab`, reading a single automation or script config from HA's REST API and printing it as JSON.
- New `read_config()` function and `ReadResult` dataclass in `apply.py`; shared `_unsupported_domain_msg()` helper de-duplicates the unsupported-domain error string.
- Adds `tests/test_cli_get_config.py` covering the happy path, not-found (400), and YAML-mode (403) error cases.

## Test plan
- [x] `ha get-automation-config <id>` returns exit 0 and a JSON payload with `ok: true` for a known automation
- [x] `ha get-automation-config <nonexistent>` returns exit 1 with `ok: false` and the HA error message
- [x] `ha get-script-config <id>` mirrors the same behaviour for scripts
- [x] Unit tests pass: `pytest tests/test_cli_get_config.py`