### PR TITLE
fix: bind completion notification to idle transition in autonomous mode

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **brief: push-notification fallback** — the always-on brief now delivers via the standard Operator Notification pattern (channel DM or push fallback) instead of requiring a configured channel, so push-only operators get a condensed one-liner rather than a silent no-op when no channel is reachable. Closes #174.
+- **session/heartbeat: bind completion notification to idle transition** — completion notification is now the final step of the Work-done flow (§6), not a standalone action; the autonomous heartbeat-pickup branch explicitly routes to §6 instead of a bare notify. Prevents sessions staying `in_progress` after autonomous task completion, which caused stale-session heartbeat alerts and delayed report archival. Closes #173.
+
 ## [1.1.6] - 2026-05-28
 
 ### Added

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Changed
 
-- **brief: push-notification fallback** — the always-on brief now delivers via the standard Operator Notification pattern (channel DM or push fallback) instead of requiring a configured channel, so push-only operators get a condensed one-liner rather than a silent no-op when no channel is reachable. Closes #174.
 - **session/heartbeat: bind completion notification to idle transition** — completion notification is now the final step of the Work-done flow (§6), not a standalone action; the autonomous heartbeat-pickup branch explicitly routes to §6 instead of a bare notify. Prevents sessions staying `in_progress` after autonomous task completion, which caused stale-session heartbeat alerts and delayed report archival. Closes #173.
 
 ## [1.1.6] - 2026-05-28

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -100,7 +100,7 @@ After evaluating the checklist, if SHELL.md status is `idle`:
 **NEXT-TASK.md pickup** (both `wait` and `discover`): check `sessions/NEXT-TASK.md`. If found, act per `escalation` in config:
 - `conservative`: notify operator, set SHELL.md to `waiting`, set `waiting_reason: "conservative_pickup"` in runtime.json.
 - `balanced`: start via `/claude-code-hermit:session-start`.
-- `autonomous`: start, notify on completion.
+- `autonomous`: start via `/claude-code-hermit:session-start`. On completion, run the `session` skill's Work-done flow (§6) — never send a bare notification without it: a notified-but-`in_progress` session triggers stale-session alerts and delays archival.
 
 **The following only when `idle_behavior: "discover"`:**
 

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -45,6 +45,8 @@ Work through tasks using whatever tools, skills, and agents are available:
 
 When the work is done, or the operator decides to move on (even if partial or blocked):
 
+**Completion notification is the final step of this flow, not a substitute for it.** Skipping the idle transition in step 6 leaves the session `in_progress`, which triggers stale-session heartbeat alerts and delays report archival until the time-based backstops kick in.
+
 1. Compile final session data **in context** — do NOT write to SHELL.md at this point. session-mgr owns the final write. Gather:
    - `Status:` one of `completed` | `partial` | `blocked`
    - `Blockers:` one line each, enough context for a cold start
@@ -68,7 +70,7 @@ When the work is done, or the operator decides to move on (even if partial or bl
    ```
    Also include the task table (if native Tasks were created).
 7. If `heartbeat.enabled` is true in config and heartbeat is not already running: start it (`/claude-code-hermit:heartbeat start`)
-8. Notify the operator: "Archived as S-NNN. Task: [summary]. Status: [outcome]. Ready for what's next."
+8. After the idle transition in step 6 succeeds: notify the operator: "Archived as S-NNN. Task: [summary]. Status: [outcome]. Ready for what's next."
 9. Once the operator says what's next: go to step 4 (plan the work)
 
 To close the session entirely, the operator runs `/claude-code-hermit:session-close` at any time.

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -45,7 +45,7 @@ Work through tasks using whatever tools, skills, and agents are available:
 
 When the work is done, or the operator decides to move on (even if partial or blocked):
 
-**Completion notification is the final step of this flow, not a substitute for it.** Skipping the idle transition in step 6 leaves the session `in_progress`, which triggers stale-session heartbeat alerts and delays report archival until the time-based backstops kick in.
+**Completion notification is the final step of this flow, not a substitute for it.** Skipping the session-mgr idle transition (step 6 below) leaves the session `in_progress`, which triggers stale-session heartbeat alerts and delays report archival until the time-based backstops kick in.
 
 1. Compile final session data **in context** — do NOT write to SHELL.md at this point. session-mgr owns the final write. Gather:
    - `Status:` one of `completed` | `partial` | `blocked`
@@ -70,7 +70,7 @@ When the work is done, or the operator decides to move on (even if partial or bl
    ```
    Also include the task table (if native Tasks were created).
 7. If `heartbeat.enabled` is true in config and heartbeat is not already running: start it (`/claude-code-hermit:heartbeat start`)
-8. After the idle transition in step 6 succeeds: notify the operator: "Archived as S-NNN. Task: [summary]. Status: [outcome]. Ready for what's next."
+8. After the session-mgr idle transition (step 6) succeeds: notify the operator: "Archived as S-NNN. Task: [summary]. Status: [outcome]. Ready for what's next."
 9. Once the operator says what's next: go to step 4 (plan the work)
 
 To close the session entirely, the operator runs `/claude-code-hermit:session-close` at any time.


### PR DESCRIPTION
## Summary

- Bind completion notification to idle transition — the autonomous heartbeat-pickup branch now explicitly runs the `session` skill's Work-done flow (§6) instead of a bare notify
- Add leading constraint to §6 stating completion notification is its final step, not a standalone action
- Gate step 8 on the §6 idle transition succeeding

## Verification

- Tests: **pass** (14.6s)

Closes #173.