### PR TITLE
feat(claude-code-dev-hermit): auto-stash managed paths before checkout

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **`claude-code-dev-hermit.branch_managed_paths` — auto-stash for harness-managed dirty paths before branch creation.** `§Branch Discipline` step 1 now partitions `git status --porcelain` output: paths in the allowlist that appear as unstaged modifications (` M`) are stashed before checkout and restored after using `git restore --worktree --source=stash@{0}` (worktree-only — no staging, no three-way merge). Default allowlist: `[".claude/settings.json"]`. Set to `[]` to restore the original strict fail-closed behaviour. All other porcelain codes and paths outside the allowlist continue to fail closed. Resolves [#92](https://github.com/gtapps/claude-code-hermit/issues/92).
+- **`claude-code-dev-hermit.branch_managed_paths` — auto-stash for harness-managed dirty paths before branch creation.** `§Branch Discipline` step 1 now partitions `git status --porcelain` output: paths in the allowlist that appear as unstaged modifications (` M`) are stashed before checkout (under marker `branch-auto-pre-checkout`) and restored after using `git restore --worktree --source=stash@{0}` (worktree-only — no staging, no three-way merge). Default allowlist: `[".claude/settings.json"]`. Set to `[]` to restore the original strict fail-closed behaviour. All other porcelain codes and paths outside the allowlist continue to fail closed. If `git checkout -b` fails after a successful stash, the agent surfaces the stash ref instead of retrying, so the operator can restore manually. Resolves [#92](https://github.com/gtapps/claude-code-hermit/issues/92).
 
 ### Files affected
 

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`claude-code-dev-hermit.branch_managed_paths` — auto-stash for harness-managed dirty paths before branch creation.** `§Branch Discipline` step 1 now partitions `git status --porcelain` output: paths in the allowlist that appear as unstaged modifications (` M`) are stashed before checkout and restored after using `git restore --worktree --source=stash@{0}` (worktree-only — no staging, no three-way merge). Default allowlist: `[".claude/settings.json"]`. Set to `[]` to restore the original strict fail-closed behaviour. All other porcelain codes and paths outside the allowlist continue to fail closed. Resolves [#92](https://github.com/gtapps/claude-code-hermit/issues/92).
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `state-templates/CLAUDE-APPEND.md` | §Branch Discipline steps 1–2 rewritten |
+| `state-templates/CLAUDE-APPEND-SAFETY.md` | Same rewrite (identical to standard template §Branch Discipline) |
+| `docs/HOW-TO-USE.md` | §2. Branch and implement updated; config key and gitignore alternative documented |
+| `docs/WORKFLOW.md` | Step 2 §Branch step 1 updated to reflect partition semantics |
+| `tests/hatch-mode.test.js` | Marker-presence asserts for `branch_managed_paths` and `git restore --worktree` in both templates |
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill detects the version gap and re-injects the updated CLAUDE-APPEND block into the project's `CLAUDE.md`.
+
+No `config.json` changes required — the default allowlist is documented in the template prose and takes effect without an explicit key.
+
 ### Changed
 
 - **Surface `/dev-pr` as the sanctioned push path in §Git Safety.** Both CLAUDE-APPEND templates and `docs/GIT-SAFETY.md` now end the "Never `git push`" rule with a pointer to `/claude-code-dev-hermit:dev-pr` as the operator-sanctioned alternative, and soften "The operator pushes" to "Stop and ask the operator." Resolves the discoverability gap where downstream LLMs offered manual-push workarounds instead of invoking the skill. `skills/dev-pr/SKILL.md` description updated with the inverse note. `tests/hatch-mode.test.js` drops the "no /dev-pr in safety template" assertion (no longer correct) and adds named positive assertions for both templates. `docs/WORKFLOW.md` updated to match the new voice. Closes PROP-027.

--- a/plugins/claude-code-dev-hermit/docs/HOW-TO-USE.md
+++ b/plugins/claude-code-dev-hermit/docs/HOW-TO-USE.md
@@ -40,10 +40,26 @@ If `/feature-dev:feature-dev` is installed and the code path is unfamiliar (fram
 
 Per `§Branch Discipline` in the injected CLAUDE.md:
 
-1. Verify clean working tree (`git status --porcelain` empty).
+1. Verify clean working tree (`git status --porcelain`). Paths listed in
+   `claude-code-dev-hermit.branch_managed_paths` (default: `[".claude/settings.json"]`)
+   that show only as unstaged modifications (porcelain ` M`) are auto-stashed before
+   checkout and restored afterwards — worktree only, no staging. Everything else stops
+   the flow and asks the operator to commit or stash first.
 2. Branch from the first entry of `protected_branches` (defaults to `main`): `git checkout -b <prefix>/<slug> origin/<base>`.
 3. Name the branch `<prefix>/<slug>` where `prefix ∈ {feature, fix, chore, hotfix}`.
 4. Log the creation to `.claude-code-hermit/sessions/SHELL.md`.
+
+**Customising the managed-paths allowlist.** Add to `.claude-code-hermit/config.json`:
+
+```json
+"claude-code-dev-hermit": {
+  "branch_managed_paths": [".claude/settings.json", ".claude/settings.local.json"]
+}
+```
+
+Set `branch_managed_paths: []` to disable auto-stash entirely and restore the strict fail-closed behaviour.
+
+**Prefer gitignore?** If you never want `.claude/settings.json` tracked, add it to `.gitignore`. Claude Code reads it either way, and it will never appear in `git status --porcelain` again — no allowlist needed.
 
 Then write the code. The CLAUDE.md `§Git Safety` rules apply throughout: no push, no `--no-verify`, no commits to protected, no force-push. At strict hook profile, `git-push-guard` blocks the dangerous commands at `bash` time.
 

--- a/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
+++ b/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
@@ -25,7 +25,11 @@ If the code path is unfamiliar AND `/feature-dev:feature-dev` is installed, the 
 
 Per `§Branch Discipline`:
 
-1. `git status --porcelain` must be empty. If dirty: stop, surface the diff, let the operator commit/stash.
+1. `git status --porcelain` is checked for unmanaged dirt. Paths in `branch_managed_paths`
+   (default `[".claude/settings.json"]`) that are unstaged modifications (` M`) are
+   auto-stashed before checkout and restored after. Anything else — untracked, deleted,
+   renamed, staged, or not in the allowlist — stops the flow: surface the diff, let the
+   operator commit or stash first.
 2. Resolve base: first entry of `claude-code-dev-hermit.protected_branches` (defaults to `main`).
 3. `git checkout -b <prefix>/<slug> origin/<base>`.
 4. Slugify the description per the 5-step rules in CLAUDE-APPEND. Prefix detection: longest case-insensitive match of `hotfix|feature|fix|chore` at input start, else `feature`.

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -22,7 +22,7 @@ Before starting code changes:
    `claude-code-dev-hermit.branch_managed_paths` (array of path strings; default
    `[".claude/settings.json"]`; set to `[]` to restore strict fail-closed behavior):
    - Porcelain code ` M` and path in the allowlist → **managed dirt**. Stash it:
-     `git stash push -m "branch-auto-<slug>" -- <managed paths>`
+     `git stash push -m "branch-auto-pre-checkout" -- <managed paths>`
      If stash fails, stop and surface the error.
    - Everything else (untracked `??`, deleted, renamed, staged-add `A `, mixed-staged
      `MM`/`AM`, or path not in allowlist) → **unmanaged dirt**: stop, surface the diff,
@@ -31,6 +31,9 @@ Before starting code changes:
 2. Branch from the first entry of `claude-code-dev-hermit.protected_branches` (defaults
    to `main`). Use `git checkout -b <prefix>/<slug> origin/<base>` so the new branch
    tracks the latest remote.
+   If checkout fails after a successful stash in step 1, do not retry blindly: surface
+   the stash ref (`stash@{0}`, message `branch-auto-pre-checkout`) so the operator can
+   restore manually, then stop.
    If you stashed managed paths in step 1, restore them now — worktree only, no staging
    (do NOT use `git checkout stash@{0} -- ...`, which stages the file):
      `git restore --worktree --source=stash@{0} -- <managed paths>`

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -18,8 +18,25 @@ If the project's own CLAUDE.md or skills define a branch-naming convention (e.g.
 
 Before starting code changes:
 
-1. Verify clean working tree (`git status --porcelain` returns empty). If dirty, stop and surface the diff — let the operator commit or stash before proceeding.
-2. Branch from the first entry of `claude-code-dev-hermit.protected_branches` (defaults to `main`). Use `git checkout -b <prefix>/<slug> origin/<base>` so the new branch tracks the latest remote.
+1. Verify clean working tree (`git status --porcelain`). Partition lines against
+   `claude-code-dev-hermit.branch_managed_paths` (array of path strings; default
+   `[".claude/settings.json"]`; set to `[]` to restore strict fail-closed behavior):
+   - Porcelain code ` M` and path in the allowlist → **managed dirt**. Stash it:
+     `git stash push -m "branch-auto-<slug>" -- <managed paths>`
+     If stash fails, stop and surface the error.
+   - Everything else (untracked `??`, deleted, renamed, staged-add `A `, mixed-staged
+     `MM`/`AM`, or path not in allowlist) → **unmanaged dirt**: stop, surface the diff,
+     let the operator commit or stash before proceeding.
+
+2. Branch from the first entry of `claude-code-dev-hermit.protected_branches` (defaults
+   to `main`). Use `git checkout -b <prefix>/<slug> origin/<base>` so the new branch
+   tracks the latest remote.
+   If you stashed managed paths in step 1, restore them now — worktree only, no staging
+   (do NOT use `git checkout stash@{0} -- ...`, which stages the file):
+     `git restore --worktree --source=stash@{0} -- <managed paths>`
+     `git stash drop`
+   If restore fails, stop and surface the error. Append to SHELL.md Progress Log:
+     `[HH:MM] branch auto-restored N managed file(s): <list>`
 3. Name the branch `<prefix>/<slug>` where `prefix ∈ {feature, fix, chore, hotfix}`. Detect the prefix as the longest match of `hotfix|feature|fix|chore` at the start of the input (case-insensitive, treated as a word). Otherwise default to `feature`.
 4. Append a one-line entry to `.claude-code-hermit/sessions/SHELL.md` Progress Log: `[HH:MM] created branch <name> from <base>`.
 

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -23,7 +23,7 @@ Before starting code changes:
    `claude-code-dev-hermit.branch_managed_paths` (array of path strings; default
    `[".claude/settings.json"]`; set to `[]` to restore strict fail-closed behavior):
    - Porcelain code ` M` and path in the allowlist → **managed dirt**. Stash it:
-     `git stash push -m "branch-auto-<slug>" -- <managed paths>`
+     `git stash push -m "branch-auto-pre-checkout" -- <managed paths>`
      If stash fails, stop and surface the error.
    - Everything else (untracked `??`, deleted, renamed, staged-add `A `, mixed-staged
      `MM`/`AM`, or path not in allowlist) → **unmanaged dirt**: stop, surface the diff,
@@ -32,6 +32,9 @@ Before starting code changes:
 2. Branch from the first entry of `claude-code-dev-hermit.protected_branches` (defaults
    to `main`). Use `git checkout -b <prefix>/<slug> origin/<base>` so the new branch
    tracks the latest remote.
+   If checkout fails after a successful stash in step 1, do not retry blindly: surface
+   the stash ref (`stash@{0}`, message `branch-auto-pre-checkout`) so the operator can
+   restore manually, then stop.
    If you stashed managed paths in step 1, restore them now — worktree only, no staging
    (do NOT use `git checkout stash@{0} -- ...`, which stages the file):
      `git restore --worktree --source=stash@{0} -- <managed paths>`

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -19,8 +19,25 @@ If the project's own CLAUDE.md or skills define a branch-naming convention (e.g.
 
 Before starting code changes:
 
-1. Verify clean working tree (`git status --porcelain` returns empty). If dirty, stop and surface the diff — let the operator commit or stash before proceeding.
-2. Branch from the first entry of `claude-code-dev-hermit.protected_branches` (defaults to `main`). Use `git checkout -b <prefix>/<slug> origin/<base>` so the new branch tracks the latest remote.
+1. Verify clean working tree (`git status --porcelain`). Partition lines against
+   `claude-code-dev-hermit.branch_managed_paths` (array of path strings; default
+   `[".claude/settings.json"]`; set to `[]` to restore strict fail-closed behavior):
+   - Porcelain code ` M` and path in the allowlist → **managed dirt**. Stash it:
+     `git stash push -m "branch-auto-<slug>" -- <managed paths>`
+     If stash fails, stop and surface the error.
+   - Everything else (untracked `??`, deleted, renamed, staged-add `A `, mixed-staged
+     `MM`/`AM`, or path not in allowlist) → **unmanaged dirt**: stop, surface the diff,
+     let the operator commit or stash before proceeding.
+
+2. Branch from the first entry of `claude-code-dev-hermit.protected_branches` (defaults
+   to `main`). Use `git checkout -b <prefix>/<slug> origin/<base>` so the new branch
+   tracks the latest remote.
+   If you stashed managed paths in step 1, restore them now — worktree only, no staging
+   (do NOT use `git checkout stash@{0} -- ...`, which stages the file):
+     `git restore --worktree --source=stash@{0} -- <managed paths>`
+     `git stash drop`
+   If restore fails, stop and surface the error. Append to SHELL.md Progress Log:
+     `[HH:MM] branch auto-restored N managed file(s): <list>`
 3. Name the branch `<prefix>/<slug>` where `prefix ∈ {feature, fix, chore, hotfix}`. Detect the prefix as the longest match of `hotfix|feature|fix|chore` at the start of the input (case-insensitive, treated as a word). Otherwise default to `feature`.
 4. Append a one-line entry to `.claude-code-hermit/sessions/SHELL.md` Progress Log: `[HH:MM] created branch <name> from <base>`.
 

--- a/plugins/claude-code-dev-hermit/tests/hatch-mode.test.js
+++ b/plugins/claude-code-dev-hermit/tests/hatch-mode.test.js
@@ -45,6 +45,10 @@ if (fs.existsSync(SAFETY)) {
   ok('§Branch Discipline present', text.includes('## Branch Discipline'));
   ok('§Technical Constraints present', text.includes('## Technical Constraints'));
   ok('§Dev Proposal Categories present', text.includes('## Dev Proposal Categories'));
+
+  ok('safety: branch_managed_paths key mentioned', text.includes('branch_managed_paths'));
+  ok('safety: git restore --worktree restore primitive mentioned',
+    text.includes('git restore --worktree --source=stash@{0}'));
 }
 
 // ── Standard template preambles + required sections ─────────────────────────
@@ -63,6 +67,10 @@ if (fs.existsSync(STANDARD)) {
   ok('§Dev Proposal Categories present', text.includes('## Dev Proposal Categories'));
   ok('standard: §Git Safety push rule names /dev-pr',
     /Never `git push`[\s\S]{0,200}\/claude-code-dev-hermit:dev-pr/.test(text));
+
+  ok('standard: branch_managed_paths key mentioned', text.includes('branch_managed_paths'));
+  ok('standard: git restore --worktree restore primitive mentioned',
+    text.includes('git restore --worktree --source=stash@{0}'));
 
   // Each preamble ends with "fallback for projects without one" or "fallback."
   const branchSection = text.match(/## Branch Discipline[\s\S]*?## Implementation Flow/);


### PR DESCRIPTION
## Summary

- Adds `claude-code-dev-hermit.branch_managed_paths` config key (default `[".claude/settings.json"]`). §Branch Discipline step 1 now partitions `git status --porcelain` output: paths matching the allowlist with porcelain code ` M` (tracked, unstaged modification) are auto-stashed before `git checkout -b` and restored after using `git restore --worktree` — no staging, no three-way merge.
- All other dirty paths (untracked, deleted, renamed, staged, or not in the allowlist) continue to fail closed.
- Operators can set `branch_managed_paths: []` to restore the original strict fail-closed behaviour.
- Removes 3+ extra manual stash/pop commands per branch creation in projects where the harness accumulates permission writes to `.claude/settings.json` across sessions.

## Test plan

- [ ] `bash plugins/claude-code-dev-hermit/tests/run-all.sh` — all 132 assertions pass
- [ ] In a scratch repo with a tracked `.claude/settings.json` modified (porcelain ` M`): agent auto-stashes, checks out the new branch, restores the file as an unstaged modification (not staged), and logs to SHELL.md
- [ ] With an unrelated untracked file added: agent fails closed and surfaces the diff
- [ ] With `branch_managed_paths: []` in config: agent fails closed even on `.claude/settings.json`
- [ ] Existing installs: run `/claude-code-hermit:hermit-evolve` to re-inject the updated §Branch Discipline prose

Closes #92