### PR TITLE
feat(hermit): walk up to hermit root in log-routine-event.sh

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **scripts/log-routine-event.sh: resolve hermit root by walking up from CWD** — CronCreate prompts fire with the session's primary working directory as `$PWD`, which may be a subdirectory of the hermit root; the script now walks up to the nearest ancestor containing `.claude-code-hermit/` so the metrics append lands in the right place instead of failing with "No such file or directory". Closes #180.
+
 ### Changed
 
 - **brief: push-notification fallback** — the always-on brief now delivers via the standard Operator Notification pattern (channel DM or push fallback) instead of requiring a configured channel, so push-only operators get a condensed one-liner rather than a silent no-op when no channel is reachable. Closes #174.

--- a/plugins/claude-code-hermit/scripts/log-routine-event.sh
+++ b/plugins/claude-code-hermit/scripts/log-routine-event.sh
@@ -8,6 +8,20 @@ id="$1"
 event="$2"
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+# CronCreate prompts fire with $PWD set to the session's primary working
+# directory, which may be a subdirectory of the hermit project root. Walk up
+# to the nearest ancestor containing .claude-code-hermit/ so the relative path
+# resolves correctly regardless of launch CWD.
+dir="$PWD"
+while [[ "$dir" != "/" ]]; do
+  [[ -d "$dir/.claude-code-hermit" ]] && break
+  dir="$(dirname "$dir")"
+done
+if [[ "$dir" == "/" ]]; then
+  echo "log-routine-event.sh: could not find .claude-code-hermit/ in any parent of $PWD" >&2
+  exit 1
+fi
+
 printf '{"ts":"%s","routine_id":"%s","event":"%s","delivery":"cron-create"}\n' \
   "$ts" "$id" "$event" \
-  >> ".claude-code-hermit/state/routine-metrics.jsonl"
+  >> "$dir/.claude-code-hermit/state/routine-metrics.jsonl"

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -634,6 +634,33 @@ run_test "reflect-precheck (ARCHIVE failed: archive_due omitted)" bash -c \
 cleanup
 
 # -------------------------------------------------------
+# log-routine-event.sh — resolves hermit root by walking up from CWD
+# -------------------------------------------------------
+workdir="$(setup_workdir)"
+metrics="$workdir/.claude-code-hermit/state/routine-metrics.jsonl"
+mkdir -p "$workdir/app/sub"
+
+# Fired from a subdirectory → appends to the ancestor's state file
+( cd "$workdir/app/sub" && bash "$REPO_ROOT/scripts/log-routine-event.sh" morning-brief fired ) >/dev/null 2>&1 || true
+run_test "log-routine-event (subdir resolves to ancestor)" bash -c \
+  "grep -q '\"routine_id\":\"morning-brief\",\"event\":\"fired\"' '$metrics'"
+
+# Fired from the hermit root → unchanged behavior
+( cd "$workdir" && bash "$REPO_ROOT/scripts/log-routine-event.sh" weekly-review skipped-waiting ) >/dev/null 2>&1 || true
+run_test "log-routine-event (root resolves to state file)" bash -c \
+  "grep -q '\"routine_id\":\"weekly-review\",\"event\":\"skipped-waiting\"' '$metrics'"
+cleanup
+
+# No .claude-code-hermit/ ancestor → non-zero exit with a clear diagnostic
+nohermit="$(mktemp -d)"
+nh_rc=0
+nh_err="$(cd "$nohermit" && bash "$REPO_ROOT/scripts/log-routine-event.sh" x fired 2>&1)" || nh_rc=$?
+run_test "log-routine-event (no ancestor exits non-zero)" bash -c "[ $nh_rc -ne 0 ]"
+run_test "log-routine-event (no ancestor diagnostic)" bash -c \
+  "echo '$nh_err' | grep -qF 'could not find .claude-code-hermit/'"
+rm -rf "$nohermit"
+
+# -------------------------------------------------------
 # Summary
 # -------------------------------------------------------
 print_results


### PR DESCRIPTION
## Summary

- walk up to hermit root in log-routine-event.sh

## Verification

- Tests: **skipped** (commands.test not configured — suite was verified manually via `bash plugins/claude-code-hermit/tests/run-all.sh` before commit, all 76 script tests pass including 4 new regression tests for this fix)
