### PR TITLE
fix(proposal-create): propagate origin into metrics so kill-criteria greps match

### DIFF
--- a/plugins/claude-code-hermit/docs/frontmatter-contract.md
+++ b/plugins/claude-code-hermit/docs/frontmatter-contract.md
@@ -20,7 +20,7 @@ Field names: lowercase with underscores. Flat only — no nested objects. Use `n
 
 **Session report** (`sessions/S-NNN-REPORT.md`): `id`, `status`, `date`, `duration`, `cost_usd`, `tags`, `proposals_created`, `task`, `escalation`, `operator_turns`. Optional: `closed_via` (`operator` | `auto`; absent in legacy reports — treat as `operator`).
 
-**Proposal** (`proposals/PROP-NNN-<slug>-HHMMSS.md`): `id`, `title`, `status`, `source`, `created`, `category`
+**Proposal** (`proposals/PROP-NNN-<slug>-HHMMSS.md`): `id`, `title`, `status`, `source`, `created`, `category`, `tags`
 
 **Weekly review** (`compiled/review-weekly-YYYY-Www.md`): `type: review`, `title`, `created`, `tags`, `generated: true`, `week`, `sessions_count`, `proposals_created`, `proposals_accepted`, `proposals_resolved`, `total_cost_usd`, `total_tokens`, `avg_session_cost_usd`, `avg_session_tokens`, `self_directed_rate`
 

--- a/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
+++ b/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
@@ -9,8 +9,8 @@ description: On-demand hermit-voice brainstorm — synthesizes memory, available
 
 After ≥8 invocations, compute two rates over `state/proposal-metrics.jsonl`:
 
-- **Triage-survival rate** — `grep '"evidence_source":"capability-brainstorm"' proposal-metrics.jsonl` to find all `triage-verdict` events from this skill. Rate = `CREATE` count ÷ total. Kill if < 25%.
-- **PROP-acceptance rate** — `grep '"capability-brainstorm"' proposal-metrics.jsonl` to find `created` events tagged `capability-brainstorm`. Cross-reference their `proposal_id` against `responded` events with `"action":"accept"`. Rate = accepted ÷ created. Kill if < 30%.
+- **Triage-survival rate** — `grep '"type":"triage-verdict".*"evidence_source":"capability-brainstorm"' state/proposal-metrics.jsonl` to find all `triage-verdict` events from this skill. Rate = `CREATE` count ÷ total. Kill if < 25%.
+- **PROP-acceptance rate** — `grep '"type":"created".*"capability-brainstorm"' state/proposal-metrics.jsonl` to find `created` events tagged `capability-brainstorm`. Cross-reference their `proposal_id` against `responded` events with `"action":"accept"`. Rate = accepted ÷ created. Kill if < 30%.
 
 If either rate is below threshold, cut this skill rather than tune it — the signal-to-noise ratio isn't there.
 

--- a/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
+++ b/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
@@ -10,7 +10,7 @@ description: On-demand hermit-voice brainstorm — synthesizes memory, available
 After ≥8 invocations, compute two rates over `state/proposal-metrics.jsonl`:
 
 - **Triage-survival rate** — `grep '"type":"triage-verdict".*"evidence_source":"capability-brainstorm"' state/proposal-metrics.jsonl` to find all `triage-verdict` events from this skill. Rate = `CREATE` count ÷ total. Kill if < 25%.
-- **PROP-acceptance rate** — `grep '"type":"created".*"capability-brainstorm"' state/proposal-metrics.jsonl` to find `created` events tagged `capability-brainstorm`. Cross-reference their `proposal_id` against `responded` events with `"action":"accept"`. Rate = accepted ÷ created. Kill if < 30%.
+- **PROP-acceptance rate** — `grep '"type":"created".*"tags":.*"capability-brainstorm"' state/proposal-metrics.jsonl` to find `created` events tagged `capability-brainstorm`. Cross-reference their `proposal_id` against `responded` events with `"action":"accept"`. Rate = accepted ÷ created. Kill if < 30%.
 
 If either rate is below threshold, cut this skill rather than tune it — the signal-to-noise ratio isn't there.
 

--- a/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
+++ b/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
@@ -7,7 +7,12 @@ description: On-demand hermit-voice brainstorm — synthesizes memory, available
 
 ## Kill criteria (read before running)
 
-After ≥8 invocations, grep `state/proposal-metrics.jsonl` for proposals tagged `capability-brainstorm`. If triage-survival rate < 25% or PROP-acceptance rate < 30%, cut this skill rather than tune it — the signal-to-noise ratio isn't there.
+After ≥8 invocations, compute two rates over `state/proposal-metrics.jsonl`:
+
+- **Triage-survival rate** — `grep '"evidence_source":"capability-brainstorm"' proposal-metrics.jsonl` to find all `triage-verdict` events from this skill. Rate = `CREATE` count ÷ total. Kill if < 25%.
+- **PROP-acceptance rate** — `grep '"capability-brainstorm"' proposal-metrics.jsonl` to find `created` events tagged `capability-brainstorm`. Cross-reference their `proposal_id` against `responded` events with `"action":"accept"`. Rate = accepted ÷ created. Kill if < 30%.
+
+If either rate is below threshold, cut this skill rather than tune it — the signal-to-noise ratio isn't there.
 
 ## 1. Gather inputs
 

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -89,7 +89,7 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js \
 
 4. Append a `created` event to proposal metrics (include `source`, `category`, and `tags` from the frontmatter):
    ```
