### PR TITLE
fix(dev-hermit): dev-quality Gate 0 hints to create feature branch on protected branch

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixed
 
-- **dev-pr Gate 1: HTTPS fallback when SSH unavailable** — when `git push` fails with `cannot run ssh` on a GitHub remote, retry over HTTPS via `gh auth git-credential` and record the fallback, instead of a generic FAIL. Makes `/dev-pr` work in Docker hermit containers without an `ssh` binary (#234).
 - **dev-quality Gate 0: protected-branch hint** — on a clean tree on a protected branch, point to §Branch Discipline instead of the generic nested-repo hint (#267).
 - **dev-pr Gate 1: HTTPS fallback when SSH unavailable** — when `git push` fails with `cannot run ssh`, retry over HTTPS via the forge's git-credential helper and record the fallback, instead of a generic FAIL. Covers GitHub (`gh`, #234) and GitLab (`glab`, #246); other forges get a tailored message naming the manual recovery path. Makes `/dev-pr` work in Docker hermit containers without an `ssh` binary. The GitLab auto-fallback targets gitlab.com, so a self-hosted instance reached via a `gitlab.`-alias host should switch origin to that instance's HTTPS remote.
 

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **dev-pr Gate 1: HTTPS fallback when SSH unavailable** — when `git push` fails with `cannot run ssh` on a GitHub remote, retry over HTTPS via `gh auth git-credential` and record the fallback, instead of a generic FAIL. Makes `/dev-pr` work in Docker hermit containers without an `ssh` binary (#234).
+- **dev-quality Gate 0: protected-branch hint** — on a clean tree on a protected branch, point to §Branch Discipline instead of the generic nested-repo hint (#267).
 
 ## [0.3.12] - 2026-06-01
 

--- a/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
@@ -10,7 +10,7 @@ Run a cleanup pass on the working-tree changes before declaring the task done. I
 ## Prerequisites
 
 - Verify `.claude-code-hermit/sessions/` exists. If not: tell the operator to run `/claude-code-hermit:hatch` and `/claude-code-dev-hermit:hatch` first.
-- Read `commands.test` from `.claude-code-hermit/config.json`. If unset, the test step is skipped — `/claude-code-hermit:simplify` still runs.
+- Read `.claude-code-hermit/config.json` once. Cache `commands.test` (if unset, the test step is skipped — `/claude-code-hermit:simplify` still runs) and `claude-code-dev-hermit.protected_branches` (default `["main", "master"]` if absent).
 
 ## Plan
 
@@ -28,7 +28,7 @@ git -C "$TARGET" status --porcelain
 
 Empty output → working tree is clean (no modified, staged, or untracked-but-not-ignored files). Any non-empty output passes Gate 0, including untracked-only changes — `/claude-code-hermit:simplify` captures new files via `git status --short` + synthetic `+++` blocks, so a task that only adds files still has cleanup scope.
 
-Before failing on empty output, check whether HEAD has commits ahead of the base:
+Before failing on empty output, run the following checks in order:
 
 1. Resolve `BASE_NAME` using the same priority order as `/dev-pr` Gate 0 step 4 (`pr_base_branch` → first non-glob `protected_branches` → `origin/HEAD` → `main`/`master`).
 2. Resolve `BASE_REF`: try `git -C "$TARGET" rev-parse --verify "$BASE_NAME" 2>/dev/null`; on failure try `git -C "$TARGET" rev-parse --verify "origin/$BASE_NAME" 2>/dev/null`; if neither resolves, skip the NOTICE.
@@ -41,7 +41,23 @@ Before failing on empty output, check whether HEAD has commits ahead of the base
            To verify the committed state passes tests, run /dev-test instead.
    ```
 
-Then FAIL `"no working-tree changes — nothing to clean up"`. Append the hint `hint: if edits are in a nested git repo, re-run with --cwd <path>` unless `--cwd` was already passed.
+4. Detect whether the current branch is protected using bash glob semantics (same pattern as `/dev-pr` Gate 0 step 1):
+
+   ```bash
+   PROTECTED_BRANCHES=(main master)   # from config.claude-code-dev-hermit.protected_branches
+   CURRENT_BRANCH=$(git -C "$TARGET" rev-parse --abbrev-ref HEAD)
+   ON_PROTECTED=0
+   for pattern in "${PROTECTED_BRANCHES[@]}"; do
+     case "$CURRENT_BRANCH" in $pattern) ON_PROTECTED=1 ;; esac
+   done
+   ```
+
+   - If `ON_PROTECTED=1`: FAIL `"no working-tree changes — nothing to clean up"` with hint:
+     ```
+     hint: you're on protected branch '<CURRENT_BRANCH>' with a clean tree.
+           create a feature branch before making changes (see CLAUDE-APPEND.md §Branch Discipline).
+     ```
+   - Otherwise: FAIL `"no working-tree changes — nothing to clean up"`. Append `hint: if edits are in a nested git repo, re-run with --cwd <path>` unless `--cwd` was already passed.
 
 ### Gate 1 — run `/claude-code-hermit:simplify`
 
@@ -150,6 +166,15 @@ dev-quality
 ```
 
 (The `hint:` line is omitted when `--cwd` was already passed.)
+
+On Gate 0 failure (clean tree, on a protected branch):
+
+```
+dev-quality
+  FAIL (Gate 0): no working-tree changes — nothing to clean up
+                 hint: you're on protected branch 'main' with a clean tree.
+                       create a feature branch before making changes (see CLAUDE-APPEND.md §Branch Discipline).
+```
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Gate 0 of `/dev-quality` now detects when the operator is on a protected branch with a clean tree (the common post-merge state: merge PR, switch back to `main`, run `/dev-quality` out of habit) and emits a targeted hint pointing to `§Branch Discipline` instead of the generic nested-repo hint.

Closes #267

## Changes

- **Prerequisites**: merged the two separate `config.json` reads into one, adding `protected_branches` cache alongside `commands.test` — mirrors `dev-pr`'s Prerequisites.
- **Gate 0 step 4**: added a protected-branch detection step after the commits-ahead NOTICE, using the bash glob-match pattern from `dev-pr` Gate 0 step 1. On a protected branch the hint replaces the nested-repo hint; on a non-protected branch the nested-repo hint is unchanged.
- **Output section**: added one new example for the protected-branch failure case.

## Test plan

- `bash plugins/claude-code-dev-hermit/tests/run-all.sh` — all 214 tests pass (verified locally).
- Manual reasoning: clean tree on `main` → protected-branch hint; clean tree on a feature branch → unchanged generic hint; dirty tree on `main` → Gate 0 passes through to Gate 1 unchanged.