### PR TITLE
feat(fitness-hermit): add Core Rule to ground training-history facts in Strava

### DIFF
--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **domain-brainstorm: on-demand training-gap brainstorm skill** — reads Strava history and MEMORY.md goals, delegates bulk aggregation to `strava-data-cruncher`, and surfaces at most 2 goal-coverage or imbalance ideas (prefixes `[goal-gap]`, `[imbalance]`) as proposals via `proposal-create`. Scoped to coverage/imbalance gaps only — cardiac-drift and load trends remain with `weekly-coaching-patterns`. Never runs autonomously.
+- **Core Rule: ground training-history facts in Strava, not memory** — records, PBs, all-time totals, counts, and cross-block comparisons require a full-history Strava query; context/compaction may drop older activities. Recent-activity questions are unaffected.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-fitness-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/CLAUDE-APPEND.md
@@ -14,6 +14,7 @@ This project has the `claude-code-fitness-hermit` plugin installed. The rules be
 - Never call `star-segment`, `connect-strava`, or `disconnect-strava` without explicit operator instruction.
 - Use `get-activity-streams` for load/intensity analysis — it's the richest data source.
 - HR zone boundaries come from `mcp__strava__get-athlete-zones` — never hardcode numeric thresholds.
+- Records, PBs, all-time totals, counts, and cross-block comparisons depend on older activities that context or compaction may drop. Ground them in a full-history Strava query (see the Strava MCP Tools table), or flag the number as unverified and offer to check. Recent-activity questions are fine from live context.
 
 ### Skills
 


### PR DESCRIPTION
## Summary

Prevents the fitness hermit from citing records, PBs, all-time totals, counts, or cross-block comparisons from compacted session context or memory. Those older activities fall out of context after compaction and lead to incorrect claims the operator has to manually correct. The rule is scoped to extent-claims so recent-activity questions remain cheap, and includes a flag-as-unverified escape to avoid forcing an expensive full-history scan on passing mentions.

Closes #225

## Changes

- `state-templates/CLAUDE-APPEND.md` — new bullet in `### Core Rules`: requires grounding historical-extent claims in a full-history Strava query (or flagging as unverified); exempts recent-activity questions from the requirement. Rule is tool-agnostic — points at the existing `### Strava MCP Tools` table rather than hardcoding tool IDs, so it survives future MCP server swaps.
- `CHANGELOG.md` — terse `### Added` bullet under `[Unreleased]`.

No new upgrade step needed: the existing `[Unreleased]` Upgrade Instructions already re-append the canonical CLAUDE-APPEND block via `hermit-evolve`, which propagates this rule to operators' CLAUDE.md on their next evolve run.

## Test plan

- `grep -n "cross-block comparisons" plugins/claude-code-fitness-hermit/state-templates/CLAUDE-APPEND.md` — confirms the rule landed in the Core Rules block (before `### Skills`).
- `bash plugins/claude-code-fitness-hermit/tests/run-all.sh` (from inside the plugin dir) — 44/44 passed.