### PR TITLE
close duplicate-block gap in hatch target migration

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -9,18 +9,17 @@
 ### Changed
 
 - **`/hatch` Step 3 is now target-aware (GH #111 follow-up).** Reads `.claude-code-hermit/state/hatch-options.json` written by core hatch and writes the CLAUDE-APPEND block to `CLAUDE.local.md` (when `target = "local"`) or `CLAUDE.md` (when `target = "committed"`). If core hatch hasn't run yet (operator's core hermit predates 1.1.1), the skill detects `core_install_scope` from `claude plugin list --json` and presents the scope-derived default at position 0 of the Visibility prompt, then stamps `hatch-options.json` with the canonical 5-field schema (`target`, `core_install_scope`, `stamped_at`, `stamped_by`, `version`). Stray-block migration is handled one-shot by the Upgrade Instructions below — hatch itself stays focused on target-aware setup and steady-state refresh.
+- **Polish following code-review pass.** Step 1 of `/hatch` now explicitly captures `prior_hatch_mode` before Step 5 overwrites it (sequencing clarification, no behavior change). The Upgrade Instructions Step 3 is now fully unattended — dropped the hand-edit detection / Carry-forward branch since `/hatch`'s single-source-of-truth contract already makes the marked block template-authoritative. Test coverage extended with 15 structural-lint assertions for target routing, the 5-field schema, scope mapping, and migration delegation.
 
 ### Upgrade Instructions
 
-Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes the following steps automatically (via Step 7's sibling upgrade flow, which runs every plugin's `### Upgrade Instructions` before its CLAUDE-APPEND sync). The migration is unconditional — `hermit-evolve` Step 7 always re-syncs the canonical block to `hatch_target` after this, so the only operator-prompted decision is hand-edit preservation.
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes the following steps automatically (via Step 7's sibling upgrade flow, which runs every plugin's `### Upgrade Instructions` before its CLAUDE-APPEND sync). The migration is unattended — no operator prompts. `hermit-evolve` Step 7 re-syncs the canonical block to `hatch_target` afterwards.
 
 1. **Resolve `hatch_target`.** Use the same fallback chain `hermit-evolve` Step 2a uses, substituting the dev marker: read `.claude-code-hermit/state/hatch-options.json` and use the `"target"` field; else check `CLAUDE.local.md` for `<!-- claude-code-dev-hermit: Development Workflow -->` → `hatch_target = "local"`; else check `CLAUDE.md` for the same marker → `hatch_target = "committed"`; else stop — the dev block is in neither file, nothing to migrate.
 
 2. **Identify the non-target file.** `non_target = (hatch_target == "local") ? "CLAUDE.md" : "CLAUDE.local.md"`.
 
-3. **If the marker is present in `non_target`:** detect hand-edits inside the marker by comparing the block content against the canonical template at this plugin version (`<installPath>/state-templates/CLAUDE-APPEND.md` if the prior block has `## Implementation Flow`, else `<installPath>/state-templates/CLAUDE-APPEND-SAFETY.md`, where `<installPath>` is the sibling plugin's install path that `hermit-evolve` Step 7 already iterates over). Treat mode-mismatch (different section list) as expected, not as hand-edits.
-   - If hand-edits exist, ask the operator: **Carry forward** (merge hand-edits into the canonical template, write the merged block to `hatch_target` file, then strip the block from `non_target`) / **Drop** (strip the block from `non_target`; let Step 7's sync re-append the clean canonical template to `hatch_target`).
-   - If no hand-edits: silently strip the block from `non_target`. Step 7's sync handles `hatch_target`.
+3. **If the marker is present in `non_target`, silently strip the marked block.** Per `/hatch`'s single-source-of-truth contract, the CLAUDE-APPEND template is authoritative and operator overrides belong outside the marked block, so no hand-edit preservation is needed. Step 7's sync re-appends the canonical block to `hatch_target` afterwards.
 
 4. **If the marker is only in `hatch_target`:** no-op. Steady state — Step 7's normal sync handles routine version-bump replacement.
 

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Duplicate dev block after core 1.1.1 target migration.** When an operator upgraded core hermit to 1.1.1 and chose `target = "local"`, core's `hermit-evolve` migrated its own block from `CLAUDE.md` to `CLAUDE.local.md` but the dev-hermit block was left behind. The subsequent sibling-sync in `hermit-evolve` Step 7 found no marker in `CLAUDE.local.md` and appended a fresh dev block there, while the pre-existing block in `CLAUDE.md` was never removed — resulting in duplicate `<!-- claude-code-dev-hermit: Development Workflow -->` blocks in both files. The Upgrade Instructions below run a one-shot migration via `hermit-evolve` Step 7 to remove the stray block.
+
+### Changed
+
+- **`/hatch` Step 3 is now self-healing (GH #111 follow-up).** Before writing the CLAUDE-APPEND block, the skill detects the marker in both target and non-target files and branches on the (in_target, in_other) tuple. The stray-block case (marker only in non-target file) prompts **Move** / **Keep in `<other_file>`** / **Skip** with mode-mismatch and hand-edit detection; the duplicate-block case (marker in both files) prompts **Remove from `<other_file>`** / **Manual** / **Skip**. On Keep, Skip, or Manual the skill exits without writing to the target file — avoiding the duplicate-block bug that prompted this fix. The selected mode template is read once and reused across the diff comparison and the eventual write.
+- **First-write `hatch-options.json` schema completed.** When dev-hermit hatch stamps the file before core hatch has run, it now writes all five canonical fields (`target`, `core_install_scope`, `stamped_at`, `stamped_by`, `version`) so a later core hatch run can apply its 1.1.1 preservation logic faithfully. The Visibility prompt also presents the scope-derived default at position 0 (recommended), matching core hatch's voice.
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes the following steps automatically (via Step 7's sibling upgrade flow, which runs every plugin's `### Upgrade Instructions` before its CLAUDE-APPEND sync). The migration is unconditional — `hermit-evolve` Step 7 always re-syncs the canonical block to `hatch_target` after this, so the only operator-prompted decision is hand-edit preservation.
+
+1. **Resolve `hatch_target`.** Use the same fallback chain `hermit-evolve` Step 2a uses, substituting the dev marker: read `.claude-code-hermit/state/hatch-options.json` and use the `"target"` field; else check `CLAUDE.local.md` for `<!-- claude-code-dev-hermit: Development Workflow -->` → `hatch_target = "local"`; else check `CLAUDE.md` for the same marker → `hatch_target = "committed"`; else stop — the dev block is in neither file, nothing to migrate.
+
+2. **Identify the non-target file.** `non_target = (hatch_target == "local") ? "CLAUDE.md" : "CLAUDE.local.md"`.
+
+3. **If the marker is present in `non_target`:** detect hand-edits inside the marker by comparing the block content against the canonical template at this plugin version (`${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md` if the prior block has `## Implementation Flow`, else `state-templates/CLAUDE-APPEND-SAFETY.md`). Treat mode-mismatch (different section list) as expected, not as hand-edits.
+   - If hand-edits exist, ask the operator: **Carry forward** (merge hand-edits into the canonical template, write the merged block to `hatch_target` file, then strip the block from `non_target`) / **Drop** (strip the block from `non_target`; let Step 7's sync re-append the clean canonical template to `hatch_target`).
+   - If no hand-edits: silently strip the block from `non_target`. Step 7's sync handles `hatch_target`.
+
+4. **If the marker is only in `hatch_target`:** no-op. Steady state — Step 7's normal sync handles routine version-bump replacement.
+
+No `config.json` changes required.
+
 ## [0.3.8] - 2026-05-21
 
 ### Changed

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -8,8 +8,7 @@
 
 ### Changed
 
-- **`/hatch` Step 3 is now self-healing (GH #111 follow-up).** Before writing the CLAUDE-APPEND block, the skill detects the marker in both target and non-target files and branches on the (in_target, in_other) tuple. The stray-block case (marker only in non-target file) prompts **Move** / **Keep in `<other_file>`** / **Skip** with mode-mismatch and hand-edit detection; the duplicate-block case (marker in both files) prompts **Remove from `<other_file>`** / **Manual** / **Skip**. On Keep, Skip, or Manual the skill exits without writing to the target file — avoiding the duplicate-block bug that prompted this fix. The selected mode template is read once and reused across the diff comparison and the eventual write.
-- **First-write `hatch-options.json` schema completed.** When dev-hermit hatch stamps the file before core hatch has run, it now writes all five canonical fields (`target`, `core_install_scope`, `stamped_at`, `stamped_by`, `version`) so a later core hatch run can apply its 1.1.1 preservation logic faithfully. The Visibility prompt also presents the scope-derived default at position 0 (recommended), matching core hatch's voice.
+- **`/hatch` Step 3 is now target-aware (GH #111 follow-up).** Reads `.claude-code-hermit/state/hatch-options.json` written by core hatch and writes the CLAUDE-APPEND block to `CLAUDE.local.md` (when `target = "local"`) or `CLAUDE.md` (when `target = "committed"`). If core hatch hasn't run yet (operator's core hermit predates 1.1.1), the skill detects `core_install_scope` from `claude plugin list --json` and presents the scope-derived default at position 0 of the Visibility prompt, then stamps `hatch-options.json` with the canonical 5-field schema (`target`, `core_install_scope`, `stamped_at`, `stamped_by`, `version`). Stray-block migration is handled one-shot by the Upgrade Instructions below — hatch itself stays focused on target-aware setup and steady-state refresh.
 
 ### Upgrade Instructions
 
@@ -19,7 +18,7 @@ Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes the following
 
 2. **Identify the non-target file.** `non_target = (hatch_target == "local") ? "CLAUDE.md" : "CLAUDE.local.md"`.
 
-3. **If the marker is present in `non_target`:** detect hand-edits inside the marker by comparing the block content against the canonical template at this plugin version (`${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md` if the prior block has `## Implementation Flow`, else `state-templates/CLAUDE-APPEND-SAFETY.md`). Treat mode-mismatch (different section list) as expected, not as hand-edits.
+3. **If the marker is present in `non_target`:** detect hand-edits inside the marker by comparing the block content against the canonical template at this plugin version (`<installPath>/state-templates/CLAUDE-APPEND.md` if the prior block has `## Implementation Flow`, else `<installPath>/state-templates/CLAUDE-APPEND-SAFETY.md`, where `<installPath>` is the sibling plugin's install path that `hermit-evolve` Step 7 already iterates over). Treat mode-mismatch (different section list) as expected, not as hand-edits.
    - If hand-edits exist, ask the operator: **Carry forward** (merge hand-edits into the canonical template, write the merged block to `hatch_target` file, then strip the block from `non_target`) / **Drop** (strip the block from `non_target`; let Step 7's sync re-append the clean canonical template to `hatch_target`).
    - If no hand-edits: silently strip the block from `non_target`. Step 7's sync handles `hatch_target`.
 

--- a/plugins/claude-code-dev-hermit/CLAUDE.md
+++ b/plugins/claude-code-dev-hermit/CLAUDE.md
@@ -27,7 +27,9 @@ Language-agnostic safety layer for any agent doing dev work in a hermit project.
 
 ## Hatch target routing
 
-`/hatch` Step 3 reads `.claude-code-hermit/state/hatch-options.json` (written by core hatch) to determine where to write the CLAUDE-APPEND block: `target = "local"` → `CLAUDE.local.md`; `target = "committed"` → `CLAUDE.md`. If core hatch hasn't run yet, the skill prompts the operator and stamps the file itself. Applies to both `CLAUDE-APPEND.md` (standard) and `CLAUDE-APPEND-SAFETY.md` (safety) templates.
+`/hatch` Step 3 reads `.claude-code-hermit/state/hatch-options.json` (written by core hatch) to determine where to write the CLAUDE-APPEND block: `target = "local"` → `CLAUDE.local.md`; `target = "committed"` → `CLAUDE.md`. If core hatch hasn't run yet, the skill detects `core_install_scope` from `claude plugin list --json`, presents the scope-derived default at position 0 of the Visibility prompt, and stamps the full canonical schema (`target`, `core_install_scope`, `stamped_at`, `stamped_by`, `version`) into `hatch-options.json`. Applies to both `CLAUDE-APPEND.md` (standard) and `CLAUDE-APPEND-SAFETY.md` (safety) templates.
+
+**Migration on target change.** When the operator flips `hatch_target` (e.g. via core 1.1.1's `hermit-evolve` Upgrade Instructions), the dev block can end up stranded in the old file. Two safety nets remove it: (1) the most recent CHANGELOG entry's `### Upgrade Instructions` run a one-shot migration via `hermit-evolve` Step 7's sibling upgrade flow; (2) re-running `/claude-code-dev-hermit:hatch` detects the marker in both target and non-target files and branches on the (in_target, in_other) tuple — prompting **Move** / **Keep** / **Skip** in the stray case, **Remove** / **Manual** / **Skip** in the duplicate case, with mode-mismatch and hand-edit detection.
 
 ## Depends On
 

--- a/plugins/claude-code-dev-hermit/CLAUDE.md
+++ b/plugins/claude-code-dev-hermit/CLAUDE.md
@@ -29,7 +29,7 @@ Language-agnostic safety layer for any agent doing dev work in a hermit project.
 
 `/hatch` Step 3 reads `.claude-code-hermit/state/hatch-options.json` (written by core hatch) to determine where to write the CLAUDE-APPEND block: `target = "local"` → `CLAUDE.local.md`; `target = "committed"` → `CLAUDE.md`. If core hatch hasn't run yet, the skill detects `core_install_scope` from `claude plugin list --json`, presents the scope-derived default at position 0 of the Visibility prompt, and stamps the full canonical schema (`target`, `core_install_scope`, `stamped_at`, `stamped_by`, `version`) into `hatch-options.json`. Applies to both `CLAUDE-APPEND.md` (standard) and `CLAUDE-APPEND-SAFETY.md` (safety) templates.
 
-**Migration on target change.** When the operator flips `hatch_target` (e.g. via core 1.1.1's `hermit-evolve` Upgrade Instructions), the dev block can end up stranded in the old file. Two safety nets remove it: (1) the most recent CHANGELOG entry's `### Upgrade Instructions` run a one-shot migration via `hermit-evolve` Step 7's sibling upgrade flow; (2) re-running `/claude-code-dev-hermit:hatch` detects the marker in both target and non-target files and branches on the (in_target, in_other) tuple — prompting **Move** / **Keep** / **Skip** in the stray case, **Remove** / **Manual** / **Skip** in the duplicate case, with mode-mismatch and hand-edit detection.
+**Migration on target change.** When the operator flips `hatch_target` (e.g. via core 1.1.1's `hermit-evolve` Upgrade Instructions), the dev block can end up stranded in the old file. The most recent CHANGELOG entry's `### Upgrade Instructions` run a one-shot migration via `hermit-evolve` Step 7's sibling upgrade flow to strip the stranded block.
 
 ## Depends On
 

--- a/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
@@ -18,6 +18,8 @@ Check if `.claude-code-hermit/` exists in the current project.
 - Missing: ask the operator (`AskUserQuestion`) "Core hermit isn't set up yet. Run `/claude-code-hermit:hatch` now?" with options `Yes — run now` / `No — I'll do it later`. If yes, invoke `/claude-code-hermit:hatch`, then continue. If no, stop.
 - Present: read `.claude-code-hermit/config.json` and the plugin's `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/hermit-meta.json`. Verify `_hermit_versions["claude-code-hermit"]` from config satisfies `required_core_version` from hermit-meta (e.g. `">=1.0.22"`). If absent or below the floor, ask whether to run `/claude-code-hermit:hermit-evolve` first; allow opt-out with a warning. (Reading the floor from hermit-meta — never hardcoding it in skill prose — keeps this skill in sync with the plugin's declared requirement.)
 
+**Capture `prior_hatch_mode`.** While reading `config.json`, also record `claude-code-dev-hermit.hatch_mode` as `prior_hatch_mode` (or `null` if unset). Step 3's skip-vs-replace decision compares against this value, and Step 5 overwrites `hatch_mode` with Step 2's answer — capturing the prior value here keeps it intact across the wizard.
+
 ### 2. Capability scan + choose mode
 
 Run all detection in a single parallel turn:
@@ -86,9 +88,9 @@ Read the plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`.
 
 Read `target_file` (treat a missing file as marker-absent — Edit will create the file in the append branch). Look for the marker `<!-- claude-code-dev-hermit: Development Workflow -->` and extract the stamped version from the existing block (if present).
 
-Compare against the run's chosen mode (from Step 2's answer this run) and the existing `hatch_mode` value read from `config.json` at Step 1 (the **prior** value, before Step 5 overwrites it):
+Compare against the run's chosen mode (from Step 2's answer this run) and `prior_hatch_mode` (captured in Step 1, before Step 5 overwrites `hatch_mode`):
 
-- **Marker present, stamped version matches plugin version, AND Step 2's mode equals the prior `hatch_mode`**: skip — block is current. Do not read the template.
+- **Marker present, stamped version matches plugin version, AND Step 2's mode equals `prior_hatch_mode`**: skip — block is current. Do not read the template.
 - **All other cases** (marker absent, stamped version stale, OR mode changed): read the mode template — `safety` → `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND-SAFETY.md`; `standard` → `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md` — and either append (marker absent) or replace the marked block (marker present). The template is the source of truth; no operator prompt is needed.
 
 Stray-block migration (block stranded in the non-target file after a target flip) is handled one-shot by the Upgrade Instructions in this version's CHANGELOG entry, executed by `hermit-evolve` Step 7. Hatch itself stays focused on target-aware setup and steady-state refresh.

--- a/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
@@ -68,24 +68,48 @@ When building the options array at runtime:
 Read the plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`.
 
 **Resolve target file:** Read `.claude-code-hermit/state/hatch-options.json`. Use the `"target"` field:
-- `"local"` → write to `CLAUDE.local.md`
-- `"committed"` or absent → write to `CLAUDE.md`
-- If the file doesn't exist (operator ran dev-hermit hatch before core hatch): ask with `AskUserQuestion` (header: "Visibility") — options: **`.local` files** (gitignored) / **Committed files** (shared). Record choice and write `.claude-code-hermit/state/hatch-options.json` with `{"target": "<choice>", "stamped_by": "claude-code-dev-hermit:hatch", "stamped_at": "<iso>"}`.
+- `"local"` → `target_file = CLAUDE.local.md`
+- `"committed"` or absent → `target_file = CLAUDE.md`
+- If the file doesn't exist (operator ran dev-hermit hatch before core hatch): detect `core_install_scope` from `claude plugin list --json` using the same precedence rules core hatch's Step 1.5 item 2 uses (filter to entries where plugin name is `claude-code-hermit` and `enabled == true`; apply precedence `local` > `project` (both require `projectPath == project root`) > `user` (any `projectPath`) > `null`; map `project` → `committed`, `local`/`user`/`null` → `local` as the scope-derived default). Ask with `AskUserQuestion` (header: "Visibility") — present the scope-derived default at position 0 with `(recommended)` in the label: **`.local` files** (gitignored — operator-personal) / **Committed files** (shared with teammates). Record the choice and write `.claude-code-hermit/state/hatch-options.json` with the full schema:
 
-Based on the mode chosen in step 2:
-- `safety` → read `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND-SAFETY.md`
-- `standard` → read `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md`
+  ```json
+  {
+    "target": "<choice>",
+    "core_install_scope": "<project|local|user|null>",
+    "stamped_at": "<current ISO 8601 timestamp with timezone offset>",
+    "stamped_by": "claude-code-dev-hermit:hatch",
+    "version": "<current dev-hermit plugin version from ${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json>"
+  }
+  ```
 
-Look for the marker comment `<!-- claude-code-dev-hermit: Development Workflow -->` in the target file.
+  This matches the canonical schema core hatch Step 9b writes, so when core hatch later runs its 1.1.1 preservation logic keeps `stamped_at`/`stamped_by` intact and adds `last_updated_at`/`last_updated_by`.
 
-- Marker absent: append the selected template to the target file.
-- Marker present, stamped version differs from the plugin version: silently replace the existing block with the selected template.
-- Marker present, versions match AND mode is unchanged from config: skip — block is current.
-- Marker present, versions match but mode changed: replace — operator switched modes.
+Compute `other_file = (target == "local") ? "CLAUDE.md" : "CLAUDE.local.md"`.
 
-The template is the source of truth. No operator prompt is needed for the replace step.
+**Select mode template and read it once:**
+- `safety` → `template = ${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND-SAFETY.md`
+- `standard` → `template = ${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md`
 
-The template is the source of truth. No operator prompt is needed for this step.
+The marker is `<!-- claude-code-dev-hermit: Development Workflow -->`. Detect presence in both files: `in_target = marker present in target_file`; `in_other = marker present in other_file`. Then branch on the (in_target, in_other) tuple:
+
+**Case A — (false, false), marker absent in both:** append `template` to `target_file`. No prompt.
+
+**Case B — (true, false), marker only in target_file (steady state):**
+- Stamped version in target block matches plugin version AND mode is unchanged from config: skip — block is current.
+- Otherwise: silently replace the existing block in `target_file` with `template`. No prompt (template is the source of truth).
+
+**Case C — (false, true), marker only in other_file (the migration case):**
+- Compare the block content in `other_file` against `template`. Surface mode mismatch and hand-edits separately:
+  - If the prior block's mode (detect by section list — e.g. `## Implementation Flow` absent → safety) differs from the currently selected mode, label the diff as "mode switch: <prior> → <current>" — not as hand-edits.
+  - Any remaining diff inside the marker is hand-edits.
+- Ask with `AskUserQuestion` (header: "Migrate dev block") — options, matching core hermit-evolve voice: **Move** (recommended; removes block from `<other_file>`, writes `template` to `<target_file>`, drops any hand-edits unless operator carries them) / **Keep in `<other_file>`** (leaves the block where it is; does NOT write to `target_file`) / **Skip** (no changes this run; does NOT write to `target_file`).
+- If hand-edits exist, ask a follow-up: carry them across or drop them. If carry: merge into `template` before writing to `target_file`.
+- On Move: remove the marked block from `other_file`, then write the (possibly-merged) template to `target_file`.
+- On Keep or Skip: do NOT fall through to Case A — that would append a fresh block to `target_file` and recreate the duplicate-block bug. Just exit Step 3.
+
+**Case D — (true, true), marker in both files (diagnostic state, e.g. partial migration):**
+- Report the state to the operator. Ask with `AskUserQuestion` (header: "Resolve duplicate") — options: **Remove from `<other_file>`** (recommended; strips the stray block, then proceeds as Case B on `target_file`) / **Manual** (exits Step 3 with no changes; operator cleans up themselves) / **Skip** (exits Step 3 with no changes).
+- On Remove: strip the marker block from `other_file`, then run Case B's logic on `target_file`.
 
 ### 4. Ask about remaining settings
 

--- a/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
@@ -70,7 +70,7 @@ Read the plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`.
 **Resolve target file:** Read `.claude-code-hermit/state/hatch-options.json`. Use the `"target"` field:
 - `"local"` → `target_file = CLAUDE.local.md`
 - `"committed"` or absent → `target_file = CLAUDE.md`
-- If the file doesn't exist (operator ran dev-hermit hatch before core hatch): detect `core_install_scope` from `claude plugin list --json` using the same precedence rules core hatch's Step 1.5 item 2 uses (filter to entries where plugin name is `claude-code-hermit` and `enabled == true`; apply precedence `local` > `project` (both require `projectPath == project root`) > `user` (any `projectPath`) > `null`; map `project` → `committed`, `local`/`user`/`null` → `local` as the scope-derived default). Ask with `AskUserQuestion` (header: "Visibility") — present the scope-derived default at position 0 with `(recommended)` in the label: **`.local` files** (gitignored — operator-personal) / **Committed files** (shared with teammates). Record the choice and write `.claude-code-hermit/state/hatch-options.json` with the full schema:
+- If the file doesn't exist (no `hatch-options.json` yet — operator's core hermit predates 1.1.1): detect `core_install_scope` from `claude plugin list --json` using the same precedence rules core hatch's Step 1.5 item 2 uses (filter to entries where plugin name is `claude-code-hermit` and `enabled == true`; apply precedence `local` > `project` (both require `projectPath == project root`) > `user` (any `projectPath`) > `null`; map `project` → `committed`, `local`/`user`/`null` → `local` as the scope-derived default). Ask with `AskUserQuestion` (header: "Visibility") — present the scope-derived default at position 0 with `(recommended)` in the label: **`.local` files** (gitignored — operator-personal) / **Committed files** (shared with teammates). Record the choice and write `.claude-code-hermit/state/hatch-options.json` with the full schema:
 
   ```json
   {
@@ -84,32 +84,14 @@ Read the plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`.
 
   This matches the canonical schema core hatch Step 9b writes, so when core hatch later runs its 1.1.1 preservation logic keeps `stamped_at`/`stamped_by` intact and adds `last_updated_at`/`last_updated_by`.
 
-Compute `other_file = (target == "local") ? "CLAUDE.md" : "CLAUDE.local.md"`.
+Read `target_file` (treat a missing file as marker-absent — Edit will create the file in the append branch). Look for the marker `<!-- claude-code-dev-hermit: Development Workflow -->` and extract the stamped version from the existing block (if present).
 
-**Select mode template and read it once:**
-- `safety` → `template = ${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND-SAFETY.md`
-- `standard` → `template = ${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md`
+Compare against the run's chosen mode (from Step 2's answer this run) and the existing `hatch_mode` value read from `config.json` at Step 1 (the **prior** value, before Step 5 overwrites it):
 
-The marker is `<!-- claude-code-dev-hermit: Development Workflow -->`. Detect presence in both files: `in_target = marker present in target_file`; `in_other = marker present in other_file`. Then branch on the (in_target, in_other) tuple:
+- **Marker present, stamped version matches plugin version, AND Step 2's mode equals the prior `hatch_mode`**: skip — block is current. Do not read the template.
+- **All other cases** (marker absent, stamped version stale, OR mode changed): read the mode template — `safety` → `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND-SAFETY.md`; `standard` → `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md` — and either append (marker absent) or replace the marked block (marker present). The template is the source of truth; no operator prompt is needed.
 
-**Case A — (false, false), marker absent in both:** append `template` to `target_file`. No prompt.
-
-**Case B — (true, false), marker only in target_file (steady state):**
-- Stamped version in target block matches plugin version AND mode is unchanged from config: skip — block is current.
-- Otherwise: silently replace the existing block in `target_file` with `template`. No prompt (template is the source of truth).
-
-**Case C — (false, true), marker only in other_file (the migration case):**
-- Compare the block content in `other_file` against `template`. Surface mode mismatch and hand-edits separately:
-  - If the prior block's mode (detect by section list — e.g. `## Implementation Flow` absent → safety) differs from the currently selected mode, label the diff as "mode switch: <prior> → <current>" — not as hand-edits.
-  - Any remaining diff inside the marker is hand-edits.
-- Ask with `AskUserQuestion` (header: "Migrate dev block") — options, matching core hermit-evolve voice: **Move** (recommended; removes block from `<other_file>`, writes `template` to `<target_file>`, drops any hand-edits unless operator carries them) / **Keep in `<other_file>`** (leaves the block where it is; does NOT write to `target_file`) / **Skip** (no changes this run; does NOT write to `target_file`).
-- If hand-edits exist, ask a follow-up: carry them across or drop them. If carry: merge into `template` before writing to `target_file`.
-- On Move: remove the marked block from `other_file`, then write the (possibly-merged) template to `target_file`.
-- On Keep or Skip: do NOT fall through to Case A — that would append a fresh block to `target_file` and recreate the duplicate-block bug. Just exit Step 3.
-
-**Case D — (true, true), marker in both files (diagnostic state, e.g. partial migration):**
-- Report the state to the operator. Ask with `AskUserQuestion` (header: "Resolve duplicate") — options: **Remove from `<other_file>`** (recommended; strips the stray block, then proceeds as Case B on `target_file`) / **Manual** (exits Step 3 with no changes; operator cleans up themselves) / **Skip** (exits Step 3 with no changes).
-- On Remove: strip the marker block from `other_file`, then run Case B's logic on `target_file`.
+Stray-block migration (block stranded in the non-target file after a target flip) is handled one-shot by the Upgrade Instructions in this version's CHANGELOG entry, executed by `hermit-evolve` Step 7. Hatch itself stays focused on target-aware setup and steady-state refresh.
 
 ### 4. Ask about remaining settings
 

--- a/plugins/claude-code-dev-hermit/tests/hatch-mode.test.js
+++ b/plugins/claude-code-dev-hermit/tests/hatch-mode.test.js
@@ -92,6 +92,37 @@ if (fs.existsSync(HATCH_SKILL)) {
   ok('references standard mode', text.includes('"standard"') || text.includes("'standard'") || text.includes('`standard`'));
   ok('references CLAUDE-APPEND-SAFETY.md', text.includes('CLAUDE-APPEND-SAFETY.md'));
   ok('references capability scan slugs', text.includes('create-pr') && text.includes('release'));
+
+  console.log('\nskills/hatch/SKILL.md target routing + schema stamping:');
+
+  ok('references hatch-options.json', text.includes('hatch-options.json'));
+  ok('reads "target" field from hatch-options.json',
+    /hatch-options\.json[\s\S]{0,200}["`]target["`]/.test(text));
+  ok('local target routes to CLAUDE.local.md',
+    /["`]local["`][\s\S]{0,80}target_file = CLAUDE\.local\.md/.test(text));
+  ok('committed target routes to CLAUDE.md',
+    /["`]committed["`][\s\S]{0,120}target_file = CLAUDE\.md/.test(text));
+
+  ok('schema stamps "target" field', /"target":\s*"/.test(text));
+  ok('schema stamps "core_install_scope" field', /"core_install_scope":\s*"/.test(text));
+  ok('schema stamps "stamped_at" field', /"stamped_at":\s*"/.test(text));
+  ok('schema stamps "stamped_by" field', /"stamped_by":\s*"claude-code-dev-hermit:hatch"/.test(text));
+  ok('schema stamps "version" field', /"version":\s*"/.test(text));
+
+  ok('detects core_install_scope from `claude plugin list --json`',
+    /core_install_scope[\s\S]{0,120}claude plugin list --json/.test(text));
+  ok('documents `project` → `committed` scope mapping',
+    /`project`[^\n]{0,20}`committed`/.test(text));
+  ok('documents `local`/`user`/`null` → `local` scope mapping',
+    /`local`\/`user`\/`null`[^\n]{0,40}`local`/.test(text));
+
+  ok('Step 1 captures `prior_hatch_mode`',
+    /Capture `prior_hatch_mode`/.test(text));
+  ok('Step 3 compares against `prior_hatch_mode`',
+    /Step 2's mode equals `prior_hatch_mode`/.test(text));
+
+  ok('delegates stray-block migration to hermit-evolve Step 7',
+    /hermit-evolve[\s\S]{0,20}Step 7/.test(text));
 }
 
 process.exit(summary() === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- close duplicate-block gap in hatch target migration

## Verification

- Tests: **pass** (18.8s)

## Notes

Scoped to `claude-code-dev-hermit` only. The same duplicate-block bug affects `claude-code-homeassistant-hermit` and `claude-code-fitness-hermit` (neither's hatch is target-aware yet, and both ship a CLAUDE-APPEND block that `hermit-evolve` Step 7 will sync to `CLAUDE.local.md` after a core 1.1.1 `target=local` migration). Follow-up branches will replicate this pattern for each sibling — independent commits per CLAUDE.md "one plugin per commit" convention.
