### PR TITLE
fix(hermit): recommended plugins respect the hermit's install scope

### DIFF
--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -247,8 +247,8 @@ Note: `multiSelect: true` is intentional — all four plugins can be selected at
 
 - All plugins are selected by default — deselect to skip
 - If no plugins are selected, skip all plugin installs
-- For each selected plugin, install it immediately:
-  `claude plugin install <plugin>@claude-plugins-official --scope project`
+- For each selected plugin, install it immediately at the hermit's scope (`core_install_scope` from Step 2; fall back to `project` when null):
+  `claude plugin install <plugin>@claude-plugins-official --scope <core_install_scope>`
 
 For each accepted plugin, also add the corresponding `scheduled_checks` entries to config.json:
 


### PR DESCRIPTION
## Summary

`/hatch` Phase 4 was hardcoding `--scope project` for all recommended plugin installs. When the hermit core is installed at `--scope local` (operator-personal, gitignored), the plugin enablement was still being written to the committed `.claude/settings.json`, leaking operator-personal tooling into shared config — the exact mismatch the scope detection was built to prevent.

The fix uses `core_install_scope` (already detected in Step 2) directly in the install command, falling back to `project` only when scope is undetectable (`null`). This matches how the Docker entrypoint already handles recommended plugin installs.

## Changes

- `hatch/SKILL.md` Phase 4: replace hardcoded `--scope project` with `--scope <core_install_scope>` (null → project fallback preserved)

## Test plan

- `bash plugins/claude-code-hermit/tests/run-all.sh` — 426 tests passed, 0 failed
- Manual: install hermit at `--scope local`, run `/hatch`, accept a recommended plugin → verify `claude plugin list --json` shows `scope: local` and committed `.claude/settings.json` was not modified

Closes #278