### PR TITLE
fix(ha-hermit): chunk fetch-history to clear Cloudflare 520 (#107)

### DIFF
--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 
 ### Fixed
 
-- **`ha fetch-history` no longer fails with Cloudflare HTTP 520 on default-scope fetches** (gh #107). `HomeAssistantClient.get_history()` now splits the requested entity IDs into chunks of 50 and merges the per-chunk responses, keeping the `filter_entity_id` query string short enough to pass through the Nabu Casa Cloudflare proxy. Restores the `Overnight:` section in `ha-morning-brief` and unblocks `ha-analyze-patterns` for deployments with large entity inventories. No CLI or skill changes; explicit `--entities` calls keep their original single-request shape when they fit under the chunk size.
+- **`ha fetch-history` no longer fails with Cloudflare HTTP 520 on default-scope fetches** (gh #107). `HomeAssistantClient.get_history()` now splits the requested entity IDs into chunks of 50 and merges the per-chunk responses, keeping the `filter_entity_id` query string short enough to pass through the Nabu Casa Cloudflare proxy. Restores the `Overnight:` section in `ha-morning-brief` and unblocks `ha-analyze-patterns` for deployments with large entity inventories. No CLI or skill changes; explicit `--entities` calls keep their original single-request shape when they fit under the chunk size. Duplicate entity IDs are now collapsed (first occurrence wins) before chunking so the chunk merge can't silently drop one chunk's rows.
 
 ## [0.1.4] - 2026-05-16
 

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **`ha fetch-history` no longer fails with Cloudflare HTTP 520 on default-scope fetches** (gh #107). `HomeAssistantClient.get_history()` now splits the requested entity IDs into chunks of 50 and merges the per-chunk responses, keeping the `filter_entity_id` query string short enough to pass through the Nabu Casa Cloudflare proxy. Restores the `Overnight:` section in `ha-morning-brief` and unblocks `ha-analyze-patterns` for deployments with large entity inventories. No CLI or skill changes; explicit `--entities` calls keep their original single-request shape when they fit under the chunk size.
+
 ## [0.1.4] - 2026-05-16
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/ha_api.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/ha_api.py
@@ -14,6 +14,10 @@ from .config import AppConfig, load_config
 
 _USER_AGENT = os.environ.get("HOMEASSISTANT_USER_AGENT") or f"ha-agent-lab/{__version__} (+https://github.com/gtapps/claude-code-hermit)"
 
+# Cloudflare/Nabu Casa rejects oversize filter_entity_id query strings with HTTP 520.
+# Empirically 24 IDs pass and 306 fail; 50 keeps URLs well under the proxy limit.
+_HISTORY_CHUNK_SIZE = 50
+
 
 @dataclass(slots=True)
 class HomeAssistantError(Exception):
@@ -68,6 +72,10 @@ class HomeAssistantClient:
         Returns {entity_id: [state_change, ...]}. Entities with no events in the window
         are absent from the result — callers that need zero-count rows synthesize them.
 
+        Large entity lists are split into chunks of _HISTORY_CHUNK_SIZE and fetched
+        sequentially to keep the filter_entity_id query string under the Cloudflare
+        proxy's URL-length limit (which otherwise rejects with HTTP 520).
+
         Raises HomeAssistantError if entity_ids is empty (avoids an unbounded all-entity fetch).
         Flags are sent as bare query params (minimal_response, not minimal_response=true)
         matching the HA REST API docs.
@@ -75,6 +83,27 @@ class HomeAssistantClient:
         if not entity_ids:
             raise HomeAssistantError("get_history requires entity_ids — pass at least one entity ID")
 
+        result: dict[str, list[dict[str, Any]]] = {}
+        for i in range(0, len(entity_ids), _HISTORY_CHUNK_SIZE):
+            chunk = entity_ids[i:i + _HISTORY_CHUNK_SIZE]
+            result.update(self._fetch_history_chunk(
+                chunk,
+                start_time,
+                end_time,
+                minimal_response=minimal_response,
+                significant_changes_only=significant_changes_only,
+            ))
+        return result
+
+    def _fetch_history_chunk(
+        self,
+        entity_ids: list[str],
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        minimal_response: bool,
+        significant_changes_only: bool,
+    ) -> dict[str, list[dict[str, Any]]]:
         start_iso = parse.quote(start_time.isoformat(), safe="")
         params = f"filter_entity_id={','.join(parse.quote(e, safe='') for e in entity_ids)}"
         params += f"&end_time={parse.quote(end_time.isoformat(), safe='')}"

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/ha_api.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/ha_api.py
@@ -74,7 +74,9 @@ class HomeAssistantClient:
 
         Large entity lists are split into chunks of _HISTORY_CHUNK_SIZE and fetched
         sequentially to keep the filter_entity_id query string under the Cloudflare
-        proxy's URL-length limit (which otherwise rejects with HTTP 520).
+        proxy's URL-length limit (which otherwise rejects with HTTP 520). Duplicate
+        entity IDs are collapsed (first occurrence wins) so chunks never re-fetch the
+        same entity and merge order can't silently drop one chunk's rows.
 
         Raises HomeAssistantError if entity_ids is empty (avoids an unbounded all-entity fetch).
         Flags are sent as bare query params (minimal_response, not minimal_response=true)
@@ -83,6 +85,7 @@ class HomeAssistantClient:
         if not entity_ids:
             raise HomeAssistantError("get_history requires entity_ids — pass at least one entity ID")
 
+        entity_ids = list(dict.fromkeys(entity_ids))
         result: dict[str, list[dict[str, Any]]] = {}
         for i in range(0, len(entity_ids), _HISTORY_CHUNK_SIZE):
             chunk = entity_ids[i:i + _HISTORY_CHUNK_SIZE]

--- a/plugins/claude-code-homeassistant-hermit/tests/test_ha_api.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_ha_api.py
@@ -165,6 +165,21 @@ def test_get_history_chunks_large_entity_lists_and_merges_results(tmp_path: Path
     assert set(result.keys()) == set(entity_ids)
 
 
+def test_get_history_dedupes_entity_ids_before_chunking(tmp_path: Path) -> None:
+    client = _make_client(tmp_path)
+    # 60 unique entities, each repeated twice → 120 entries
+    entity_ids = [f"light.x{i:03d}" for i in range(60)] * 2
+    captured: list[str] = []
+
+    with patch.object(client, "get", side_effect=lambda p: captured.append(p) or []):
+        client.get_history(entity_ids, _T0, _T1)
+
+    # After de-dup: 60 entities → 2 chunks of 50 and 10, not 3 chunks of 50/50/20
+    assert len(captured) == 2
+    chunk_sizes = [len(_parse_filter_entity_ids(p)) for p in captured]
+    assert chunk_sizes == [50, 10]
+
+
 # ---------------------------------------------------------------------------
 # select_home_assistant_url (pre-existing tests)
 # ---------------------------------------------------------------------------

--- a/plugins/claude-code-homeassistant-hermit/tests/test_ha_api.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_ha_api.py
@@ -122,6 +122,50 @@ def test_get_history_requires_explicit_end_time(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# get_history — chunking for large entity lists
+# ---------------------------------------------------------------------------
+
+def _parse_filter_entity_ids(path: str) -> list[str]:
+    from urllib.parse import parse_qs, unquote, urlparse
+    query = parse_qs(urlparse(path).query)
+    return unquote(query["filter_entity_id"][0]).split(",")
+
+
+def test_get_history_single_chunk_when_under_limit(tmp_path: Path) -> None:
+    client = _make_client(tmp_path)
+    captured: list[str] = []
+
+    with patch.object(client, "get", side_effect=lambda p: captured.append(p) or []):
+        client.get_history([f"light.x{i:03d}" for i in range(50)], _T0, _T1)
+
+    # Exactly at the chunk size — still one request, no chunking overhead
+    assert len(captured) == 1
+    assert len(_parse_filter_entity_ids(captured[0])) == 50
+
+
+def test_get_history_chunks_large_entity_lists_and_merges_results(tmp_path: Path) -> None:
+    client = _make_client(tmp_path)
+    entity_ids = [f"light.x{i:03d}" for i in range(120)]
+    captured: list[str] = []
+
+    def _fake_get(path: str) -> list:
+        captured.append(path)
+        ids = _parse_filter_entity_ids(path)
+        # HA returns one inner list per entity that had events
+        return [[{"entity_id": eid, "state": "on"}] for eid in ids]
+
+    with patch.object(client, "get", side_effect=_fake_get):
+        result = client.get_history(entity_ids, _T0, _T1)
+
+    # 120 entities at chunk size 50 → ceil(120/50) == 3 chunks
+    assert len(captured) == 3
+    chunk_sizes = [len(_parse_filter_entity_ids(p)) for p in captured]
+    assert chunk_sizes == [50, 50, 20]
+    # Merged result covers every requested entity
+    assert set(result.keys()) == set(entity_ids)
+
+
+# ---------------------------------------------------------------------------
 # select_home_assistant_url (pre-existing tests)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `HomeAssistantClient.get_history()` now splits requested entity IDs into chunks of 50 and merges per-chunk responses, keeping the `filter_entity_id` query string short enough to pass through the Nabu Casa Cloudflare proxy (which otherwise rejects with HTTP 520).
- Restores the `Overnight:` section in `ha-morning-brief` and unblocks `ha-analyze-patterns` for deployments with large entity inventories.
- No CLI or skill changes; explicit `--entities` calls under the chunk size still issue a single request.

## Test plan
- [x] `pytest tests/test_ha_api.py tests/test_history.py -v` — all 28 tests pass, including two new chunking tests.
- [x] `pytest tests/` — full plugin suite (182 tests) passes.
- [x] Operator verification: `${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha fetch-history --window-days 1` returns 200 against a Nabu Casa instance, and `snapshot-ha-history-1d-latest.json` lands with `returned_entities` covering the full default scope.

## Follow-up (not in this PR)
- `HomeAssistantClient._request()` only retries on `URLError`, not on HTTP 5xx. Chunking widens the blast radius: a transient 502/503/504 on chunk 3 of 6 aborts the whole fetch and discards completed chunks. Pre-existing behavior; touching it would affect every HA API call site. Worth a separate proposal if 5xx retry is wanted across the board.

Closes #107