### PR TITLE
feat(claude-code-hermit): surface compiled/ schema drift at session start

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **startup-context: schema-drift warning at session start** — surfaces a "Schema Drift" block when any `compiled/` artifact has a `type` not declared in `knowledge-schema.md ## Work Products`, closing the up-to-7-day lag before the weekly Knowledge Health check fires. Silent when schema is absent/empty (weekly review handles that) or when all types are declared. Reuses the existing `parseSchema` logic from `knowledge-lint.js`. Closes #208.
+
 ## [1.1.7] - 2026-05-31
 
 ### Fixed

--- a/plugins/claude-code-hermit/scripts/knowledge-lint.js
+++ b/plugins/claude-code-hermit/scripts/knowledge-lint.js
@@ -331,4 +331,4 @@ if (require.main === module) {
   console.log(`\n(${counts.raw} raw, ${counts.compiled} compiled, ${counts.archived} archived)`);
 }
 
-module.exports = { lint };
+module.exports = { lint, parseSchema };

--- a/plugins/claude-code-hermit/scripts/startup-context.js
+++ b/plugins/claude-code-hermit/scripts/startup-context.js
@@ -11,7 +11,8 @@ process.stdout.on('error', () => {});
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { readFileWithFrontmatter, newestByType, globDir } = require('./lib/frontmatter');
+const { readFrontmatter, readFileWithFrontmatter, newestByType, globDir } = require('./lib/frontmatter');
+const { parseSchema } = require('./knowledge-lint');
 
 const AGENT_DIR = process.env.AGENT_DIR || '.claude-code-hermit';
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..');
@@ -24,6 +25,7 @@ const BUDGETS = {
   operator:      2000,
   session:       3000,
   knowledge:     1000, // compiled/ artifacts — read from config, 1000 default
+  schemaDrift:    400, // only emitted when compiled/ types are undeclared in knowledge-schema.md
   storageDrift:   500, // only emitted when misplaced files are found
   cost:           500,
   report:        1500,
@@ -251,6 +253,34 @@ function main() {
         const suffix = hits.length > 5 ? `\n(${hits.length - 5} more)` : '';
         const body = `${hits.length} path${hits.length !== 1 ? 's' : ''} invisible to session injection and archival:\n${lines}${suffix}\nMove files into .claude-code-hermit/raw/ or compiled/ (flat). See docs/plugin-hermit-storage.md.`;
         emit('Storage Drift', body.slice(0, BUDGETS.storageDrift));
+      }
+    } catch {}
+  }
+
+  // -------------------------------------------------------
+  // 5b. Schema drift (priority 2.9, budget 400 — silent when clean or no schema)
+  // -------------------------------------------------------
+  if (totalChars < HARD_CAP) {
+    try {
+      const schemaPath = path.resolve(AGENT_DIR, 'knowledge-schema.md');
+      const schema = parseSchema(schemaPath);
+      if (schema) {
+        const compiledDir = path.resolve(AGENT_DIR, 'compiled');
+        const compiledFiles = globDir(compiledDir, /^[^.].*\.md$/);
+        const undeclared = new Map(); // type -> first filename
+        for (const f of compiledFiles) {
+          const fm = readFrontmatter(f);
+          if (!fm || !fm.type) continue;
+          if (!schema.workProducts.has(fm.type) && !undeclared.has(fm.type)) {
+            undeclared.set(fm.type, path.basename(f));
+          }
+        }
+        if (undeclared.size > 0) {
+          const lines = Array.from(undeclared.entries())
+            .map(([t, f]) => `- \`${t}\` (e.g. compiled/${f})`).join('\n');
+          const body = `${undeclared.size} undeclared type${undeclared.size !== 1 ? 's' : ''} in compiled/ — add to knowledge-schema.md ## Work Products:\n${lines}`;
+          emit('Schema Drift', body.slice(0, BUDGETS.schemaDrift));
+        }
       }
     } catch {}
   }

--- a/plugins/claude-code-hermit/tests/run-hooks.sh
+++ b/plugins/claude-code-hermit/tests/run-hooks.sh
@@ -384,6 +384,30 @@ run_test "startup-context (section priority)" bash -c \
   "out=\$(CLAUDE_PLUGIN_ROOT='$REPO_ROOT' node '$REPO_ROOT/scripts/startup-context.js' 2>/dev/null); echo \"\$out\" | grep -q 'Operator' && [ \${#out} -lt 8000 ]"
 cleanup
 
