### PR TITLE
feat(hermit-scribe): auto-derive issue labels from proposal metadata

### DIFF
--- a/plugins/hermit-scribe/CHANGELOG.md
+++ b/plugins/hermit-scribe/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **hermit-scribe: auto-derive issue labels** — type label from proposal `category` (`bug`/`chore`/`enhancement`) and plugin-scope label when a single scope resolves, on top of the always-present `hermit-filed`.
+
+---
+
 ## [0.0.4] - 2026-05-31
 
 ### Added

--- a/plugins/hermit-scribe/CLAUDE.md
+++ b/plugins/hermit-scribe/CLAUDE.md
@@ -39,10 +39,13 @@ HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexisten
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /dev/null /dev/null
 
 # Extra label args should parse cleanly and reach token acquisition
-TMP_DIR="$(mktemp -d)" && printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
-HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent \
-  node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" \
-  "$TMP_DIR/t" "$TMP_DIR/b.md" enhancement homeassistant-hermit; rm -r "$TMP_DIR"
+TMP_DIR="$(mktemp -d)" && (
+  trap 'rm -r "$TMP_DIR"' EXIT
+  printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
+  HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent \
+    node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" \
+    "$TMP_DIR/t" "$TMP_DIR/b.md" enhancement homeassistant-hermit
+)
 ```
 
 The script takes two positional file paths: title file (single line; trimmed) and body file (markdown). Both are read directly; nothing is interpolated into shell commands, so title content is safe from quoting issues.

--- a/plugins/hermit-scribe/CLAUDE.md
+++ b/plugins/hermit-scribe/CLAUDE.md
@@ -39,8 +39,10 @@ HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexisten
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /dev/null /dev/null
 
 # Extra label args should parse cleanly and reach token acquisition
+TMP_DIR="$(mktemp -d)" && printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
 HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent \
-  node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /tmp/t /tmp/b enhancement homeassistant-hermit
+  node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" \
+  "$TMP_DIR/t" "$TMP_DIR/b.md" enhancement homeassistant-hermit
 ```
 
 The script takes two positional file paths: title file (single line; trimmed) and body file (markdown). Both are read directly; nothing is interpolated into shell commands, so title content is safe from quoting issues.

--- a/plugins/hermit-scribe/CLAUDE.md
+++ b/plugins/hermit-scribe/CLAUDE.md
@@ -39,7 +39,7 @@ HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexisten
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /dev/null /dev/null
 
 # Extra label args should parse cleanly and reach token acquisition
-TMP_DIR="$(mktemp -d)" && printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
+TMP_DIR="$(mktemp -d)" && trap 'rm -rf "$TMP_DIR"' EXIT && printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
 HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent \
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" \
   "$TMP_DIR/t" "$TMP_DIR/b.md" enhancement homeassistant-hermit

--- a/plugins/hermit-scribe/CLAUDE.md
+++ b/plugins/hermit-scribe/CLAUDE.md
@@ -15,7 +15,7 @@ claude plugin install hermit-scribe@claude-code-hermit --scope local
 
 - `agents/issue-sanitizer.md`: subagent that sanitizes draft issue content before filing — strips anything personal or specific to the operator's machine and project unless it's clearly part of an upstream hermit plugin. Tools: none (pure text transform).
 - `skills/hermit-scribe/SKILL.md`: the skill, namespaced as `/hermit-scribe:hermit-scribe`
-- `skills/hermit-scribe/file-issue.js`: Node stdlib script that signs the JWT, gets an install token, and POSTs the issue. Supports `--check <proposal-id>` to query existing issues before filing, and `--comment <issue-number> <body-file>` to post a comment on an existing issue.
+- `skills/hermit-scribe/file-issue.js`: Node stdlib script that signs the JWT, gets an install token, and POSTs the issue. Positional args: `<title-file> <body-file> [label...]` — extra labels are appended to the always-present `hermit-filed` label and passed in the POST body. Supports `--check <proposal-id>` to query existing issues before filing, and `--comment <issue-number> <body-file>` to post a comment on an existing issue. Exports `{ buildLabels }` for unit testing.
 - `.claude-plugin/plugin.json`: plugin manifest
 
 ## Required env vars
