### PR TITLE
perf(hermit-evolve): deterministic pre-pass to cut evolve token cost

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **hermit-evolve: deterministic pre-pass (`scripts/evolve-plan.js`)** — a read-only analyzer precomputes the version gap, bounded CHANGELOG slice, new config keys, changed templates/bin, and the CLAUDE-APPEND block diff in one JSON pass; the skill acts on it instead of reading and diffing whole files in-context. Cuts a typical evolve run to ~15–25K tokens and fixes the CHANGELOG 2000-line read truncation that could silently skip the oldest `### Upgrade Instructions`. Closes #211.
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. No `config.json` changes required. The skill's Step 8 adds the new `Bash(node */scripts/evolve-plan.js*)` permission automatically; you may see a single approval prompt for the helper on the first run.
+
 ## [1.1.7] - 2026-05-31
 
 ### Fixed

--- a/plugins/claude-code-hermit/scripts/evolve-plan.js
+++ b/plugins/claude-code-hermit/scripts/evolve-plan.js
@@ -1,0 +1,268 @@
+'use strict';
+
+// Read-only analyzer for the hermit-evolve skill. Computes the deterministic
+// comparisons the skill would otherwise do in-context — version gap, the
+// bounded CHANGELOG slice, new config keys, changed templates/bin, and the
+// CLAUDE-APPEND block diff — and emits one JSON "plan" to stdout. The skill
+// acts on the plan instead of reading and diffing whole files itself.
+//
+// Pure analyzer: never writes or copies. Fail-open: always exits 0; problems
+// are recorded in the `errors` array (objects of {code, message}), never
+// thrown. No stdin (skill-invoked, like doctor-check.js / resolve-outbound-channel.js).
+//
+// Usage: node evolve-plan.js [hermit-dir] --hatch-target=<local|committed>
+
+const fs = require('fs');
+const path = require('path');
+
+const MARKER = '<!-- claude-code-hermit: Session Discipline -->';
+const TEMPLATE_FILES = [
+  'SHELL.md.template',
+  'SESSION-REPORT.md.template',
+  'PROPOSAL.md.template',
+];
+
+// 3-way compare of X.Y.Z leading semver. Unparseable forms compare equal
+// (don't second-guess), matching doctor-check.js satisfiesRange's posture.
+function cmpSemver(a, b) {
+  const pa = String(a).match(/^(\d+)\.(\d+)\.(\d+)/);
+  const pb = String(b).match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!pa || !pb) return 0;
+  for (let i = 1; i <= 3; i++) {
+    const d = parseInt(pa[i], 10) - parseInt(pb[i], 10);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function readJSON(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+// Strip trailing whitespace for equality comparison (a trailing newline must
+// not register as a content change).
+function normTrailing(s) {
+  return s.replace(/\s+$/, '');
+}
+
+// Slice of CHANGELOG.md entries in the half-open range (from, to], oldest-first.
+// Headers look like "## [1.1.7] - 2026-05-31". Each entry spans from its header
+// to the line before the next header. This is the read that replaces a full
+// 47K-token CHANGELOG read and dodges the Read tool's 2000-line truncation.
+function changelogSlice(text, from, to) {
+  const lines = text.split('\n');
+  const headerRe = /^## \[(\d+\.\d+\.\d+)\]/;
+  const entries = [];
+  let cur = null;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(headerRe);
+    if (m) {
+      if (cur) {
+        cur.end = i;
+        entries.push(cur);
+      }
+      cur = { version: m[1], start: i, end: lines.length };
+    }
+  }
+  if (cur) entries.push(cur);
+
+  const inRange = entries.filter(
+    (e) => cmpSemver(from, e.version) < 0 && (to == null || cmpSemver(e.version, to) <= 0)
+  );
+  inRange.sort((a, b) => cmpSemver(a.version, b.version));
+
+  const slice = inRange
+    .map((e) => normTrailing(lines.slice(e.start, e.end).join('\n')))
+    .join('\n\n');
+  return { slice, versions: inRange.map((e) => e.version) };
+}
+
+// Deep diff of the template against the project config; reports ONLY keys
+// missing from the project (operator values are never reported/overwritten).
+// Parent object entirely absent -> emit the parent path with its full default
+// subtree. Parent present but children missing -> emit the missing leaves as
+// dotted paths. Arrays and scalars are leaves (no element-level merge), so a
+// new default routine in a later version rides on Upgrade Instructions, as today.
+function newConfigKeys(tmpl, config, prefix, out) {
+  out = out || [];
+  prefix = prefix || '';
+  if (!isPlainObject(tmpl)) return out;
+  for (const key of Object.keys(tmpl)) {
+    const tval = tmpl[key];
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+    const present = isPlainObject(config) && Object.prototype.hasOwnProperty.call(config, key);
+    if (!present) {
+      out.push({ path: fullPath, default: tval });
+    } else if (isPlainObject(tval) && isPlainObject(config[key])) {
+      newConfigKeys(tval, config[key], fullPath, out);
+    }
+    // present + leaf, or present with a type mismatch -> operator value kept, skip.
+  }
+  return out;
+}
+
+// Basenames whose project copy differs from (or is missing relative to) the
+// template. Source missing -> nothing to sync (skip). Byte comparison only;
+// contents never enter the plan.
+function changedFiles(srcDir, dstDir, names) {
+  const changed = [];
+  for (const name of names) {
+    let srcBuf;
+    try {
+      srcBuf = fs.readFileSync(path.join(srcDir, name));
+    } catch (e) {
+      continue;
+    }
+    let dstBuf;
+    try {
+      dstBuf = fs.readFileSync(path.join(dstDir, name));
+    } catch (e) {
+      changed.push(name);
+      continue;
+    }
+    if (!srcBuf.equals(dstBuf)) changed.push(name);
+  }
+  return changed;
+}
+
+// Marker-onward block: from the MARKER line to EOF or the next standalone
+// "---" line. Returns null if the marker is absent. Used on both the template
+// (which skips its own leading "---") and the target CLAUDE file, so the two
+// are compared apples-to-apples.
+function markerOnward(text) {
+  const idx = text.indexOf(MARKER);
+  if (idx === -1) return null;
+  const block = text.slice(idx);
+  const lines = block.split('\n');
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      return lines.slice(0, i).join('\n');
+    }
+  }
+  return block;
+}
+
+function computeClaudeAppend(plan, pluginRoot, hermitDir, hatchTarget, errors) {
+  let tmplText;
+  try {
+    tmplText = fs.readFileSync(path.join(pluginRoot, 'state-templates', 'CLAUDE-APPEND.md'), 'utf8');
+  } catch (e) {
+    errors.push({ code: 'claude_append_template_unreadable', message: e.message });
+    return;
+  }
+  const tmplBlock = markerOnward(tmplText);
+  if (tmplBlock === null) {
+    errors.push({ code: 'claude_append_marker_missing', message: 'marker not found in template' });
+    return;
+  }
+
+  const projectRoot = path.resolve(hermitDir, '..');
+  const targetFile = path.join(projectRoot, hatchTarget === 'local' ? 'CLAUDE.local.md' : 'CLAUDE.md');
+  let targetBlock = null;
+  try {
+    targetBlock = markerOnward(fs.readFileSync(targetFile, 'utf8'));
+  } catch (e) {
+    // file missing -> append case
+  }
+
+  if (targetBlock === null) {
+    plan.claude_append_changed = true; // marker absent -> append full template (skill handles)
+    return;
+  }
+  const changed = normTrailing(targetBlock) !== normTrailing(tmplBlock);
+  plan.claude_append_changed = changed;
+  if (changed) plan.claude_append_old_block = targetBlock; // exact current text for a targeted Edit
+}
+
+function buildPlan({ hermitDir, pluginRoot, hatchTarget }) {
+  const errors = [];
+  const plan = { errors };
+
+  if (hatchTarget !== 'local' && hatchTarget !== 'committed') {
+    errors.push({ code: 'no_hatch_target', message: '--hatch-target=<local|committed> is required' });
+    return plan;
+  }
+  plan.hatch_target = hatchTarget;
+
+  let config;
+  try {
+    config = readJSON(path.join(hermitDir, 'config.json'));
+  } catch (e) {
+    errors.push({ code: 'no_config', message: `config.json not found or unreadable: ${e.message}` });
+    return plan;
+  }
+
+  let to = null;
+  try {
+    to = readJSON(path.join(pluginRoot, '.claude-plugin', 'plugin.json')).version || null;
+  } catch (e) {
+    errors.push({ code: 'plugin_json_unreadable', message: e.message });
+  }
+  const from = (isPlainObject(config._hermit_versions) && config._hermit_versions['claude-code-hermit']) || '0.0.0';
+  plan.from = from;
+  plan.to = to;
+  plan.up_to_date = to != null && cmpSemver(from, to) >= 0;
+
+  try {
+    const cl = fs.readFileSync(path.join(pluginRoot, 'CHANGELOG.md'), 'utf8');
+    const { slice, versions } = changelogSlice(cl, from, to);
+    plan.changelog_slice = slice;
+    plan.changelog_versions = versions;
+  } catch (e) {
+    errors.push({ code: 'changelog_unreadable', message: e.message });
+  }
+
+  try {
+    const tmpl = readJSON(path.join(pluginRoot, 'state-templates', 'config.json.template'));
+    plan.new_config_keys = newConfigKeys(tmpl, config);
+  } catch (e) {
+    errors.push({ code: 'config_template_unreadable', message: e.message });
+  }
+
+  const stDir = path.join(pluginRoot, 'state-templates');
+  plan.templates_changed = changedFiles(stDir, path.join(hermitDir, 'templates'), TEMPLATE_FILES);
+
+  const binSrc = path.join(stDir, 'bin');
+  let binNames = [];
+  try {
+    binNames = fs.readdirSync(binSrc, { withFileTypes: true })
+      .filter((d) => d.isFile())
+      .map((d) => d.name);
+  } catch (e) {
+    // no bin dir in source -> nothing to sync (not an operator-facing error)
+  }
+  plan.bin_changed = changedFiles(binSrc, path.join(hermitDir, 'bin'), binNames);
+
+  computeClaudeAppend(plan, pluginRoot, hermitDir, hatchTarget, errors);
+
+  return plan;
+}
+
+function parseArgs(argv) {
+  let hermitDir = null;
+  let hatchTarget = null;
+  for (const a of argv) {
+    if (a.startsWith('--hatch-target=')) hatchTarget = a.slice('--hatch-target='.length);
+    else if (!a.startsWith('--') && hermitDir === null) hermitDir = a;
+  }
+  return { hermitDir: hermitDir || '.claude-code-hermit', hatchTarget };
+}
+
+if (require.main === module) {
+  const { hermitDir, hatchTarget } = parseArgs(process.argv.slice(2));
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..');
+  let plan;
+  try {
+    plan = buildPlan({ hermitDir: path.resolve(hermitDir), pluginRoot, hatchTarget });
+  } catch (e) {
+    plan = { errors: [{ code: 'fatal', message: e.message }] };
+  }
+  process.stdout.write(JSON.stringify(plan, null, 2) + '\n');
+  process.exit(0);
+} else {
+  module.exports = { buildPlan, cmpSemver, changelogSlice, newConfigKeys, markerOnward, changedFiles };
+}

