### PR TITLE
fix(claude-code-hermit): exclude review-weekly files from raw reference check

### DIFF
--- a/plugins/claude-code-hermit/scripts/archive-raw.js
+++ b/plugins/claude-code-hermit/scripts/archive-raw.js
@@ -30,9 +30,9 @@ const cutoffMs = retentionDays * 24 * 60 * 60 * 1000;
 const now = Date.now();
 
 // --- Load compiled artifact bodies for reference check ---
-// review-weekly-*.md are auto-generated lint reports; they list expired raw filenames
+// review-weekly-*.md are auto-generated weekly review reports; they list expired raw filenames
 // in their Knowledge Health section, which would falsely "pin" those files and prevent
-// archiving. Exclude them — only genuine work products count as protective references.
+// archiving. Exclude them — only genuine compiled work products count as protective references.
 const compiledBodies = new Map(); // basename -> body text
 for (const fullPath of globDir(compiledDir, /^[^.].*\.md$/)) {
   if (path.basename(fullPath).startsWith('review-weekly-')) continue;

--- a/plugins/claude-code-hermit/scripts/archive-raw.js
+++ b/plugins/claude-code-hermit/scripts/archive-raw.js
@@ -30,8 +30,12 @@ const cutoffMs = retentionDays * 24 * 60 * 60 * 1000;
 const now = Date.now();
 
 // --- Load compiled artifact bodies for reference check ---
+// review-weekly-*.md are auto-generated lint reports; they list expired raw filenames
+// in their Knowledge Health section, which would falsely "pin" those files and prevent
+// archiving. Exclude them — only genuine work products count as protective references.
 const compiledBodies = new Map(); // basename -> body text
 for (const fullPath of globDir(compiledDir, /^[^.].*\.md$/)) {
+  if (path.basename(fullPath).startsWith('review-weekly-')) continue;
   try {
     compiledBodies.set(path.basename(fullPath), fs.readFileSync(fullPath, 'utf8'));
   } catch {}

--- a/plugins/claude-code-hermit/scripts/knowledge-lint.js
+++ b/plugins/claude-code-hermit/scripts/knowledge-lint.js
@@ -81,7 +81,7 @@ function lint(hermitDir, options = {}) {
         if (!result || !result.fm) return null;
         const lineCount = result.content.split('\n').length;
         const bodyChars = result.body.length;
-        compiledBodies.set(f, result.body);
+        if (!f.startsWith('review-weekly-')) compiledBodies.set(f, result.body);
         return { file: f, fm: result.fm, lineCount, bodyChars };
       } catch { return null; }
     }).filter(Boolean);
