### PR TITLE
feat(claude-code-hermit): per-routine reflect_after flag + reflect --quick mode

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- **routines: `reflect_after: true` optional flag** — appends `/claude-code-hermit:reflect --quick` to the routine's CronCreate prompt, closing the same-day feedback gap for late-day routines whose Tier-1 `current-session` observations would otherwise wait until the next morning's scheduled reflect. The append is skipped when the routine's own skill is `reflect`. Closes #142.
+- **reflect: `--quick` mode** — bypasses the cadence precheck, binds `$PHASE = adult`, skips cost_spike / proposal scan / Resolution Check / Component Health, and scans only live SHELL.md `## Findings` / `## Blockers` for Tier-1 `current-session` candidates. Does not call `update-reflection-state.js` so the next scheduled reflect fires normally.
+
 ### Fixed
 
 - **heartbeat: start subcommand reads state file before writing** — fixes "File has not been read yet" failure on always-on restart when `state/heartbeat-monitor.runtime.json` exists from a prior session.

--- a/plugins/claude-code-hermit/agents/hermit-config-validator.md
+++ b/plugins/claude-code-hermit/agents/hermit-config-validator.md
@@ -44,6 +44,8 @@ For each routine in `routines[]`:
 - `schedule` (string, 5-field cron: `minute hour dom month dow`)
 - `skill` (string, must contain `:`)
 - `enabled` (boolean)
+- `run_during_waiting` (boolean, optional) — if present, must be `true` or `false`
+- `reflect_after` (boolean, optional) — if present, must be `true` or `false`
 
 ### 4. Channel structure
 

--- a/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
@@ -57,6 +57,8 @@ Replace `<pluginRoot>` with the resolved absolute path from step 1, `<id>` with 
 
 **Special case — `heartbeat-restart`:** append ` Then invoke /claude-code-hermit:hermit-routines load to re-arm all routine CronCreates and reset the 7-day expiry clock.` to the prompt (after the trailing `fired` log line). Daily re-arm via this routine is what keeps routine CronCreates from ever reaching the 7-day auto-expiry in always-on deployments.
 
+**`reflect_after: true`:** when a routine config entry has `reflect_after: true`, append ` Then invoke /claude-code-hermit:reflect --quick.` to the prompt (after the trailing `fired` log line, and after the `heartbeat-restart` append if both apply).
+
 ### list
 
 Show configured routines from `config.json` (not from CronList — this is the config view, not the live view).
