### PR TITLE
feat(fitness-hermit): surface strength-session recovery signal in daily sync and weekly review

### DIFF
--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **strava-sync + weekly-load-review: surface strength-session recovery signal** — the daily sync derives a fatigue tier (`moderate`/`light`/`none`) from each new WeightTraining/Workout `moving_time` and appends a leg-fatigue note to the 21:30 summary; the weekly review reports strength as `[N] sessions ([M] min)` and persists `strength_minutes` to `strava-weekly-baselines.json` (additive field). No new state files or API calls. Closes #258.
 - **domain-brainstorm: on-demand training-gap brainstorm skill** — reads Strava history and MEMORY.md goals, delegates bulk aggregation to `strava-data-cruncher`, and surfaces at most 2 goal-coverage or imbalance ideas (prefixes `[goal-gap]`, `[imbalance]`) as proposals via `proposal-create`. Scoped to coverage/imbalance gaps only — cardiac-drift and load trends remain with `weekly-coaching-patterns`. Never runs autonomously.
 - **Core Rule: ground training-history facts in Strava, not memory** — records, PBs, all-time totals, counts, and cross-block comparisons require a full-history Strava query; context/compaction may drop older activities. Recent-activity questions are unaffected.
 

--- a/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
@@ -24,7 +24,7 @@ Check for new Strava activities uploaded today. Compare against the last known a
    - Log: date, type (run/ride/weight training), distance (km), duration, name
    - If it's a **run > 10km**: call `mcp__strava__get-activity-streams` with keys `heartrate,velocity_smooth,altitude,cadence`. Compute average HR zone distribution using the zone boundaries from Step 5. Flag if >30% time in Z4+.
    - If it's a **run on a day after a hard session (Z4+ flagged)**: note "recovery day recommended tomorrow".
-   - If it's a **WeightTraining or Workout**: derive a fatigue tier from `moving_time` (already in the Step 2 payload) — `≥45 min → moderate`, `30–44 min → light`, `<30 min → none`. Track the highest tier seen across all new strength activities today (`moderate` > `light` > `none`).
+   - If it's a **WeightTraining or Workout**: derive a fatigue tier from `moving_time` (already in the Step 2 payload, in seconds; divide by 60 for minutes) — `≥45 min → moderate`, `30–44 min → light`, `<30 min → none`. Track the highest tier seen across all new strength activities today (`moderate` > `light` > `none`).
    - If **no activity today** (0 new): check if yesterday also had 0 new. If 2+ consecutive rest days after a non-rest day, log: "2 consecutive rest days — intentional recovery or missed session?"
 7. Write the highest new activity ID to `state/strava-last-activity-id.txt`.
 8. For each new activity whose Strava `type` is `Run`, invoke `/claude-code-fitness-hermit:activity-deep-dive <id>` to produce a full coaching analysis.

--- a/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-strava-sync.md
@@ -24,6 +24,7 @@ Check for new Strava activities uploaded today. Compare against the last known a
    - Log: date, type (run/ride/weight training), distance (km), duration, name
    - If it's a **run > 10km**: call `mcp__strava__get-activity-streams` with keys `heartrate,velocity_smooth,altitude,cadence`. Compute average HR zone distribution using the zone boundaries from Step 5. Flag if >30% time in Z4+.
    - If it's a **run on a day after a hard session (Z4+ flagged)**: note "recovery day recommended tomorrow".
+   - If it's a **WeightTraining or Workout**: derive a fatigue tier from `moving_time` (already in the Step 2 payload) — `≥45 min → moderate`, `30–44 min → light`, `<30 min → none`. Track the highest tier seen across all new strength activities today (`moderate` > `light` > `none`).
    - If **no activity today** (0 new): check if yesterday also had 0 new. If 2+ consecutive rest days after a non-rest day, log: "2 consecutive rest days — intentional recovery or missed session?"
 7. Write the highest new activity ID to `state/strava-last-activity-id.txt`.
 8. For each new activity whose Strava `type` is `Run`, invoke `/claude-code-fitness-hermit:activity-deep-dive <id>` to produce a full coaching analysis.
@@ -33,6 +34,7 @@ Check for new Strava activities uploaded today. Compare against the last known a
 9. Send a summary via the configured channel. Format:
    ```
    Daily sync: [X run Xkm, Y ride, Z weights]. [Flag if any]
+   ⚠️ Strength session today [light|moderate] — monitor leg fatigue on tomorrow's run.   ← omit if tier is none or no strength activity
    Reply 'RPE 1-10 [notes]' to log perceived effort (e.g. '7, heavy legs').
    ```
    If no channel is configured, log the summary (without the RPE prompt) to SHELL.md Progress Log and proceed to step 10.

--- a/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-weekly-load-review.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-weekly-load-review.md
@@ -21,7 +21,7 @@ Pull the last 14 days of Strava activities and compute weekly training load summ
 4. For each week compute:
    - Run: total distance (km), total elevation (m), session count
    - Bike: total distance (km), session count
