### PR TITLE
docs(claude-code-hermit): clarify OPERATOR.md vs CLAUDE.md for behavioral rules

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **docs: clarify OPERATOR.md vs CLAUDE.md** — FAQ entry and how-to-use pointer; behavioral rules belong in CLAUDE.md, not OPERATOR.md. Closes #262.
 - **session-close: memory-review fallback when reflect short-circuits** — captures single-session discoveries on operator closes where reflect's cadence precheck returns EMPTY. Skipped on `--auto` by construction. Closes #230.
 
 ### Fixed

--- a/plugins/claude-code-hermit/docs/faq.md
+++ b/plugins/claude-code-hermit/docs/faq.md
@@ -95,6 +95,15 @@ By design, no. OPERATOR.md is human-curated — the hermit reads it but never wr
 
 ---
 
+## OPERATOR.md vs CLAUDE.md — where does it go?
+
+- **OPERATOR.md** — project context the operator curates: priorities, constraints, stakeholder notes, approval rules. Loaded at session start. Never auto-edited.
+- **CLAUDE.md** (or **CLAUDE.local.md**) — behavioral instructions for Claude Code: "when X happens, do Y", skill-invocation patterns, coding conventions. Loaded on every invocation (sessions, heartbeats, routines, channel messages) and edited normally.
+
+Rule of thumb: *what the project is* → OPERATOR.md. *What Claude should do* → CLAUDE.md.
+
+---
+
 ## What's the difference between a "hermit" and a "hermit plugin"?
 
 - **Hermit** = the running assistant instance in your project — what you get after running `/hatch`.

--- a/plugins/claude-code-hermit/docs/how-to-use.md
+++ b/plugins/claude-code-hermit/docs/how-to-use.md
@@ -50,6 +50,8 @@ A web app. Be careful.
 
 The whole file is loaded on session start — write what matters, keep it short. Update anytime: just tell Hermit "update OPERATOR.md with [your change]."
 
+Behavioral "when X, do Y" rules belong in `CLAUDE.md`, not here — see [the FAQ](faq.md#operatormd-vs-claudemd--where-does-it-go).
+
 ---
 
 ## Your First Session


### PR DESCRIPTION
## Summary

Operators wanting Claude to react to hermit events (e.g. "when `SESSION_STATE_CHANGED:idle` arrives, invoke `/serve stop`") naturally reach for `OPERATOR.md`. That's the wrong home: it loads only at session start and is mechanically blocked from auto-edits. Behavioral "when X do Y" rules need to go in `CLAUDE.md`, which loads on every invocation. No docs explained this distinction.

## Changes

- `docs/faq.md` — new Q&A entry "OPERATOR.md vs CLAUDE.md — where does it go?" added immediately after the existing "Can the hermit modify OPERATOR.md?" entry, where operators already land when researching this.
- `docs/how-to-use.md` — one-line pointer at the end of the `### OPERATOR.md` section directing to the new FAQ entry.
- `CHANGELOG.md` — `[Unreleased] ### Added` bullet.

## Test plan

- Docs-only change; no code affected. Verify the FAQ entry renders correctly and the `how-to-use.md` link resolves to the right anchor (`#operatormd-vs-claudemd--where-does-it-go`).

Closes #262