### PR TITLE
fix(claude-code-dev-hermit): remove code-review plugin from hatch recommendations

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **hatch + dev-quality: drop `code-review` companion plugin** — `code-review@claude-plugins-official` is built into Claude Code since v2.1.150; removed it from hatch's companion picker and the `/dev-quality` install guard (#279).
+
 ## [0.3.13] - 2026-06-04
 
 ### Fixed

--- a/plugins/claude-code-dev-hermit/CLAUDE.md
+++ b/plugins/claude-code-dev-hermit/CLAUDE.md
@@ -6,7 +6,7 @@ Language-agnostic safety layer for any agent doing dev work in a hermit project.
 
 - `skills/hatch/` — one-time setup wizard. Idempotent, re-runnable, defaults to strict hook profile.
 - `skills/dev-pr/` — push the current feature branch and open a PR with an inline-assembled body. Refuses on protected branches, dirty trees, or zero commits ahead.
-- `skills/dev-quality/` — pre-wrap quality gate: runs `/claude-code-hermit:simplify` on the working tree (cleanup pass) and re-runs `commands.test` if configured. Surfaces failures; suggests `/code-review:code-review` when installed for a deeper correctness review.
+- `skills/dev-quality/` — pre-wrap quality gate: runs `/claude-code-hermit:simplify` on the working tree (cleanup pass) and re-runs `commands.test` if configured. Surfaces failures; suggests native `/code-review` for a deeper correctness review.
 - `skills/dev-test/` — run the configured test suite and record the result to `state/last-test.json`. Useful for mid-task verification and warming the `/dev-pr` test cache.
 - `skills/domain-brainstorm/` — on-demand codebase friction brainstorm: reads git churn, last test signal, manifest drift, and README coverage to surface at most 2 `[prefix]`-tagged improvement proposals. Operator-invoked only. Kill criteria: retire if triage-survival < 25% or PROP-acceptance < 30% after ≥8 runs.
 - `scripts/git-push-guard.js` — strict-profile-only `PreToolUse` hook for Bash. Blocks `--no-verify`, `--force`/`-f` (always), `--force-with-lease` on protected branches or without an explicit refspec, `--mirror`/`--all`, and direct push to any branch in `claude-code-dev-hermit.protected_branches`.
@@ -21,7 +21,7 @@ Language-agnostic safety layer for any agent doing dev work in a hermit project.
 
 ## Constraints
 
