### PR TITLE
fix(homeassistant-hermit): ha-integration-health refreshes stale snapshot before analysis

### DIFF
--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **ha-integration-health: refresh stale/missing snapshot before analysis** — the daily check used to skip and exit 0 when `snapshot-ha-normalized-latest.json` was stale or missing, so in always-on deployments (where `daily-ha-context` doesn't run during waiting) it never produced output and `reflect-scheduled-checks` filed a backwards proposal to lengthen the interval. It now self-heals by running `refresh-context` first; if HA is unreachable it skips with a distinct `refresh failed` message so the backoff counter isn't tripped.
+
 ## [0.1.8] - 2026-06-01
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-integration-health/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-integration-health/SKILL.md
@@ -37,5 +37,6 @@ Degraded domains: N
 
 If nothing is flagged: `No actionable findings. (D domains scanned)`.
 If snapshot is stale or missing and HA is unreachable: `No actionable findings. (skipped: snapshot stale, refresh failed — <error>)`.
+If the snapshot exists but can't be parsed: `No actionable findings. (skipped: snapshot unreadable — <error>)`.
 
 Keep stdout to this shape — no prose, no extra sections.

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-integration-health/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-integration-health/SKILL.md
@@ -20,7 +20,7 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha integration-health
 ```
 
 The CLI:
-- Checks that `snapshot-ha-normalized-latest.json` exists and is fresh (< 24h). If stale or missing, emits the skip message and exits cleanly.
+- Checks that `snapshot-ha-normalized-latest.json` exists and is fresh (< 24h). If stale or missing, runs `ha refresh-context` first to bring it up to date, then proceeds with analysis.
 - Groups entities by domain prefix, computes unavailable ratios, and flags domains where `total >= 3` AND `ratio >= 0.5`.
 - Writes `.claude-code-hermit/state/integration-health-degraded-domains.json` — a machine-readable state artifact consumed by `ha-analyze-patterns` (via `silence.py`) to suppress overlapping `long_unavailable` findings.
 - Prints the findings block to stdout in the documented format below.
@@ -36,6 +36,6 @@ Degraded domains: N
 ```
 
 If nothing is flagged: `No actionable findings. (D domains scanned)`.
-If snapshot is stale or missing: `No actionable findings. (skipped: snapshot stale or missing)`.
+If snapshot is stale or missing and HA is unreachable: `No actionable findings. (skipped: snapshot stale, refresh failed — <error>)`.
 
 Keep stdout to this shape — no prose, no extra sections.

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
@@ -347,7 +347,7 @@ def _handle_integration_health(root: Path, config: Any) -> int:
     try:
         mtime = datetime.fromtimestamp(snapshot_path.stat().st_mtime, tz=UTC)
         stale = datetime.now(UTC) - mtime > timedelta(hours=24)
-    except FileNotFoundError:
+    except OSError:
         stale = True
 
     if stale:

--- a/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
+++ b/plugins/claude-code-homeassistant-hermit/src/ha_agent_lab/cli.py
@@ -127,7 +127,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "ha" and args.ha_command == "integration-health":
-        return _handle_integration_health(root)
+        return _handle_integration_health(root, config)
 
     if args.command == "ha" and args.ha_command == "refresh-context":
         try:
@@ -338,20 +338,28 @@ def _handle_fetch_history(root: Path, config: Any, window_days: int, entity_over
     return 0
 
 
-def _handle_integration_health(root: Path) -> int:
+def _handle_integration_health(root: Path, config: Any) -> int:
     today = date.today().isoformat()
     header = f"ha-integration-health findings — {today}"
     snapshot_path = normalized_context_path(root)
 
+    stale = False
     try:
         mtime = datetime.fromtimestamp(snapshot_path.stat().st_mtime, tz=UTC)
-        if datetime.now(UTC) - mtime > timedelta(hours=24):
-            print(f"{header}\nNo actionable findings. (skipped: snapshot stale or missing)")
-            return 0
-        normalized = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        stale = datetime.now(UTC) - mtime > timedelta(hours=24)
     except FileNotFoundError:
-        print(f"{header}\nNo actionable findings. (skipped: snapshot stale or missing)")
-        return 0
+        stale = True
+
+    if stale:
+        try:
+            client = HomeAssistantClient(config)
+            refresh_context(root, client)
+        except HomeAssistantError as exc:
+            print(f"{header}\nNo actionable findings. (skipped: snapshot stale, refresh failed — {exc})")
+            return 0
+
+    try:
+        normalized = json.loads(snapshot_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         print(f"{header}\nNo actionable findings. (skipped: snapshot unreadable — {exc})")
         return 0

--- a/plugins/claude-code-homeassistant-hermit/tests/test_integration_health.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_integration_health.py
@@ -162,3 +162,26 @@ def test_cli_integration_health_skips_cleanly_when_refresh_fails(tmp_path: Path,
     out = capsys.readouterr().out
     assert rc == 0
     assert "refresh failed" in out
+
+
+def test_cli_integration_health_refreshes_when_stat_raises_oserror(tmp_path: Path, capsys, monkeypatch):
+    import ha_agent_lab.cli as cli_mod
+    from ha_agent_lab.cli import _handle_integration_health
+
+    snapshot_path = tmp_path / ".claude-code-hermit" / "raw" / "snapshot-ha-normalized-latest.json"
+    _setup_refresh_monkeypatch(monkeypatch, cli_mod, snapshot_path)
+
+    real_stat = Path.stat
+
+    def boom_stat(self, *args, **kwargs):
+        if self == snapshot_path:
+            raise PermissionError("stat denied")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", boom_stat)
+
+    rc = _handle_integration_health(tmp_path, object())
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "skipped" not in out
+    assert "Degraded domains:" in out

--- a/plugins/claude-code-homeassistant-hermit/tests/test_integration_health.py
+++ b/plugins/claude-code-homeassistant-hermit/tests/test_integration_health.py
@@ -94,35 +94,71 @@ def test_cli_integration_health_emits_existing_stdout_shape(tmp_path: Path, caps
     snapshot = {"entity_index": idx, "unavailable_entities": unavail}
     (raw / "snapshot-ha-normalized-latest.json").write_text(json.dumps(snapshot), encoding="utf-8")
 
-    rc = _handle_integration_health(tmp_path)
+    rc = _handle_integration_health(tmp_path, object())
     out = capsys.readouterr().out
     assert rc == 0
     assert out.startswith("ha-integration-health findings —")
     assert "Degraded domains:" in out
 
 
-def test_cli_integration_health_skips_when_snapshot_missing(tmp_path: Path, capsys):
+def _setup_refresh_monkeypatch(monkeypatch, cli_mod, snapshot_path: Path) -> None:
+    idx, unavail = _make_entities("sensor", 6, 4)
+    fresh = {"entity_index": idx, "unavailable_entities": unavail}
+
+    def fake_refresh(root, client):
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(json.dumps(fresh), encoding="utf-8")
+
+    monkeypatch.setattr(cli_mod, "refresh_context", fake_refresh)
+    monkeypatch.setattr(cli_mod, "HomeAssistantClient", lambda config: object())
+
+
+def test_cli_integration_health_refreshes_and_proceeds_when_snapshot_missing(tmp_path: Path, capsys, monkeypatch):
+    import ha_agent_lab.cli as cli_mod
     from ha_agent_lab.cli import _handle_integration_health
 
-    rc = _handle_integration_health(tmp_path)
+    snapshot_path = tmp_path / ".claude-code-hermit" / "raw" / "snapshot-ha-normalized-latest.json"
+    _setup_refresh_monkeypatch(monkeypatch, cli_mod, snapshot_path)
+
+    rc = _handle_integration_health(tmp_path, object())
     out = capsys.readouterr().out
     assert rc == 0
-    assert "skipped: snapshot stale or missing" in out
+    assert "skipped" not in out
+    assert "Degraded domains:" in out
 
 
-def test_cli_integration_health_skips_when_snapshot_stale(tmp_path: Path, capsys, monkeypatch):
+def test_cli_integration_health_refreshes_and_proceeds_when_snapshot_stale(tmp_path: Path, capsys, monkeypatch):
+    import os
+    import ha_agent_lab.cli as cli_mod
     from ha_agent_lab.cli import _handle_integration_health
 
     raw = tmp_path / ".claude-code-hermit" / "raw"
     raw.mkdir(parents=True)
     snapshot_path = raw / "snapshot-ha-normalized-latest.json"
     snapshot_path.write_text("{}", encoding="utf-8")
-
     stale_time = (datetime.now(UTC) - timedelta(hours=25)).timestamp()
-    import os
     os.utime(snapshot_path, (stale_time, stale_time))
+    _setup_refresh_monkeypatch(monkeypatch, cli_mod, snapshot_path)
 
-    rc = _handle_integration_health(tmp_path)
+    rc = _handle_integration_health(tmp_path, object())
     out = capsys.readouterr().out
     assert rc == 0
-    assert "skipped: snapshot stale or missing" in out
+    assert "skipped" not in out
+    assert "Degraded domains:" in out
+
+
+def test_cli_integration_health_skips_cleanly_when_refresh_fails(tmp_path: Path, capsys, monkeypatch):
+    import ha_agent_lab.cli as cli_mod
+    from ha_agent_lab.cli import _handle_integration_health
+    from ha_agent_lab.ha_api import HomeAssistantError
+
+    def fail_refresh(root, client):
+        raise HomeAssistantError("HA unreachable")
+
+    monkeypatch.setattr(cli_mod, "HomeAssistantClient", lambda config: object())
+    monkeypatch.setattr(cli_mod, "refresh_context", fail_refresh)
+
+    rc = _handle_integration_health(tmp_path, object())
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "refresh failed" in out


### PR DESCRIPTION
## Summary

`ha-integration-health` is a default-enabled daily scheduled-check. Before this fix it would silently skip and exit 0 whenever `snapshot-ha-normalized-latest.json` was older than 24h or missing, emitting `(skipped: snapshot stale or missing)`. The only refresher (`daily-ha-context`) runs with `run_during_waiting: false`, so in always-on/waiting deployments the snapshot aged out every day and the check never produced output. After 3 consecutive empty runs, `reflect-scheduled-checks` would file a spurious proposal to *lengthen* the interval — the exact opposite of the right remedy.

This fix makes the check self-heal the stale/missing snapshot before analyzing, mirroring the existing idiom in `ha-boot` (refresh-when-stale-or-missing) and `_handle_fetch_history` (refresh-when-missing). If HA is unreachable during the refresh, the check still exits 0 with a distinct `(skipped: snapshot stale, refresh failed — <error>)` message so the `reflect-scheduled-checks` backoff counter isn't tripped.

Closes #248

## Changes

- `cli.py` — `_handle_integration_health` accepts `config`, detects stale/missing snapshot, attempts `refresh_context` on stale/missing, degrades cleanly if HA is unreachable
- `SKILL.md` — updated prose and output-contract section to match the new refresh-then-analyze behavior
- `tests/test_integration_health.py` — two old skip-only tests replaced by three new behavior tests (stale→refresh→analyze, missing→refresh→analyze, refresh-fail→clean-skip); extracted `_setup_refresh_monkeypatch` helper to eliminate copy-paste

## Test plan

```
cd plugins/claude-code-homeassistant-hermit
.venv/bin/pytest tests/test_integration_health.py -v
```

All 11 tests pass, including the three new cases that exercise the refresh path and its HA-unreachable fallback.