@@ -37,6 +37,10 @@ Place the private key at `.claude.local/hermit-scribe-key.pem` (`.claude.local/`
 # Should exit non-zero with a clear error message (missing key), not a crash
 HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent \
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /dev/null /dev/null
+
+# Extra label args should parse cleanly and reach token acquisition
+HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent \
+  node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /tmp/t /tmp/b enhancement homeassistant-hermit
 ```
 
 The script takes two positional file paths: title file (single line; trimmed) and body file (markdown). Both are read directly; nothing is interpolated into shell commands, so title content is safe from quoting issues.

--- a/plugins/hermit-scribe/CLAUDE.md
+++ b/plugins/hermit-scribe/CLAUDE.md
@@ -39,10 +39,10 @@ HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexisten
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /dev/null /dev/null
 
 # Extra label args should parse cleanly and reach token acquisition
-TMP_DIR="$(mktemp -d)" && trap 'rm -r "$TMP_DIR"' EXIT && printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
+TMP_DIR="$(mktemp -d)" && printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
 HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent \
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" \
-  "$TMP_DIR/t" "$TMP_DIR/b.md" enhancement homeassistant-hermit
+  "$TMP_DIR/t" "$TMP_DIR/b.md" enhancement homeassistant-hermit; rm -r "$TMP_DIR"
 ```
 
 The script takes two positional file paths: title file (single line; trimmed) and body file (markdown). Both are read directly; nothing is interpolated into shell commands, so title content is safe from quoting issues.

--- a/plugins/hermit-scribe/CLAUDE.md
+++ b/plugins/hermit-scribe/CLAUDE.md
@@ -39,7 +39,7 @@ HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexisten
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /dev/null /dev/null
 
 # Extra label args should parse cleanly and reach token acquisition
-TMP_DIR="$(mktemp -d)" && trap 'rm -rf "$TMP_DIR"' EXIT && printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
+TMP_DIR="$(mktemp -d)" && trap 'rm -r "$TMP_DIR"' EXIT && printf 't\n' > "$TMP_DIR/t" && printf 'b\n' > "$TMP_DIR/b.md" && \
 HERMIT_GH_APP_ID=1 HERMIT_GH_APP_INSTALL_ID=2 HERMIT_GH_APP_KEY_FILE=/nonexistent \
   node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" \
   "$TMP_DIR/t" "$TMP_DIR/b.md" enhancement homeassistant-hermit

--- a/plugins/hermit-scribe/README.md
+++ b/plugins/hermit-scribe/README.md
@@ -57,7 +57,7 @@ For proposal-backed issues: the skill globs `.claude-code-hermit/proposals/PROP-
 
 For ad-hoc issues: supply title and body directly. The operator's title is passed through verbatim (no CC enforcement); translation and sanitization still apply.
 
-All issues get the `hermit-filed` label.
+All issues get the `hermit-filed` label. Proposal-backed issues also receive a type label derived from `category` (`bug` → `bug`; `infrastructure`/`investigation` → `chore`; otherwise `enhancement`) and, when a single plugin scope was resolved, a scope label matching the stripped slug (e.g. `homeassistant-hermit`). These labels must already exist on the target repo — unknown ones are silently dropped or auto-created by GitHub, so filing never errors on a missing label.
 
 ### Dedup
 
@@ -101,7 +101,7 @@ hermit-scribe/
         └── file-issue.js       stdlib: JWT → install token → POST /issues; --check flag
 ```
 
-`file-issue.js` is a single-shot Node script: signs an RS256 JWT from the App private key, exchanges it for an installation access token at `POST /app/installations/{id}/access_tokens`, then `POST /repos/{owner}/{repo}/issues` with the `hermit-filed` label. Two HTTPS round-trips per invocation. Node is required (Claude Code already provides it).
+`file-issue.js` is a single-shot Node script: signs an RS256 JWT from the App private key, exchanges it for an installation access token at `POST /app/installations/{id}/access_tokens`, then `POST /repos/{owner}/{repo}/issues` with the derived label set (`hermit-filed` always, plus any extra labels passed as trailing positional args). Two HTTPS round-trips per invocation. Node is required (Claude Code already provides it).
 
 ## License
 

--- a/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
+++ b/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
@@ -104,7 +104,7 @@ Parse the response: split on the `<<<HERMIT_SCRIBE_BODY>>>` line. Everything bef
 Present the post-translation, post-sanitization content to the operator as a **single message** containing, in order:
 1. Proposed title
 2. Complete issue body — everything that will be written to the issue, including the `---\n*Filed via hermit-scribe...*` footer
-3. Labels that will be applied (informational — no operator editing): `Labels: hermit-filed, <type>[, <scope>]`
+3. Labels that will be applied (informational — no operator editing): `Labels: hermit-filed[, <type>[, <scope>]]`
 4. Confirmation prompt: `File this issue? (yes / edit / cancel)`
 
 If the content exceeds the channel's message-size limit (Discord: 2000 chars), split into multiple messages. The confirmation prompt MUST appear in the FINAL message only — never in the first. Do NOT replace the body with placeholders like "(see below)" — inline the full body.

--- a/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
+++ b/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
@@ -104,7 +104,7 @@ Parse the response: split on the `<<<HERMIT_SCRIBE_BODY>>>` line. Everything bef
 Present the post-translation, post-sanitization content to the operator as a **single message** containing, in order:
 1. Proposed title
 2. Complete issue body — everything that will be written to the issue, including the `---\n*Filed via hermit-scribe...*` footer
-3. Labels that will be applied (informational — no operator editing): `Labels: hermit-filed[, <type>[, <scope>]]`
+3. Labels that will be applied (informational — no operator editing): `Labels: hermit-filed (always); plus <type> and optional <scope> for proposal-backed issues`
 4. Confirmation prompt: `File this issue? (yes / edit / cancel)`
 
 If the content exceeds the channel's message-size limit (Discord: 2000 chars), split into multiple messages. The confirmation prompt MUST appear in the FINAL message only — never in the first. Do NOT replace the body with placeholders like "(see below)" — inline the full body.

--- a/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
+++ b/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
@@ -50,6 +50,11 @@ If the operator named a proposal (`PROP-NNN`):
 
    Build: `<type>(<scope>): <title>` if scope present, else `<type>: <title>`.
 
+**Derive labels** from the same category and scope values used above:
+   - Always derive a type label: `bug` → `bug`; `infrastructure`/`investigation` → `chore`; all others (including unknown) → `enhancement`.
+   - If a single scope was resolved for the title above, use that stripped scope token as an additional label (e.g. `homeassistant-hermit`, `hermit-scribe`). Omit if scope was absent or ambiguous.
+   - `hermit-filed` is always applied by the script — do NOT include it in the labels you pass as arguments.
+
 5. Construct draft body with the four body sections, then append:
    ```
    ---
@@ -99,7 +104,8 @@ Parse the response: split on the `<<<HERMIT_SCRIBE_BODY>>>` line. Everything bef
 Present the post-translation, post-sanitization content to the operator as a **single message** containing, in order:
 1. Proposed title
 2. Complete issue body — everything that will be written to the issue, including the `---\n*Filed via hermit-scribe...*` footer
-3. Confirmation prompt: `File this issue? (yes / edit / cancel)`
+3. Labels that will be applied (informational — no operator editing): `Labels: hermit-filed, <type>[, <scope>]`
+4. Confirmation prompt: `File this issue? (yes / edit / cancel)`
 
 If the content exceeds the channel's message-size limit (Discord: 2000 chars), split into multiple messages. The confirmation prompt MUST appear in the FINAL message only — never in the first. Do NOT replace the body with placeholders like "(see below)" — inline the full body.
 
@@ -118,8 +124,20 @@ Use the Write tool to create two files inside that directory:
 
 **Step 6: run the script.**
 
-Substitute the same path from step 5:
+Substitute the same path from step 5 and append the derived type label and (if resolved) scope label as trailing arguments. Do NOT include `hermit-filed` — the script always adds it.
 
+```bash
+node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" \
+  /tmp/tmp.AbCdEf/title /tmp/tmp.AbCdEf/body.md <type-label> [<scope-label>]
+```
+
+For example, a `capability` proposal scoped to `homeassistant-hermit`:
+```bash
+node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" \
+  /tmp/tmp.AbCdEf/title /tmp/tmp.AbCdEf/body.md enhancement homeassistant-hermit
+```
+
+For an ad-hoc issue (no proposal), omit the label args entirely:
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/skills/hermit-scribe/file-issue.js" /tmp/tmp.AbCdEf/title /tmp/tmp.AbCdEf/body.md
 ```

--- a/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
+++ b/plugins/hermit-scribe/skills/hermit-scribe/SKILL.md
@@ -104,7 +104,7 @@ Parse the response: split on the `<<<HERMIT_SCRIBE_BODY>>>` line. Everything bef
 Present the post-translation, post-sanitization content to the operator as a **single message** containing, in order:
 1. Proposed title
 2. Complete issue body — everything that will be written to the issue, including the `---\n*Filed via hermit-scribe...*` footer
-3. Labels that will be applied (informational — no operator editing): `Labels: hermit-filed (always); plus <type> and optional <scope> for proposal-backed issues`
+3. Labels that will be applied (informational — no operator editing): `Labels: hermit-filed (always); plus bug/enhancement/chore and optional homeassistant-hermit/hermit-scribe for proposal-backed issues`
 4. Confirmation prompt: `File this issue? (yes / edit / cancel)`
 
 If the content exceeds the channel's message-size limit (Discord: 2000 chars), split into multiple messages. The confirmation prompt MUST appear in the FINAL message only — never in the first. Do NOT replace the body with placeholders like "(see below)" — inline the full body.

--- a/plugins/hermit-scribe/skills/hermit-scribe/file-issue.js
+++ b/plugins/hermit-scribe/skills/hermit-scribe/file-issue.js
@@ -159,7 +159,7 @@ async function commentMode() {
   process.stdout.write(comment.html_url + "\n");
 }
 
-function buildLabels(extra) {
+function buildLabels(extra = []) {
   return [...new Set(["hermit-filed", ...extra])];
 }
 

--- a/plugins/hermit-scribe/skills/hermit-scribe/file-issue.js
+++ b/plugins/hermit-scribe/skills/hermit-scribe/file-issue.js
@@ -159,6 +159,10 @@ async function commentMode() {
   process.stdout.write(comment.html_url + "\n");
 }
 
+function buildLabels(extra) {
+  return [...new Set(["hermit-filed", ...extra])];
+}
+
 async function main() {
   if (process.argv[2] === "--check") {
     await checkMode();
@@ -170,9 +174,12 @@ async function main() {
     return;
   }
 
-  const [, , titleFile, bodyFile] = process.argv;
+  const titleFile = process.argv[2];
+  const bodyFile = process.argv[3];
+  const extraLabels = process.argv.slice(4);
+
   if (!titleFile || !bodyFile) {
-    process.stderr.write("Usage: node file-issue.js <title-file> <body-file>\n");
+    process.stderr.write("Usage: node file-issue.js <title-file> <body-file> [label...]\n");
     process.exit(1);
   }
 
@@ -192,13 +199,17 @@ async function main() {
     "POST",
     `/repos/${owner}/${repo}/issues`,
     `Bearer ${token}`,
-    { title, body: issueBody, labels: ["hermit-filed"] }
+    { title, body: issueBody, labels: buildLabels(extraLabels) }
   );
 
   process.stdout.write(issue.html_url + "\n");
 }
 
-main().catch((err) => {
-  process.stderr.write(err.message + "\n");
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(err.message + "\n");
+    process.exit(1);
+  });
+}
+
+module.exports = { buildLabels };

--- a/plugins/hermit-scribe/tests/cli.test.js
+++ b/plugins/hermit-scribe/tests/cli.test.js
@@ -176,6 +176,10 @@ test("buildLabels([]) returns [hermit-filed]", () => {
   assertDeepEqual(buildLabels([]), ["hermit-filed"], "labels");
 });
 
+test("buildLabels(undefined) returns [hermit-filed]", () => {
+  assertDeepEqual(buildLabels(undefined), ["hermit-filed"], "labels");
+});
+
 test("buildLabels with extra labels puts hermit-filed first", () => {
   assertDeepEqual(
     buildLabels(["bug", "homeassistant-hermit"]),

--- a/plugins/hermit-scribe/tests/cli.test.js
+++ b/plugins/hermit-scribe/tests/cli.test.js
@@ -8,6 +8,7 @@ const { generateKeyPairSync } = require("crypto");
 const path = require("path");
 
 const SCRIPT = path.join(__dirname, "..", "skills", "hermit-scribe", "file-issue.js");
+const { buildLabels } = require(SCRIPT);
 
 let pass = 0;
 let fail = 0;
@@ -159,6 +160,42 @@ test("empty title file is rejected", () => {
 
 test("whitespace-only title file is rejected after trim", () => {
   assertFails(fullEnv, [wsTitleFile, bodyFile], /Title file is empty/);
+});
+
+// --- buildLabels unit tests ---
+
+function assertDeepEqual(actual, expected, label) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${label}: expected ${e}, got ${a}`);
+  }
+}
+
+test("buildLabels([]) returns [hermit-filed]", () => {
+  assertDeepEqual(buildLabels([]), ["hermit-filed"], "labels");
+});
+
+test("buildLabels with extra labels puts hermit-filed first", () => {
+  assertDeepEqual(
+    buildLabels(["bug", "homeassistant-hermit"]),
+    ["hermit-filed", "bug", "homeassistant-hermit"],
+    "labels"
+  );
+});
+
+test("buildLabels deduplicates hermit-filed if passed explicitly", () => {
+  assertDeepEqual(buildLabels(["hermit-filed", "bug"]), ["hermit-filed", "bug"], "labels");
+});
+
+// --- trailing label args CLI test ---
+
+test("trailing label args do not break arg parsing (reaches token acquisition)", () => {
+  assertFails(
+    { ...fullEnv, HERMIT_GH_APP_KEY_FILE: "/nonexistent/key.pem" },
+    [titleFile, bodyFile, "bug", "homeassistant-hermit"],
+    /HERMIT_GH_APP_KEY_FILE=.*does not exist/
+  );
 });
 
 console.log("");


### PR DESCRIPTION
## Summary

Filed issues have carried only the `hermit-filed` label since the plugin launched. This adds automatic type and scope labels — derived from the same proposal `category` and resolved plugin slug that already drive the Conventional-Commits title — so issues are categorized on GitHub without any new operator input.

## Changes

- **`file-issue.js`**: `buildLabels(extra)` helper (Set-based dedup, `hermit-filed` always first); accepts extra labels as trailing positional args (`argv.slice(4)`); exports `{ buildLabels }` for unit tests via `if (require.main === module)` guard
- **`SKILL.md`**: "Derive labels" subsection in Step 1 (type from category, scope label when exactly one slug resolves); informational `Labels:` line in the operator preview; updated Step 6 command examples
- **`tests/cli.test.js`**: 4 new tests — `buildLabels` unit tests (default, extras, dedup) and a CLI test confirming trailing label args don't disturb validation flow; 17/17 pass
- **Docs**: README label description, CLAUDE.md file-issue.js description and smoke test, CHANGELOG `[Unreleased]` entry

## Label taxonomy

Proposal-backed issues only (ad-hoc issues get `hermit-filed` only):
- Type label: `bug` → `bug`; `infrastructure`/`investigation` → `chore`; all others → `enhancement`
- Scope label: the stripped plugin slug (e.g. `homeassistant-hermit`) when exactly one scope resolved — omitted when absent or ambiguous

Labels must pre-exist on the target repo. Missing labels are silently dropped or auto-created by GitHub; filing never errors on a missing label.

## Test plan

```bash
bash plugins/hermit-scribe/tests/run-all.sh
# expect: 17 passed, 0 failed
```