### PR TITLE
feat(hermit): log reflection-judge suppression reasons by code

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **reflection-judge: per-code suppress counters** — `reflection-state.json → counters.judge_suppress_by_code` now accumulates suppression counts by canonical code (`no-evidence`, `no-sessions`, `covered-by-memory`). The reflect skill passes the per-code map in its State Update payload; `update-reflection-state.js` merges it cumulatively. `/hermit-health` surfaces the non-zero mix (e.g. `suppress mix — no-evidence:12, covered-by-memory:3`) on the reflect routine bullet, making the Component Health "gate may be too strict" signal verifiable.
+
 ## [1.1.5] - 2026-05-25
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/update-reflection-state.js
+++ b/plugins/claude-code-hermit/scripts/update-reflection-state.js
@@ -42,6 +42,7 @@ c.empty_runs = intOf(c.empty_runs);
 c.judge_accept = intOf(c.judge_accept);
 c.judge_downgrade = intOf(c.judge_downgrade);
 c.judge_suppress = intOf(c.judge_suppress);
+if (!c.judge_suppress_by_code || typeof c.judge_suppress_by_code !== 'object') c.judge_suppress_by_code = {};
 c.proposals_created = intOf(c.proposals_created);
 c.micro_proposals_queued = intOf(c.micro_proposals_queued);
 
@@ -56,6 +57,11 @@ c.empty_runs += ranWithCandidates ? 0 : 1;
 c.judge_accept += intOf(payload.judge_accept);
 c.judge_downgrade += intOf(payload.judge_downgrade);
 c.judge_suppress += intOf(payload.judge_suppress);
+if (payload.judge_suppress_by_code && typeof payload.judge_suppress_by_code === 'object') {
+  for (const [code, n] of Object.entries(payload.judge_suppress_by_code)) {
+    c.judge_suppress_by_code[code] = intOf(c.judge_suppress_by_code[code]) + intOf(n);
+  }
+}
 c.proposals_created += proposalsCreated;
 c.micro_proposals_queued += microQueued;
 c.last_output_at = (proposalsCreated + microQueued > 0) ? now : (c.last_output_at ?? null);