@@ -66,10 +68,11 @@ Show configured routines from `config.json` (not from CronList — this is the c
 3. Display table:
 ```
 Routines (config.json):
-  #  ID                 Schedule      Skill                                    RDW    Status
-  1. heartbeat-restart  0 4 * * *     claude-code-hermit:heartbeat start       true   enabled
-  2. weekly-review      0 23 * * 0    claude-code-hermit:weekly-review         false  disabled
+  #  ID                 Schedule      Skill                                    RDW    RA     Status
+  1. heartbeat-restart  0 4 * * *     claude-code-hermit:heartbeat start       true   false  enabled
+  2. weekly-review      0 23 * * 0    claude-code-hermit:weekly-review         false  false  disabled
 ```
+`RA` is `true` when `reflect_after: true` is set on the routine entry, `false` otherwise.
 
 ### status
 

--- a/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
@@ -57,7 +57,7 @@ Replace `<pluginRoot>` with the resolved absolute path from step 1, `<id>` with 
 
 **Special case — `heartbeat-restart`:** append ` Then invoke /claude-code-hermit:hermit-routines load to re-arm all routine CronCreates and reset the 7-day expiry clock.` to the prompt (after the trailing `fired` log line). Daily re-arm via this routine is what keeps routine CronCreates from ever reaching the 7-day auto-expiry in always-on deployments.
 
-**`reflect_after: true`:** when a routine config entry has `reflect_after: true`, append ` Then invoke /claude-code-hermit:reflect --quick.` to the prompt (after the trailing `fired` log line, and after the `heartbeat-restart` append if both apply).
+**`reflect_after: true`:** when a routine config entry has `reflect_after: true`, append ` Then, only if the skill actually fired (not skipped-waiting), invoke /claude-code-hermit:reflect --quick.` to the prompt (after the trailing `fired` log line, and after the `heartbeat-restart` append if both apply). **Skip this append when the routine's `skill` is `claude-code-hermit:reflect`** — chaining reflect after reflect is wasteful and a config foot-gun.
 
 ### list
 

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -12,14 +12,14 @@ This skill is **silent by default**. Only notify the operator (per the channel p
 
 If `$ARGUMENTS` contains `--quick` (invoked as `/claude-code-hermit:reflect --quick`):
 
-- **Skip step 1** (precheck) entirely — the cadence gate does not apply.
+- **Skip the precheck** entirely — the cadence gate does not apply.
 - **Bind `$PHASE = adult`** — skip the compute phase eval.
-- **Skip steps 3, 5, 6** (cost_spike, proposal scan, Resolution Check) and the Component Health section.
+- **Skip the cost_spike read, proposal scan, Resolution Check, and Component Health section.** Only the live SHELL.md scan + judge + outcomes path runs.
 - Read SHELL.md `## Findings` and `## Blockers` for actionable patterns. **Only Tier-1 + `Evidence Source: current-session` candidates are eligible** — see § Three-Condition Rule, condition 1. Candidates that would need archived-session evidence or belong to Tier 2/3 are deferred silently to the next scheduled reflect.
 - For each candidate that passes the evidence integrity rule: run `claude-code-hermit:proposal-triage`, then `claude-code-hermit:reflection-judge`. ACCEPT/DOWNGRADE verdicts route through the standard Outcomes path (micro-approval queue for Tier 1/2, `/claude-code-hermit:proposal-create` for Tier 3).
 - Append one Progress Log line: `[HH:MM] reflect (quick, post-routine) — N candidates; verdicts: accept=A downgrade=D suppress=S; outcomes: <list or "none">`.
-- **Do not call `update-reflection-state.js`** — quick runs are event-driven, not cadence ticks. Mutating `last_run_at` would suppress the next scheduled reflect.
-- Then stop. Do not continue to step 1.
+- **Do not call `update-reflection-state.js`** — quick runs are event-driven, not cadence ticks. Mutating `last_run_at` would suppress the next scheduled reflect. Consequence: judge verdicts from quick runs do not accumulate into the Component Health counters (`judge_accept` / `judge_suppress`); on daemons with frequent `reflect_after` use, those counters will under-represent total judge activity. This is intentional — cadence preservation wins.
+- Then stop. Do not continue to the scheduled-reflect steps below.
 
 1. Run the precheck to determine whether a full reflect run is warranted:
    ```

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -8,6 +8,19 @@ Pause and think about your recent work.
 
 This skill is **silent by default**. Only notify the operator (per the channel policy in CLAUDE.md § Operator Notification) if reflect produces an outcome: a proposal candidate, a micro-approval, a resolved proposal, a graduated sub-threshold observation, or a cost spike.
 
+## Quick mode
+
+If `$ARGUMENTS` contains `--quick` (invoked as `/claude-code-hermit:reflect --quick`):
+
+- **Skip step 1** (precheck) entirely — the cadence gate does not apply.
+- **Bind `$PHASE = adult`** — skip the compute phase eval.
+- **Skip steps 3, 5, 6** (cost_spike, proposal scan, Resolution Check) and the Component Health section.
+- Read SHELL.md `## Findings` and `## Blockers` for actionable patterns. **Only Tier-1 + `Evidence Source: current-session` candidates are eligible** — see § Three-Condition Rule, condition 1. Candidates that would need archived-session evidence or belong to Tier 2/3 are deferred silently to the next scheduled reflect.
+- For each candidate that passes the evidence integrity rule: run `claude-code-hermit:proposal-triage`, then `claude-code-hermit:reflection-judge`. ACCEPT/DOWNGRADE verdicts route through the standard Outcomes path (micro-approval queue for Tier 1/2, `/claude-code-hermit:proposal-create` for Tier 3).
+- Append one Progress Log line: `[HH:MM] reflect (quick, post-routine) — N candidates; verdicts: accept=A downgrade=D suppress=S; outcomes: <list or "none">`.
+- **Do not call `update-reflection-state.js`** — quick runs are event-driven, not cadence ticks. Mutating `last_run_at` would suppress the next scheduled reflect.
+- Then stop. Do not continue to step 1.
+
 1. Run the precheck to determine whether a full reflect run is warranted:
    ```
    node ${CLAUDE_PLUGIN_ROOT}/scripts/reflect-precheck.js .claude-code-hermit ${CLAUDE_PLUGIN_ROOT}


### PR DESCRIPTION
## Summary

Adds a `reflect_after: true` optional field to routine config entries. When set, the routine's CronCreate prompt is extended to invoke `/claude-code-hermit:reflect --quick` after the skill completes — closing the same-day feedback gap for late-day routines whose Tier-1 current-session observations would otherwise wait until the next morning's scheduled reflect.

The `--quick` mode bypasses the cadence precheck, binds `$PHASE = adult`, skips cost_spike / proposal scan / Resolution Check, and scans only live SHELL.md `## Findings` / `## Blockers` for Tier-1 + `Evidence Source: current-session` candidates. It does not call `update-reflection-state.js` so the next scheduled reflect fires as normal.

Closes #142.

## Changes

- `skills/reflect/SKILL.md` — new `## Quick mode` section documenting the `--quick` invocation path and its constraints
- `skills/hermit-routines/SKILL.md` — `reflect_after: true` prompt-append clause (mirrors `heartbeat-restart` precedent); `RA` column in the `list` table
- `agents/hermit-config-validator.md` — `run_during_waiting` and `reflect_after` documented as optional boolean routine fields with type qualifier

## Test plan

- All 67 hook contract + 84 unit + 69 script/static tests pass (`bash tests/run-all.sh` in `plugins/claude-code-hermit/`).
- Manual: add `"reflect_after": true` to a routine in `.claude-code-hermit/config.json`, run `/claude-code-hermit:hermit-routines load`, inspect the registered CronCreate prompt via `/claude-code-hermit:hermit-routines status` — should end with `Then invoke /claude-code-hermit:reflect --quick.`
- Manual: invoke `/claude-code-hermit:reflect --quick` against a SHELL.md with no actionable Findings — expect a single Progress Log line `reflect (quick, post-routine) — 0 candidates` with no other side effects.