### PR TITLE
feat(brief): suppress evening 'session still open' note when always_on + daily-auto-close enabled

### DIFF
--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -41,7 +41,7 @@ Emphasize backward-looking content:
 - Read `.claude-code-hermit/cost-summary.md` for today's cost and token total. If the summary is stale (its frontmatter `updated` date is not today), the cost-tracker will regenerate it on the next interaction — use the trend table's today row (Cost and Tokens columns) or fall back to scanning reports.
 - Key findings or patterns noticed
 - What to look at tomorrow
-- After generating summary: if SHELL.md Status is `in_progress` or has progress entries since last report, note it in the brief (e.g., "Session still open — run /session-close to archive.") and let the operator close explicitly. Idle transitions are owned by the `session` skill and `session-mgr`; brief does not trigger them.
+- After generating summary: if SHELL.md Status is `in_progress` or has progress entries since last report, note it in the brief (e.g., "Session still open — run /session-close to archive.") and let the operator close explicitly. Exception: if `config.always_on` is `true` AND `config.routines` contains an enabled entry with skill containing `daily-auto-close`, suppress the note — the auto-close routine archives it at midnight. Idle transitions are owned by the `session` skill and `session-mgr`; brief does not trigger them.
 
 ### No flag (default)
 


### PR DESCRIPTION
## Summary

In always-on setups with `daily-auto-close` configured, the evening brief was appending "Session still open — run /session-close to archive." even though the routine archives the session automatically at midnight. In always-on mode the brief ships as a push notification, so this was user-visible false-alarm noise on every evening run.

## Changes

- `skills/brief/SKILL.md` — adds a suppression exception to the `--evening` block: if `config.always_on` is `true` AND `config.routines` contains an enabled entry with skill containing `daily-auto-close`, the note is suppressed. All other cases keep the existing behaviour.

The gate mirrors the existing `config.always_on` + enabled-routine idiom already used in `session-start/SKILL.md`, so no new pattern is introduced.

## Test plan

- Re-read the edited bullet and confirm the gate matches the `session-start/SKILL.md` idiom.
- `bash plugins/claude-code-hermit/tests/run-all.sh` — all 30 tests pass (verified locally).
- Logic trace of the four cases:
  - `always_on=true` + `daily-auto-close` enabled → note suppressed ✓
  - `always_on=true` + `daily-auto-close` disabled → note kept ✓
  - `always_on=false` (any routine state) → note kept ✓
  - session not `in_progress` / no progress → no note (unchanged) ✓

Closes #232