@@ -118,7 +118,9 @@ function lint(hermitDir, options = {}) {
   for (const raw of rawFiles) {
     const filename = raw.file;
 
-    // Check if any compiled/ body references this filename
+    // Check if any compiled/ body references this filename.
+    // review-weekly-*.md are excluded from compiledBodies at build time above so they
+    // don't mask the very files they report as expired.
     let referenced = false;
     for (const [, body] of compiledBodies) {
       if (body.includes(filename)) { referenced = true; break; }

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -165,15 +165,24 @@ workdir="$(setup_workdir)"
 mkdir -p "$workdir/.claude-code-hermit/raw" "$workdir/.claude-code-hermit/compiled"
 echo '{}' > "$workdir/.claude-code-hermit/config.json"
 # Expired raw named ONLY by a review file -> should archive
-printf -- '---\ntitle: expired\ncreated: 2025-01-01T00:00:00+00:00\n---\ndata' \
+# Use very old dates so this test is stable regardless of the current wall clock.
+printf -- '---\ntitle: expired\ncreated: 2000-01-01T00:00:00+00:00\n---\ndata' \
   > "$workdir/.claude-code-hermit/raw/expired-snap.md"
 # Expired raw named by a genuine compiled work product -> should stay retained
-printf -- '---\ntitle: cited\ncreated: 2025-01-01T00:00:00+00:00\n---\ndata' \
+printf -- '---\ntitle: cited\ncreated: 2000-01-01T00:00:00+00:00\n---\ndata' \
   > "$workdir/.claude-code-hermit/raw/cited-snap.md"
-printf -- '---\ntype: review\ncreated: 2025-01-15T00:00:00+00:00\n---\n### Knowledge Health\n- raw/expired-snap.md [14d] — Past retention.\n' \
+printf -- '---\ntype: review\ncreated: 2000-01-15T00:00:00+00:00\n---\n### Knowledge Health\n- raw/expired-snap.md [14d] — Past retention.\n' \
   > "$workdir/.claude-code-hermit/compiled/review-weekly-2025-W03.md"
-printf -- '---\ntype: briefing\ncreated: 2025-01-15T00:00:00+00:00\n---\nDerived from cited-snap.md.\n' \
+printf -- '---\ntype: briefing\ncreated: 2000-01-15T00:00:00+00:00\n---\nDerived from cited-snap.md.\n' \
   > "$workdir/.claude-code-hermit/compiled/work.md"
+
+# Regression: review-weekly must not mask stale raw in knowledge-lint
+lint_outfile="$(mktemp)"
+node "$REPO_ROOT/scripts/knowledge-lint.js" "$workdir/.claude-code-hermit" > "$lint_outfile" 2>&1
+run_test "knowledge-lint (review-weekly does not mask stale)" grep -q '^stale ' "$lint_outfile"
+run_test "knowledge-lint (expired raw flagged stale)" grep -q 'raw/expired-snap.md' "$lint_outfile"
+rm -f "$lint_outfile"
+
 outfile="$(mktemp)"
 node "$REPO_ROOT/scripts/archive-raw.js" "$workdir/.claude-code-hermit" > "$outfile" 2>&1
 run_test "archive-raw (review-weekly does not pin, real ref does)" grep -q '1 archived, 1 retained' "$outfile"

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -157,6 +157,32 @@ run_test "knowledge-lint (schema: declared type is clean)" bash -c \
 cleanup
 
 # -------------------------------------------------------
+# archive-raw.js
+# -------------------------------------------------------
+
+# review-weekly must not pin expired raw files, but a real compiled work product must
+workdir="$(setup_workdir)"
+mkdir -p "$workdir/.claude-code-hermit/raw" "$workdir/.claude-code-hermit/compiled"
+echo '{}' > "$workdir/.claude-code-hermit/config.json"
+# Expired raw named ONLY by a review file -> should archive
+printf -- '---\ntitle: expired\ncreated: 2025-01-01T00:00:00+00:00\n---\ndata' \
+  > "$workdir/.claude-code-hermit/raw/expired-snap.md"
+# Expired raw named by a genuine compiled work product -> should stay retained
+printf -- '---\ntitle: cited\ncreated: 2025-01-01T00:00:00+00:00\n---\ndata' \
+  > "$workdir/.claude-code-hermit/raw/cited-snap.md"
+printf -- '---\ntype: review\ncreated: 2025-01-15T00:00:00+00:00\n---\n### Knowledge Health\n- raw/expired-snap.md [14d] — Past retention.\n' \
+  > "$workdir/.claude-code-hermit/compiled/review-weekly-2025-W03.md"
+printf -- '---\ntype: briefing\ncreated: 2025-01-15T00:00:00+00:00\n---\nDerived from cited-snap.md.\n' \
+  > "$workdir/.claude-code-hermit/compiled/work.md"
+outfile="$(mktemp)"
+node "$REPO_ROOT/scripts/archive-raw.js" "$workdir/.claude-code-hermit" > "$outfile" 2>&1
+run_test "archive-raw (review-weekly does not pin, real ref does)" grep -q '1 archived, 1 retained' "$outfile"
+run_test "archive-raw (review-named file archived)" test -f "$workdir/.claude-code-hermit/raw/.archive/expired-snap.md"
+run_test "archive-raw (work-product-cited file retained)" test -f "$workdir/.claude-code-hermit/raw/cited-snap.md"
+rm -f "$outfile"
+cleanup
+
+# -------------------------------------------------------
 # update-reflection-state.js
 # -------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`archive-raw.js` and `knowledge-lint.js` both decide whether a raw file is "still referenced" by scanning every `compiled/*.md` body for the raw filename via `body.includes(filename)`. The weekly review file (`review-weekly-*.md`) lists stale raw filenames in its Knowledge Health section, so it was falsely pinning the files it reported as expired — archiving drained nothing, and knowledge-lint stopped surfacing them as stale. Excluding auto-generated review files from the reference check fixes both.

## Changes
- `archive-raw.js`: skip `review-weekly-*` when loading `compiledBodies` (exclusion at map-build time)
- `knowledge-lint.js`: same exclusion at `compiledBodies` build time; inner reference loop simplified back to `[, body]`
- `tests/run-scripts.sh`: first archive-raw regression tests, pinning both directions — review file does not pin, genuine work product does

## Test plan
- `bash plugins/claude-code-hermit/tests/run-all.sh` — all suites pass including 3 new archive-raw assertions
- Manual: temp state with a 2025-dated `raw/foo.md` + `compiled/review-weekly-*.md` listing it → `node scripts/archive-raw.js` reports `1 archived` (pre-fix: `0 archived, 1 retained`)

Closes #202