### PR TITLE
fix(hermit): knowledge-lint parses bold markdown type entries in knowledge-schema.md

### DIFF
--- a/plugins/claude-code-hermit/scripts/knowledge-lint.js
+++ b/plugins/claude-code-hermit/scripts/knowledge-lint.js
@@ -18,7 +18,7 @@ const { readFrontmatter, readFileWithFrontmatter, newestByType, globDirRecursive
 
 function parseSchema(schemaPath) {
   // Returns { workProducts: Set<string>, rawCaptures: Set<string> }, null if present but empty, false if missing.
-  // Bullet grammar: lines matching `^-\s+([\w-]+):` under each section heading.
+  // Bullet grammar: lines matching `^-\s+([\w-]+):` or `^-\s+\*\*([\w-]+)\*\*:` under each section heading.
   let text;
   try { text = fs.readFileSync(schemaPath, 'utf8'); } catch { return false; }
   text = text.replace(/<!--[\s\S]*?-->/g, '');
@@ -29,7 +29,7 @@ function parseSchema(schemaPath) {
     if (/^##\s+Work Products\b/.test(line)) { section = 'work'; continue; }
     if (/^##\s+Raw Captures\b/.test(line)) { section = 'raw'; continue; }
     if (/^##/.test(line)) { section = null; continue; }
-    const m = line.match(/^-\s+([\w-]+):/);
+    const m = line.match(/^-\s+(?:\*\*)?([\w-]+)(?:\*\*)?:/);
     if (!m) continue;
     if (section === 'work') workProducts.add(m[1]);
     if (section === 'raw') rawCaptures.add(m[1]);

--- a/plugins/claude-code-hermit/scripts/knowledge-lint.js
+++ b/plugins/claude-code-hermit/scripts/knowledge-lint.js
@@ -29,10 +29,11 @@ function parseSchema(schemaPath) {
     if (/^##\s+Work Products\b/.test(line)) { section = 'work'; continue; }
     if (/^##\s+Raw Captures\b/.test(line)) { section = 'raw'; continue; }
     if (/^##/.test(line)) { section = null; continue; }
-    const m = line.match(/^-\s+(?:\*\*)?([\w-]+)(?:\*\*)?:/);
+    const m = line.match(/^-\s+(?:\*\*([\w-]+)\*\*|([\w-]+)):/);
     if (!m) continue;
-    if (section === 'work') workProducts.add(m[1]);
-    if (section === 'raw') rawCaptures.add(m[1]);
+    const type = m[1] || m[2];
+    if (section === 'work') workProducts.add(type);
+    if (section === 'raw') rawCaptures.add(type);
   }
   if (workProducts.size === 0 && rawCaptures.size === 0) return null;
   return { workProducts, rawCaptures };

--- a/plugins/claude-code-hermit/state-templates/knowledge-schema.md.template
+++ b/plugins/claude-code-hermit/state-templates/knowledge-schema.md.template
@@ -1,5 +1,5 @@
 # Knowledge Schema
-<!-- knowledge-lint.js reads ## Work Products and ## Raw Captures to enforce type declarations. Bullet lines matching `- <type>:` are parsed; HTML comment blocks are ignored. -->
+<!-- knowledge-lint.js reads ## Work Products and ## Raw Captures to enforce type declarations. Bullet lines matching `- <type>:` or `- **<type>**:` are parsed; HTML comment blocks are ignored. -->
 
 <!-- Co-evolve this file with your operator over time.
      Defines what this hermit produces — plumbing, not policy.

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -156,6 +156,20 @@ run_test "knowledge-lint (schema: declared type is clean)" bash -c \
   "node '$REPO_ROOT/scripts/knowledge-lint.js' '$workdir/.claude-code-hermit' | grep -q 'Knowledge base is clean'"
 cleanup
 
+# 6c. Bold-format schema — entries written as `- **type**:` are parsed (no schema-empty, no undeclared-type)
+workdir="$(setup_workdir)"
+mkdir -p "$workdir/.claude-code-hermit/raw" "$workdir/.claude-code-hermit/compiled"
+echo '{}' > "$workdir/.claude-code-hermit/config.json"
+printf -- '## Work Products\n- **briefing**: daily summary\n\n## Raw Captures\n- **source**: fetched articles\n' \
+  > "$workdir/.claude-code-hermit/knowledge-schema.md"
+printf -- '---\ntitle: fresh\ntype: source\ncreated: 2026-04-14T00:00:00+00:00\n---\ndata' \
+  > "$workdir/.claude-code-hermit/raw/fresh-snap.md"
+printf -- '---\ntitle: summary\ntype: briefing\ncreated: 2026-04-14T00:00:00+00:00\n---\nBased on fresh-snap.md data' \
+  > "$workdir/.claude-code-hermit/compiled/summary.md"
+run_test "knowledge-lint (bold schema entries parsed)" bash -c \
+  "node '$REPO_ROOT/scripts/knowledge-lint.js' '$workdir/.claude-code-hermit' | grep -q 'Knowledge base is clean'"
+cleanup
+
 # -------------------------------------------------------
 # update-reflection-state.js
 # -------------------------------------------------------


### PR DESCRIPTION
## Summary

Operators who write `knowledge-schema.md` using bold markdown type entries (`- **type**:`) got a false `schema-empty` lint finding even when content was present. The `parseSchema` regex only matched the plain format, so bold entries were silently dropped and the schema appeared empty. This removes the false positive at the root by accepting both formats.

## Changes

- `scripts/knowledge-lint.js`: regex in `parseSchema` now accepts an optional `**` wrapper around type names (`(?:\*\*)?`); inline grammar comment updated to match
- `state-templates/knowledge-schema.md.template`: parser comment notes both accepted formats
- `tests/run-scripts.sh`: new test 6c confirms a bold-format schema lints clean (no `schema-empty`, no `undeclared-type`)

## Test plan

- `bash plugins/claude-code-hermit/tests/run-all.sh` — all 10 knowledge-lint cases pass, including the new bold-format case

Closes #197