--- a/plugins/claude-code-hermit/skills/hermit-health/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-health/SKILL.md
@@ -16,7 +16,7 @@ Read the following (gracefully skip any file that doesn't exist):
 
 1. `.claude-code-hermit/state/alert-state.json` — `active` array and `suppressed` array; each entry has `type`, `timestamp`, `message`.
 2. `.claude-code-hermit/state/runtime.json` — `last_activity`, `session_id`.
-3. `.claude-code-hermit/state/reflection-state.json` — `last_reflection` timestamp.
+3. `.claude-code-hermit/state/reflection-state.json` — `last_reflection` timestamp and `counters.judge_suppress_by_code` map.
 4. `.claude-code-hermit/config.json` — `routines` array (id, schedule, enabled); `channels` object (each channel's `dm_channel_id`).
 5. `.claude-code-hermit/proposals/PROP-*.md` — glob; count by `status` frontmatter field.
 
@@ -26,7 +26,7 @@ Read the following (gracefully skip any file that doesn't exist):
 
 **Proposal queue:** Count proposals with `status: proposed` (pending operator review) and `status: accepted` (in flight, not yet resolved). If both zero: "Queue empty."
 
-**Routine engagement:** From `config.json.routines`, list each routine with `enabled: true` and its schedule. For the `reflect` routine, use `reflection-state.json → last_reflection` to show when it last ran. For other routines, report schedule and enabled state — per-routine last-run tracking is not yet available.
+**Routine engagement:** From `config.json.routines`, list each routine with `enabled: true` and its schedule. For the `reflect` routine, use `reflection-state.json → last_reflection` to show when it last ran; also check `counters.judge_suppress_by_code` — if any code has a non-zero count, append a compact suppress-mix suffix on the same bullet: `suppress mix — no-evidence:N, covered-by-memory:N, no-sessions:N` (omit codes with count 0; omit the suffix entirely when all counts are 0 or the map is absent). For other routines, report schedule and enabled state — per-routine last-run tracking is not yet available.
 
 **Channel availability:** From `config.json.channels`, for each configured channel, check whether `dm_channel_id` is set. Report "ready" or "not yet paired (no dm_channel_id — send a message first)".
 
@@ -44,7 +44,7 @@ Reply in ≤1500 chars. Use exactly this section structure:
 (or: Queue empty.)
 
 ### Routine engagement
-- [id]: enabled, schedule [cron], [last run or "no run data"]
+- [id]: enabled, schedule [cron], [last run or "no run data"] [suppress mix suffix if applicable]
 - [id]: disabled
 (or: Routine engagement — config.json not found.)
 

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -240,14 +240,16 @@ After each reflection run, call `update-reflection-state.js` with the run's verd
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/scripts/update-reflection-state.js \
   .claude-code-hermit/state/reflection-state.json \
-  '{"last_resolution_check":"<last-PROP-NNN-or-null>","ran_with_candidates":<true|false>,"judge_accept":<N>,"judge_downgrade":<N>,"judge_suppress":<N>,"proposals_created":<N>,"micro_proposals_queued":<N>}'
+  '{"last_resolution_check":"<last-PROP-NNN-or-null>","ran_with_candidates":<true|false>,"judge_accept":<N>,"judge_downgrade":<N>,"judge_suppress":<N>,"judge_suppress_by_code":{"no-evidence":<N>,"no-sessions":<N>,"covered-by-memory":<N>},"proposals_created":<N>,"micro_proposals_queued":<N>}'
 ```
+
+For `judge_suppress_by_code`: count SUPPRESS verdicts from the judge grouped by canonical code (`no-evidence`, `no-sessions`, `covered-by-memory`). Omit codes with a zero count; omit the key entirely when `judge_suppress` is 0.
 
 Include `"last_digest_at":"<now ISO>"` in the payload only when a juvenile digest fired in this run (see Outcomes → phase-aware surfacing). Omit otherwise — the script preserves the prior value.
 
 Include `"last_sparse_nudge":{"<PROP-NNN>":"<now ISO>"}` when a sparse-pattern nudge was emitted this run (step 4e). The script merges the provided map into the existing `last_sparse_nudge` top-level key. Omit if no sparse nudge was emitted — the script preserves the prior map.
 
-The script handles: counter increments, `last_reflection`/`last_run_at` timestamps, missing-counters fallback, `since` preservation, `last_digest_at` passthrough, `last_sparse_nudge` merge, and atomic write. It always exits 0 — if the write fails it logs one line to stderr and continues. Counters are diagnostic, not audit-grade — a missed increment is acceptable.
+The script handles: counter increments, `last_reflection`/`last_run_at` timestamps, missing-counters fallback, `since` preservation, `last_digest_at` passthrough, `last_sparse_nudge` merge, `judge_suppress_by_code` accumulation, and atomic write. It always exits 0 — if the write fails it logs one line to stderr and continues. Counters are diagnostic, not audit-grade — a missed increment is acceptable.
 
 ## Progress Log Entry (non-empty runs)
 

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -211,6 +211,38 @@ run_test "update-reflection-state (last_sparse_nudge merge)" bash -c \
   "python3 -c \"import json; d=json.load(open('$workdir/.claude-code-hermit/state/reflection-state.json')); n=d['last_sparse_nudge']; assert n['PROP-001']=='2026-04-01T00:00:00Z' and n['PROP-002']=='2026-04-22T00:00:00Z'\""
 cleanup
 
+# 11a. judge_suppress_by_code — first run initializes map and accumulates codes
+workdir="$(setup_workdir)"
+echo '{"counters":{"total_runs":1}}' > "$workdir/.claude-code-hermit/state/reflection-state.json"
+node "$REPO_ROOT/scripts/update-reflection-state.js" \
+  "$workdir/.claude-code-hermit/state/reflection-state.json" \
+  '{"ran_with_candidates":true,"judge_suppress":2,"judge_suppress_by_code":{"no-evidence":1,"covered-by-memory":1}}' >/dev/null
+run_test "update-reflection-state (judge_suppress_by_code: initial accumulation)" bash -c \
+  "python3 -c \"import json; d=json.load(open('$workdir/.claude-code-hermit/state/reflection-state.json')); c=d['counters']; assert c['judge_suppress_by_code']['no-evidence']==1 and c['judge_suppress_by_code']['covered-by-memory']==1 and 'no-sessions' not in c['judge_suppress_by_code']\""
+cleanup
+
+# 11b. judge_suppress_by_code — second run accumulates into existing counts
+workdir="$(setup_workdir)"
+echo '{"counters":{"total_runs":2,"judge_suppress":2,"judge_suppress_by_code":{"no-evidence":1,"covered-by-memory":1}}}' \
+  > "$workdir/.claude-code-hermit/state/reflection-state.json"
+node "$REPO_ROOT/scripts/update-reflection-state.js" \
+  "$workdir/.claude-code-hermit/state/reflection-state.json" \
+  '{"ran_with_candidates":true,"judge_suppress":2,"judge_suppress_by_code":{"no-evidence":1,"no-sessions":1}}' >/dev/null
+run_test "update-reflection-state (judge_suppress_by_code: cumulative accumulation)" bash -c \
+  "python3 -c \"import json; d=json.load(open('$workdir/.claude-code-hermit/state/reflection-state.json')); c=d['counters']; assert c['judge_suppress_by_code']['no-evidence']==2 and c['judge_suppress_by_code']['covered-by-memory']==1 and c['judge_suppress_by_code']['no-sessions']==1\""
+cleanup
+
+# 11c. judge_suppress_by_code — absent from payload leaves existing map unchanged
+workdir="$(setup_workdir)"
+echo '{"counters":{"total_runs":3,"judge_suppress_by_code":{"no-evidence":5}}}' \
+  > "$workdir/.claude-code-hermit/state/reflection-state.json"
+node "$REPO_ROOT/scripts/update-reflection-state.js" \
+  "$workdir/.claude-code-hermit/state/reflection-state.json" \
+  '{"ran_with_candidates":false}' >/dev/null
+run_test "update-reflection-state (judge_suppress_by_code: absent payload preserves map)" bash -c \
+  "python3 -c \"import json; d=json.load(open('$workdir/.claude-code-hermit/state/reflection-state.json')); c=d['counters']; assert c['judge_suppress_by_code']['no-evidence']==5\""
+cleanup
+
 # -------------------------------------------------------
 # heartbeat-precheck.js
 # -------------------------------------------------------


### PR DESCRIPTION
## Summary

Operators seeing "judge may be too strict" in the reflect Component Health check had no way to verify whether the suppressions were legitimate (low-quality candidates) or a miscalibrated gate. This change closes that gap by accumulating per-code suppression counts in `reflection-state.json` and surfacing them in `/hermit-health`.

## Changes

- **`update-reflection-state.js`** — accepts `judge_suppress_by_code` map in the payload and merges it cumulatively into `counters.judge_suppress_by_code`, initializing the map on first use. No behavior change to any existing counter.
- **`skills/reflect/SKILL.md`** — State Update payload now includes `judge_suppress_by_code` with per-code counts from the judge's SUPPRESS verdicts. Canonical codes: `no-evidence`, `no-sessions`, `covered-by-memory`.
- **`skills/hermit-health/SKILL.md`** — reads `counters.judge_suppress_by_code` and appends a suppress-mix suffix on the reflect routine bullet when any code has a non-zero count (e.g. `suppress mix — no-evidence:12, covered-by-memory:3`). Suffix is omitted when all zero.
- **`tests/run-scripts.sh`** — 3 new contract tests for `update-reflection-state.js`: initial accumulation, cumulative accumulation across runs, and absent-payload preservation.

## Test plan

- `bash plugins/claude-code-hermit/tests/run-all.sh` from inside the plugin dir — all 349 tests pass (verified before commit).
- Manual verification: `node plugins/claude-code-hermit/scripts/update-reflection-state.js /tmp/test-state.json '{"judge_suppress":2,"judge_suppress_by_code":{"no-evidence":1,"covered-by-memory":1}}'` — repeat twice, confirm counts accumulate.

Closes #143