-   node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js .claude-code-hermit/state/proposal-metrics.jsonl '{"ts":"<now ISO>","type":"created","proposal_id":"PROP-NNN-slug-HHMMSS","source":"<source>","category":"<category>","tags":["<tag>"]}'
+   node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js .claude-code-hermit/state/proposal-metrics.jsonl '{"ts":"<now ISO>","type":"created","proposal_id":"PROP-NNN-slug-HHMMSS","source":"<source>","category":"<category>","tags":["<tag-1>","<tag-2>"]}'
    ```
 5. Update state summary:
    ```

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -37,8 +37,9 @@ After receiving the verdict, append one event to `state/proposal-metrics.jsonl`:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js \
   .claude-code-hermit/state/proposal-metrics.jsonl \
-  '{"ts":"<now ISO>","type":"triage-verdict","verdict":"<CREATE|SUPPRESS|DUPLICATE>","caller":"proposal-create"}'
+  '{"ts":"<now ISO>","type":"triage-verdict","verdict":"<CREATE|SUPPRESS|DUPLICATE>","caller":"proposal-create","evidence_source":"<evidence source>"}'
 ```
+`evidence_source` is the `Evidence Source:` value the caller passed (default `archived-session`).
 
 - `CREATE` — proceed with the steps below
 - `DUPLICATE:<PROP-ID> — <reason>`: stop, report to the caller: "Proposal already exists as <PROP-ID>"
@@ -76,6 +77,7 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js \
        - `capability` — new agent, skill, or heartbeat item
        - `constraint` — OPERATOR.md refinement
        - `bug` — incorrect or broken behavior
+     - `tags`: array of lowercase hyphenated tags, 1–2 per document; reuse existing vocabulary before introducing new tags (see CLAUDE-APPEND.md tag discipline). Callers may supply specific tags — e.g. `capability-brainstorm` passes `[capability-brainstorm, ideation]`. Default `[]` if none supplied.
      - `title`: short proposal title (same text used in the H1 heading after the dash)
      - `resolved_date`: `null` (set later by reflect when pattern is confirmed gone)
    - Fill in the title in the H1 heading
@@ -85,9 +87,9 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js \
 
 3. Add a reference to the proposal in `.claude-code-hermit/sessions/SHELL.md` under the Findings section
 
-4. Append a `created` event to proposal metrics (include `source` and `category` from the frontmatter):
+4. Append a `created` event to proposal metrics (include `source`, `category`, and `tags` from the frontmatter):
    ```
-   node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js .claude-code-hermit/state/proposal-metrics.jsonl '{"ts":"<now ISO>","type":"created","proposal_id":"PROP-NNN-slug-HHMMSS","source":"manual","category":"improvement"}'
+   node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js .claude-code-hermit/state/proposal-metrics.jsonl '{"ts":"<now ISO>","type":"created","proposal_id":"PROP-NNN-slug-HHMMSS","source":"<source>","category":"<category>","tags":["<tag>"]}'
    ```
 5. Update state summary:
    ```

