### PR TITLE
fix(homeassistant-hermit): hatch now extends knowledge-schema.md with HA types

### DIFF
--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are d
 
 Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes the following step automatically (via Step 7's sibling upgrade flow).
 
-1. **Extend knowledge-schema.md with HA types.** Read `.claude-code-hermit/knowledge-schema.md`. Check if `- analysis:` is present — if so, skip (already up to date). If absent, append the following under `## Work Products`:
+1. **Extend knowledge-schema.md with HA types.** Read `.claude-code-hermit/knowledge-schema.md`. Check if either `- analysis:` or `- **analysis**:` is present — if so, skip (already up to date). If absent, append the following under `## Work Products`:
 
    ```
    - brief: morning/evening house brief. location: compiled/brief-<morning|evening>-<date>.md

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **hatch: knowledge-schema.md now seeded with HA artifact types** — weekly-review Knowledge Health no longer flags HA `.md` artifacts as `undeclared-type`. Covers `brief`, `context`, `presence-report` (Work Products) and `audit`, `simulation`, `apply`, `remove`, `analysis` (Raw Captures).
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `skills/hatch/SKILL.md` | New Step 7.6: idempotent knowledge-schema extension; final-report line |
+| `tests/test_hatch_skill.py` | Structural tests for Step 7.6 |
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill executes the following step automatically (via Step 7's sibling upgrade flow).
+
+1. **Extend knowledge-schema.md with HA types.** Read `.claude-code-hermit/knowledge-schema.md`. Check if `- analysis:` is present — if so, skip (already up to date). If absent, append the following under `## Work Products`:
+
+   ```
+   - brief: morning/evening house brief. location: compiled/brief-<morning|evening>-<date>.md
+   - context: foundational house/system profile. location: compiled/context-house-profile-<date>.md
+   - presence-report: presence history and tracker diagnostics. location: compiled/presence-report-<date>.md
+   ```
+
+   And under `## Raw Captures`:
+
+   ```
+   - audit: HA operational audit (safety, integration-health, context-refresh). location: raw/audit-ha-<type>-<date>.md
+   - simulation: HA automation simulation result. location: raw/audit-ha-simulation-<slug>-<date>.md
+   - apply: HA automation apply result. location: raw/audit-ha-apply-<slug>-<date>.md
+   - remove: HA automation/script delete audit. location: raw/audit-ha-remove-<slug>-<date>.md
+   - analysis: HA pattern analysis. location: raw/patterns-<date>.md
+   ```
+
+   Use Edit to append.
+
+---
+
 ## [0.1.7] - 2026-05-31
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
@@ -167,8 +167,7 @@ Write the chosen value to `config.json` as `ha_safety_mode`. Default to `strict`
 
 Read `.claude-code-hermit/knowledge-schema.md`.
 
-Check if `- analysis:` is present in the file. This string only appears as the last Raw Captures bullet written — so its presence means both blocks were fully written on a prior run.
-
+Check if either `- analysis:` or `- **analysis**:` is present in the file. This string only appears as the last Raw Captures bullet written — so its presence means both blocks were fully written on a prior run.
 If **absent**, append the following block under `## Work Products` (create the section header if the base schema only has a template stub):
 
 ```

--- a/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
@@ -163,6 +163,36 @@ Read `ha_safety_mode` from `.claude-code-hermit/config.json`.
 
 Write the chosen value to `config.json` as `ha_safety_mode`. Default to `strict` if the operator skips or is unsure.
 
+### 7.6 Knowledge-schema extension
+
+Read `.claude-code-hermit/knowledge-schema.md`.
+
+Check if `- analysis:` is present in the file. This string only appears as the last Raw Captures bullet written — so its presence means both blocks were fully written on a prior run.
+
+If **absent**, append the following block under `## Work Products` (create the section header if the base schema only has a template stub):
+
+```
+- brief: morning/evening house brief. location: compiled/brief-<morning|evening>-<date>.md
+- context: foundational house/system profile. location: compiled/context-house-profile-<date>.md
+- presence-report: presence history and tracker diagnostics. location: compiled/presence-report-<date>.md
+```
+
+And under `## Raw Captures` (create if absent):
+
+```
+- audit: HA operational audit (safety, integration-health, context-refresh). location: raw/audit-ha-<type>-<date>.md
+- simulation: HA automation simulation result. location: raw/audit-ha-simulation-<slug>-<date>.md
+- apply: HA automation apply result. location: raw/audit-ha-apply-<slug>-<date>.md
+- remove: HA automation/script delete audit. location: raw/audit-ha-remove-<slug>-<date>.md
+- analysis: HA pattern analysis. location: raw/patterns-<date>.md
+```
+
+If already present: skip (idempotent).
+
+Use Edit to make the changes.
+
+---
+
 ### 8. Stamp version and register routines
 
 Write `_hermit_versions["claude-code-homeassistant-hermit"]` into `.claude-code-hermit/config.json` with the current plugin version.
@@ -236,6 +266,7 @@ hatch complete
   ✓  boot_skill: /claude-code-homeassistant-hermit:ha-boot (set | already set | operator override preserved)
   ✓  Routines registered: daily-ha-context, morning-brief (disabled by default), evening-brief
   ✓  Scheduled checks registered: ha-patterns, ha-safety-audit, ha-integration-health
+  ✓  knowledge-schema.md: HA types added (or already present)
 
 Manual steps remaining:
   - Enable 'Model Context Protocol Server' integration in Home Assistant (if not done)

--- a/plugins/claude-code-homeassistant-hermit/tests/test_hatch_skill.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_hatch_skill.py
@@ -102,8 +102,13 @@ def test_has_knowledge_schema_extension_step(skill_text: str):
 
 
 def test_knowledge_schema_idempotency_sentinel(skill_text: str):
-    # The sentinel that gates the idempotency check must be the last-written bullet.
-    assert "- analysis:" in skill_text
+    # The sentinel must appear as the actual typed bullet in the appended block,
+    # not just as a backtick-quoted example in the prose description.
+    assert "- analysis: HA pattern analysis" in skill_text
+
+
+def test_knowledge_schema_declares_context(skill_text: str):
+    assert "- context:" in skill_text
 
 
 def test_knowledge_schema_declares_brief(skill_text: str):

--- a/plugins/claude-code-homeassistant-hermit/tests/test_hatch_skill.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_hatch_skill.py
@@ -93,3 +93,46 @@ def test_marker_replacement_specifies_closing_marker(skill_text: str):
 
 def test_delegates_stray_block_migration_to_hermit_evolve(skill_text: str):
     assert re.search(r"hermit-evolve[\s\S]{0,20}Step 7", skill_text)
+
+
+# --- Knowledge-schema extension (Step 7.6) ---
+
+def test_has_knowledge_schema_extension_step(skill_text: str):
+    assert "Knowledge-schema extension" in skill_text
+
+
+def test_knowledge_schema_idempotency_sentinel(skill_text: str):
+    # The sentinel that gates the idempotency check must be the last-written bullet.
+    assert "- analysis:" in skill_text
+
+
+def test_knowledge_schema_declares_brief(skill_text: str):
+    assert "- brief:" in skill_text
+
+
+def test_knowledge_schema_declares_presence_report(skill_text: str):
+    assert "- presence-report:" in skill_text
+
+
+def test_knowledge_schema_declares_audit(skill_text: str):
+    assert "- audit:" in skill_text
+
+
+def test_knowledge_schema_declares_simulation(skill_text: str):
+    assert "- simulation:" in skill_text
+
+
+def test_knowledge_schema_declares_apply(skill_text: str):
+    assert "- apply:" in skill_text
+
+
+def test_knowledge_schema_declares_remove(skill_text: str):
+    assert "- remove:" in skill_text
+
+
+def test_knowledge_schema_extension_uses_edit_tool(skill_text: str):
+    assert "Use Edit to make the changes." in skill_text
+
+
+def test_knowledge_schema_final_report_line(skill_text: str):
+    assert "knowledge-schema.md: HA types added" in skill_text


### PR DESCRIPTION
## Summary

HA operators with existing hermits saw every HA `.md` artifact flagged as `undeclared-type` under weekly-review's Knowledge Health — because the core hatch seeds `knowledge-schema.md` with only the generic defaults (`note`, `review`, `input`) and the HA hatch never extended it. The fix adds an idempotent Step 7.6 to the HA hatch that appends the 8 HA Markdown types, and ships the same patch to existing operators via a `hermit-evolve` Upgrade Instruction.

## Changes

- `skills/hatch/SKILL.md` — new `### 7.6 Knowledge-schema extension` step (after Safety mode, before Step 8): reads `.claude-code-hermit/knowledge-schema.md`, checks for `- analysis:` as the idempotency sentinel, and appends Work Products (`brief`, `context`, `presence-report`) and Raw Captures (`audit`, `simulation`, `apply`, `remove`, `analysis`) via Edit if absent. Final report gains a `✓ knowledge-schema.md` line.
- `tests/test_hatch_skill.py` — 10 new structural grep-level tests covering the step, each declared type, the idempotency sentinel, the Edit-not-Write contract, and the final-report line.
- `CHANGELOG.md` — `[Unreleased]` entry with `### Upgrade Instructions` for `hermit-evolve` to backfill existing operators' live schemas (same sentinel-gated append).

## Test plan

- `cd plugins/claude-code-homeassistant-hermit && python -m pytest tests/test_hatch_skill.py -v` — 27 passed (verified locally).
- JSON/YAML types (`snapshot`, `automation`, `script`) are intentionally excluded: `knowledge-lint.js` only scans `.md` files and classifies by frontmatter `type`; these carry no hermit frontmatter by design, so declaring them would produce `unused-declaration` noise in verbose lint contexts without fixing any real violation.

Closes #203