### PR TITLE
feat(claude-code-hermit): add archive-compiled.js to rotate old compiled artifacts

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **archive-compiled.js** — weekly-review now rotates compiled artifacts, keeping the newest 2 per type; `foundational`-tagged artifacts exempt. Companion to `archive-raw.js`. (#201)
+
 ## [1.1.7] - 2026-05-31
 
 ### Fixed

--- a/plugins/claude-code-hermit/scripts/archive-compiled.js
+++ b/plugins/claude-code-hermit/scripts/archive-compiled.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// archive-compiled.js — rotates old compiled artifacts into compiled/.archive/
+// Zero npm dependencies. Node stdlib only.
+// Usage: node archive-compiled.js <hermit-state-dir>
+//   hermit-state-dir: path to .claude-code-hermit/ in the target project (default: .claude-code-hermit)
+//
+// Retention: keeps the newest KEEP_PER_TYPE artifacts per type; foundational-tagged
+// artifacts are always retained and excluded from the per-type count.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { readFrontmatter, globDir } = require('./lib/frontmatter');
+
+const KEEP_PER_TYPE = 2;
+
+const hermitDir = process.argv[2] || '.claude-code-hermit';
+const compiledDir = path.join(hermitDir, 'compiled');
+const archiveDir = path.join(compiledDir, '.archive');
+
+const fullPaths = globDir(compiledDir, /^[^.].*\.md$/);
+if (fullPaths.length === 0) {
+  console.log('compiled/ does not exist or is empty — nothing to archive.');
+  process.exit(0);
+}
+
+fs.mkdirSync(archiveDir, { recursive: true });
+
+let archived = 0;
+let retained = 0;
+let skipped = 0;
+
+const artifacts = [];
+for (const filePath of fullPaths) {
+  const filename = path.basename(filePath);
+  const fm = readFrontmatter(filePath);
+
+  if (!fm || !fm.type || !fm.created) {
+    skipped++;
+    continue;
+  }
+
+  const created = new Date(fm.created);
+  if (isNaN(created.getTime())) {
+    skipped++;
+    continue;
+  }
+
+  artifacts.push({ filePath, filename, fm, created });
+}
+
+const rotatable = [];
+for (const a of artifacts) {
+  if ((a.fm.tags || []).includes('foundational')) {
+    retained++;
+  } else {
+    rotatable.push(a);
+  }
+}
+
+const byType = new Map();
+for (const a of rotatable) {
+  if (!byType.has(a.fm.type)) byType.set(a.fm.type, []);
+  byType.get(a.fm.type).push(a);
+}
+
+for (const [, group] of byType) {
+  group.sort((a, b) => b.created - a.created);
+
+  for (let i = 0; i < group.length; i++) {
+    if (i < KEEP_PER_TYPE) {
+      retained++;
+      continue;
+    }
+    const dest = path.join(archiveDir, group[i].filename);
+    try {
+      fs.renameSync(group[i].filePath, dest);
+      archived++;
+    } catch {
+      skipped++;
+    }
+  }
+}
+
+console.log(`archive-compiled: ${archived} archived, ${retained} retained, ${skipped} skipped.`);
+if (archived > 0) {
+  console.log(`Archived to ${archiveDir}`);
+}

--- a/plugins/claude-code-hermit/scripts/archive-compiled.js
+++ b/plugins/claude-code-hermit/scripts/archive-compiled.js
@@ -73,7 +73,12 @@ for (const [, group] of byType) {
       retained++;
       continue;
     }
-    const dest = path.join(archiveDir, group[i].filename);
+    let dest = path.join(archiveDir, group[i].filename);
+    if (fs.existsSync(dest)) {
+      const ext = path.extname(dest);
+      const base = path.basename(dest, ext);
+      dest = path.join(archiveDir, `${base}-${Date.now()}${ext}`);
+    }
     try {
       fs.renameSync(group[i].filePath, dest);
       archived++;

--- a/plugins/claude-code-hermit/scripts/knowledge-lint.js
+++ b/plugins/claude-code-hermit/scripts/knowledge-lint.js
@@ -275,7 +275,8 @@ function lint(hermitDir, options = {}) {
   // --- Counts ---
   let archivedCount = 0;
   try {
-    archivedCount = globDirRecursive(archiveDir).length;
+    archivedCount = globDirRecursive(archiveDir).length
+                  + globDirRecursive(path.join(compiledDir, '.archive')).length;
   } catch {}
 
   return {

--- a/plugins/claude-code-hermit/skills/weekly-review/SKILL.md
+++ b/plugins/claude-code-hermit/skills/weekly-review/SKILL.md
@@ -45,8 +45,15 @@ Generates the weekly review for the current ISO week.
    ```
    Report how many were archived, retained, and skipped.
 
+6. Archive superseded compiled artifacts:
+   ```
+   node ${CLAUDE_PLUGIN_ROOT}/scripts/archive-compiled.js .claude-code-hermit
+   ```
+   Report how many were archived, retained, and skipped.
+
 ## Notes
 
 - Safe to run manually at any time — re-runs overwrite the current week's review.
 - The routine is enabled by default for new installs. Existing operators who haven't opted in can enable it via `/claude-code-hermit:hermit-settings`.
 - `archive-raw.js` only moves files — it never deletes. Archived files land in `raw/.archive/` and can be restored manually.
+- `archive-compiled.js` only moves files — it never deletes. Keeps the newest 2 artifacts per type; `foundational`-tagged artifacts are always retained. Archived files land in `compiled/.archive/` and can be restored manually.

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -16,6 +16,7 @@ bash "$SCRIPT_DIR/test-docker-baseline-content.sh"   || rc=$?
 bash "$SCRIPT_DIR/test-template-skill-sync.sh"       || rc=$?
 bash "$SCRIPT_DIR/test-hatch-options-contract.sh"    || rc=$?
 bash "$SCRIPT_DIR/test-archive-shell.sh"             || rc=$?
+bash "$SCRIPT_DIR/test-archive-compiled.sh"         || rc=$?
 bash "$SCRIPT_DIR/test-hook-registration-form.sh"          || rc=$?
 bash "$SCRIPT_DIR/test-channel-responder-reply-rule.sh"    || rc=$?
 bash "$SCRIPT_DIR/test-proposal-act-accept-flow.sh"        || rc=$?

--- a/plugins/claude-code-hermit/tests/test-archive-compiled.sh
+++ b/plugins/claude-code-hermit/tests/test-archive-compiled.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tests for archive-compiled.js — rotates old compiled artifacts.
+# Usage: bash tests/test-archive-compiled.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "=== archive-compiled.js ==="
+echo ""
+
+ARCHIVE="$REPO_ROOT/scripts/archive-compiled.js"
+
+# Helper: write a minimal compiled artifact with given type, created date, and optional tags.
+write_artifact() {
+  local dir="$1" name="$2" type="$3" created="$4" tags="${5:-}"
+  local tags_line=""
+  [ -n "$tags" ] && tags_line=$'\n'"tags: [$tags]"
+  printf -- "---\ntype: %s\ncreated: %s%s\n---\nBody content.\n" \
+    "$type" "$created" "$tags_line" > "$dir/$name"
+}
+
+# -------------------------------------------------------
+# 1. Basic rotation: 3 artifacts of the same type → 1 archived (oldest), 2 retained
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/compiled"
+d="$workdir/.claude-code-hermit/compiled"
+write_artifact "$d" "review-2025-W01.md" "review" "2025-01-05T00:00:00.000Z"
+write_artifact "$d" "review-2025-W02.md" "review" "2025-01-12T00:00:00.000Z"
+write_artifact "$d" "review-2025-W03.md" "review" "2025-01-19T00:00:00.000Z"
+
+out="$(node "$ARCHIVE" "$workdir/.claude-code-hermit")"
+run_test "rotation: oldest archived" bash -c "[ -f '$d/.archive/review-2025-W01.md' ]"
+run_test "rotation: W02 retained" bash -c "[ -f '$d/review-2025-W02.md' ]"
+run_test "rotation: W03 retained" bash -c "[ -f '$d/review-2025-W03.md' ]"
+run_test "rotation: 1 archived in output" bash -c "echo '$out' | grep -qF '1 archived'"
+run_test "rotation: 2 retained in output" bash -c "echo '$out' | grep -qF '2 retained'"
+rm -rf "$workdir"
+
+# -------------------------------------------------------
+# 2. Foundational exemption: foundational artifact is never archived
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/compiled"
+d="$workdir/.claude-code-hermit/compiled"
+write_artifact "$d" "review-2025-W01.md" "review" "2025-01-05T00:00:00.000Z"
+write_artifact "$d" "review-2025-W02.md" "review" "2025-01-12T00:00:00.000Z"
+# Oldest date but tagged foundational — must not be archived
+write_artifact "$d" "review-old-foundational.md" "review" "2024-01-01T00:00:00.000Z" "foundational"
+
+out="$(node "$ARCHIVE" "$workdir/.claude-code-hermit")"
+run_test "foundational: not archived" bash -c "[ -f '$d/review-old-foundational.md' ]"
+run_test "foundational: .archive/ not created (nothing else to archive)" \
+  bash -c "[ ! -d '$d/.archive' ] || [ \$(ls '$d/.archive/' 2>/dev/null | wc -l) -eq 0 ]"
+run_test "foundational: 0 archived in output" bash -c "echo '$out' | grep -qF '0 archived'"
+rm -rf "$workdir"
+
+# -------------------------------------------------------
+# 3. Skipped: artifact missing type or created → left in place, counted as skipped
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/compiled"
+d="$workdir/.claude-code-hermit/compiled"
+# Missing type
+printf -- "---\ncreated: 2025-01-05T00:00:00.000Z\n---\nBody.\n" > "$d/no-type.md"
+# Missing created
+printf -- "---\ntype: note\n---\nBody.\n" > "$d/no-created.md"
+
+out="$(node "$ARCHIVE" "$workdir/.claude-code-hermit")"
+run_test "skipped: no-type.md left in place" bash -c "[ -f '$d/no-type.md' ]"
+run_test "skipped: no-created.md left in place" bash -c "[ -f '$d/no-created.md' ]"
+run_test "skipped: 2 skipped in output" bash -c "echo '$out' | grep -qF '2 skipped'"
+rm -rf "$workdir"
+
+# -------------------------------------------------------
+# 4. Fail-open: no state dir → exit 0
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+node "$ARCHIVE" "$workdir/nonexistent" >/dev/null 2>&1
+ec=$?
+run_test "fail-open: exit 0 with no state dir" bash -c "[ $ec -eq 0 ]"
+rm -rf "$workdir"
+
+# -------------------------------------------------------
+# Summary
+# -------------------------------------------------------
+print_results


### PR DESCRIPTION
## Summary

`compiled/` artifacts accumulated indefinitely — weekly review files in particular pile up at one per week with no GC. This adds `archive-compiled.js` as a non-destructive companion to the existing `archive-raw.js`, wired into `weekly-review` as Step 6. The main practical payoff is eliminating multiplied `oversized` lint findings in the weekly Knowledge Health report (the lint check scans all compiled files, not just the injected working set).

Note: context injection is unaffected — `startup-context.js` already injects only the newest artifact per type via `newestByType()`, so accumulation never caused context bloat.

## Changes

- **`scripts/archive-compiled.js`** (new): groups `compiled/*.md` by `type`, sorts by `created` descending, keeps the newest 2 per type (`KEEP_PER_TYPE = 2` hardcoded), moves overflow to `compiled/.archive/`. Foundational-tagged artifacts (`tags: [foundational]`) are always retained. Zero deps, fail-open, mirrors `archive-raw.js` structure.
- **`scripts/knowledge-lint.js`**: includes `compiled/.archive` in the `archived` count so the lint summary stays accurate once compiled archiving starts.
- **`skills/weekly-review/SKILL.md`**: wires in Step 6 + Notes bullet alongside the existing `archive-raw.js` step.
- **`tests/test-archive-compiled.sh`** (new): 12 tests covering rotation, foundational exemption, missing-field skip, and fail-open. Registered in `run-all.sh`.

Deliberately simpler than the filed proposal: no config key (housekeeping with no real per-operator variance), no schema parse (group by `fm.type` directly), no reference-safety check (keep-newest-N + foundational exemption is sufficient).

## Test plan

- `bash plugins/claude-code-hermit/tests/run-all.sh` — all 290 tests pass including new `test-archive-compiled.sh` (12/12).
- Manual: create 3 same-type compiled artifacts, run `node scripts/archive-compiled.js <dir>`, confirm oldest moves to `compiled/.archive/` and two newest remain.

Closes #201