### PR TITLE
fix(archive-raw): cover dated .json snapshots and pin -latest aliases

### DIFF
--- a/plugins/claude-code-hermit/docs/plugin-hermit-storage.md
+++ b/plugins/claude-code-hermit/docs/plugin-hermit-storage.md
@@ -9,7 +9,7 @@ Everything else is infra managed by the base hermit (`state/`, `sessions/`, `pro
 
 ## Why these two and nothing else
 
-The `compiled/` directory is scanned at session start to inject foundational context. `scripts/archive-raw.js` and the weekly review run retention only against `raw/`. Anything outside these two paths is invisible to both mechanisms — your audits won't surface at session start, and your snapshots will never be archived.
+The `compiled/` directory is scanned at session start to inject foundational context. `scripts/archive-raw.js` and the weekly review run retention against `raw/`, covering both dated `.md` and `.json` artifacts. Fixed-name `-latest.*` aliases are never archived. Anything outside these two paths is invisible to both mechanisms — your audits won't surface at session start, and your snapshots will never be archived.
 
 This mirrors the Karpathy raw-vs-compiled split: raw is the immutable ground truth, compiled is the LLM-maintained derivative. The filesystem layout is fixed; the `type` field in frontmatter is what differentiates work products within each directory.
 

--- a/plugins/claude-code-hermit/scripts/archive-raw.js
+++ b/plugins/claude-code-hermit/scripts/archive-raw.js
@@ -38,7 +38,7 @@ for (const fullPath of globDir(compiledDir, /^[^.].*\.md$/)) {
 }
 
 // --- Scan raw/ ---
-const rawFullPaths = globDir(rawDir, /^[^.].*\.md$/);
+const rawFullPaths = globDir(rawDir, /^[^.].*\.(md|json)$/);
 if (rawFullPaths.length === 0) {
   console.log('raw/ does not exist or is empty — nothing to archive.');
   process.exit(0);
@@ -50,19 +50,26 @@ fs.mkdirSync(archiveDir, { recursive: true });
 let archived = 0;
 let retained = 0;
 let skipped = 0;
+let pinned = 0;
 
 for (const filePath of rawFullPaths) {
   const filename = path.basename(filePath);
-  const fm = readFrontmatter(filePath);
 
-  // Skip if no frontmatter or no created date — can't determine age
-  if (!fm || !fm.created) {
-    skipped++;
+  // Pin -latest.* aliases — they're overwritten in place, never accumulate
+  if (/-latest\.(md|json)$/.test(filename)) {
+    pinned++;
     continue;
   }
 
-  const created = new Date(fm.created);
-  if (isNaN(created.getTime())) {
+  // Resolve artifact age: prefer frontmatter `created`, fall back to YYYY-MM-DD in filename
+  const fm = readFrontmatter(filePath);
+  let created = fm && fm.created ? new Date(fm.created) : null;
+  if (!created || isNaN(created.getTime())) {
+    const m = filename.match(/(\d{4}-\d{2}-\d{2})/);
+    created = m ? new Date(m[1]) : null;
+  }
+
+  if (!created || isNaN(created.getTime())) {
     skipped++;
     continue;
   }
@@ -97,7 +104,7 @@ for (const filePath of rawFullPaths) {
   }
 }
 
-console.log(`archive-raw: ${archived} archived, ${retained} retained, ${skipped} skipped.`);
+console.log(`archive-raw: ${archived} archived, ${retained} retained, ${skipped} skipped, ${pinned} pinned (-latest).`);
 if (archived > 0) {
   console.log(`Archived to ${archiveDir}`);
 }

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -22,4 +22,5 @@ bash "$SCRIPT_DIR/test-proposal-act-accept-flow.sh"        || rc=$?
 bash "$SCRIPT_DIR/test-simplify-totals-contract.sh"        || rc=$?
 bash "$SCRIPT_DIR/test-auto-close.sh"                      || rc=$?
 bash "$SCRIPT_DIR/test-evolve-plan.sh"                     || rc=$?
+bash "$SCRIPT_DIR/test-archive-raw.sh"                     || rc=$?
 exit $rc

--- a/plugins/claude-code-hermit/tests/test-archive-raw.sh
+++ b/plugins/claude-code-hermit/tests/test-archive-raw.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Tests for archive-raw.js — retention, -latest pinning, .json support, filename-date fallback.
+# Usage: bash tests/test-archive-raw.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "=== archive-raw.js ==="
+echo ""
+
+ARCHIVE="$REPO_ROOT/scripts/archive-raw.js"
+# archive-raw.js uses Date.now() directly; to control "now" we manipulate file dates via filenames.
+# We use dates well in the past (2020) to guarantee they're expired under any retention window.
+PAST="2020-01-01"
+RECENT="2099-12-31"
+
+# -------------------------------------------------------
+# Helper: make a minimal hermit state dir with raw/ and config.json
+# -------------------------------------------------------
+make_hermit() {
+  local dir
+  dir="$(mktemp -d)"
+  mkdir -p "$dir/.claude-code-hermit/raw"
+  mkdir -p "$dir/.claude-code-hermit/compiled"
+  cat > "$dir/.claude-code-hermit/config.json" <<'EOF'
+{"knowledge":{"raw_retention_days":14}}
+EOF
+  echo "$dir"
+}
+
+# -------------------------------------------------------
+# 1. Expired dated .md with frontmatter → archived
+# -------------------------------------------------------
+workdir="$(make_hermit)"
+cat > "$workdir/.claude-code-hermit/raw/note-${PAST}.md" <<EOF
+---
+title: Old note
+type: input
+created: ${PAST}T00:00:00Z
+tags: []
+---
+body
+EOF
+out="$(cd "$workdir" && node "$ARCHIVE" .claude-code-hermit 2>&1)"
+run_test "md frontmatter: archived (output says 1 archived)" bash -c "echo '$out' | grep -qE '^archive-raw: 1 archived, 0 retained, 0 skipped, 0 pinned'"
+run_test "md frontmatter: file moved to .archive/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/.archive/note-${PAST}.md' ] && [ ! -f '$workdir/.claude-code-hermit/raw/note-${PAST}.md' ]"
+cleanup
+
+# -------------------------------------------------------
+# 2. Expired dated .json with YYYY-MM-DD in filename, no frontmatter → archived via filename fallback
+# -------------------------------------------------------
+workdir="$(make_hermit)"
+echo '{"entities":[]}' > "$workdir/.claude-code-hermit/raw/snapshot-ha-context-${PAST}.json"
+out="$(cd "$workdir" && node "$ARCHIVE" .claude-code-hermit 2>&1)"
+run_test "json filename-date: archived (output says 1 archived)" bash -c "echo '$out' | grep -qE '^archive-raw: 1 archived, 0 retained, 0 skipped, 0 pinned'"
+run_test "json filename-date: file moved to .archive/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/.archive/snapshot-ha-context-${PAST}.json' ] && [ ! -f '$workdir/.claude-code-hermit/raw/snapshot-ha-context-${PAST}.json' ]"
+cleanup
+
+# -------------------------------------------------------
+# 3. -latest.md and -latest.json → pinned, never archived even when old
+# -------------------------------------------------------
+workdir="$(make_hermit)"
+cat > "$workdir/.claude-code-hermit/raw/patterns-latest.md" <<EOF
+---
+title: Latest patterns
+type: analysis
+created: ${PAST}T00:00:00Z
+tags: []
+---
+body
+EOF
+echo '{"entities":[]}' > "$workdir/.claude-code-hermit/raw/snapshot-ha-normalized-latest.json"
+out="$(cd "$workdir" && node "$ARCHIVE" .claude-code-hermit 2>&1)"
+run_test "latest alias: output says 0 archived" bash -c "echo '$out' | grep -qE '^archive-raw: 0 archived'"
+run_test "latest alias: pinned count = 2" bash -c "echo '$out' | grep -qE '2 pinned'"
+run_test "latest alias: patterns-latest.md still in raw/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/patterns-latest.md' ]"
+run_test "latest alias: snapshot-ha-normalized-latest.json still in raw/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/snapshot-ha-normalized-latest.json' ]"
+cleanup
+
+# -------------------------------------------------------
+# 4. .json with no date in filename and no frontmatter → skipped
+# -------------------------------------------------------
+workdir="$(make_hermit)"
+echo '{"state":"unknown"}' > "$workdir/.claude-code-hermit/raw/nodatefile.json"
+out="$(cd "$workdir" && node "$ARCHIVE" .claude-code-hermit 2>&1)"
+run_test "json no-date: output says 1 skipped" bash -c "echo '$out' | grep -qE '^archive-raw: 0 archived, 0 retained, 1 skipped'"
+run_test "json no-date: file still in raw/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/nodatefile.json' ]"
+cleanup
+
+# -------------------------------------------------------
+# 5. Recent dated .json (not yet expired) → retained
+# -------------------------------------------------------
+workdir="$(make_hermit)"
+echo '{"entities":[]}' > "$workdir/.claude-code-hermit/raw/snapshot-ha-context-${RECENT}.json"
+out="$(cd "$workdir" && node "$ARCHIVE" .claude-code-hermit 2>&1)"
+run_test "json recent: output says 1 retained" bash -c "echo '$out' | grep -qE '^archive-raw: 0 archived, 1 retained'"
+run_test "json recent: file still in raw/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/snapshot-ha-context-${RECENT}.json' ]"
+cleanup
+
+# -------------------------------------------------------
+# 6. Expired .json referenced by a compiled/ artifact → retained (safety check)
+# -------------------------------------------------------
+workdir="$(make_hermit)"
+echo '{"entities":[]}' > "$workdir/.claude-code-hermit/raw/snapshot-ha-context-${PAST}.json"
+cat > "$workdir/.claude-code-hermit/compiled/briefing-2020-01-05.md" <<'EOF'
+---
+title: Briefing
+type: briefing
+---
+See snapshot-ha-context-2020-01-01.json for details.
+EOF
+out="$(cd "$workdir" && node "$ARCHIVE" .claude-code-hermit 2>&1)"
+run_test "json compiled-ref safety: output says 1 retained" bash -c "echo '$out' | grep -qE '^archive-raw: 0 archived, 1 retained'"
+run_test "json compiled-ref safety: file still in raw/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/snapshot-ha-context-${PAST}.json' ]"
+cleanup
+
+# -------------------------------------------------------
+# 7. Mixed bag: expired .md (frontmatter) + expired .json (filename) + -latest.json → 2 archived, 1 pinned
+# -------------------------------------------------------
+workdir="$(make_hermit)"
+cat > "$workdir/.claude-code-hermit/raw/audit-${PAST}.md" <<EOF
+---
+title: Audit
+type: audit
+created: ${PAST}T00:00:00Z
+tags: []
+---
+body
+EOF
+echo '{"entities":[]}' > "$workdir/.claude-code-hermit/raw/snapshot-ha-history-7d-${PAST}.json"
+echo '{"entities":[]}' > "$workdir/.claude-code-hermit/raw/snapshot-ha-normalized-latest.json"
+out="$(cd "$workdir" && node "$ARCHIVE" .claude-code-hermit 2>&1)"
+run_test "mixed: output says 2 archived, 1 pinned" bash -c "echo '$out' | grep -qE '^archive-raw: 2 archived, 0 retained, 0 skipped, 1 pinned'"
+run_test "mixed: -latest.json still in raw/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/snapshot-ha-normalized-latest.json' ]"
+run_test "mixed: dated .md moved to .archive/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/.archive/audit-${PAST}.md' ]"
+run_test "mixed: dated .json moved to .archive/" bash -c \
+  "[ -f '$workdir/.claude-code-hermit/raw/.archive/snapshot-ha-history-7d-${PAST}.json' ]"
+cleanup
+
+print_results


### PR DESCRIPTION
## Summary

`archive-raw.js` only scanned `*.md` files, leaving domain-hermit JSON snapshots (`snapshot-ha-context-<date>.json`, `activity-fetch-<date>.json`, etc.) exempt from the `raw_retention_days` retention window forever. A second latent bug: `-latest.*` pointer files (e.g. `patterns-latest.md`, `snapshot-ha-normalized-latest.json`) carry the same `created` frontmatter as their dated siblings, making them silently archivable after the retention period — breaking the live pointers read by 7+ HA skills.

## Changes

- **`archive-raw.js`**: broaden glob to `(md|json)`, add `-latest.*` pin (never archived), fall back to `YYYY-MM-DD` in filename for age resolution when a `.json` file has no frontmatter
- **`tests/test-archive-raw.sh`**: 18 new test cases covering expired `.md` (frontmatter path), expired `.json` (filename-date fallback), `-latest` pinning for both extensions, no-date skip, recent retained, compiled-reference safety, and a mixed-bag integration case
- **`tests/run-all.sh`**: register the new suite
- **`docs/plugin-hermit-storage.md`**: one-sentence update noting `.md`+`.json` coverage and `-latest.*` pinning

## Test plan

```bash
cd plugins/claude-code-hermit && bash tests/test-archive-raw.sh  # 18/18
bash tests/run-all.sh                                            # full suite, 0 failures
```

Closes #209