### PR TITLE
fix(dev-hermit): derive owner/repo explicitly in dev-pr Gate 3 for SSH alias remotes

### DIFF
--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -165,16 +165,31 @@ Write the body to a temp file (avoids shell-quoting issues with multi-line markd
 PR_BODY_TMP=$(mktemp)
 # (Write tool wrote the body to $PR_BODY_TMP)
 
+# Derive owner/repo from origin so SSH host aliases (e.g. git@github.com-work:org/repo.git)
+# don't break gh/glab auto-detection. Falls back to bare invocation if the URL can't be parsed.
+OWNER_REPO=$(git remote get-url origin 2>/dev/null \
+  | sed -E 's#^(git@[^:]+:|ssh://[^/]+/|https?://[^/]+/)##; s#\.git$##')
+
 case "$TOOL" in
   gh)
-    $PR_CREATE --title "$TITLE" --body-file "$PR_BODY_TMP" --base "$BASE"
+    if [ -n "$OWNER_REPO" ]; then
+      $PR_CREATE --repo "$OWNER_REPO" --head "$CURRENT_BRANCH" \
+        --title "$TITLE" --body-file "$PR_BODY_TMP" --base "$BASE"
+    else
+      $PR_CREATE --title "$TITLE" --body-file "$PR_BODY_TMP" --base "$BASE"
+    fi
     ;;
   glab)
     # glab mr create uses --description (string) and --target-branch, not --body-file/--base
-    $PR_CREATE --title "$TITLE" --description "$(cat "$PR_BODY_TMP")" --target-branch "$BASE"
+    if [ -n "$OWNER_REPO" ]; then
+      $PR_CREATE -R "$OWNER_REPO" --source-branch "$CURRENT_BRANCH" \
+        --title "$TITLE" --description "$(cat "$PR_BODY_TMP")" --target-branch "$BASE"
+    else
+      $PR_CREATE --title "$TITLE" --description "$(cat "$PR_BODY_TMP")" --target-branch "$BASE"
+    fi
     ;;
   *)
-    # Custom command: Gate 3 passes gh-style flags.
+    # Custom command: Gate 3 passes gh-style flags (no --repo; the wrapper owns repo resolution).
     # Wrap your CLI in a script that accepts --title --body-file --base if it uses different flags.
     $PR_CREATE --title "$TITLE" --body-file "$PR_BODY_TMP" --base "$BASE"
     ;;


### PR DESCRIPTION
## Summary

`gh pr create` auto-detects the target repo from the `origin` remote URL. When operators use a custom SSH hostname alias (e.g. `git@github.com-work:org/repo.git`, a standard multi-account pattern), `gh` cannot resolve the alias to a known GitHub host and exits with a misleading "run `gh auth login`" error. The `glab mr create` branch has the identical latent dependency.

Gate 3 now derives `owner/repo` from the `origin` URL via a host-agnostic prefix-strip `sed`, then passes `--repo`/`--head` (gh) and `-R`/`--source-branch` (glab) explicitly. A fallback to the bare invocation preserves today's behavior when the URL can't be parsed (empty remote, exotic format).

## Changes

- `dev-pr/SKILL.md` Gate 3: add `OWNER_REPO` derivation before the `case` block using `sed -E 's#^(git@[^:]+:|ssh://[^/]+/|https?://[^/]+/)##; s#\.git$##'` — handles SSH aliases, `ssh://host[:port]/` form, HTTPS, and dotted repo names
- `gh` arm: pass `--repo "$OWNER_REPO" --head "$CURRENT_BRANCH"` when parse succeeds, bare fallback otherwise
- `glab` arm: pass `-R "$OWNER_REPO" --source-branch "$CURRENT_BRANCH"` symmetrically (same latent bug, same fix)
- `*)` comment: clarify that the custom-command arm stays bare (wrapper owns repo resolution)

## Test plan

Parse table verified in shell against all representative URL forms:
- `git@github.com:gtapps/claude-code-hermit.git` → `gtapps/claude-code-hermit` (normal remote, regression)
- `git@github.com-work:owner/repo.git` → `owner/repo` (the alias bug case)
- `git@host:owner/repo.js.git` → `owner/repo.js` (dotted repo name — proves the refined parse over the issue's original regex)
- `ssh://git@host:22/owner/repo.git` → `owner/repo` (ssh:// form)
- `https://github.com/owner/repo.git` → `owner/repo` (HTTPS)
- empty / no remote → empty → bare fallback engages

Structural lint: `bash plugins/claude-code-dev-hermit/tests/run-all.sh` — 204/204 passed.

Closes #235