### PR TITLE
fitness-hermit: strava-sync auto-triggers activity-deep-dive for new runs

### DIFF
--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **strava-sync: auto-trigger activity-deep-dive for new runs** — the daily sync runs a full coaching deep-dive for each new run (capped at the 3 most-recent, skipped IDs logged). Deep-dive failures are logged to the Progress Log and not retried, since the cursor has already advanced.
+
+### Changed
+
+- **capture-activity-rpe: refresh deep-dive after RPE capture** — re-runs `activity-deep-dive` for `Run` activities so the artifact includes RPE, which is unavailable at sync time.
+
+---
+
 ## [0.0.5] - 2026-05-21
 
 ### Fixed

--- a/plugins/claude-code-fitness-hermit/skills/capture-activity-rpe/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/capture-activity-rpe/SKILL.md
@@ -53,3 +53,5 @@ Self-triggers on RPE-shaped replies while `state/strava-pending-rpe.json` is fre
    ```
    Got it — RPE <rpe>/10 saved for <pending.name>.
    ```
+
+7. **Refresh the deep-dive.** If `pending.sport` is `Run`, re-invoke `/claude-code-fitness-hermit:activity-deep-dive <pending.activity_id>`. The `strava-sync` routine generated this activity's deep-dive before any RPE existed, so re-running now folds the RPE in — the skill reads `state/activity-notes.json` at its step 3b and overwrites `compiled/activity-<id>-*.md`. For non-`Run` sports the routine writes no deep-dive, so skip.

--- a/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
@@ -26,9 +26,10 @@ Check for new Strava activities uploaded today. Compare against the last known a
    - If it's a **run on a day after a hard session (Z4+ flagged)**: note "recovery day recommended tomorrow".
    - If **no activity today** (0 new): check if yesterday also had 0 new. If 2+ consecutive rest days after a non-rest day, log: "2 consecutive rest days — intentional recovery or missed session?"
 7. Write the highest new activity ID to `state/strava-last-activity-id.txt`.
-8. For each new **Run** in the new activities list, invoke `/claude-code-fitness-hermit:activity-deep-dive <id>` to produce a full coaching analysis.
+8. For each new activity whose Strava `type` is `Run`, invoke `/claude-code-fitness-hermit:activity-deep-dive <id>` to produce a full coaching analysis.
    - Cap at 3: if more than 3 new runs exist, process the 3 most recent by ID.
    - If the cap is hit, log the skipped IDs to SHELL.md Progress Log: `Skipped deep-dive (cap): <id>, <id>, ...`
+   - If a deep-dive invocation fails, log `Deep-dive failed: <id>` to SHELL.md Progress Log and continue. The cursor advanced at step 7, so failed analyses are not retried — the log is the only record.
 9. Send a summary via the configured channel. Format:
    ```
    Daily sync: [X run Xkm, Y ride, Z weights]. [Flag if any]

--- a/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
@@ -26,18 +26,21 @@ Check for new Strava activities uploaded today. Compare against the last known a
    - If it's a **run on a day after a hard session (Z4+ flagged)**: note "recovery day recommended tomorrow".
    - If **no activity today** (0 new): check if yesterday also had 0 new. If 2+ consecutive rest days after a non-rest day, log: "2 consecutive rest days — intentional recovery or missed session?"
 7. Write the highest new activity ID to `state/strava-last-activity-id.txt`.
-8. Send a summary via the configured channel. Format:
+8. For each new **Run** in the new activities list, invoke `/claude-code-fitness-hermit:activity-deep-dive <id>` to produce a full coaching analysis.
+   - Cap at 3: if more than 3 new runs exist, process the 3 most recent by ID.
+   - If the cap is hit, log the skipped IDs to SHELL.md Progress Log: `Skipped deep-dive (cap): <id>, <id>, ...`
+9. Send a summary via the configured channel. Format:
    ```
    Daily sync: [X run Xkm, Y ride, Z weights]. [Flag if any]
    Reply 'RPE 1-10 [notes]' to log perceived effort (e.g. '7, heavy legs').
    ```
-   If no channel is configured, log the summary (without the RPE prompt) to SHELL.md Progress Log and proceed to step 9.
+   If no channel is configured, log the summary (without the RPE prompt) to SHELL.md Progress Log and proceed to step 10.
    - After a successful send, write `.claude-code-hermit/state/strava-pending-rpe.json` with the activity whose ID matches the cursor from step 7:
      ```json
      {"activity_id": <id>, "name": "<name>", "sport": "<Run|Ride|WeightTraining|…>", "synced_at": "<ISO 8601>"}
      ```
    - If the send failed or was skipped, do not write this file — a stale pending entry could bind a future RPE reply to unseen activities.
-9. Close session idle.
+10. Close session idle.
 
 ## Anomaly Flags
 


### PR DESCRIPTION
## Summary

- fitness-hermit: strava-sync auto-triggers activity-deep-dive for new runs

## Verification

- Tests: **pass** (18.7s)