-   - Strength: session count, total duration in minutes as `strength_minutes` (sum `moving_time` over WeightTraining/Workout activities — already in the Step 2 payload, no extra call)
+   - Strength: session count, total duration in minutes as `strength_minutes` (sum `moving_time` over WeightTraining/Workout activities — already in the Step 2 payload, no extra call; `moving_time` is in seconds, so divide the sum by 60)
    - Total active days
 5. Read `state/strava-weekly-baselines.json` and `state/activity-notes.json` (or `{}` if absent) in the same turn. The baselines file is used in step 6; the activity notes will be used in step 8.
 6. Compare this week's run distance to the 4-week rolling average from the baseline file:

--- a/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-weekly-load-review.md
+++ b/plugins/claude-code-fitness-hermit/state-templates/compiled/routine-weekly-load-review.md
@@ -21,14 +21,14 @@ Pull the last 14 days of Strava activities and compute weekly training load summ
 4. For each week compute:
    - Run: total distance (km), total elevation (m), session count
    - Bike: total distance (km), session count
-   - Strength: session count
+   - Strength: session count, total duration in minutes as `strength_minutes` (sum `moving_time` over WeightTraining/Workout activities — already in the Step 2 payload, no extra call)
    - Total active days
 5. Read `state/strava-weekly-baselines.json` and `state/activity-notes.json` (or `{}` if absent) in the same turn. The baselines file is used in step 6; the activity notes will be used in step 8.
 6. Compare this week's run distance to the 4-week rolling average from the baseline file:
    - >25% above average → 🔴 "Load spike: [X]km vs [avg]km average"
    - >25% below average → 🟡 "Load dip: [X]km vs [avg]km average"
    - Within range → 🟢 "Consistent load"
-7. Update `state/strava-weekly-baselines.json`: append this week's totals. Keep only the last 8 weeks.
+7. Update `state/strava-weekly-baselines.json`: append this week's totals (including `strength_minutes`). Keep only the last 8 weeks.
 8. From the activity list fetched in step 2, collect the IDs of this week's activities. Filter the `activity-notes.json` read in step 5 to those IDs. If 2 or more RPE entries exist, compute the average (one decimal place) and prepare the line: `💬 Avg RPE: X.X/10 (N=<count>)`. Otherwise prepare no RPE line.
 
    Send a message via the configured channel. If no channel is configured, log the summary to SHELL.md Progress Log instead and skip the notification.
@@ -36,7 +36,7 @@ Pull the last 14 days of Strava activities and compute weekly training load summ
    📅 Weekly review — w/e [date]
    🏃 Run: [X]km ([N] sessions, [E]m elev) [flag]
    🚴 Bike: [X]km ([N] sessions)
-   💪 Strength: [N] sessions
+   💪 Strength: [N] sessions ([M] min)
    💬 Avg RPE: X.X/10 (N=3)           ← omit this line if fewer than 2 rated
    Next week: [one-sentence recommendation based on load]
    ```


### PR DESCRIPTION
## Summary

Strength training sessions were invisible to both the daily sync and weekly review — they got logged as a neutral count with no load signal. This means the hermit could send "tomorrow: 10km Z2 easy" right after a heavy leg day without any fatigue context.

This closes issue #258 (originally proposed a `preworkout-alert` routine and a schema extension to `activity-notes.json` that don't exist; this PR delivers the same intent through consumers that already exist).

## Changes

**`routine-strava-sync.md` (Part A — resolves #258)**
- Step 6: for each new `WeightTraining` or `Workout` activity, derive a fatigue tier from `moving_time` already in the `get-recent-activities` payload — `≥45 min → moderate`, `30–44 min → light`, `<30 min → none`. Tracks the highest tier across today's new strength activities.
- Step 9: conditionally appends `⚠️ Strength session today [light|moderate] — monitor leg fatigue on tomorrow's run.` to the 21:30 summary. Omitted when tier is `none` or no strength activity. No new state write, no extra API call.

**`routine-weekly-load-review.md` (Part B — follow-up)**
- Step 4: sums `moving_time` over WeightTraining/Workout into `strength_minutes` alongside session count (data already in the Step 2 payload, no extra call).
- Step 7: persists `strength_minutes` to `strava-weekly-baselines.json` (additive field; `monday-planning` reads by name and is unaffected).
- Step 8 template: `💪 Strength: [N] sessions ([M] min)` — strength is now a duration-weighted load metric, not a neutral count.

## Why this approach (not the issue's)

The issue proposed writing `session_kind`/`recovery` into `activity-notes.json` (an RPE store with a `{rpe, notes, recorded_at}` schema read by four call sites) and consuming it from a `preworkout-alert` routine that does not exist (grep `preworkout` across the plugin = 0 matches). That would be a dead write into a schema it doesn't fit.

This PR delivers the same operator-facing value through the 21:30 daily summary (better-timed than a morning alert — the operator reads it the night before tomorrow's run) and the weekly review (where load accounting already lives).

## Test plan

- Routine files are cron-driven prompt templates; plugin test suite (`bash plugins/claude-code-fitness-hermit/tests/run-all.sh`) passes: 44/44.
- Manual end-to-end (needs live Strava + a recent WeightTraining activity): dry-run `strava-sync` and confirm the summary carries the fatigue note; dry-run `weekly-load-review` and confirm `([M] min)` on the strength line.
- Propagation to existing operators: `hermit-evolve` Step 7's routine version-bump replacement re-syncs the two compiled routine files on the next `/release` bump. No `config.json` changes required.

Closes #258