### PR TITLE
fix(claude-code-hermit): read heartbeat-monitor.runtime.json before writing in start subcommand

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **heartbeat: start subcommand reads state file before writing** — fixes "File has not been read yet" failure on always-on restart when `state/heartbeat-monitor.runtime.json` exists from a prior session.
+
 ## [1.1.5] - 2026-05-25
 
 ### Added

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -55,7 +55,7 @@ Start the heartbeat as a persistent CC Monitor subprocess.
 1. Read `heartbeat.every` from config (default: `"2h"`). Parse to seconds (`"30m"` → 1800, `"2h"` → 7200, etc).
 2. Resolve the script path: `${CLAUDE_PLUGIN_ROOT}/scripts/heartbeat-monitor.sh` (resolve at skill execution time — not available inside the subprocess).
 3. Sweep any pre-existing CronCreate entry for the old recurring-cron approach: `CronList` → if an entry's `prompt` matches `/claude-code-hermit:heartbeat run`, `CronDelete` it. Idempotent.
-4. If a Monitor with description `heartbeat-monitor` exists (TaskList), TaskStop it. Also remove any prior entry from `state/heartbeat-monitor.runtime.json`.
+4. Read `state/heartbeat-monitor.runtime.json` if it exists (Write requires a prior Read in the same session). If a Monitor with description `heartbeat-monitor` exists (TaskList), TaskStop it. Also remove any prior entry from `state/heartbeat-monitor.runtime.json`.
 5. Register a new Monitor:
    - `description`: `heartbeat-monitor` (reserved slot — operators must not reuse this description for ad-hoc `/watch` entries)
    - `command`: `bash <abs_script_path> <interval_seconds> $PWD/.claude-code-hermit`


### PR DESCRIPTION
## Summary

The `heartbeat start` subcommand writes to `state/heartbeat-monitor.runtime.json` twice (step 4 clears any prior entry; step 6 writes the new monitor record), but neither step was preceded by a Read in the same session. The CC Write tool enforces read-before-write, so on any always-on restart where the file exists from the prior session the skill would fail with "File has not been read yet."

Adds a single Read instruction to step 4, which satisfies the precondition for both writes. Mirrors the pattern already present in the `stop` subcommand (read in step 1, write in step 2).

## Changes

- `plugins/claude-code-hermit/skills/heartbeat/SKILL.md` — step 4 of `### start`: prepend `Read state/heartbeat-monitor.runtime.json if it exists (Write requires a prior Read in the same session).`

## Test plan

- On an always-on hermit that has an existing `state/heartbeat-monitor.runtime.json` from a prior session, start a fresh session and run `/claude-code-hermit:heartbeat start`. Expect: no "File has not been read yet" error; file updated with new `task_id` and `started_at`; SHELL.md Monitoring section shows "Heartbeat: monitor started".
- Run `/claude-code-hermit:heartbeat start` a second time in the same session to confirm idempotency (existing Monitor stopped, state file rewritten with new task_id).

Closes #140.