### PR TITLE
fix(claude-code-hermit): drop disable-model-invocation from session skill (#229)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **session bootstrap: drop `disable-model-invocation` from session skill** — always-on multi-step boot invokes it via the Skill tool, which the flag rejected; bare hermits (single step) were unaffected, making the failure look intermittent (#229).
 - **hatch: always default `push_notifications: true` on fresh hatch** — removed the channel-choice derivation that wrote `false` whenever a channel was selected. The runtime guard in `CLAUDE-APPEND.md` already enforces channel-first delivery with push as fallback, so the hatch-time override was discarding the fallback unnecessarily. Both Quick and Advanced modes now leave `push_notifications` at the template default (`true`); re-init still preserves the existing value.
 
 ### Upgrade Instructions

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: session
 description: Start or resume a work session with full context loading and work tracking. Use at the beginning of work.
-disable-model-invocation: true
 ---
 # Session
 

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1437,5 +1437,25 @@ class TestKillMetricsContract(unittest.TestCase):
         )
 
 
+class TestBootstrapSkills(unittest.TestCase):
+    """Skills reachable from hermit-start.py's bootstrap `steps` are invoked
+    via the Skill tool when 2+ steps produce the prose path.
+    Any `disable-model-invocation: true` among them silently breaks first
+    boot (issue #229). Keep them model-invocable."""
+
+    BOOTSTRAP_SKILLS = ('heartbeat', 'hermit-routines', 'session')
+
+    def test_bootstrap_skills_are_model_invocable(self):
+        offenders = []
+        for skill in self.BOOTSTRAP_SKILLS:
+            text = (REPO / 'skills' / skill / 'SKILL.md').read_text()
+            parts = text.split('---\n', 2)
+            fm = parts[1] if len(parts) == 3 else ''
+            if 'disable-model-invocation: true' in fm:
+                offenders.append(skill)
+        self.assertEqual(offenders, [],
+                         f'Bootstrap skills must stay model-invocable; offenders: {offenders}')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Removes `disable-model-invocation: true` from `skills/session/SKILL.md` so always-on hermits with heartbeat or routines enabled can complete their multi-step first boot.

`hermit-start.py` delivers the bootstrap as prose when 2+ steps are configured ("Invoke these skills in order: …"), forcing the model to call each step via the Skill tool. The flag caused that call to be rejected for `session`, silently aborting session init on first boot. Single-step hermits (heartbeat/routines both off) were unaffected, making the failure look intermittent.

The flag was introduced in the initial Phase-1 scaffold with no documented intent, and `session-start` (which `session` directly wraps) already lacks it.

## Changes

- `skills/session/SKILL.md` — remove `disable-model-invocation: true`
- `tests/run-contracts.py` — add `TestBootstrapSkills` contract test; asserts no bootstrap-reachable skill (`heartbeat`, `hermit-routines`, `session`) carries the flag, preventing silent reintroduction
- `CHANGELOG.md` — `[Unreleased]` `### Fixed` bullet

## Test plan

- `bash tests/run-all.sh` — 90 contract tests + all other suites pass
- Guard confirmed: temporarily re-adding the flag causes `TestBootstrapSkills` to fail with `"Bootstrap skills must stay model-invocable; offenders: ['session']"`

Closes #229