### PR TITLE
feat(claude-code-dev-hermit): Gate 2 bypass-field rendering for /dev-pr

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- **`/dev-pr` Gate 2 renders a `### Gate 0 Override` audit section in the PR body when `state/last-test.json.bypass` is present.** No current writer; reserved for the planned `/dev-test --capture-baseline`. When the bypass field is absent, the Verification section renders as today (`Tests: **pass**`); when present, Gate 2 renders `Tests: **audited override** (reason: <bypass.reason>)` followed by a `### Gate 0 Override` block with `base_sha` and `summary` from the bypass field. Refs #91.
+
 - **Surface `/dev-pr` as the sanctioned push path in §Git Safety.** Both CLAUDE-APPEND templates and `docs/GIT-SAFETY.md` now end the "Never `git push`" rule with a pointer to `/claude-code-dev-hermit:dev-pr` as the operator-sanctioned alternative, and soften "The operator pushes" to "Stop and ask the operator." Resolves the discoverability gap where downstream LLMs offered manual-push workarounds instead of invoking the skill. `skills/dev-pr/SKILL.md` description updated with the inverse note. `tests/hatch-mode.test.js` drops the "no /dev-pr in safety template" assertion (no longer correct) and adds named positive assertions for both templates. `docs/WORKFLOW.md` updated to match the new voice. Closes PROP-027.
 
 ## [0.3.6] - 2026-05-13

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -141,7 +141,9 @@ Build the title and body inline, no helper script.
 
 2. **Context** — if `state/bindings.json` has `bindings[branch].external = { source, id, url, title }`, emit a `## Context` heading followed by a single line containing a markdown link. The link text is the bold-wrapped string `<source> <id>` (e.g. `**Linear PROJ-123**`), the link target is `url`, and the line ends with ` — <title>`. Concrete example for `{source: "Linear", id: "PROJ-123", url: "https://linear.app/...", title: "fix login redirect"}` produces a single line beginning with `**` then the bold-bracketed link then ` — fix login redirect`. If `external.title` is missing, drop the ` — <title>` suffix. If `external.url` is missing, skip the section entirely.
 
-3. **Verification** — read `state/last-test.json` (written by the `record-test-result` hook; Gate 0 step 3 already verified it exists, matches HEAD, and passed). Format:
+3. **Verification** — read `state/last-test.json` (written by the `record-test-result` hook; Gate 0 step 3 already verified it exists, matches HEAD, and passed).
+
+   **If `last-test.json.bypass` is absent**, render as:
 
    ```
    ## Verification
@@ -150,6 +152,21 @@ Build the title and body inline, no helper script.
    ```
 
    The duration is `last-test.json.duration_ms / 1000` rounded to one decimal (or `(unrecorded)` if `duration_ms` is null). Lint / typecheck / format runs may be added if `state/last-test.json` is later extended to record those (current implementation tracks only the test command). Never invent results.
+
+   **If `last-test.json.bypass` is present** (a future automated baseline writer populates this), render instead:
+
+   ```
+   ## Verification
+
+   - Tests: **audited override** (reason: <bypass.reason>)
+
+   ### Gate 0 Override
+
+   - base_sha: <bypass.base_sha>
+   - summary: <bypass.summary>
+   ```
+
+   Reproduce `bypass.reason`, `bypass.base_sha`, and `bypass.summary` verbatim from the JSON field.
 
 4. **Screenshots** — if `.claude-code-hermit/raw/screenshots/<binding-id>/manifest.json` exists, emit a `## Screenshots` heading followed by one bullet per manifest entry. Each bullet is a markdown image: a leading `- ` then `!`, then the alt text in square brackets (the `criterion` field), then the source in parentheses (the `path` field). The `binding-id` is `bindings[branch].external.id` if present, else `branch.replace(/\//g, '-')`. If `config.scope === 'local'` and any path isn't a `https://` URL, add a note line below the bullets: `_Note: screenshots in raw/ are gitignored under local scope — they will appear as broken images in the PR._`
 


### PR DESCRIPTION
## Summary

Minimal replacement for #95. Adds only the durable contribution from that PR's exploration: a conditional Gate 2 rendering rule in `skills/dev-pr/SKILL.md` that emits a `### Gate 0 Override` audit section in the PR body when `state/last-test.json.bypass` is present, with `reason` emitted directly from the field so any future writer is forward-compatible.

## What this is

Reserved infrastructure for the planned `/dev-test --capture-baseline` work (issue #91). No current path writes the `bypass` field. When the field is absent, Gate 2 renders exactly as today. When a future writer populates it, the audit block appears in the PR body automatically with no further SKILL.md changes.

## What this PR is NOT

#95 also shipped a 132-line manual jq-based protocol doc (`docs/GATE-0-OVERRIDE.md`), CLAUDE-APPEND.md and WORKFLOW.md cross-references, and a README link to the doc. Those were dropped after the operator-side review concluded the manual protocol would not actually be used in practice (operators hitting Gate 0 on pre-existing base failures will use `gh pr create` manually, not hand-craft jq), and the doc's own "Next iteration" section explicitly framed it as a stopgap. Closing #95 in favor of this minimal scope.

## Scope

- `skills/dev-pr/SKILL.md` Gate 2 step 3 (Verification): conditional render based on `last-test.json.bypass` presence.
- `CHANGELOG.md`: one bullet under `[Unreleased]` `### Changed`.

Refs #91.

## Test plan

- [x] `bash tests/run-all.sh` from `plugins/claude-code-dev-hermit/`: 37/37 green.
- [x] `node tests/skill-structure.test.js`: passes (internal links resolve, frontmatter intact, gate count unchanged).
- Manual trace of the conditional render: when `bypass` is absent, Gate 2 renders the existing `Tests: **pass**` form unchanged. When `bypass` is present, Gate 2 renders `Tests: **audited override** (reason: <bypass.reason>)` plus the override block.