### PR TITLE
feat(dev-hermit): extend dev-pr SSH→HTTPS fallback to GitLab + unsupported-forge message

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **dev-pr Gate 1: HTTPS fallback when SSH unavailable** — when `git push` fails with `cannot run ssh` on a GitHub remote, retry over HTTPS via `gh auth git-credential` and record the fallback, instead of a generic FAIL. Makes `/dev-pr` work in Docker hermit containers without an `ssh` binary (#234).
+- **dev-pr Gate 1: HTTPS fallback when SSH unavailable** — when `git push` fails with `cannot run ssh`, retry over HTTPS via the forge's git-credential helper and record the fallback, instead of a generic FAIL. Covers GitHub (`gh`, #234) and GitLab (`glab`, #246); other forges get a tailored message naming the manual recovery path. Makes `/dev-pr` work in Docker hermit containers without an `ssh` binary. The GitLab auto-fallback targets gitlab.com, so a self-hosted instance reached via a `gitlab.`-alias host should switch origin to that instance's HTTPS remote.
 
 ## [0.3.12] - 2026-06-01
 

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -154,6 +154,9 @@ BEHIND=$(git rev-list --count "HEAD..$REMOTE_SHA")
 
     - Success: record `push: HTTPS fallback (SSH unavailable)` and continue to Gate 2.
     - Failure (or `glab` not found): FAIL `"SSH unavailable and HTTPS fallback failed; ensure glab is authenticated (glab auth login)"`.
+    - Note: this rewrite assumes gitlab.com SaaS. A self-hosted GitLab reached via a
+      `gitlab.`-alias host resolves to gitlab.com and fails auth; switch origin to that
+      instance's HTTPS remote instead.
 
   - **Otherwise** (`bitbucket` / `custom` / unknown): FAIL `"SSH push failed because no ssh
     binary is available, and automatic HTTPS fallback is only supported for GitHub and GitLab.

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -126,23 +126,41 @@ BEHIND=$(git rev-list --count "HEAD..$REMOTE_SHA")
 
 **On push failure.** Capture stderr.
 
-- If stderr contains `cannot run ssh` **and** `FORGE=github` (from Gate 0 step 0b): the
-  container has no SSH binary but `gh` is the configured tool. Derive the HTTPS URL from
-  `git remote get-url origin`: `git@github.com:OWNER/REPO(.git)?` →
-  `https://github.com/OWNER/REPO.git`; for a `github.`-alias host (e.g.
-  `git@github.work:OWNER/REPO.git`, matching Gate 0's `github.` rule), take the
-  `OWNER/REPO` tail and prefix `https://github.com/`. Retry:
+- If stderr contains `cannot run ssh`: the container has no SSH binary. Dispatch on `FORGE`
+  (from Gate 0 step 0b):
 
-  ```bash
-  git -c "credential.helper=!gh auth git-credential" \
-    push https://github.com/<owner>/<repo>.git "$CURRENT_BRANCH:$CURRENT_BRANCH"
-  ```
+  - **`FORGE=github`**: derive the HTTPS URL from `git remote get-url origin`:
+    `git@github.com:OWNER/REPO(.git)?` → `https://github.com/OWNER/REPO.git`; for a
+    `github.`-alias host (e.g. `git@github.work:OWNER/REPO.git`, matching Gate 0's `github.`
+    rule), take the `OWNER/REPO` tail and prefix `https://github.com/`. Retry:
 
-  - Success: record `push: HTTPS fallback (SSH unavailable)` and continue to Gate 2.
-  - Failure (or `gh` not found): FAIL `"SSH unavailable and HTTPS fallback failed; ensure gh is authenticated (gh auth login)"`.
+    ```bash
+    git -c "credential.helper=!gh auth git-credential" \
+      push https://github.com/<owner>/<repo>.git "$CURRENT_BRANCH:$CURRENT_BRANCH"
+    ```
 
-- Any other failure (including `cannot run ssh` on a non-GitHub forge): FAIL with stderr
-  tail + recovery hint.
+    - Success: record `push: HTTPS fallback (SSH unavailable)` and continue to Gate 2.
+    - Failure (or `gh` not found): FAIL `"SSH unavailable and HTTPS fallback failed; ensure gh is authenticated (gh auth login)"`.
+
+  - **`FORGE=gitlab`**: derive the HTTPS URL from `git remote get-url origin`:
+    `git@gitlab.com:OWNER/REPO(.git)?` → `https://gitlab.com/OWNER/REPO.git`; for a
+    `gitlab.`-alias host (e.g. `git@gitlab.work:OWNER/REPO.git`, matching Gate 0's `gitlab.`
+    rule), take the `OWNER/REPO` tail and prefix `https://gitlab.com/`. Retry:
+
+    ```bash
+    git -c "credential.helper=!glab auth git-credential" \
+      push https://gitlab.com/<owner>/<repo>.git "$CURRENT_BRANCH:$CURRENT_BRANCH"
+    ```
+
+    - Success: record `push: HTTPS fallback (SSH unavailable)` and continue to Gate 2.
+    - Failure (or `glab` not found): FAIL `"SSH unavailable and HTTPS fallback failed; ensure glab is authenticated (glab auth login)"`.
+
+  - **Otherwise** (`bitbucket` / `custom` / unknown): FAIL `"SSH push failed because no ssh
+    binary is available, and automatic HTTPS fallback is only supported for GitHub and GitLab.
+    For this forge, either install an SSH client, or switch origin to an HTTPS remote with a
+    credential helper configured (git remote set-url origin https://...)"`.
+
+- Any other failure: FAIL with stderr tail + recovery hint.
 
 ### Gate 2 — assemble title and body
 

--- a/plugins/claude-code-dev-hermit/tests/forge-awareness.test.js
+++ b/plugins/claude-code-dev-hermit/tests/forge-awareness.test.js
@@ -98,9 +98,11 @@ ok('glab mr create documented', devPr.includes('glab mr create'));
 
 console.log('\ndev-pr SKILL.md — Gate 0 forge sanity check:');
 
-ok('not configured message present', devPr.includes('not configured'));
-ok('FORGE=github check present',     devPr.includes('FORGE=github'));
-ok('FORGE=gitlab check present',     devPr.includes('FORGE=gitlab'));
+ok('not configured message present',        devPr.includes('not configured'));
+ok('FORGE=github check present',            devPr.includes('FORGE=github'));
+ok('FORGE=gitlab check present',            devPr.includes('FORGE=gitlab'));
+ok('GitLab SSH→HTTPS fallback present',     devPr.includes('!glab auth git-credential'));
+ok('unsupported-forge SSH message present', devPr.includes('only supported for GitHub and GitLab'));
 
 // ── dev-pr — Gate 3 exact flag assertions ───────────────────────────────────
 


### PR DESCRIPTION
## Summary

Extends the SSH→HTTPS push fallback in `/dev-pr` Gate 1 (added in #234 / PR #241) to cover GitLab and give a clear error for unsupported forges.

Previously the fallback was GitHub-only: `cannot run ssh` + `FORGE=github` triggered an automatic HTTPS retry via `gh auth git-credential`. GitLab operators in SSH-less Docker containers hit the same failure with no auto-recovery. Bitbucket/custom operators got a generic error that didn't explain what was wrong.

## Changes

- **`skills/dev-pr/SKILL.md`** — restructures the Gate 1 push-failure block from three separate `cannot run ssh AND FORGE=X` checks into a single `cannot run ssh` outer guard with an inner FORGE dispatch:
  - `FORGE=github` → existing `gh auth git-credential` HTTPS fallback (unchanged)
  - `FORGE=gitlab` → new `glab auth git-credential` HTTPS fallback (symmetric mirror)
  - otherwise → tailored FAIL message explaining SSH is unavailable and that automatic HTTPS fallback is GitHub/GitLab-only, with the manual recovery path (`git remote set-url origin https://...`)
- **`tests/forge-awareness.test.js`** — two new presence assertions for the GitLab fallback credential helper string and the unsupported-forge message; re-aligns the Gate 0 block to consistent column width.

## Test plan

- `cd plugins/claude-code-dev-hermit && bash tests/run-all.sh` — 43 forge-awareness assertions pass (including the two new ones), full suite green.
- Manual (same untestability as the existing GitHub fallback — needs a real forge + missing SSH binary + authenticated CLI): GitLab Docker-hermit operator with authenticated `glab` → retry over HTTPS, `push: HTTPS fallback (SSH unavailable)` recorded. Bitbucket/custom operator → tailored message, not the generic hint.

Closes #246.