+# 37a. startup-context — schema drift: undeclared compiled type surfaces warning
+workdir="$(setup_workdir)"
+cd "$workdir"
+mkdir -p "$workdir/.claude-code-hermit/compiled"
+printf -- '---\ntitle: Test\ntype: undeclared-widget\ncreated: 2025-01-01\n---\nBody.\n' \
+  > "$workdir/.claude-code-hermit/compiled/test-artifact.md"
+printf -- '## Work Products\n- known-type: a declared type\n\n## Raw Captures\n' \
+  > "$workdir/.claude-code-hermit/knowledge-schema.md"
+run_test "startup-context (schema drift — undeclared type)" bash -c \
+  "AGENT_DIR='$workdir/.claude-code-hermit' CLAUDE_PLUGIN_ROOT='$REPO_ROOT' node '$REPO_ROOT/scripts/startup-context.js' | grep -qF -- 'undeclared-widget'"
+cleanup
+
+# 37b. startup-context — schema drift: declared type is silent
+workdir="$(setup_workdir)"
+cd "$workdir"
+mkdir -p "$workdir/.claude-code-hermit/compiled"
+printf -- '---\ntitle: Test\ntype: known-type\ncreated: 2025-01-01\n---\nBody.\n' \
+  > "$workdir/.claude-code-hermit/compiled/test-artifact.md"
+printf -- '## Work Products\n- known-type: a declared type\n\n## Raw Captures\n' \
+  > "$workdir/.claude-code-hermit/knowledge-schema.md"
+run_test "startup-context (schema drift — declared type, no warning)" bash -c \
+  "! AGENT_DIR='$workdir/.claude-code-hermit' CLAUDE_PLUGIN_ROOT='$REPO_ROOT' node '$REPO_ROOT/scripts/startup-context.js' | grep -qF -- 'Schema Drift'"
+cleanup
+
 # -------------------------------------------------------
 # generate-summary tests
 # -------------------------------------------------------

--- a/plugins/claude-code-hermit/tests/run-hooks.sh
+++ b/plugins/claude-code-hermit/tests/run-hooks.sh
@@ -393,7 +393,7 @@ printf -- '---\ntitle: Test\ntype: undeclared-widget\ncreated: 2025-01-01\n---\n
 printf -- '## Work Products\n- known-type: a declared type\n\n## Raw Captures\n' \
   > "$workdir/.claude-code-hermit/knowledge-schema.md"
 run_test "startup-context (schema drift — undeclared type)" bash -c \
-  "AGENT_DIR='$workdir/.claude-code-hermit' CLAUDE_PLUGIN_ROOT='$REPO_ROOT' node '$REPO_ROOT/scripts/startup-context.js' | grep -qF -- 'undeclared-widget'"
+  "out=\$(AGENT_DIR='$workdir/.claude-code-hermit' CLAUDE_PLUGIN_ROOT='$REPO_ROOT' node '$REPO_ROOT/scripts/startup-context.js'); echo \"\$out\" | grep -qF -- '---Schema Drift---' && echo \"\$out\" | grep -qF -- 'undeclared-widget'"
 cleanup
 
 # 37b. startup-context — schema drift: declared type is silent


### PR DESCRIPTION
## Summary

Undeclared `compiled/` artifact types were only surfaced by the weekly Knowledge Health check, creating up to a 7-day lag before operators see warnings. This adds an immediate "Schema Drift" block at session start that flags any `compiled/` artifact whose `type` field is not declared in `knowledge-schema.md ## Work Products`.

## Changes

- **`scripts/knowledge-lint.js`** — exports `parseSchema` (previously internal-only), so callers don't need to re-implement the bullet-grammar parser
- **`scripts/startup-context.js`** — new section 5b "Schema Drift": parses `knowledge-schema.md` once per session start, re-globs `compiled/` (independent of section 4's artifact list, which drops entries lacking `fm.created`), collects distinct undeclared types, emits a char-capped block. Silent when schema is absent/empty (weekly review handles that separately). Fails open like all other sections
- **`tests/run-hooks.sh`** — two new tests in the startup-context section: undeclared type surfaces the block; declared type is silent

## Test plan

- `bash plugins/claude-code-hermit/tests/run-hooks.sh` — 74/74 pass, including new tests 37a and 37b
- Manual smoke-test confirmed: undeclared type emits `---Schema Drift---` block naming the type; declared type produces no block

Closes #208