### PR TITLE
feat(hermit): capture interactive channel patterns as SHELL.md findings

### DIFF
--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -139,6 +139,24 @@ This is how the agent learns the DM channel ID for proactive outbound notificati
 - Always reference the current task so the operator knows you're oriented
 - If you can't handle the request, say so clearly and suggest what the operator should do
 
+## 4. Capture Interactive Patterns
+
+After sending the response, check whether this turn revealed a durable signal worth recording. Append **at most one** line to SHELL.md `## Findings` when the turn matches one of these conditions:
+
+- **Stated preference or rule** — the operator explicitly said how they want something done going forward ("always include the cost", "stop sending the brief before 9", "I prefer X over Y").
+- **Recurring request type** — you recognise this as the same kind of request handled earlier in this session or in recent session context loaded at start, not a first occurrence.
+- **Correction or emergency implying a durable preference** — "stop doing X", "don't do that again", "revert" with a reason that names a general behaviour.
+
+**Do not write a finding** for: one-off questions, research turns with no preference signal, task assignments, status checks, or micro-approval responses. When in doubt, write nothing — the next scheduled reflect catches genuine recurrence via archived-session evidence.
+
+Format (one line, appended under `## Findings`):
+
+```
+[HH:MM] Channel pattern: <one-line description of the preference or recurrence>
+```
+
+Do not classify tier, tag Evidence Source, or decide memory-vs-proposal. Reflect reads this line as `current-session` evidence (`Evidence Source: current-session`, `Sessions: current`) and runs triage and the reflection-judge to decide the outcome.
+
 ## Note
 
 This skill is a stub for the Channels research preview (Claude Code v2.1.110+). As Channels matures, extend this skill with:


### PR DESCRIPTION
## Summary

Adds a `## 4. Capture Interactive Patterns` step to `channel-responder`. After handling a channel message, the agent appends one line to SHELL.md `## Findings` when the turn reveals a stated operator preference, a recurring request type, or a correction implying a durable preference. Reflect's existing `current-session` path then picks it up — no new trigger infrastructure needed.

## Changes

- `channel-responder/SKILL.md`: new section defines the capture bar (three qualifying conditions), the format (`[HH:MM] Channel pattern: …`), the explicit negative cases (one-off questions, status checks, task assignments, micro-approvals), and a delegation note — reflect runs triage and reflection-judge to decide memory/proposal/no-action.

## Why this approach instead of the issue's proposal

Issue #253 proposed a `reflect_after_channel_turns` counter that fires `reflect --quick` past a threshold. That mechanism rests on two false premises: `channel-activity.json` has no counter (only a `last_reply_at` timestamp), and `reflect --quick` only acts on SHELL.md `## Findings` — which channel-responder never wrote to. The trigger would have been a near-guaranteed no-op.

The real gap was capture, not triggering. Once a finding is in SHELL.md, the scheduled reflect and any `reflect_after: true` routine already consume it. This PR fixes the capture side only, keeping the trigger complexity at zero.

## Test plan

- `bash tests/run-all.sh` from `plugins/claude-code-hermit/` — all 75 hook contract + 90 script/static + all other suites pass (0 failures, verified before commit).
- Manual: send a channel message stating a preference; confirm one `[HH:MM] Channel pattern: …` line appears under `## Findings` in SHELL.md. Send a plain question; confirm nothing is written.
- Run `/claude-code-hermit:reflect --quick`; confirm the appended line is evaluated as a Tier-1 `current-session` candidate.

Closes #253