### PR TITLE
fix(archive-raw): name each skipped file and reason in output

### DIFF
--- a/plugins/claude-code-hermit/scripts/archive-raw.js
+++ b/plugins/claude-code-hermit/scripts/archive-raw.js
@@ -49,7 +49,7 @@ fs.mkdirSync(archiveDir, { recursive: true });
 
 let archived = 0;
 let retained = 0;
-let skipped = 0;
+const skippedFiles = []; // { file, reason } — surfaced by name so operators can fix the root cause
 
 for (const filePath of rawFullPaths) {
   const filename = path.basename(filePath);
@@ -57,13 +57,13 @@ for (const filePath of rawFullPaths) {
 
   // Skip if no frontmatter or no created date — can't determine age
   if (!fm || !fm.created) {
-    skipped++;
+    skippedFiles.push({ file: filename, reason: 'missing created: frontmatter' });
     continue;
   }
 
   const created = new Date(fm.created);
   if (isNaN(created.getTime())) {
-    skipped++;
+    skippedFiles.push({ file: filename, reason: `unparseable created: "${fm.created}"` });
     continue;
   }
 
@@ -92,12 +92,15 @@ for (const filePath of rawFullPaths) {
   try {
     fs.renameSync(filePath, dest);
     archived++;
-  } catch {
-    skipped++;
+  } catch (err) {
+    skippedFiles.push({ file: filename, reason: `move failed: ${err.message}` });
   }
 }
 
-console.log(`archive-raw: ${archived} archived, ${retained} retained, ${skipped} skipped.`);
+console.log(`archive-raw: ${archived} archived, ${retained} retained, ${skippedFiles.length} skipped.`);
 if (archived > 0) {
   console.log(`Archived to ${archiveDir}`);
+}
+for (const { file, reason } of skippedFiles) {
+  console.log(`archive-raw: skipped ${file} — ${reason}`);
 }

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -22,4 +22,5 @@ bash "$SCRIPT_DIR/test-proposal-act-accept-flow.sh"        || rc=$?
 bash "$SCRIPT_DIR/test-simplify-totals-contract.sh"        || rc=$?
 bash "$SCRIPT_DIR/test-auto-close.sh"                      || rc=$?
 bash "$SCRIPT_DIR/test-evolve-plan.sh"                     || rc=$?
+bash "$SCRIPT_DIR/test-archive-raw.sh"                     || rc=$?
 exit $rc

--- a/plugins/claude-code-hermit/tests/test-archive-raw.sh
+++ b/plugins/claude-code-hermit/tests/test-archive-raw.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Tests for archive-raw.js — raw artifact archival and skip diagnostics.
+# Usage: bash tests/test-archive-raw.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "=== archive-raw.js ==="
+echo ""
+
+SCRIPT="$REPO_ROOT/scripts/archive-raw.js"
+created_old="$(date -u -d '30 days ago' '+%Y-%m-%d' 2>/dev/null || date -u -v-30d '+%Y-%m-%d')"
+
+# -------------------------------------------------------
+# 1. Empty raw/ — nothing to archive
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/raw"
+out="$(node "$SCRIPT" "$workdir/.claude-code-hermit")"
+run_test "empty raw/: nothing to archive message" bash -c "echo '$out' | grep -q 'nothing to archive'"
+cleanup
+
+# -------------------------------------------------------
+# 2. Valid expired unreferenced file — archived
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/raw"
+mkdir -p "$workdir/.claude-code-hermit/compiled"
+# created 30 days ago (past default 14-day retention)
+cat > "$workdir/.claude-code-hermit/raw/old-note.md" <<EOF
+---
+created: $created_old
+type: input
+---
+Old content.
+EOF
+out="$(node "$SCRIPT" "$workdir/.claude-code-hermit")"
+run_test "valid expired: 1 archived" bash -c "echo '$out' | grep -qF '1 archived'"
+run_test "valid expired: 0 skipped" bash -c "echo '$out' | grep -qF '0 skipped'"
+run_test "valid expired: file moved to .archive/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/.archive/old-note.md' ]"
+run_test "valid expired: file no longer in raw/" bash -c \
+  "[ ! -f '$workdir/.claude-code-hermit/raw/old-note.md' ]"
+cleanup
+
+# -------------------------------------------------------
+# 3. File with no created: key — skipped with named reason
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/raw"
+cat > "$workdir/.claude-code-hermit/raw/no-date.md" <<'EOF'
+---
+type: input
+---
+Missing created field.
+EOF
+out="$(node "$SCRIPT" "$workdir/.claude-code-hermit")"
+run_test "missing created: 1 skipped" bash -c "echo '$out' | grep -qF '1 skipped'"
+run_test "missing created: named in output" bash -c "echo '$out' | grep -qF 'no-date.md'"
+run_test "missing created: reason text" bash -c "echo '$out' | grep -q 'missing created'"
+run_test "missing created: file stays in raw/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/no-date.md' ]"
+cleanup
+
+# -------------------------------------------------------
+# 4. File with malformed created: value — skipped with named reason
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/raw"
+cat > "$workdir/.claude-code-hermit/raw/bad-date.md" <<'EOF'
+---
+created: not-a-date
+type: input
+---
+Bad date value.
+EOF
+out="$(node "$SCRIPT" "$workdir/.claude-code-hermit")"
+run_test "malformed created: 1 skipped" bash -c "echo '$out' | grep -qF '1 skipped'"
+run_test "malformed created: named in output" bash -c "echo '$out' | grep -qF 'bad-date.md'"
+run_test "malformed created: unparseable reason" bash -c "echo '$out' | grep -q 'unparseable'"
+cleanup
+
+# -------------------------------------------------------
+# 5. Referenced file — retained even if past retention
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/raw"
+mkdir -p "$workdir/.claude-code-hermit/compiled"
+cat > "$workdir/.claude-code-hermit/raw/referenced.md" <<EOF
+---
+created: $created_old
+type: input
+---
+Referenced content.
+EOF
+cat > "$workdir/.claude-code-hermit/compiled/briefing.md" <<'EOF'
+---
+type: note
+---
+See referenced.md for context.
+EOF
+out="$(node "$SCRIPT" "$workdir/.claude-code-hermit")"
+run_test "referenced: 1 retained" bash -c "echo '$out' | grep -qF '1 retained'"
+run_test "referenced: 0 archived" bash -c "echo '$out' | grep -qF '0 archived'"
+run_test "referenced: file stays in raw/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/referenced.md' ]"
+cleanup
+
+# -------------------------------------------------------
+# 6. Mixed bag: valid+expired, missing-created, malformed-created, referenced
+#    Summary counts and per-file skip lines all present
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/raw"
+mkdir -p "$workdir/.claude-code-hermit/compiled"
+
+cat > "$workdir/.claude-code-hermit/raw/archivable.md" <<EOF
+---
+created: $created_old
+type: input
+---
+Archivable.
+EOF
+cat > "$workdir/.claude-code-hermit/raw/no-created.md" <<'EOF'
+---
+type: input
+---
+No created.
+EOF
+cat > "$workdir/.claude-code-hermit/raw/bad-created.md" <<'EOF'
+---
+created: oops
+type: input
+---
+Bad.
+EOF
+cat > "$workdir/.claude-code-hermit/raw/kept.md" <<EOF
+---
+created: $created_old
+type: input
+---
+Kept.
+EOF
+cat > "$workdir/.claude-code-hermit/compiled/ref.md" <<'EOF'
+---
+type: note
+---
+kept.md is referenced here.
+EOF
+
+out="$(node "$SCRIPT" "$workdir/.claude-code-hermit")"
+run_test "mixed: 1 archived" bash -c "echo '$out' | grep -qF '1 archived'"
+run_test "mixed: 1 retained" bash -c "echo '$out' | grep -qF '1 retained'"
+run_test "mixed: 2 skipped" bash -c "echo '$out' | grep -qF '2 skipped'"
+run_test "mixed: no-created.md named" bash -c "echo '$out' | grep -qF 'no-created.md'"
+run_test "mixed: bad-created.md named" bash -c "echo '$out' | grep -qF 'bad-created.md'"
+cleanup
+
+# -------------------------------------------------------
+# 7. Exit code is always 0 (fail-open)
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+node "$SCRIPT" "$workdir/nonexistent-hermit" >/dev/null 2>&1
+ec=$?
+run_test "fail-open: exit 0 with missing state dir" bash -c "[ $ec -eq 0 ]"
+cleanup
+
+# -------------------------------------------------------
+# Summary
+# -------------------------------------------------------
+print_results


### PR DESCRIPTION
## Summary

`archive-raw.js` silently folded all unskippable files into a single `skipped` count. Files with missing or malformed `created:` frontmatter stayed in `raw/` indefinitely with no breadcrumb to the root cause. This change names each skipped file and the specific reason so the weekly-review skill's model can surface actionable diagnostics to the operator.

## Changes

- `scripts/archive-raw.js` — replaced the `skipped` counter with a `skippedFiles` array; emits one `archive-raw: skipped <file> — <reason>` line per unskippable file (`missing created: frontmatter`, `unparseable created: "…"`, or `move failed: …`). Summary line count is unchanged in the happy path.
- `tests/test-archive-raw.sh` — new test file: 7 cases / 21 assertions covering empty dir, valid archive, missing `created:`, malformed `created:`, referenced-retain, mixed bag, and fail-open. Wired into `run-all.sh`.

Closes #210

## Test plan

```bash
cd plugins/claude-code-hermit
bash tests/test-archive-raw.sh   # 21/21 pass
bash tests/run-all.sh            # full suite green
```