--- a/plugins/claude-code-hermit/state-templates/PROPOSAL.md.template
+++ b/plugins/claude-code-hermit/state-templates/PROPOSAL.md.template
@@ -9,6 +9,7 @@ accepted_date: null
 resolved_date: null
 related_sessions: []
 category: improvement
+tags: []
 responded: false
 self_eval_key: null
 accepted_in_session: null

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1401,15 +1401,21 @@ class TestKillMetricsContract(unittest.TestCase):
 
     def test_proposal_create_triage_verdict_has_evidence_source(self):
         """proposal-create triage-verdict event must include evidence_source."""
-        self.assertIn('"evidence_source"', self._proposal_create,
-                      'proposal-create triage-verdict event is missing evidence_source — '
-                      'triage-survival rate cannot be segmented by brainstorm origin')
+        self.assertIn(
+            '"type":"triage-verdict","verdict":"<CREATE|SUPPRESS|DUPLICATE>","caller":"proposal-create","evidence_source":"<evidence source>"',
+            self._proposal_create,
+            'proposal-create triage-verdict emitter example is missing evidence_source — '
+            'triage-survival rate cannot be segmented by brainstorm origin',
+        )
 
     def test_proposal_create_created_event_has_tags(self):
         """proposal-create created event must include tags."""
-        self.assertIn('"tags"', self._proposal_create,
-                      'proposal-create created event is missing tags — '
-                      'PROP-acceptance rate cannot be segmented by brainstorm origin')
+        self.assertIn(
+            '"type":"created","proposal_id":"PROP-NNN-slug-HHMMSS","source":"<source>","category":"<category>","tags":["<tag-1>","<tag-2>"]',
+            self._proposal_create,
+            'proposal-create created emitter example is missing tags — '
+            'PROP-acceptance rate cannot be segmented by brainstorm origin',
+        )
 
     def test_capability_brainstorm_kill_criteria_references_evidence_source(self):
         """capability-brainstorm kill criteria must reference evidence_source for triage-survival."""

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1374,5 +1374,59 @@ class TestChannelResolverContract(unittest.TestCase):
         )
 
 
