### PR TITLE
feat(hermit): surface plugin upgrade in always-on morning brief

### DIFF
--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -24,6 +24,7 @@ Emphasize forward-looking content:
 - If `config.always_on` is `false`: frame as "here's where things stand" rather than "what happened overnight"
 - What's queued (NEXT-TASK.md, open proposals)
 - If auto-memory seems sparse (new instance, fresh machine), read the latest S-NNN-REPORT.md for context recovery
+- If `config.always_on` is `true`: run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-upgrade.sh" "${CLAUDE_PLUGIN_ROOT}"` from the project root. If it emits an `---Upgrade Available---` section, append a final line to the brief: `⚠ Plugin update available: <the version line>. Run /claude-code-hermit:hermit-evolve.` Output nothing if the script is silent. (Interactive operators already see this notice at session-start step 2; the gate avoids double-notification.)
 
 <!-- keep in sync with plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md step 9a — same MP lifecycle protocol -->
 After composing the morning brief, check `state/micro-proposals.json → pending` for entries with `status: "pending"` **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**:

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -24,7 +24,7 @@ Emphasize forward-looking content:
 - If `config.always_on` is `false`: frame as "here's where things stand" rather than "what happened overnight"
 - What's queued (NEXT-TASK.md, open proposals)
 - If auto-memory seems sparse (new instance, fresh machine), read the latest S-NNN-REPORT.md for context recovery
-- If `config.always_on` is `true`: run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-upgrade.sh" "${CLAUDE_PLUGIN_ROOT}"` from the project root. If it emits an `---Upgrade Available---` section, append a final line to the brief: `⚠ Plugin update available: <the version line>. Run /claude-code-hermit:hermit-evolve.` Output nothing if the script is silent. (Interactive operators already see this notice at session-start step 2; the gate avoids double-notification.)
+- If `config.always_on` is `true`: run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-upgrade.sh" "${CLAUDE_PLUGIN_ROOT}"` from the project root. If it emits an `---Upgrade Available---` section, append a final line to the brief: `⚠ Plugin update available: <the version line>` (the version line already ends with `Run /claude-code-hermit:hermit-evolve`; do not repeat it). Output nothing if the script is silent. (Interactive operators already see this notice at session-start step 2; the gate avoids double-notification.)
 
 <!-- keep in sync with plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md step 9a — same MP lifecycle protocol -->
 After composing the morning brief, check `state/micro-proposals.json → pending` for entries with `status: "pending"` **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**:


### PR DESCRIPTION
## Summary

In always-on deployments, `check-upgrade.sh` runs only at Claude Code process boot via the SessionStart hook. A `/plugin update` applied while the process is running leaves the version mismatch undetected until the next restart — which could be days away. The morning brief is the one daily-recurring channel touchpoint that re-reads state live, making it the right place to surface this.

## Changes

- `brief --morning` now runs `check-upgrade.sh` (passing `CLAUDE_PLUGIN_ROOT` as `$1`, matching the existing `startup-context.js` call site) when `config.always_on` is `true`.
- If the script emits an `---Upgrade Available---` section, a final line is appended to the brief: `⚠ Plugin update available: <version line>. Run /claude-code-hermit:hermit-evolve.`
- Gated on `always_on` — interactive operators already see the upgrade notice at session-start step 2; the gate avoids double-notification.
- Reuses `check-upgrade.sh` rather than reimplementing the `_hermit_versions` comparison (single source of truth).

Note: benefits only always-on operators who have a morning brief routine enabled (opt-in via hatch). The HA hermit's `ha-morning-brief` skill is not covered — out of scope.

## Test plan

- Set `config.always_on: true` and `_hermit_versions["claude-code-hermit"]` below `plugin.json` version; invoke `/claude-code-hermit:brief --morning` — confirm `⚠ Plugin update available:` line appears.
- Set versions to match; re-run — confirm no upgrade line.
- Set `config.always_on: false` with a stale version; re-run — confirm line is absent.
- `bash plugins/claude-code-hermit/tests/run-all.sh` — all 425 tests pass.

Closes #254.