### PR TITLE
heartbeat digest renders proposal titles

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **brief: push-notification fallback** — the always-on brief now delivers via the standard Operator Notification pattern (channel DM or push fallback) instead of requiring a configured channel, so push-only operators get a condensed one-liner rather than a silent no-op when no channel is reachable. Closes #174.
 - **session/heartbeat: bind completion notification to idle transition** — completion notification is now the final step of the Work-done flow (§6), not a standalone action; the autonomous heartbeat-pickup branch explicitly routes to §6 instead of a bare notify. Prevents sessions staying `in_progress` after autonomous task completion, which caused stale-session heartbeat alerts and delayed report archival. Closes #173.
+- **heartbeat: digest renders proposal titles** — suppressed `proposal-pending:<PROP-NNN>` entries in the daily digest now render as `PROP-NNN "title"` (read from proposal frontmatter) instead of the bare dedup key, so operators can identify pending proposals without opening the repo; falls back to the bare key on zero or multiple file matches. Closes #191.
 
 ## [1.1.6] - 2026-05-28
 

--- a/plugins/claude-code-hermit/skills/heartbeat/reference.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/reference.md
@@ -31,6 +31,7 @@ Before appending any alert to SHELL.md Monitoring:
    - **Not suppressed:** Append `[HH:MM] Heartbeat: resolved — {text}`. Remove entry.
    - **Suppressed:** Resolve silently — remove entry, omit from next daily digest.
 4. **Daily digest:** If `last_digest_date` is not today and suppressed alerts exist: notify the operator `Suppressed alert digest: {list with counts and ages}`. Set `last_digest_date` to today.
+   - **Proposal entries:** For any suppressed key matching `proposal-pending:<PROP-NNN>`, render it as `PROP-NNN "<title>"` rather than the raw key. Find the title by reading frontmatter `title` from `proposals/PROP-NNN-*.md` (also check legacy `proposals/PROP-NNN.md`). If exactly one file matches, render its title; on zero or multiple matches, fall back to the bare key — never block the digest.
 5. **Micro-proposal check:** Read `state/micro-proposals.json → pending`. For each entry where `status === "pending"` and `tier === 1`: append `[HH:MM] Heartbeat: micro-proposal '{id}' awaiting operator input — {question}`. Use key `micro-proposal-pending:<id>` for dedup.
 6. Write `state/alert-state.json`. **Write `alerts{}` and `self_eval{}` only — do NOT write `total_ticks` (owned by the precheck script).**
 


### PR DESCRIPTION
## Summary

- Heartbeat daily digest renders proposal titles — suppressed `proposal-pending` alerts now show `PROP-NNN "title"` instead of the bare key, so mobile operators can identify pending proposals without a context switch

## Verification

- Tests: **pass** (20.4s — `bash plugins/claude-code-hermit/tests/run-all.sh`, 215 assertions; run pre-final-commit, final commit was a style-only simplify pass on the same line)