+class TestKillMetricsContract(unittest.TestCase):
+    """Contract: kill-metrics origin tokens must reach proposal-metrics.jsonl.
+
+    Guards against the silent breakage where capability-brainstorm (or any future
+    brainstorm skill) declares kill criteria that grep for an origin token that no
+    writer ever emits.  The three emitter shapes and the kill-criteria grep targets
+    must stay in sync — so each assertion checks both sides of the contract.
+    """
+
+    PROPOSAL_TEMPLATE = REPO / 'state-templates' / 'PROPOSAL.md.template'
+    PROPOSAL_CREATE = REPO / 'skills' / 'proposal-create' / 'SKILL.md'
+    CAPABILITY_BRAINSTORM = REPO / 'skills' / 'capability-brainstorm' / 'SKILL.md'
+
+    @classmethod
+    def setUpClass(cls):
+        cls._proposal_template = cls.PROPOSAL_TEMPLATE.read_text()
+        cls._proposal_create = cls.PROPOSAL_CREATE.read_text()
+        cls._capability_brainstorm = cls.CAPABILITY_BRAINSTORM.read_text()
+
+    def test_proposal_template_has_tags_field(self):
+        """PROPOSAL.md.template must declare a tags field so proposal-create can write it."""
+        self.assertIn('tags:', self._proposal_template,
+                      'PROPOSAL.md.template is missing the tags field — '
+                      'brainstorm origin can never be preserved in proposal frontmatter')
+
+    def test_proposal_create_triage_verdict_has_evidence_source(self):
+        """proposal-create triage-verdict event must include evidence_source."""
+        self.assertIn('"evidence_source"', self._proposal_create,
+                      'proposal-create triage-verdict event is missing evidence_source — '
+                      'triage-survival rate cannot be segmented by brainstorm origin')
+
+    def test_proposal_create_created_event_has_tags(self):
+        """proposal-create created event must include tags."""
+        self.assertIn('"tags"', self._proposal_create,
+                      'proposal-create created event is missing tags — '
+                      'PROP-acceptance rate cannot be segmented by brainstorm origin')
+
+    def test_capability_brainstorm_kill_criteria_references_evidence_source(self):
+        """capability-brainstorm kill criteria must reference evidence_source for triage-survival."""
+        self.assertIn('evidence_source', self._capability_brainstorm,
+                      'capability-brainstorm kill criteria no longer references evidence_source — '
+                      'triage-survival grep target has drifted from the emitter')
+
+    def test_capability_brainstorm_kill_criteria_references_tags(self):
+        """capability-brainstorm kill criteria must reference tags for acceptance rate."""
+        parts = self._capability_brainstorm.split('## Kill criteria')
+        self.assertGreater(len(parts), 1,
+                           'capability-brainstorm SKILL.md is missing the Kill criteria section')
+        kill_section = parts[1].split('## ')[0]
+        self.assertIn('capability-brainstorm', kill_section,
+                      'capability-brainstorm kill criteria no longer references the tag token — '
+                      'acceptance-rate grep target has drifted from what proposal-create emits')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1411,7 +1411,7 @@ class TestKillMetricsContract(unittest.TestCase):
     def test_proposal_create_created_event_has_tags(self):
         """proposal-create created event must include tags."""
         self.assertIn(
-            '"type":"created","proposal_id":"PROP-NNN-slug-HHMMSS","source":"<source>","category":"<category>","tags":["<tag-1>","<tag-2>"]',
+            '"type":"created","proposal_id":"PROP-NNN-slug-HHMMSS","source":"<source>","category":"<category>","tags":[',
             self._proposal_create,
             'proposal-create created emitter example is missing tags — '
             'PROP-acceptance rate cannot be segmented by brainstorm origin',
@@ -1429,9 +1429,12 @@ class TestKillMetricsContract(unittest.TestCase):
         self.assertGreater(len(parts), 1,
                            'capability-brainstorm SKILL.md is missing the Kill criteria section')
         kill_section = parts[1].split('## ')[0]
-        self.assertIn('capability-brainstorm', kill_section,
-                      'capability-brainstorm kill criteria no longer references the tag token — '
-                      'acceptance-rate grep target has drifted from what proposal-create emits')
+        self.assertIn(
+            'grep \'"type":"created".*"tags":.*"capability-brainstorm"\' state/proposal-metrics.jsonl',
+            kill_section,
+            'capability-brainstorm kill criteria no longer references the created-event grep token — '
+            'acceptance-rate grep target has drifted from what proposal-create emits',
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

`capability-brainstorm`'s kill criteria grep matched nothing because `proposal-create` never emitted origin tokens into `proposal-metrics.jsonl`. The `triage-verdict` event carried no brainstorm marker, and the `created` event had no `tags` field — so the kill criterion (triage-survival < 25% or PROP-acceptance < 30%) could never be computed.

## Changes

- **`PROPOSAL.md.template`** — adds `tags: []` field, aligning the template with `frontmatter-contract.md` line 12 and `hermit-brain`'s expectation.
- **`proposal-create/SKILL.md`** — three additive edits: `evidence_source` on `triage-verdict` events (enables triage-survival rate by origin); `tags` frontmatter field with caller-supply convention; `tags` on `created` events (enables PROP-acceptance rate by origin).
- **`capability-brainstorm/SKILL.md`** — kill-criteria section rewritten with precise, runnable grep commands now that both origin tokens land in the log.
- **`docs/frontmatter-contract.md`** — adds `tags` to the Proposal schema line, resolving an existing inconsistency (line 12 declared `tags` required; line 23's proposal entry omitted it).
- **`tests/run-contracts.py`** — new `TestKillMetricsContract` class (5 assertions) with `setUpClass` caching; guards that the grep targets and emitters cannot drift apart silently.

## Test plan

- `cd plugins/claude-code-hermit && bash tests/run-all.sh` — full core suite green.
- `python3 tests/run-contracts.py -v` — all 5 new `TestKillMetricsContract` assertions pass.
- Manual trace: a brainstorm-origin proposal now produces a `triage-verdict` line with `"evidence_source":"capability-brainstorm"` and a `created` line with `"tags":["capability-brainstorm","ideation"]`, so `grep capability-brainstorm .claude-code-hermit/state/proposal-metrics.jsonl` returns both events.