### PR TITLE
fix(claude-code-hermit): add fresh-read annotations to state-reading skills

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **brief/proposal-list/heartbeat/reflect: fresh-read annotations on state-reading steps** — adds an inline nudge to each skill's load-bearing current-state reads instructing the agent to re-read the file now rather than reuse a value from a pre-compaction context summary; prevents stale proposal statuses and session state from appearing in operator-facing outputs after compaction. Closes #192.
 - **scripts/log-routine-event.sh: resolve hermit root by walking up from CWD** — CronCreate prompts fire with the session's primary working directory as `$PWD`, which may be a subdirectory of the hermit root; the script now walks up to the nearest ancestor containing `.claude-code-hermit/` so the metrics append lands in the right place instead of failing with "No such file or directory". Closes #180.
 
 ### Changed

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -84,7 +84,7 @@ Next: description of next action (or "Session complete" if all done)
 - For the "Done" line: list completed task subjects from `TaskList`, comma-separated. If too many, show first 3 and "+ N more"
 - For the "Next" line: show the first pending or in_progress task from `TaskList`. If blocked, show "Blocked: reason"
 - If summarizing a completed report: "Next" becomes the report's "Next Start Point" content
-- After composing the 5-line output: scan `.claude-code-hermit/proposals/` for files with `source: auto-detected` and `status: proposed` (read from YAML frontmatter if present, fall back to bullet metadata) **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. If any exist, append a 6th line: `Proposals: N auto-detected proposal(s) pending review`
+- After composing the 5-line output: scan `.claude-code-hermit/proposals/` for files with `source: auto-detected` and `status: proposed` (read from YAML frontmatter if present, fall back to bullet metadata). **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction).** If any exist, append a 6th line: `Proposals: N auto-detected proposal(s) pending review`
 
 ## Daily Summary Format
 

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -26,7 +26,7 @@ Emphasize forward-looking content:
 - If auto-memory seems sparse (new instance, fresh machine), read the latest S-NNN-REPORT.md for context recovery
 
 <!-- keep in sync with plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md step 9a — same MP lifecycle protocol -->
-After composing the morning brief, check `state/micro-proposals.json → pending` for entries with `status: "pending"`:
+After composing the morning brief, check `state/micro-proposals.json → pending` for entries with `status: "pending"` **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**:
 - If **one or more** pending entries with `follow_up_count` of 0: append each as a final line: `MP-YYYYMMDD-N (tier N): [question]` — Reply `"MP-YYYYMMDD-N yes"` or `"MP-YYYYMMDD-N no"`. (Bare `yes`/`no` accepted when only one pending.)
 - For any entry with `follow_up_count` of 1: append with softer framing: "Still waiting on MP-YYYYMMDD-N: [question] — ignore again to drop it". Increment `follow_up_count` to 2.
 - For any entry with `follow_up_count` >= 2: read `question` first, then set `status: "expired"`, remove from `pending`. Append `micro-resolved` event via `append-metrics.js` with `"action":"expired","question":"<question>"`. Do not resurrect unless fresh evidence accumulates from scratch.
@@ -49,7 +49,7 @@ Current behavior — general purpose summary as described below.
 
 ## Plan
 
-1. Check if `.claude-code-hermit/sessions/SHELL.md` exists:
+1. Check if `.claude-code-hermit/sessions/SHELL.md` exists **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**:
    - If Status is `in_progress`: summarize the active task (existing behavior below)
    - If Status is `idle` (session between tasks): format as:
      ```
@@ -84,7 +84,7 @@ Next: description of next action (or "Session complete" if all done)
 - For the "Done" line: list completed task subjects from `TaskList`, comma-separated. If too many, show first 3 and "+ N more"
 - For the "Next" line: show the first pending or in_progress task from `TaskList`. If blocked, show "Blocked: reason"
 - If summarizing a completed report: "Next" becomes the report's "Next Start Point" content
-- After composing the 5-line output: scan `.claude-code-hermit/proposals/` for files with `source: auto-detected` and `status: proposed` (read from YAML frontmatter if present, fall back to bullet metadata). If any exist, append a 6th line: `Proposals: N auto-detected proposal(s) pending review`
+- After composing the 5-line output: scan `.claude-code-hermit/proposals/` for files with `source: auto-detected` and `status: proposed` (read from YAML frontmatter if present, fall back to bullet metadata) **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. If any exist, append a 6th line: `Proposals: N auto-detected proposal(s) pending review`
 
 ## Daily Summary Format
 

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -36,7 +36,7 @@ This subcommand is the handler for `HEARTBEAT_EVALUATE` notifications emitted by
      4. Emit `HEARTBEAT_AUTO_CLOSED`. Stop. Do NOT run the EVALUATE flow — the session is being archived; generating stale-session alerts for a closing session would create phantom dedup entries.
    - `EVALUATE` → continue to step 3.
 3. Read `${CLAUDE_PLUGIN_ROOT}/skills/heartbeat/reference.md` for the semantic key taxonomy, alert deduplication procedure, self-evaluation steps, and output format.
-4. Read `.claude-code-hermit/HEARTBEAT.md`, `config.json`, `state/runtime.json`, `.claude-code-hermit/sessions/SHELL.md`.
+4. Read `.claude-code-hermit/HEARTBEAT.md`, `config.json`, `state/runtime.json`, `.claude-code-hermit/sessions/SHELL.md`. **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**
 5. **Stale session check.** If `session_state` is `waiting`: skip. If `in_progress`:
    - Read the last `## Progress Log` entry timestamp from SHELL.md. Use session start time if none.
    - If elapsed > `heartbeat.stale_threshold` (default `"2h"`): generate alert with key `stale-session`.