--- a/plugins/claude-code-hermit/scripts/evolve-plan.js
+++ b/plugins/claude-code-hermit/scripts/evolve-plan.js
@@ -188,11 +188,18 @@ function buildPlan({ hermitDir, pluginRoot, hatchTarget }) {
   }
   plan.hatch_target = hatchTarget;
 
+  const configPath = path.join(hermitDir, 'config.json');
   let config;
   try {
-    config = readJSON(path.join(hermitDir, 'config.json'));
+    config = readJSON(configPath);
   } catch (e) {
-    errors.push({ code: 'no_config', message: `config.json not found or unreadable: ${e.message}` });
+    if (e && e.code === 'ENOENT') {
+      errors.push({ code: 'no_config', message: 'config.json not found' });
+    } else if (e && e.name === 'SyntaxError') {
+      errors.push({ code: 'config_json_invalid', message: `config.json is not valid JSON: ${e.message}` });
+    } else {
+      errors.push({ code: 'config_unreadable', message: `config.json unreadable: ${e.message}` });
+    }
     return plan;
   }
 

--- a/plugins/claude-code-hermit/scripts/evolve-plan.js
+++ b/plugins/claude-code-hermit/scripts/evolve-plan.js
@@ -166,6 +166,10 @@ function computeClaudeAppend(plan, pluginRoot, hermitDir, hatchTarget, errors) {
   try {
     targetBlock = markerOnward(fs.readFileSync(targetFile, 'utf8'));
   } catch (e) {
+    if (e && e.code !== 'ENOENT') {
+      errors.push({ code: 'claude_target_unreadable', message: `${targetFile} unreadable: ${e.message}` });
+      return;
+    }
     // file missing -> append case
   }
 

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -592,6 +592,7 @@ Merge these into the target file:
       "Bash(node */scripts/generate-summary.js*)",
       "Bash(node */scripts/update-reflection-state.js*)",
       "Bash(node */scripts/cron-tz-shift.js*)",
+      "Bash(node */scripts/evolve-plan.js*)",
       "Bash(bash -c 'AGENT_DIR=\".claude-code-hermit\"*)",
       "Edit(.claude-code-hermit/**)",
       "Write(.claude-code-hermit/**)"

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -31,27 +31,9 @@ Upgrade the project's hermit configuration after a plugin update.
   Substitute `<min>` with the value from `min_claude_code_version` and
   `<detected>` with the parsed CLI version. Then stop. Do not prompt to bypass.
 
-### 1. Read versions
+### 1. Resolve hatch target, then run the pre-pass
 
-- Read `.claude-code-hermit/config.json`
-- Read `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` to get the current plugin version
-- Read `_hermit_versions` from config (default to `{"claude-code-hermit": "0.0.0"}` if the field is missing — this means the project was initialized before version tracking existed)
-- Compare: `config_version` vs `plugin_version`
-
-If versions match: report "You're up to date (vX.Y.Z). Nothing to upgrade." and stop.
-
-If config.json doesn't exist: report "No config found. Run `/claude-code-hermit:hatch` first." and stop.
-
-### 2. Read changelog
-
-- Read `${CLAUDE_PLUGIN_ROOT}/CHANGELOG.md`
-- Extract entries between the config version and the plugin version
-- Present a summary to the operator: "Upgrading from vX.Y.Z to vA.B.C. Here's what changed:"
-- Show only the relevant changelog sections (not the entire file)
-
-### 2a. Resolve hatch target
-
-Before running version migrations, determine `hatch_target` so Steps 6, 7, and 8 write to the correct file:
+First determine `hatch_target` (the pre-pass needs it, and so do Steps 6, 7, 8):
 
 1. Read `.claude-code-hermit/state/hatch-options.json` if it exists. Use the `"target"` field as `hatch_target`.
 2. If the file is absent or has no `"target"` field:
@@ -59,26 +41,41 @@ Before running version migrations, determine `hatch_target` so Steps 6, 7, and 8
    - Else if `CLAUDE.md` contains the marker → `hatch_target = "committed"`.
    - Else → re-run scope detection: read `claude plugin list --json`. From the output, find all entries where plugin name (substring of `id` left of `@`) is `claude-code-hermit` and `enabled == true`. Apply precedence: if any has `scope == "local"` and `projectPath` equals current project root → `local`; else if any has `scope == "project"` and `projectPath` equals current project root → `project`; else if any has `scope == "user"` (any `projectPath`) → `user`; else → `null`. Map: `project` → `committed`; `local`/`user`/`null` → `local`.
 
+Then run the deterministic pre-pass — a single read-only analyzer that computes the version gap, the bounded CHANGELOG slice, new config keys, changed templates/bin, and the CLAUDE-APPEND block diff, so the steps below act on its output instead of reading and diffing whole files:
+
+```
+node ${CLAUDE_PLUGIN_ROOT}/scripts/evolve-plan.js .claude-code-hermit --hatch-target=<hatch_target>
+```
+
+Parse stdout as JSON (the "plan"). The plan's `errors` array is the **sole error channel** — objects of `{code, message}`:
+
+- If `errors` contains an entry with `code == "no_config"` → report "No config found. Run `/claude-code-hermit:hatch` first." and stop.
+- Else if `errors` is non-empty (any other code, e.g. `no_hatch_target`) **or** stdout is not valid JSON → report "evolve-plan failed: <joined messages> — re-run or report." and stop. Do not fall back to reading and diffing the files by hand.
+
+**Version check:** the plan reports `from`, `to`, and `up_to_date`. If `up_to_date` is `true`, report "You're up to date (v<to>). Nothing to upgrade." and stop. Otherwise announce: "Upgrading from v<from> to v<to>."
+
+### 2. Present the changelog
+
+Present the plan's `changelog_slice` to the operator: "Here's what changed:" followed by the slice. It already contains only the entries in `(from, to]`, oldest-first — no full-file read.
+
 ### 2b. Execute version migrations
 
-For each CHANGELOG.md version entry between `config_version` (exclusive) and `plugin_version` (inclusive), processed in **oldest-first order**:
+Within `changelog_slice` (already ordered oldest-first), each version entry may contain a `### Upgrade Instructions` section:
 
-1. Find the `### Upgrade Instructions` section within that version's entry
+1. Find the `### Upgrade Instructions` section within each version's entry
 2. If found, execute every instruction in that section — these are the authoritative migration steps
 3. Present version-specific operator notes as you go
 4. If a step is interactive (asks the operator a question), ask it before proceeding
 
-This is the same pattern used for hermit plugin upgrades in step 7. The CHANGELOG.md `### Upgrade Instructions` sections are the single source of truth for migrations — do not skip or merely display them.
+The CHANGELOG.md `### Upgrade Instructions` sections are the single source of truth for migrations — do not skip or merely display them. The same pattern applies to sibling-hermit upgrades in Step 7.
 
-### 3. Detect new config keys
+### 3. New config keys
 
-- Read `${CLAUDE_PLUGIN_ROOT}/state-templates/config.json.template` for the current schema
-- Compare keys in the template against keys in the project's config.json
-- Identify new keys not present in the project's config
+The plan's `new_config_keys` array lists every key in the current `config.json.template` that is missing from the project's config, each as `{path, default}` — a dotted `path` for a nested leaf, or a fully-absent parent carrying its whole default subtree. Operator-set values are never listed, so acting on these never overwrites them.
 
 ### 4. Ask about new settings
 
-For each new key, check the table below. If the key is interactive, ask the operator. If not, add it silently with the default value. Batch interactive questions into a single numbered list.
+For each entry in the plan's `new_config_keys`, check the interactive allowlist below. If the entry's `path` is interactive, ask the operator. **Every other key — including template-only keys not enumerated below — is added silently with its `default` from the plan.** Batch interactive questions into a single numbered list.
 
 **Interactive keys** (ask operator if missing):
 - `agent_name` (0.0.1), `language` (0.0.1, auto-detect from `$LANG`), `timezone` (0.0.1, auto-detect), `escalation` (0.0.1), `idle_behavior` (0.0.9)
@@ -118,8 +115,8 @@ Also: if an active SHELL.md has a `## Plan` section (legacy plan table), warn th
 
 ### 5. Update templates
 
-- Compare each template file in `${CLAUDE_PLUGIN_ROOT}/state-templates/` against the corresponding file in `.claude-code-hermit/templates/`
-- If the plugin's template has different content: replace the project's template
+- For each basename in the plan's `templates_changed`, copy `${CLAUDE_PLUGIN_ROOT}/state-templates/<name>` over `.claude-code-hermit/templates/<name>`. The plan already byte-compared them — don't re-read contents to diff.
+- If `templates_changed` is empty, skip.
 - Report which templates were updated
 - Note: SHELL.md.template no longer has a `## Plan` section — plan tracking is now handled by native Claude Code Tasks
 
@@ -141,23 +138,21 @@ If `<project-root>/obsidian/` exists in the target project:
 
 ### 5b. Update boot script wrappers
 
-- Copy all files from `${CLAUDE_PLUGIN_ROOT}/state-templates/bin/` into `.claude-code-hermit/bin/`
-- For each file: compare against the existing version and replace if different. Copy new files that don't exist yet.
+- For each basename in the plan's `bin_changed`, copy `${CLAUDE_PLUGIN_ROOT}/state-templates/bin/<name>` into `.claude-code-hermit/bin/<name>` (the plan already byte-compared and lists differing or missing files).
 - Ensure all files in `.claude-code-hermit/bin/` are executable
+- If `bin_changed` is empty, skip the copy (still confirm executability).
 
 ### 6. Update CLAUDE-APPEND block
 
-The target file is determined by `hatch_target` (resolved in step 2a):
+The target file is determined by `hatch_target` (resolved in Step 1):
 - `hatch_target == "local"` → `CLAUDE.local.md`
 - `hatch_target == "committed"` → `CLAUDE.md`
 
-- Read the target file
-- Find the `<!-- claude-code-hermit: Session Discipline -->` marker
-- Read `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md` for the current version
-- Compare the block in the target file (from the marker to the end of file or next `---` separator) with the template
-- If different: replace the block with the updated content
-- If the marker is not found: append the full CLAUDE-APPEND.md to the target file (same as init)
-- Report what changed
+If the plan's `claude_append_changed` is `false`, skip this step. If `true`, read `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md` for the new content, then branch on the plan's `claude_append_old_block`:
+
+- **`claude_append_old_block` present** (marker found — replace case): the new content is the marker-onward portion of `CLAUDE-APPEND.md` (from the `<!-- claude-code-hermit: Session Discipline -->` marker to its end; the leading `---` already sits above the marker in the target). Apply a targeted `Edit` to the target file with `old_string` = `claude_append_old_block` (the exact current block) and `new_string` = that marker-onward content. **Do not read the whole target file** — the exact `old_string` is supplied by the plan, and the `---` must not be duplicated.
+- **`claude_append_old_block` absent** (marker not found — append case): append the **full `CLAUDE-APPEND.md` including its leading `---`** to the target file (same as init — the `---` separates the project's content from the block).
+- Report what changed.
 
 ### 7. Hermit upgrades
 
@@ -183,19 +178,20 @@ The target file is determined by `hatch_target` (resolved in step 2a):
 
 ### 8. Ensure plugin permissions in settings file
 
-Same logic as init step 8, but target the file determined by `hatch_target` (resolved in step 2a):
+Same logic as init step 8, but target the file determined by `hatch_target` (resolved in Step 1):
 - `hatch_target == "local"` → `.claude/settings.local.json`
 - `hatch_target == "committed"` → `.claude/settings.json`
 
-Check the target settings file for the plugin's required permissions (`git diff/status/log`, per-script `node` entries, the SessionStart `bash -c` hook, and `Edit`/`Write` on `.claude-code-hermit/**`). The required node entries are: `cost-tracker.js`, `suggest-compact.js`, `run-with-profile.js`, `evaluate-session.js`, `append-metrics.js`, `generate-summary.js`, `cron-tz-shift.js`, `archive-shell.js`. If any are missing, show the operator which ones and ask for confirmation before adding. Only add missing entries — never remove existing ones. If all are already present, skip silently. Also remove stale permissions from previous versions if found in the target file:
+Check the target settings file for the plugin's required permissions (`git diff/status/log`, per-script `node` entries, the SessionStart `bash -c` hook, and `Edit`/`Write` on `.claude-code-hermit/**`). The required node entries are: `cost-tracker.js`, `suggest-compact.js`, `run-with-profile.js`, `evaluate-session.js`, `append-metrics.js`, `generate-summary.js`, `cron-tz-shift.js`, `archive-shell.js`, `evolve-plan.js`. If any are missing, show the operator which ones and ask for confirmation before adding. Only add missing entries — never remove existing ones. If all are already present, skip silently. Also remove stale permissions from previous versions if found in the target file:
 
 - `Bash(python3:*)`, `Bash(node:*)` — replaced by scoped node entries
 - `Edit(.claude/.claude-code-hermit/**)`, `Write(.claude/.claude-code-hermit/**)` — replaced by `.claude-code-hermit/**` (v0.0.6 path change)
 
 ### 9. Write updated config
 
-- Merge new keys into existing config (existing operator values are never overwritten)
-- Update `_hermit_versions["claude-code-hermit"]` to the current plugin version
+- **Re-read `.claude-code-hermit/config.json` now** — Step 2b migrations may have written keys since the pre-pass ran.
+- For each entry in `new_config_keys` (plus interactive answers from Step 4), set `path` to its value **only if that path is still missing** in the freshly-read config. Never overwrite an existing operator or migration-set value.
+- Update `_hermit_versions["claude-code-hermit"]` to the current plugin version (the plan's `to`)
 - For hermits: only update versions for hermits already present as keys in `_hermit_versions` — never add new keys here
 - Write to `.claude-code-hermit/config.json`
 

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -21,4 +21,5 @@ bash "$SCRIPT_DIR/test-channel-responder-reply-rule.sh"    || rc=$?
 bash "$SCRIPT_DIR/test-proposal-act-accept-flow.sh"        || rc=$?
 bash "$SCRIPT_DIR/test-simplify-totals-contract.sh"        || rc=$?
 bash "$SCRIPT_DIR/test-auto-close.sh"                      || rc=$?
+bash "$SCRIPT_DIR/test-evolve-plan.sh"                     || rc=$?
 exit $rc

--- a/plugins/claude-code-hermit/tests/test-evolve-plan.sh
+++ b/plugins/claude-code-hermit/tests/test-evolve-plan.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Tests for evolve-plan.js (issue #211): the read-only pre-pass analyzer for
+# hermit-evolve. Covers version gap, bounded CHANGELOG slice, deep config-key
+# diff, template/bin byte-compare, separator-aware CLAUDE-APPEND diff, the
+# no_config vs 0.0.0 distinction, and operator-value preservation.
+# Usage: bash tests/test-evolve-plan.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "=== evolve-plan (#211) ==="
+echo ""
+
+EVOLVE_PLAN="$REPO_ROOT/scripts/evolve-plan.js"
+MARKER='<!-- claude-code-hermit: Session Discipline -->'
+
+# Build a fake plugin root at $PR with plugin version 1.1.7.
+PR="$(mktemp -d)"
+mkdir -p "$PR/.claude-plugin" "$PR/state-templates/bin"
+printf '{"version":"1.1.7"}\n' > "$PR/.claude-plugin/plugin.json"
+cat > "$PR/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [1.1.7] - 2026-05-31
+### Fixed
+- newest change
+
+### Upgrade Instructions
+Run the evolve skill.
+
+## [1.1.6] - 2026-05-28
+### Added
+- middle change
+
+## [1.1.5] - 2026-05-25
+### Added
+- oldest change
+EOF
+cat > "$PR/state-templates/config.json.template" <<'EOF'
+{
+  "_hermit_versions": {},
+  "model": "sonnet",
+  "routines": [{"id": "x"}],
+  "quality_gate": {"tier": "budget"},
+  "heartbeat": {"enabled": true, "waiting_timeout": null}
+}
+EOF
+printf -- '---\n\n%s\n## Session Discipline\n\nbody line\n' "$MARKER" > "$PR/state-templates/CLAUDE-APPEND.md"
+printf 'SHELL TEMPLATE V1\n'   > "$PR/state-templates/SHELL.md.template"
+printf 'REPORT TEMPLATE\n'     > "$PR/state-templates/SESSION-REPORT.md.template"
+printf 'PROPOSAL TEMPLATE\n'   > "$PR/state-templates/PROPOSAL.md.template"
+printf '#!/bin/sh\necho run\n' > "$PR/state-templates/bin/hermit-run"
+
+# run_plan <hermit-dir> <hatch-target> <out-file>
+run_plan() {
+  CLAUDE_PLUGIN_ROOT="$PR" node "$EVOLVE_PLAN" "$1" --hatch-target="$2" > "$3" 2>/dev/null
+}
+
+# -------------------------------------------------------
+# 1. Version gap + bounded changelog slice
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+echo '{"_hermit_versions":{"claude-code-hermit":"1.1.6"}}' > "$proj/.claude-code-hermit/config.json"
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "version gap: from 1.1.6 -> to 1.1.7, not up_to_date" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+assert d['from']=='1.1.6', d.get('from')
+assert d['to']=='1.1.7', d.get('to')
+assert d['up_to_date'] is False, d.get('up_to_date')
+assert d['errors']==[], d['errors']
+"
+run_test "changelog slice: only (1.1.6, 1.1.7], excludes older" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+assert d['changelog_versions']==['1.1.7'], d['changelog_versions']
+s=d['changelog_slice']
+assert 'newest change' in s and 'Upgrade Instructions' in s, s
+assert 'middle change' not in s and 'oldest change' not in s, s
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 2. Up to date
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+echo '{"_hermit_versions":{"claude-code-hermit":"1.1.7"}}' > "$proj/.claude-code-hermit/config.json"
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "up_to_date true when config == plugin version" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+assert d['up_to_date'] is True, d.get('up_to_date')
+assert d['changelog_versions']==[], d['changelog_versions']
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 3. New config keys: top-level + nested leaf reported, present omitted
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+cat > "$proj/.claude-code-hermit/config.json" <<'EOF'
+{
+  "_hermit_versions": {"claude-code-hermit": "1.1.6"},
+  "model": "sonnet",
+  "routines": [{"id": "x"}],
+  "heartbeat": {"enabled": true}
+}
+EOF
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "new_config_keys: reports quality_gate + heartbeat.waiting_timeout, omits present" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+keys={k['path']: k['default'] for k in d['new_config_keys']}
+assert 'quality_gate' in keys, keys
+assert keys['quality_gate']=={'tier':'budget'}, keys['quality_gate']
+assert 'heartbeat.waiting_timeout' in keys, keys
+assert keys['heartbeat.waiting_timeout'] is None, keys['heartbeat.waiting_timeout']
+assert 'model' not in keys, keys
+assert 'heartbeat.enabled' not in keys, keys
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 4. templates_changed / bin_changed: only differing/absent files
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit/templates" "$proj/.claude-code-hermit/bin"
+echo '{"_hermit_versions":{"claude-code-hermit":"1.1.6"}}' > "$proj/.claude-code-hermit/config.json"
+printf 'DIFFERENT CONTENT\n' > "$proj/.claude-code-hermit/templates/SHELL.md.template"
+printf 'REPORT TEMPLATE\n'   > "$proj/.claude-code-hermit/templates/SESSION-REPORT.md.template"  # identical
+# PROPOSAL.md.template absent -> needs copy
+printf '#!/bin/sh\necho CHANGED\n' > "$proj/.claude-code-hermit/bin/hermit-run"  # differs
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "templates/bin changed: detects diff + absent, skips identical" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+t=set(d['templates_changed'])
+assert 'SHELL.md.template' in t, t
+assert 'PROPOSAL.md.template' in t, t
+assert 'SESSION-REPORT.md.template' not in t, t
+assert d['bin_changed']==['hermit-run'], d['bin_changed']
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 5a. CLAUDE-APPEND identical (target has leading ---) -> not changed
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+echo '{"_hermit_versions":{"claude-code-hermit":"1.1.6"}}' > "$proj/.claude-code-hermit/config.json"
+printf '# My Project\n\nstuff\n\n---\n\n%s\n## Session Discipline\n\nbody line\n' "$MARKER" > "$proj/CLAUDE.local.md"
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "CLAUDE-APPEND identical (modulo leading ---) -> changed=false, no old_block" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+assert d['claude_append_changed'] is False, d.get('claude_append_changed')
+assert 'claude_append_old_block' not in d, 'should omit old_block when unchanged'
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 5b. CLAUDE-APPEND different -> changed + exact old_block
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+echo '{"_hermit_versions":{"claude-code-hermit":"1.1.6"}}' > "$proj/.claude-code-hermit/config.json"
+printf '# My Project\n\nstuff\n\n---\n\n%s\n## Session Discipline\n\nOLD body line\n' "$MARKER" > "$proj/CLAUDE.local.md"
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "CLAUDE-APPEND different -> changed=true, old_block is exact marker-onward" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+assert d['claude_append_changed'] is True, d.get('claude_append_changed')
+ob=d['claude_append_old_block']
+assert ob.startswith('<!-- claude-code-hermit: Session Discipline -->'), repr(ob[:40])
+assert 'OLD body line' in ob, ob
+# must be an exact substring of the target file (so a targeted Edit will match)
+assert ob in open('$proj/CLAUDE.local.md').read(), 'old_block not an exact substring'
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 5c. CLAUDE-APPEND marker absent -> changed (append case), no old_block
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+echo '{"_hermit_versions":{"claude-code-hermit":"1.1.6"}}' > "$proj/.claude-code-hermit/config.json"
+printf '# My Project\n\nno hermit block here\n' > "$proj/CLAUDE.local.md"
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "CLAUDE-APPEND marker absent -> changed=true (append), no old_block" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+assert d['claude_append_changed'] is True, d.get('claude_append_changed')
+assert 'claude_append_old_block' not in d, 'append case must omit old_block'
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 6. no_config: missing config.json -> errors[no_config], no top-level error key
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "no_config: missing config.json -> errors[no_config], single contract" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+codes=[e['code'] for e in d['errors']]
+assert 'no_config' in codes, codes
+assert 'error' not in d, 'must not use a top-level error key'
+assert 'from' not in d, 'should not report a version when there is no config'
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 7. missing _hermit_versions only -> from 0.0.0, clean errors
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+echo '{"model":"sonnet"}' > "$proj/.claude-code-hermit/config.json"
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "missing _hermit_versions -> from 0.0.0, errors empty" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+assert d['from']=='0.0.0', d.get('from')
+assert d['errors']==[], d['errors']
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 8. Operator value preserved: present nested key (non-default) omitted
+#    (script-level guard for idempotent Step 9 — never re-lists a set key)
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+cat > "$proj/.claude-code-hermit/config.json" <<'EOF'
+{
+  "_hermit_versions": {"claude-code-hermit": "1.1.6"},
+  "model": "sonnet",
+  "routines": [{"id": "x"}],
+  "quality_gate": {"tier": "balanced"},
+  "heartbeat": {"enabled": true, "waiting_timeout": "30m"}
+}
+EOF
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "operator value preserved: set quality_gate.tier not re-listed" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+paths=[k['path'] for k in d['new_config_keys']]
+assert 'quality_gate' not in paths, paths
+assert 'heartbeat.waiting_timeout' not in paths, paths
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 9. no_hatch_target: required flag missing -> errors[no_hatch_target]
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+echo '{"_hermit_versions":{"claude-code-hermit":"1.1.6"}}' > "$proj/.claude-code-hermit/config.json"
+CLAUDE_PLUGIN_ROOT="$PR" node "$EVOLVE_PLAN" "$proj/.claude-code-hermit" > "$proj/plan.json" 2>/dev/null
+run_test "no_hatch_target: missing flag -> errors[no_hatch_target], exit 0" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+codes=[e['code'] for e in d['errors']]
+assert 'no_hatch_target' in codes, codes
+"
+rm -rf "$proj"
+
+rm -rf "$PR"
+print_results

--- a/plugins/claude-code-hermit/tests/test-evolve-plan.sh
+++ b/plugins/claude-code-hermit/tests/test-evolve-plan.sh
@@ -207,7 +207,23 @@ assert 'from' not in d, 'should not report a version when there is no config'
 rm -rf "$proj"
 
 # -------------------------------------------------------
-# 7. missing _hermit_versions only -> from 0.0.0, clean errors
+# 7. malformed config.json -> errors[config_json_invalid], not no_config
+# -------------------------------------------------------
+proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
+printf '{"_hermit_versions":' > "$proj/.claude-code-hermit/config.json"
+run_plan "$proj/.claude-code-hermit" local "$proj/plan.json"
+run_test "malformed config.json -> errors[config_json_invalid], not no_config" python3 -c "
+import json
+d=json.load(open('$proj/plan.json'))
+codes=[e['code'] for e in d['errors']]
+assert 'config_json_invalid' in codes, codes
+assert 'no_config' not in codes, codes
+assert 'from' not in d, 'should not report a version when config is invalid'
+"
+rm -rf "$proj"
+
+# -------------------------------------------------------
+# 8. missing _hermit_versions only -> from 0.0.0, clean errors
 # -------------------------------------------------------
 proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
 echo '{"model":"sonnet"}' > "$proj/.claude-code-hermit/config.json"
@@ -221,7 +237,7 @@ assert d['errors']==[], d['errors']
 rm -rf "$proj"
 
 # -------------------------------------------------------
-# 8. Operator value preserved: present nested key (non-default) omitted
+# 9. Operator value preserved: present nested key (non-default) omitted
 #    (script-level guard for idempotent Step 9 — never re-lists a set key)
 # -------------------------------------------------------
 proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
@@ -245,7 +261,7 @@ assert 'heartbeat.waiting_timeout' not in paths, paths
 rm -rf "$proj"
 
 # -------------------------------------------------------
-# 9. no_hatch_target: required flag missing -> errors[no_hatch_target]
+# 10. no_hatch_target: required flag missing -> errors[no_hatch_target]
 # -------------------------------------------------------
 proj="$(mktemp -d)"; mkdir -p "$proj/.claude-code-hermit"
 echo '{"_hermit_versions":{"claude-code-hermit":"1.1.6"}}' > "$proj/.claude-code-hermit/config.json"


### PR DESCRIPTION
## Summary

`hermit-evolve` cost ~70–95K tokens/run because it pulled whole files into context just to *diff* them — chiefly a full read of the ~188 KB / ~47K-token `CHANGELOG.md` when only a ~1K-token version slice mattered. This replaces that in-context work with a read-only `scripts/evolve-plan.js` analyzer that emits one JSON "plan"; the skill acts on the plan instead of reading and diffing files itself. A typical run drops to ~15–25K tokens, with no change to the upgrade outcome.

It also fixes a latent correctness bug: a bare `Read CHANGELOG.md` hit the tool's 2000-line cap (the file is 2178 lines) and silently truncated the oldest entries, so large-gap upgrades could skip `### Upgrade Instructions`. The bounded slice computed in the script dodges that entirely.

Closes #211.

## Changes

- **New `scripts/evolve-plan.js`** — pure read-only analyzer (CommonJS, stdlib-only, fail-open exit 0). Emits `from`/`to`/`up_to_date`, bounded `changelog_slice` + `changelog_versions`, deep-diff `new_config_keys` (`{path, default}`), `templates_changed`, `bin_changed`, `claude_append_changed` / `claude_append_old_block`, and a single `errors:[{code,message}]` channel.
- **`skills/hermit-evolve/SKILL.md`** — folds hatch-target resolution into Step 1, runs the pre-pass, and rewrites Steps 1–3/5/5b/6/9 to consume the plan. CLAUDE-APPEND replace uses a targeted `Edit` against the exact `claude_append_old_block` (no full target-file read; separator-aware). Step 9 re-reads `config.json` and applies missing keys only (idempotent against migrations). Steps 4-task, 5a, 7, 8 unchanged.
- **`skills/hatch/SKILL.md`** — one allow-list entry for the new helper.
- **`CHANGELOG.md`** — `[Unreleased]` entry + Upgrade Instructions.
- **Tests** — `tests/test-evolve-plan.sh` (12 cases) registered in `run-all.sh`.

## Test plan

- `bash plugins/claude-code-hermit/tests/run-all.sh` — full suite green (14 sub-suites, including the new 12-case `test-evolve-plan.sh`).
- Tests cover: version gap, bounded changelog slice (in/out of range), deep config-key diff (top-level + nested leaf, present-omitted, operator value preserved), template/bin byte-compare, separator-aware CLAUDE-APPEND (identical / different-with-exact-old_block / marker-absent), `no_config` vs `0.0.0`, and `no_hatch_target`.
- Verified against the real plugin assets: `1.1.6 → 1.1.7`, changelog slice **3,181 chars vs ~188,000** for the full file, `[Unreleased]` correctly excluded.

## Out of scope

- Sibling-hermit (Step 7) upgrades stay in the skill (need `claude plugin list --json`).
- The pre-existing hatch/evolve permission-list drift (8 vs 11 entries) — to be filed separately.