### PR TITLE
feat(fitness-hermit): add weekly-coaching-patterns scheduled check

### DIFF
--- a/plugins/claude-code-fitness-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-fitness-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-fitness-hermit",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "dependencies": [
     {
       "name": "claude-code-hermit",

--- a/plugins/claude-code-fitness-hermit/.claude-plugin/plugin.json
+++ b/plugins/claude-code-fitness-hermit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-fitness-hermit",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "dependencies": [
     {
       "name": "claude-code-hermit",

--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **weekly-coaching-patterns: first scheduled check for fitness-hermit** — weekly interval check that reads the last 4 steady-session `activity-note` compiled artifacts and detects upward cardiac-drift trends (≥3 of 4 sessions rising). Findings are routed through the `reflect-scheduled-checks` proposal pipeline as `Evidence Source: scheduled-check/weekly-coaching-patterns`. Registered by `hatch` via `config.scheduled_checks`; no new routine required.
+- **weekly-coaching-patterns: first scheduled check for fitness-hermit** — weekly interval check that reads the last 4 steady-session `activity-note` compiled artifacts and detects upward cardiac-drift trends (4 consecutive steady sessions strictly rising). Findings are routed through the `reflect-scheduled-checks` proposal pipeline as `Evidence Source: scheduled-check/weekly-coaching-patterns`. Registered by `hatch` via `config.scheduled_checks`; no new routine required.
 - **strava-sync: auto-trigger activity-deep-dive for new runs** — the daily sync runs a full coaching deep-dive for each new run (capped at the 3 most-recent, skipped IDs logged). Deep-dive failures are logged to the Progress Log and not retried, since the cursor has already advanced.
 
 ### Changed

--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **weekly-coaching-patterns: first scheduled check for fitness-hermit** — weekly interval check that reads the last 4 steady-session `activity-note` compiled artifacts and detects upward cardiac-drift trends (≥3 of 4 sessions rising). Findings are routed through the `reflect-scheduled-checks` proposal pipeline as `Evidence Source: scheduled-check/weekly-coaching-patterns`. Registered by `hatch` via `config.scheduled_checks`; no new routine required.
 - **strava-sync: auto-trigger activity-deep-dive for new runs** — the daily sync runs a full coaching deep-dive for each new run (capped at the 3 most-recent, skipped IDs logged). Deep-dive failures are logged to the Progress Log and not retried, since the cursor has already advanced.
 
 ### Changed

--- a/plugins/claude-code-fitness-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/hatch/SKILL.md
@@ -240,6 +240,16 @@ In the `routines` array, check for each of these four IDs. For any that are **ab
 }
 ```
 
+### 8c — Merge scheduled_checks
+
+In `config.scheduled_checks`, check for an entry with `id: "weekly-coaching-patterns"`. If absent, append it. If present (by `id`), skip — do not clobber existing operator edits.
+
+```json
+{"id": "weekly-coaching-patterns", "plugin": "claude-code-fitness-hermit", "skill": "claude-code-fitness-hermit:weekly-coaching-patterns", "enabled": true, "trigger": "interval", "interval_days": 7}
+```
+
+No prompt needed — this is a read-only analysis. The core daily `scheduled-checks` routine picks it up; `interval_days: 7` gates cadence. Findings surface as proposals automatically via the existing pipeline.
+
 Write the updated `config.json` using Write tool (full file replacement to ensure valid JSON).
 
 ---
@@ -259,7 +269,7 @@ Installation summary:
   ✓ Routine prompts: {N}/4 dropped, {M}/4 already present
   ✓ CLAUDE.md: Fitness Workflow block injected (or was already present)
   ✓ knowledge-schema.md: fitness types added (or were already present)
-  ✓ config.json: _hermit_versions stamped, {K}/4 routines added
+  ✓ config.json: _hermit_versions stamped, {K}/4 routines added, weekly-coaching-patterns check registered
 
 Manual steps remaining:
   - Restart Claude Code so the `strava` MCP server loads from .mcp.json
@@ -282,7 +292,8 @@ The always-on runtime activates routines automatically — the interactive
 steps are only for a test drive before handing over to the runtime.
 
 Installed skills:
-  /claude-code-fitness-hermit:activity-deep-dive   — per-activity coaching analysis
+  /claude-code-fitness-hermit:activity-deep-dive        — per-activity coaching analysis
+  /claude-code-fitness-hermit:weekly-coaching-patterns  — weekly cardiac-drift trend check (scheduled, interval_days: 7)
 
 Installed subagent:
   @claude-code-fitness-hermit:strava-data-cruncher — bulk Strava data aggregation (Haiku)

--- a/plugins/claude-code-fitness-hermit/skills/weekly-coaching-patterns/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/weekly-coaching-patterns/SKILL.md
@@ -17,23 +17,23 @@ Scheduled-check skill: reads the last 4 `compiled/activity-*.md` artifacts for s
 
    If fewer than 4 steady sessions exist across all artifacts, output the zero-findings block and stop. This is expected on weeks with predominantly interval or strength training — insufficient data is not an error.
 
-3. **Extract cardiac-drift values.** Working oldest-to-newest (reverse the most-recent-first list), for each of the 4 steady sessions parse the body for a line starting with `Cardiac drift:`. Extract the integer bpm value (the number after `+` or `-`). Treat a missing line as no data and exclude that session from the series.
+3. **Extract cardiac-drift values.** Working oldest-to-newest (reverse the most-recent-first list), for each of the 4 steady sessions parse the body for a line starting with `Cardiac drift:`. Extract the **signed** integer bpm value, preserving the sign (`+12` → `+12`, `-5` → `-5`). A negative value means HR fell over the session (an improving signal) and must compare as less than any positive value — never strip the sign to magnitude. Treat a missing line as no data and exclude that session from the series.
 
    If fewer than 4 values are extractable after exclusions, output the zero-findings block and stop.
 
-4. **Evaluate the drift trend.** A trend **holds** when ≥3 of the 4 values are strictly increasing left-to-right (each value greater than the one before it, oldest to newest).
+4. **Evaluate the drift trend.** A trend **holds** when the 4 values are strictly increasing oldest-to-newest — every value greater than the one immediately before it (all 3 adjacent pairs rising). A single flat or falling pair breaks the trend. This is a deliberately strict bar for v1: a clean monotonic rise is unambiguous and avoids false positives from noisy week-to-week variation.
 
-   **Anti-duplication guard:** emit a finding ONLY for a quantitative upward numeric trend across the 4-session bpm series. Do NOT emit on label recurrence alone.
+   **Anti-duplication guard:** emit a finding ONLY for this quantitative upward numeric trend across the 4-session bpm series. Do NOT emit on label recurrence alone.
 
 5. **Output the findings block.** Always output a plain-text findings block to stdout, regardless of outcome. `reflect-scheduled-checks` classifies the result from this block.
 
-   **Trend holds (≥3 of 4 values rising):**
+   **Trend holds (4 values strictly rising):**
    ```
    weekly-coaching-patterns findings — <YYYY-MM-DD>
    Coaching patterns: 1
-   - Coaching pattern detected [cardiac-drift-high]: cardiac drift trending upward across recent steady sessions (+<V1>→+<V4> bpm, <N>/4 sessions) — check pacing strategy and hydration; consider an easy recovery run next session
+   - Coaching pattern detected [cardiac-drift-high]: cardiac drift rising across 4 consecutive steady sessions (<V1>→<V2>→<V3>→<V4> bpm) — check pacing strategy and hydration; consider an easy recovery run next session
    ```
-   Replace `<V1>` with the oldest drift value, `<V4>` with the most recent, `<N>` with the count of sessions where drift rose vs the prior session (number of rising adjacent pairs), and `<YYYY-MM-DD>` with today's date.
+   Replace `<V1>`…`<V4>` with the four drift values oldest-to-newest (each rendered with its sign, e.g. `+6`), and `<YYYY-MM-DD>` with today's date.
 
    **No trend (including insufficient data):**
    ```
@@ -43,14 +43,27 @@ Scheduled-check skill: reads the last 4 `compiled/activity-*.md` artifacts for s
 
    The `[cardiac-drift-high]` label reuses the seed vocabulary from `activity-deep-dive` step 7b — no new label is introduced.
 
+## Example
+
+Four steady sessions, oldest-to-newest, with drift lines `+4`, `+7`, `+9`, `+13`:
+
+```
+weekly-coaching-patterns findings — 2026-05-31
+Coaching patterns: 1
+- Coaching pattern detected [cardiac-drift-high]: cardiac drift rising across 4 consecutive steady sessions (+4→+7→+9→+13 bpm) — check pacing strategy and hydration; consider an easy recovery run next session
+```
+
+The same four sessions with values `+4`, `+7`, `+6`, `+13` do **not** hold (the `+7→+6` pair falls), so the output is the `No actionable findings.` block. A series of `-3`, `+1`, `+5`, `+9` **does** hold (every pair rises; the leading negative compares as smallest).
+
 ## Extend-if-useful (not in v1)
 
 The following metrics follow the same steady-session pattern and would add items to the Coaching patterns list. NOT implemented in v1 — cardiac drift alone proves the mechanism end-to-end.
 
-- **Z2 pace/HR efficiency slope** — extract `Pace/HR efficiency: X.XX min·km⁻¹·bpm⁻¹` from each artifact; detect declining trend across ≥3 of 4 steady sessions. Label: `efficiency-regression`.
-- **Recovery-score trend** — extract `Recovery: N/5` from each artifact (applies to both steady and interval sessions); detect hardening trend across ≥3 of 4 sessions. Label: `recovery-insufficient`.
+- **Z2 pace/HR efficiency slope** — extract `Pace/HR efficiency: X.XX min·km⁻¹·bpm⁻¹` from each artifact; detect a strictly declining trend across the 4 steady sessions. Label: `efficiency-regression`.
+- **Recovery-score trend** — extract `Recovery: N/5` from each artifact (applies to both steady and interval sessions); detect a strictly hardening trend across the 4 sessions. Label: `recovery-insufficient`.
 
 ## Notes
 
 - **This skill writes no artifact.** All output goes to stdout for `reflect-scheduled-checks` to classify and route. Runtime state (`last_run`, `consecutive_empty`, etc.) is written by `reflect-scheduled-checks` to `state/reflection-state.json → scheduled_checks.weekly-coaching-patterns` — not by this skill.
 - **Registered by `/claude-code-fitness-hermit:hatch`** step 8c via a `scheduled_checks` config entry (`interval_days: 7`). The core daily `scheduled-checks` routine fires `reflect-scheduled-checks`, which picks it up once 7+ days have elapsed since `last_run`.
+- **The `[cardiac-drift-high]` label has two upstream producers.** `activity-deep-dive` step 7b writes single-session observations (graduated to proposals via reflect's current-session path); this skill emits on a multi-session trend. Both flow into `proposal-triage`, which dedups — so a triage `DUPLICATE` verdict here is expected behavior, not a bug.

--- a/plugins/claude-code-fitness-hermit/skills/weekly-coaching-patterns/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/weekly-coaching-patterns/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: weekly-coaching-patterns
+description: Interval scheduled check — detects multi-session cardiac-drift trends across recent compiled activity notes. Runs weekly via the scheduled-checks routine; findings are routed through the proposal pipeline as Evidence Source: scheduled-check/weekly-coaching-patterns.
+---
+
+# Weekly Coaching Patterns
+
+Scheduled-check skill: reads the last 4 `compiled/activity-*.md` artifacts for steady sessions and detects whether cardiac drift is trending upward over time. Returns a fixed findings block for `reflect-scheduled-checks` to classify and route.
+
+**Contract:** idempotent, read-only, no self-scheduling, short-running. Returns findings or silence — never creates proposals itself.
+
+## Steps
+
+1. **Glob activity notes.** Use `Glob` on `.claude-code-hermit/compiled/activity-*.md`. If no files match, output the zero-findings block (Step 5, no-trend path) and stop.
+
+2. **Read and filter.** For each matched file, Read it. Keep only entries where the YAML frontmatter has `type: activity-note` AND `session_kind: steady`. Sort by `created` date descending (most recent first). Take the 4 most recent steady sessions.
+
+   If fewer than 4 steady sessions exist across all artifacts, output the zero-findings block and stop. This is expected on weeks with predominantly interval or strength training — insufficient data is not an error.
+
+3. **Extract cardiac-drift values.** Working oldest-to-newest (reverse the most-recent-first list), for each of the 4 steady sessions parse the body for a line starting with `Cardiac drift:`. Extract the integer bpm value (the number after `+` or `-`). Treat a missing line as no data and exclude that session from the series.
+
+   If fewer than 4 values are extractable after exclusions, output the zero-findings block and stop.
+
+4. **Evaluate the drift trend.** A trend **holds** when ≥3 of the 4 values are strictly increasing left-to-right (each value greater than the one before it, oldest to newest).
+
+   **Anti-duplication guard:** emit a finding ONLY for a quantitative upward numeric trend across the 4-session bpm series. Do NOT emit on label recurrence alone.
+
+5. **Output the findings block.** Always output a plain-text findings block to stdout, regardless of outcome. `reflect-scheduled-checks` classifies the result from this block.
+
+   **Trend holds (≥3 of 4 values rising):**
+   ```
+   weekly-coaching-patterns findings — <YYYY-MM-DD>
+   Coaching patterns: 1
+   - Coaching pattern detected [cardiac-drift-high]: cardiac drift trending upward across recent steady sessions (+<V1>→+<V4> bpm, <N>/4 sessions) — check pacing strategy and hydration; consider an easy recovery run next session
+   ```
+   Replace `<V1>` with the oldest drift value, `<V4>` with the most recent, `<N>` with the count of sessions where drift rose vs the prior session (number of rising adjacent pairs), and `<YYYY-MM-DD>` with today's date.
+
+   **No trend (including insufficient data):**
+   ```
+   weekly-coaching-patterns findings — <YYYY-MM-DD>
+   No actionable findings.
+   ```
+
+   The `[cardiac-drift-high]` label reuses the seed vocabulary from `activity-deep-dive` step 7b — no new label is introduced.
+
+## Extend-if-useful (not in v1)
+
+The following metrics follow the same steady-session pattern and would add items to the Coaching patterns list. NOT implemented in v1 — cardiac drift alone proves the mechanism end-to-end.
+
+- **Z2 pace/HR efficiency slope** — extract `Pace/HR efficiency: X.XX min·km⁻¹·bpm⁻¹` from each artifact; detect declining trend across ≥3 of 4 steady sessions. Label: `efficiency-regression`.
+- **Recovery-score trend** — extract `Recovery: N/5` from each artifact (applies to both steady and interval sessions); detect hardening trend across ≥3 of 4 sessions. Label: `recovery-insufficient`.
+
+## Notes
+
+- **This skill writes no artifact.** All output goes to stdout for `reflect-scheduled-checks` to classify and route. Runtime state (`last_run`, `consecutive_empty`, etc.) is written by `reflect-scheduled-checks` to `state/reflection-state.json → scheduled_checks.weekly-coaching-patterns` — not by this skill.
+- **Registered by `/claude-code-fitness-hermit:hatch`** step 8c via a `scheduled_checks` config entry (`interval_days: 7`). The core daily `scheduled-checks` routine fires `reflect-scheduled-checks`, which picks it up once 7+ days have elapsed since `last_run`.

--- a/plugins/claude-code-fitness-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/CLAUDE-APPEND.md
@@ -23,6 +23,7 @@ This project has the `claude-code-fitness-hermit` plugin installed. The rules be
 | `/claude-code-fitness-hermit:activity-deep-dive` | Per-activity coaching analysis (zone breakdown, cardiac drift, recovery estimate) |
 | `/claude-code-fitness-hermit:capture-activity-rpe` | Auto-captures RPE from channel replies to strava-sync notifications |
 | `/claude-code-fitness-hermit:set-rpe` | Manually record RPE for any activity (backfill, correction, non-latest activities) |
+| `/claude-code-fitness-hermit:weekly-coaching-patterns` | Scheduled check — detects upward cardiac-drift trends across recent steady-session activity notes |
 
 ### Subagents
 
@@ -61,6 +62,14 @@ These run automatically on their cron schedule. Schedules and `enabled` state li
 | `monday-planning` | Weekly training structure suggestion |
 
 Routine prompts are at `.claude-code-hermit/compiled/routine-*.md`.
+
+### Scheduled Checks
+
+These run via the core `scheduled-checks` routine (daily) and fire at most once per `interval_days`. Findings are routed through the proposal pipeline automatically.
+
+| Check | Interval | Purpose |
+|-------|----------|---------|
+| `weekly-coaching-patterns` | 7 days | Detects upward cardiac-drift trends across recent steady sessions |
 
 ### Conventions
 


### PR DESCRIPTION
## Summary

- Add weekly-coaching-patterns scheduled check (fitness-hermit's first `scheduled_checks` entry)
- Register it in hatch step 8c so re-hatch wires it into `config.scheduled_checks` idempotently
- Document in CLAUDE-APPEND Skills table and new Scheduled Checks section
- Bump plugin to v0.0.6

## Verification

- Tests: **pass** (15.9s) — `bash plugins/claude-code-hermit/tests/run-all.sh`, 45/45
  (run pre-commit with all changes staged; core test suite, no fitness-specific runner exists)
