### PR TITLE
feat(claude-code-hermit): add memory-review fallback to session-close when reflect short-circuits

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **session-close: memory-review fallback when reflect short-circuits** — captures single-session discoveries on operator closes where reflect's cadence precheck returns EMPTY. Skipped on `--auto` by construction. Closes #230.
+
 ### Fixed
 
 - **hatch: always default `push_notifications: true` on fresh hatch** — removed the channel-choice derivation that wrote `false` whenever a channel was selected. The runtime guard in `CLAUDE-APPEND.md` already enforces channel-first delivery with push as fallback, so the hatch-time override was discarding the fallback unnecessarily. Both Quick and Advanced modes now leave `push_notifications` at the template default (`true`); re-init still preserves the existing value.

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -53,6 +53,7 @@ If the archive in step 7 fails, leave `pending-close.json` in place so the next 
 3. Confirm the "Next Start Point" is clear enough for a fresh session to resume without questions
 4. If any high-leverage improvements were discovered during work, create proposals via the `claude-code-hermit:proposal-create` skill
 5. Invoke the `claude-code-hermit:reflect` skill to reflect on accumulated experience. Reflect no longer requires archived reports — it uses memory. This runs before archiving so any findings are included in the archived report. **Skip on `--auto`** — during auto-close, `session_state` is still `in_progress`, which forces reflect-precheck into compute phase before the `closed_via: auto` filter can run; there is no operator-curated session content to reflect on anyway.
+   If reflect returns `reflect: no candidates`, scan this session's `## Findings` and `## Progress Log` for non-obvious discoveries not already in memory and issue the standard "remember it" reflection for any that clear the auto-memory threshold. Apply WHAT_NOT_TO_SAVE as normal.
 6. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for completed tasks only — pending/in_progress tasks persist for next session.
 7. Archive the session via `claude-code-hermit:session-mgr` (full close — finalize SHELL.md and replace with fresh template in one operation). Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
    ```


### PR DESCRIPTION
## Summary

When reflect's cadence precheck returns `EMPTY`, it short-circuits before reaching its memory-review pass. This leaves single-session discoveries (framework quirks, architectural behaviors, debugging root-causes) uncaptured on those closes. This adds a two-sentence fallback in Step 5 that fires only on the `reflect: no candidates` signal, keeping the delegate-to-reflect design intact for normal closes.

## Changes

- `session-close/SKILL.md` Step 5: adds a fallback that scans `## Findings` and `## Progress Log` and issues the standard "remember it" reflection when reflect short-circuits on an empty precheck

## Test plan

- All 75 + 89 + 84 core plugin tests pass (`bash plugins/claude-code-hermit/tests/run-all.sh`)
- `--auto` path explicitly skips steps 1–5, so the fallback is absent there by construction

Closes #230