### PR TITLE
fix(claude-code-hermit): use persisted task_id for heartbeat monitor dedup

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **heartbeat start: deterministic dedup via persisted task_id** — step 4 now reads `state/heartbeat-monitor.runtime.json` and TaskStops the recorded `task_id` before falling back to a TaskList description scan. Prevents duplicate monitors when the daily `heartbeat-restart` routine fires while a prior monitor is still alive.
+
 ## [1.1.5] - 2026-05-25
 
 ### Added

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -55,7 +55,7 @@ Start the heartbeat as a persistent CC Monitor subprocess.
 1. Read `heartbeat.every` from config (default: `"2h"`). Parse to seconds (`"30m"` → 1800, `"2h"` → 7200, etc).
 2. Resolve the script path: `${CLAUDE_PLUGIN_ROOT}/scripts/heartbeat-monitor.sh` (resolve at skill execution time — not available inside the subprocess).
 3. Sweep any pre-existing CronCreate entry for the old recurring-cron approach: `CronList` → if an entry's `prompt` matches `/claude-code-hermit:heartbeat run`, `CronDelete` it. Idempotent.
-4. If a Monitor with description `heartbeat-monitor` exists (TaskList), TaskStop it. Also remove any prior entry from `state/heartbeat-monitor.runtime.json`.
+4. Read `state/heartbeat-monitor.runtime.json` if it exists. If it contains a `task_id`, TaskStop that task — ignore not-found errors (the monitor may have already exited). Then TaskList → TaskStop any remaining task with description `heartbeat-monitor` (fallback for orphans where the runtime file was never written). Clear any prior entry from `state/heartbeat-monitor.runtime.json`.
 5. Register a new Monitor:
    - `description`: `heartbeat-monitor` (reserved slot — operators must not reuse this description for ad-hoc `/watch` entries)
    - `command`: `bash <abs_script_path> <interval_seconds> $PWD/.claude-code-hermit`


### PR DESCRIPTION
## Summary

The `heartbeat start` step 4 matched existing monitors by description via `TaskList`, which is non-deterministic — the LLM can truncate or miss results, causing a second monitor to register alongside the first when the daily `heartbeat-restart` routine fires. `state/heartbeat-monitor.runtime.json` already records the prior `task_id` (written in step 6) but was unused. This fix makes the persisted id the primary stop signal, with a `TaskList` description scan as a fallback for orphans.

## Changes

- `skills/heartbeat/SKILL.md` — step 4 of `### start`: read runtime file first, TaskStop by `task_id`, then TaskList fallback for orphans (where file was never written). Also satisfies the CC read-before-write contract for the step 6 Write.
- `CHANGELOG.md` — `[Unreleased] ### Fixed` entry.

## Test plan

- Run `/claude-code-hermit:heartbeat start` twice in succession in a session with an existing `state/heartbeat-monitor.runtime.json`. After the second run, `TaskList` should show exactly one `heartbeat-monitor` task.
- Delete the runtime file, register a monitor, then start again — the `TaskList` fallback should catch the orphan.

Closes #157
Closes #140