### PR TITLE
fix(dev-hermit): dev-pr Gate 1 SSH-unavailable fallback to HTTPS via gh

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **dev-pr Gate 1: HTTPS fallback when SSH unavailable** — when `git push` fails with `cannot run ssh` on a GitHub remote, retry over HTTPS via `gh auth git-credential` and record the fallback, instead of a generic FAIL. Makes `/dev-pr` work in Docker hermit containers without an `ssh` binary (#234).
+
 ## [0.3.12] - 2026-06-01
 
 ### Added

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -124,7 +124,25 @@ BEHIND=$(git rev-list --count "HEAD..$REMOTE_SHA")
 - `AHEAD > 0`: regular push: `git push origin "$CURRENT_BRANCH"`.
 - Both 0: skip push, record `push: already up to date`.
 
-On push failure: FAIL with stderr tail + recovery hint.
+**On push failure.** Capture stderr.
+
+- If stderr contains `cannot run ssh` **and** `FORGE=github` (from Gate 0 step 0b): the
+  container has no SSH binary but `gh` is the configured tool. Derive the HTTPS URL from
+  `git remote get-url origin`: `git@github.com:OWNER/REPO(.git)?` →
+  `https://github.com/OWNER/REPO.git`; for a `github.`-alias host (e.g.
+  `git@github-work:OWNER/REPO.git`), take the `OWNER/REPO` tail and prefix
+  `https://github.com/`. Retry:
+
+  ```bash
+  git -c "credential.helper=!gh auth git-credential" \
+    push https://github.com/<owner>/<repo>.git "$CURRENT_BRANCH:$CURRENT_BRANCH"
+  ```
+
+  - Success: record `push: HTTPS fallback (SSH unavailable)` and continue to Gate 2.
+  - Failure (or `gh` not found): FAIL `"SSH unavailable and HTTPS fallback failed; ensure gh is authenticated (gh auth login)"`.
+
+- Any other failure (including `cannot run ssh` on a non-GitHub forge): FAIL with stderr
+  tail + recovery hint.
 
 ### Gate 2 — assemble title and body
 

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -130,8 +130,8 @@ BEHIND=$(git rev-list --count "HEAD..$REMOTE_SHA")
   container has no SSH binary but `gh` is the configured tool. Derive the HTTPS URL from
   `git remote get-url origin`: `git@github.com:OWNER/REPO(.git)?` →
   `https://github.com/OWNER/REPO.git`; for a `github.`-alias host (e.g.
-  `git@github-work:OWNER/REPO.git`), take the `OWNER/REPO` tail and prefix
-  `https://github.com/`. Retry:
+  `git@github.work:OWNER/REPO.git`, matching Gate 0's `github.` rule), take the
+  `OWNER/REPO` tail and prefix `https://github.com/`. Retry:
 
   ```bash
   git -c "credential.helper=!gh auth git-credential" \


### PR DESCRIPTION
## Summary

When `git push` fails with `cannot run ssh` in a Docker hermit container (where `ssh` is intentionally absent), Gate 1 had no recovery path — it fell through to a generic FAIL with no actionable hint. This adds an HTTPS fallback for GitHub remotes that retries the push using `gh auth git-credential`, which is already a `/dev-pr` dependency (Gate 3 uses `gh pr create`).

## Changes

- `skills/dev-pr/SKILL.md` — Gate 1: replace the single-line `"On push failure: FAIL"` with a branched handler. When stderr contains `cannot run ssh` and `FORGE=github` (guaranteed by Gate 0 to mean `TOOL=gh`): derive the HTTPS URL from the `git@` remote, retry via `git -c credential.helper=!gh auth git-credential push https://...`, record `push: HTTPS fallback (SSH unavailable)`, and continue. Any other failure (including `cannot run ssh` on non-GitHub forges) keeps the existing generic FAIL path.

## Test plan

- `bash plugins/claude-code-dev-hermit/tests/run-all.sh` from inside the plugin dir: all tests pass (run and confirmed in this session).
- Manual positive: in an env with no `ssh` binary and a `git@github.com:` origin, `/dev-pr` should retry over HTTPS, record the fallback, and proceed to open the PR.
- Manual negative: same SSH-absent env with a GitLab origin should hit the generic FAIL path, not the GitHub fallback.

Closes #234.