### PR TITLE
fix(hermit-routines): validate pluginRoot before the load reset

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- **hermit-routines: validate `pluginRoot` before the load reset** — `load` aborts with an error if `$CLAUDE_PLUGIN_ROOT` is empty or its `scripts/` are missing, before the Step 3 CronDelete sweep. Prevents a bad plugin root from tearing down working routine CronCreates and leaving them unreplaced. Closes #251.
 - **session bootstrap: drop `disable-model-invocation` from session skill** — always-on multi-step boot invokes it via the Skill tool, which the flag rejected; bare hermits (single step) were unaffected, making the failure look intermittent (#229).
 - **hatch: always default `push_notifications: true` on fresh hatch** — removed the channel-choice derivation that wrote `false` whenever a channel was selected. The runtime guard in `CLAUDE-APPEND.md` already enforces channel-first delivery with push as fallback, so the hatch-time override was discarding the fallback unnecessarily. Both Quick and Advanced modes now leave `push_notifications` at the template default (`true`); re-init still preserves the existing value.
 

--- a/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
@@ -23,6 +23,8 @@ Register and manage scheduled routines as per-session CronCreate jobs. Each rout
 Called automatically by `hermit-start.py` on always-on launches. Can also be called manually to apply config changes mid-session.
 
 1. Resolve the plugin root path: run `echo $CLAUDE_PLUGIN_ROOT` via Bash. Store as `pluginRoot`. Read `config.timezone` from `.claude-code-hermit/config.json`. Store as `configTz` (may be null — the shift helper treats null as a no-op). This env var is available at skill execution time but NOT inside cron-delivered prompts — it must be baked into each prompt at registration.
+
+   **Validate `pluginRoot` before proceeding.** If `pluginRoot` is empty or `<pluginRoot>/scripts/log-routine-event.sh` does not exist (`test -f`), abort `load` immediately — do **not** run the Step 3 reset or register any CronCreate — and log one line: `Routine load aborted: plugin scripts not found at "<pluginRoot>" (CLAUDE_PLUGIN_ROOT unresolved or wrong). No routines registered or reset.` This is a whole-`load` abort, not the per-routine isolation of Step 4: a bad `pluginRoot` breaks every routine's baked paths, and aborting before Step 3 protects the prior session's CronCreates from being torn down and left unreplaced.
 2. Read `config.routines`, filter `enabled: true`. If none, log "No enabled routines in config." and stop.
 3. Call `CronList`. For each entry whose prompt contains `[hermit-routine:`: call `CronDelete` with its ID. Unconditional reset — ensures stale entries from prior sessions are cleared and the 7-day auto-expiry clock is reset.
 4. For each enabled routine, build the prompt string (see templates below), then call `CronCreate`:


### PR DESCRIPTION
## Summary

`hermit-routines load` resolves `$CLAUDE_PLUGIN_ROOT` at skill execution time and bakes the path into every routine CronCreate prompt. If the variable is empty or wrong, Step 3 unconditionally tears down the prior session's working routine CronCreates before Step 4 fails to register replacements — leaving the session with zero routines.

This adds a fail-fast existence check at the end of Step 1, before the Step 3 reset, so a bad `pluginRoot` surfaces as one clear error rather than a destructive cascade.

## Changes

- `skills/hermit-routines/SKILL.md` — guard added to Step 1: if `pluginRoot` is empty or `scripts/log-routine-event.sh` is missing, abort `load` immediately (before the CronDelete sweep) with a single diagnostic line.

## Test plan

- Contract tests pass: `bash plugins/claude-code-hermit/tests/run-all.sh` (30/30 passed locally).
- Guard sanity: `test -f /nonexistent/scripts/log-routine-event.sh` exits 1 — bad path correctly triggers abort; empty `$CLAUDE_PLUGIN_ROOT` does the same.

Closes #251.