--- a/plugins/claude-code-hermit/skills/proposal-list/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-list/SKILL.md
@@ -10,7 +10,7 @@ Lists all proposals with status, source, and age. Auto-detected proposals (from 
 
 ### 1. Read all proposals
 
-Read all files matching `.claude-code-hermit/proposals/PROP-*.md`.
+Read all files matching `.claude-code-hermit/proposals/PROP-*.md`. **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**
 
 If no proposals exist: respond "No proposals found." and stop.
 

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -28,7 +28,7 @@ If `$ARGUMENTS` contains `--quick` (invoked as `/claude-code-hermit:reflect --qu
    Read the verdict (first line of output):
    - `EMPTY` → the precheck found no due phases and no compute activity. It has already updated `reflection-state.json` and appended the mandatory Progress Log line to SHELL.md. Emit `reflect: no candidates` and stop.
    - `RUN|<phases-json>` → continue to step 2. The JSON object lists which phases are due (`cost_spike`, `resolution_check`, `compute`, `digest`, `newborn`). Skip evaluation sections for phases not listed — they are not due this run.
-2. Read SHELL.md for current context.
+2. Read SHELL.md for current context. **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**
 3. Read last 20 lines of cost-log.jsonl. If `cost_spike` is listed in the phases JSON: compute today's total and the 7-day median. If today's total > 2× the 7-day median (and both are non-zero), record the spike to project memory as a sub-threshold observation with pattern `cost_spike: $X.XX vs 7d median $Y.YY` and today's session_id — it becomes input to later reflects and may graduate via the recurrence rule. If `cost_spike` is not listed, skip this read.
 4. **Compute phase** — gates adapt to hermit age so cold-start installs produce visible output without eroding mature-hermit rigor.
    - Read `counters.since` from `state/reflection-state.json` (set once at hatch, never rewritten). If missing or unparseable → default `$PHASE = adult` and continue. Never block.

--- a/plugins/claude-code-hermit/skills/session-start/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-start/SKILL.md
@@ -13,7 +13,7 @@ All state lives under `.claude-code-hermit/` in the project root.
 
 1. Read `.claude-code-hermit/config.json` for agent identity settings (`agent_name`, `language`)
 2. If the SessionStart hook output above includes "---Upgrade Available---", mention it to the operator. Do NOT block session start.
-3. **Read `state/runtime.json`** for lifecycle state. This is the single source of truth — never parse SHELL.md `Status:` for decisions.
+3. **Read `state/runtime.json`** for lifecycle state **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. This is the single source of truth — never parse SHELL.md `Status:` for decisions.
    - **Advisory lock check:** Try to acquire `state/.lifecycle.lock` non-blocking. If held by another process (hermit-start.py, hermit-stop.py), tell the operator "A lifecycle operation is in progress — wait for it to complete" and abort.
    - **If runtime.json is missing:** This is either a first run or a pre-runtime.json installation. If SHELL.md exists, treat as a first session and proceed normally. If neither exists, this is a fresh installation — proceed to step 5.
    - **Interrupted transition recovery (P3):** If `transition` is not null, use `claude-code-hermit:session-mgr` to resume the interrupted operation:
@@ -133,7 +133,7 @@ All state lives under `.claude-code-hermit/` in the project root.
 ## Context to Load
 
 - `.claude-code-hermit/OPERATOR.md` (always)
-- `.claude-code-hermit/sessions/SHELL.md` (if exists)
+- `.claude-code-hermit/sessions/SHELL.md` (if exists) **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**
 - Most recent `.claude-code-hermit/sessions/S-*-REPORT.md` (for continuity — only the latest one)
 - `.claude-code-hermit/state/runtime.json` (always — for lifecycle state)
 


### PR DESCRIPTION
## Summary

- Add fresh-read annotations to skills that read current state after compaction

## Verification

- Tests: **pass** (20.7s)