-- Before implementing any new capability, check Claude Code docs (https://code.claude.com/docs) and plugins (https://claude.com/plugins) for native features that already cover it. If overlap exists, delegate — don't build. Specifically: built-in skills (`/code-review`, `/batch`, `/debug`), the plugin-owned `/claude-code-hermit:simplify` cleanup pass, and the `code-review@claude-plugins-official` plugin already cover common surfaces; link to them from CLAUDE-APPEND or this README rather than reimplementing.
+- Before implementing any new capability, check Claude Code docs (https://code.claude.com/docs) and plugins (https://claude.com/plugins) for native features that already cover it. If overlap exists, delegate — don't build. Specifically: built-in skills (`/code-review`, `/batch`, `/debug`) and the plugin-owned `/claude-code-hermit:simplify` cleanup pass already cover common surfaces; link to them from CLAUDE-APPEND or this README rather than reimplementing.
 
 ## Hook Profiles
 

--- a/plugins/claude-code-dev-hermit/README.md
+++ b/plugins/claude-code-dev-hermit/README.md
@@ -118,7 +118,7 @@ See [docs/GIT-SAFETY.md](docs/GIT-SAFETY.md) for the full safety model and the t
 **Optional workflow skills** (for greenfield projects — skip if you already have your own `/commit`, `/create-pr`, or `/release` skills):
 
 - **`dev-pr` skill** — Push the current feature branch and open a PR with body assembled from commits + last test result + screenshots + optional project template. Runs tests automatically on cache miss — fresh HEAD pass hits instantly; anything else triggers the test runner.
-- **`dev-quality` skill** — Pre-wrap quality gate. Runs `/claude-code-hermit:simplify` (cleanup pass) on the working tree, re-runs `commands.test`, and reports pass/fail. Suggests `/code-review:code-review` if available for a deeper correctness review — never invokes it.
+- **`dev-quality` skill** — Pre-wrap quality gate. Runs `/claude-code-hermit:simplify` (cleanup pass) on the working tree, re-runs `commands.test`, and reports pass/fail. Suggests the native `/code-review` for a deeper correctness review — never invokes it.
 - **`dev-test` skill** — Run the configured test suite and record the result to `last-test.json`. Useful for mid-task verification and warming the `/dev-pr` cache.
 
 ---

--- a/plugins/claude-code-dev-hermit/docs/HOW-TO-USE.md
+++ b/plugins/claude-code-dev-hermit/docs/HOW-TO-USE.md
@@ -59,7 +59,7 @@ Per `§Tests Before PR`:
 2. If tests pass, proceed.
 3. If tests fail, `git checkout -- <changed-files>` to revert the applied edits and stop. Surface the regression.
 
-For PR review, security-sensitive changes, or large refactors, invoke `/code-review:code-review` (from the optional `code-review` plugin) after the dev-quality pass — that's the deeper bug-finding option.
+For PR review, security-sensitive changes, or large refactors, invoke `/code-review` (built-in) after the dev-quality pass — that's the deeper bug-finding option.
 
 ### 5. Open the PR
 

--- a/plugins/claude-code-dev-hermit/docs/RECOMMENDED-PLUGINS.md
+++ b/plugins/claude-code-dev-hermit/docs/RECOMMENDED-PLUGINS.md
@@ -2,17 +2,7 @@
 
 The `/claude-code-dev-hermit:hatch` wizard offers these during setup. All are official plugins from `claude-plugins-official` — install individually or accept them all at once.
 
----
-
-## code-review
-
-GitHub: [anthropics/code-review](https://github.com/anthropics/claude-code/tree/main/plugins/code-review)
-
-```bash
-claude plugin install code-review@claude-plugins-official --scope project
-```
-
-Official Anthropic plugin — PR-level code review with git-blame context and inline GitHub comments. Invoke via `/code-review:code-review` explicitly when the stakes warrant it: someone else's PR, security-sensitive changes, large refactors where history matters. The CLAUDE-APPEND `§Tests Before PR` rule covers the lighter-weight `/claude-code-hermit:simplify` cleanup pass that runs on every commit; `/code-review:code-review` is for when you want git-blame context, prior PR comments, and inline GitHub comments.
+> **Note:** `/code-review` is built into Claude Code since v2.1.150. No plugin install needed — invoke it directly for PR-level review with git-blame context.
 
 ---
 

--- a/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
+++ b/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
@@ -54,7 +54,7 @@ Per `§Tests Before PR`:
 2. If tests pass → proceed.
 3. If tests fail → `git checkout -- <changed-files>` to revert the applied edits, surface the regression, stop.
 
-For high-stakes changes, optionally invoke `/code-review:code-review` (from the optional `code-review` companion plugin) after the dev-quality pass — that's the deeper bug-finding option.
+For high-stakes changes, optionally invoke `/code-review` (built-in) after the dev-quality pass — that's the deeper bug-finding option.
 
 ### Step 6 — PR
 

--- a/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-quality
-description: Pre-wrap quality gate. Runs /claude-code-hermit:simplify for a cleanup pass on the working-tree diff (including untracked files), re-runs commands.test, and reports results. Suggests /code-review:code-review when installed. Run this before committing.
+description: Pre-wrap quality gate. Runs /claude-code-hermit:simplify for a cleanup pass on the working-tree diff (including untracked files), re-runs commands.test, and reports results. Suggests /code-review for a deeper review. Run this before committing.
 ---
 
 # /dev-quality
@@ -89,13 +89,13 @@ Use `timeout: 600000`. Records the result to `last-test.json`.
 
 **Tests pass:**
 
-Report the outcome. Then check whether `/code-review:code-review` is in the agent's available slash-command list. If available, append:
+Report the outcome. Append:
 
 ```
-next: suggest the operator run /code-review:code-review for a deeper review before commit
+next: suggest the operator run /code-review for a deeper review before commit
 ```
 
-Do **not** invoke `/code-review:code-review` autonomously — operator decision only. Skill exits clean; reviewed changes remain uncommitted for the operator to commit.
+Do **not** invoke `/code-review` autonomously — operator decision only. Skill exits clean; reviewed changes remain uncommitted for the operator to commit.
 
 **Tests fail:**
 
@@ -110,7 +110,7 @@ dev-quality
   diff:        12 files modified
   simplify:    applied 4 · deduped 1 · principle-rejected 2 · stale-anchor skips 0 · parse failures 0
   tests:       pass (12.3s)
-  next:        suggest operator run /code-review:code-review (installed)
+  next:        suggest operator run /code-review
   status:      ok
 ```
 
@@ -179,7 +179,7 @@ dev-quality
 ## Rules
 
 - **Main session only.** Subagents cannot invoke skills (see CLAUDE-APPEND §Technical Constraints) — `/dev-quality` only fires from the main session.
-- **Never invokes `/code-review:code-review`.** Suggests it to the operator when available; the operator decides.
+- **Never invokes `/code-review`.** Suggests it to the operator; the operator decides.
 - **Never commits.** Leaves the diff uncommitted for the operator.
 - **Never modifies the working tree on test failure.** Surfaces the regression and stops; no rollback.
 - **Writes `last-test.json`, but no cross-skill contract.** The record is written at the pre-commit HEAD. After committing, `/dev-pr` sees a stale SHA and re-runs tests — expected behaviour.

--- a/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
@@ -210,7 +210,6 @@ questions: [
     question: "Install companion plugins?",
     multiSelect: true,
     options: [
-      { label: "code-review", description: "Second-pass review for PRs and high-stakes code" },
       { label: "feature-dev", description: "Architect/explorer/reviewer agents for guided feature dev" },
       { label: "context7", description: "Live docs lookup for framework APIs" }
     ]
@@ -273,7 +272,7 @@ Updated:
   PR template: <path or 'none'>  [standard mode only]
 
 Companion plugins:
-  [installed: code-review, feature-dev, context7  /  partial  /  none]
+  [installed: feature-dev, context7  /  partial  /  none]
 
 Available skills:
   /claude-code-dev-hermit:hatch    — re-run to update settings (idempotent)

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -80,4 +80,4 @@ Tier mapping:
 - Cleanup pass: `/claude-code-hermit:simplify` (parallel reviewers, applies its own edits)
 - Parallel changes across many files: `/batch` (built-in)
 - Diagnostics: `/debug` (built-in)
-- High-stakes review: `/code-review:code-review` (from `code-review@claude-plugins-official`, recommended companion)
+- High-stakes review: `/code-review` (built-in)

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -46,7 +46,7 @@ After making code changes:
 1. Run the configured test command (`claude-code-dev-hermit.commands.test`, set via `/claude-code-dev-hermit:hatch`). If unset, ask the operator for the command and offer to save it via `hatch`.
 2. If tests fail, fix the failures or surface them in the response — **do not declare the task done with broken tests**.
 3. If the task is non-trivial and `/feature-dev:feature-dev` is installed, run it first when the code path is unfamiliar (framework lifecycle hooks, ORM internals, build-tool plugins, auth middleware). The trigger is **unfamiliarity, not urgency**. Skip for: doc/prompt/config edits, single-line fixes, code paths you've already read end-to-end.
-4. Before declaring the task done: run `/claude-code-dev-hermit:dev-quality`. It runs `/claude-code-hermit:simplify` on the working tree (cleanup pass) and re-runs `commands.test` if configured. If tests regress, investigate before committing. If `/code-review:code-review` is installed (`code-review@claude-plugins-official`), the skill will tell you to suggest it to the operator for a deeper correctness review — do not invoke that skill autonomously. **Nested git repo?** If your work is happening inside a nested git repo (true submodule, Composer path package, npm/pnpm path workspace, vendored dep edited in place), pass `--cwd <relative/path>` so `/dev-quality` scopes git ops, `/claude-code-hermit:simplify`, and the test re-run to that repo. State still lives under the parent's `.claude-code-hermit/`, but the captured SHA is the child's HEAD.
+4. Before declaring the task done: run `/claude-code-dev-hermit:dev-quality`. It runs `/claude-code-hermit:simplify` on the working tree (cleanup pass) and re-runs `commands.test` if configured. If tests regress, investigate before committing. The skill will suggest the native `/code-review` to the operator for deeper correctness review — do not invoke it autonomously. **Nested git repo?** If your work is happening inside a nested git repo (true submodule, Composer path package, npm/pnpm path workspace, vendored dep edited in place), pass `--cwd <relative/path>` so `/dev-quality` scopes git ops, `/claude-code-hermit:simplify`, and the test re-run to that repo. State still lives under the parent's `.claude-code-hermit/`, but the captured SHA is the child's HEAD.
 
 ## Tests Before PR
 
@@ -104,4 +104,4 @@ Tier mapping:
 - Cleanup pass: `/claude-code-hermit:simplify` (parallel reviewers, applies its own edits; `/dev-quality` wraps it)
 - Parallel changes across many files: `/batch` (built-in)
 - Diagnostics: `/debug` (built-in)
-- High-stakes review: `/code-review:code-review` (from `code-review@claude-plugins-official`, recommended companion)
+- High-stakes review: `/code-review` (built-in)


### PR DESCRIPTION
## Summary

Since CC 2.1.150, `/code-review` ships natively. The `code-review@claude-plugins-official` plugin no longer needs to be prompted during hatch — users who want the plugin-specific extras (inline GitHub comments) can still install it manually.

## Changes

- **`skills/hatch/SKILL.md`** — removed `code-review` from the companion plugins `AskUserQuestion`; updated summary report example
- **`skills/dev-quality/SKILL.md`** — always suggest native `/code-review` (removed the "check if plugin is installed" guard); updated frontmatter description, output example, and rules
- **`docs/RECOMMENDED-PLUGINS.md`** — removed the `code-review` section; added a note that `/code-review` is built-in since v2.1.150
- **`state-templates/CLAUDE-APPEND.md`** and **`CLAUDE-APPEND-SAFETY.md`** — updated Dev Quick Reference and §Implementation Flow to reference native `/code-review` instead of the plugin
- **`CLAUDE.md`**, **`README.md`**, **`docs/HOW-TO-USE.md`**, **`docs/WORKFLOW.md`** — removed plugin install references; point to built-in `/code-review`

## Test plan

- Run `/claude-code-dev-hermit:hatch` on a test project and verify `code-review` no longer appears in the companion plugins question
- Run `/claude-code-dev-hermit:dev-quality` and confirm the output now always shows `next: suggest operator run /code-review` (not conditional on plugin install)
- Confirm the native `/code-review` invocation still works as before (no change to its behavior)

Closes #279