### PR TITLE
fix(hermit-evolve): step 10 sends Operator Notification after upgrade

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **hermit-evolve step 10** — after printing the upgrade summary, the skill now fires the standard Operator Notification (channel DM or push fallback) with a condensed one-line message. Always-on operators no longer miss upgrades that completed while they weren't watching the terminal. Closes #141.
+
 ## [1.1.5] - 2026-05-25
 
 ### Added

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -228,3 +228,5 @@ Run /claude-code-hermit:hermit-settings to adjust any settings.
 ```
 
 Adjust the summary based on what actually changed. Omit sections where nothing changed.
+
+After printing the summary, notify the operator per CLAUDE-APPEND.md § Operator Notification with a condensed one-line message such as `"Hermit upgraded: vOLD → vNEW. N settings added, M templates refreshed."` Omit segments where nothing changed.


### PR DESCRIPTION
## Summary

`hermit-evolve` step 10 only printed the upgrade summary to the terminal. In always-on deployments the operator is not watching the terminal, so upgrades completed silently — the operator had no way to know a migration ran unless they checked SHELL.md manually.

This adds one instruction to step 10: after printing the summary, fire the proactive Operator Notification (channel DM or push fallback) using the same `§ Operator Notification` protocol already used by `heartbeat` and other skills. Sessions where nothing changed emit a condensed one-liner; sessions where nothing changed in a segment omit that segment.

## Changes

- `plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md` — append notification instruction at end of step 10

## Test plan

- All 250+ contract tests pass (`bash tests/run-all.sh` in the plugin dir — no test covers skill markdown prose, but the contract suite confirms no regressions).
- Manual smoke: install via `--plugin-dir`, backdated `_hermit_versions["claude-code-hermit"]` in config, run `/claude-code-hermit:hermit-evolve` — model should issue both the printed summary and the channel/push notification.

Closes #141