### PR TITLE
claude-code-hermit: brief push-notification fallback when no channel is reachable

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **brief: push-notification fallback** — the always-on brief now delivers via the standard Operator Notification pattern (channel DM or push fallback) instead of requiring a configured channel, so push-only operators get a condensed one-liner rather than a silent no-op when no channel is reachable. Closes #174.
+
 ## [1.1.6] - 2026-05-28
 
 ### Added

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -8,7 +8,7 @@ Provide a concise executive summary of recent session activity. Designed for mor
 
 ## Always-On Delivery Rule
 
-If `config.always_on` is `true` and channels are configured, send all operator-facing output via the configured channel — the terminal is unmonitored in always-on mode. In interactive mode, output to terminal. This applies to all flags below.
+If `config.always_on` is `true`, deliver all operator-facing output per `CLAUDE-APPEND.md § Operator Notification`. The terminal is unmonitored in always-on mode. For the push-fallback branch, condense the brief to a single line (≤200 chars, no markdown): include whichever of yesterday's/today's cost, open proposal count, and active heartbeat alerts are present and non-zero; omit zero or unavailable fields. Example: `Brief: 16 proposals open, yesterday $0.42, 1 alert — open CC to view`. In interactive mode, output to terminal. This applies to all flags below.
 
 ## Flags
 


### PR DESCRIPTION
## Summary

- claude-code-hermit: brief push-notification fallback when no channel is reachable

## Notes

Tests run manually in-session (`bash plugins/claude-code-hermit/tests/run-all.sh`) — all passed (70 hook contract + 84 Python + 20 cron-tz + 18 docker-security + 11 docker-baseline + 35 template-skill-sync + 18 hatch-options + 36 archive-shell + others = 0 failures). No test command is configured in `.claude-code-hermit/config.json`, so `last-test.json` was not updated.

Closes #174.
