### PR TITLE
fix(hermit): extend daily-auto-close to cover idle sessions

### DIFF
--- a/plugins/claude-code-hermit/scripts/heartbeat-precheck.js
+++ b/plugins/claude-code-hermit/scripts/heartbeat-precheck.js
@@ -61,7 +61,7 @@ if (process.env.HERMIT_NOW) {
   const pendingClose = readJSON(path.join(stateDir, 'state', 'pending-close.json'));
   if (pendingClose !== null) {
     const runtime = readJSON(path.join(stateDir, 'state', 'runtime.json')) ?? {};
-    if (runtime.session_state === 'in_progress') {
+    if (runtime.session_state === 'in_progress' || runtime.session_state === 'idle') {
       const lastAction = readJSON(path.join(stateDir, 'state', 'last-operator-action.json'));
       const tStr = lastAction && typeof lastAction.at === 'string' ? lastAction.at : null;
       const t = tStr ? new Date(tStr).getTime() : NaN;

--- a/plugins/claude-code-hermit/skills/daily-auto-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/daily-auto-close/SKILL.md
@@ -15,15 +15,15 @@ The skill is invoked by the `daily-auto-close` routine at `0 0 * * *` (local). T
 3. Check whether `.claude-code-hermit/state/pending-close.json` exists.
 4. Branch:
 
-   **a. `session_state != "in_progress"`** — nothing to close.
+   **a. `session_state` not in `{"in_progress", "idle"}`** — nothing to close.
    - If `pending-close.json` exists → delete it (stale flag from a prior session that already closed). Use the Bash tool: `rm -f .claude-code-hermit/state/pending-close.json`.
    - Stop. Do not notify the operator. Do not write to `routine-metrics.jsonl` (no-op events are not part of the existing `log-routine-event.sh` vocabulary).
 
-   **b. `session_state == "in_progress"` AND `now - last_operator_action > 10min`** — safe lull; close directly.
+   **b. `session_state` in `{"in_progress", "idle"}` AND `now - last_operator_action > 10min`** — safe lull; close directly.
    - Invoke `/claude-code-hermit:session-close --auto`. The auto-close path archives the session and clears `pending-close.json` itself on archive success.
    - Stop.
 
-   **c. `session_state == "in_progress"` AND `now - last_operator_action ≤ 10min`** — operator is currently active; queue.
+   **c. `session_state` in `{"in_progress", "idle"}` AND `now - last_operator_action ≤ 10min`** — operator is currently active; queue.
    - Write `.claude-code-hermit/state/pending-close.json` with `{"queued_at":"<now ISO>","queued_by":"daily-auto-close"}` (singleton; overwrite unconditionally). Use the Write tool.
    - Stop. The heartbeat-precheck drain block will emit `AUTO_CLOSE` on the next tick where the operator has been idle >10 minutes.
 

--- a/plugins/claude-code-hermit/tests/test-auto-close.sh
+++ b/plugins/claude-code-hermit/tests/test-auto-close.sh
@@ -381,7 +381,9 @@ run_test "drain: pending-close + last_op < 10min + in_progress → does NOT emit
 cleanup
 
 # -------------------------------------------------------
-# drain.3. pending-close.json + session_state == idle → not AUTO_CLOSE (stale flag)
+# drain.3. pending-close.json + session_state == idle + lull > 10min → AUTO_CLOSE
+# (idle sessions now participate in the midnight close — always-on deployments
+#  where work happens via channels/routines without a formal task get daily archival)
 # -------------------------------------------------------
 workdir="$(mktemp -d)"
 hb_setup "$workdir"
@@ -390,7 +392,21 @@ echo '{"queued_at":"2026-05-20T22:00:00+00:00","queued_by":"daily-auto-close"}' 
 echo '{"at":"2026-05-20T22:30:00+00:00"}' > "$workdir/.claude-code-hermit/state/last-operator-action.json"
 echo '{"session_state":"idle"}' > "$workdir/.claude-code-hermit/state/runtime.json"
 out="$(cd "$workdir" && HERMIT_NOW="2026-05-20T22:45:00+00:00" node "$HEARTBEAT_PRECHECK" .claude-code-hermit)"
-run_test "drain: pending-close + session_state idle → does NOT emit AUTO_CLOSE" bash -c "[ '$out' != 'AUTO_CLOSE' ]"
+run_test "drain: pending-close + idle + lull > 10min → AUTO_CLOSE" bash -c "[ '$out' = 'AUTO_CLOSE' ]"
+cleanup
+
+# -------------------------------------------------------
+# drain.3b. pending-close.json + session_state == idle + last_op < 10min → not AUTO_CLOSE
+# (operator is between tasks but recently active — respect the lull threshold)
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+hb_setup "$workdir"
+echo '{"queued_at":"2026-05-20T22:00:00+00:00","queued_by":"daily-auto-close"}' \
+  > "$workdir/.claude-code-hermit/state/pending-close.json"
+echo '{"at":"2026-05-20T22:40:00+00:00"}' > "$workdir/.claude-code-hermit/state/last-operator-action.json"
+echo '{"session_state":"idle"}' > "$workdir/.claude-code-hermit/state/runtime.json"
+out="$(cd "$workdir" && HERMIT_NOW="2026-05-20T22:45:00+00:00" node "$HEARTBEAT_PRECHECK" .claude-code-hermit)"
+run_test "drain: pending-close + idle + last_op < 10min → does NOT emit AUTO_CLOSE" bash -c "[ '$out' != 'AUTO_CLOSE' ]"
 cleanup
 
 # -------------------------------------------------------


### PR DESCRIPTION
## Summary

`daily-auto-close` skipped sessions in `idle` state, so always-on deployments where work happens through channels or routines (without a formal task) could run for days without archival. This starves `reflect`, `weekly-review`, and `hermit-brain` of the archives they need.

Extends both the midnight skill and the heartbeat pending-close drain to treat `idle` the same as `in_progress`: close directly on a 10-min lull, queue if the operator was recently active.

Closes #139

## Changes

- `heartbeat-precheck.js` line 64: pending-close drain now includes `|| runtime.session_state === 'idle'` so a queued close is actually drained for idle sessions
- `daily-auto-close/SKILL.md`: branches a/b/c updated to use `not in {"in_progress", "idle"}` / `in {"in_progress", "idle"}` conditions
- `test-auto-close.sh`: drain.3 updated (was asserting idle = no AUTO_CLOSE, now asserts AUTO_CLOSE on lull); drain.3b added for idle + recent-action = no AUTO_CLOSE

## Test plan

```bash
cd plugins/claude-code-hermit && bash tests/run-all.sh
```

45 passed, 0 failed.