### PR TITLE
feat(claude-code-hermit): add Verification section to proposal workflow

### DIFF
--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -108,9 +108,14 @@ When the operator accepts a proposal:
            - `RUN: <reason>` → invoke `/claude-code-hermit:simplify` per the `quality` tier above. Notification: "PROP-NNN implemented and resolved. Judge: <reason>. /simplify applied N edits (M deduped, K rejected on principle)." When `N == 0` use "… /simplify made no changes." Same totals-missing fallback as the `quality` tier.
            - `SKIP: <reason>` → skip `/claude-code-hermit:simplify`. Notification: "PROP-NNN implemented and resolved. Judge skipped /simplify: <reason>."
 
-         **No post-apply test gate fires before step f resolves** — the operator authorized the accept; broken applies ship unless the operator runs `/claude-code-dev-hermit:dev-quality` afterwards.
+         **The quality gate is cleanup, not correctness** — `/simplify` does not check that the proposal works. Correctness is verified by the `## Verification` gate in step (e.6); proposals with no defined verification still resolve, but the skip is recorded.
 
          Best-effort throughout: if any step errors out (judge fails, `/simplify` failed or totals unavailable, file read fails), log a one-line warning to SHELL.md Findings and fall back to skip. The gate never blocks resolution.
+     e.6. **Verification gate.** Read the proposal's `## Verification` section.
+         - If it contains real steps (more than the HTML-comment placeholder), perform them now — after the quality gate has applied any `/simplify` edits — before resolving. If a defined step fails, **do not resolve**: report the failure to the operator (or channel in autonomous mode) and stop.
+         - If the section is empty, missing, or contains only its placeholder comment, append `Verification: none defined for PROP-NNN — skipped.` to SHELL.md `## Findings` and proceed. The omission is recorded, not blocked.
+
+         Unlike the e.5 quality gate (best-effort, never blocks), e.6 **blocks resolution when a defined verification step fails** — that is the correctness check the quality gate does not provide.
      f. When verifiably done: run `/proposal-act resolve PROP-NNN`, then notify the operator (or channel in autonomous mode) with the tier-appropriate message from (e.5).
 
    - **"Create a session task"** → Write `.claude-code-hermit/sessions/NEXT-TASK.md`:

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -81,7 +81,7 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js \
      - `title`: short proposal title (same text used in the H1 heading after the dash)
      - `resolved_date`: `null` (set later by reflect when pattern is confirmed gone)
    - Fill in the title in the H1 heading
-   - while writing the body: write a clear Context, Problem, Proposed Solution, and Impact
+   - while writing the body: write a clear Context, Problem, Proposed Solution, Impact, and Verification (never leave blank — state the check, or an explicit "none needed because…")
    - Leave "Operator Decision" blank — the operator fills that in
    - Do NOT write bullet-point metadata (`- **Created:**`, etc.) — all metadata lives in frontmatter only
 

--- a/plugins/claude-code-hermit/state-templates/PROPOSAL.md.template
+++ b/plugins/claude-code-hermit/state-templates/PROPOSAL.md.template
@@ -28,5 +28,9 @@ accepted_in_session: null
 ## Impact
 <!-- Effort vs benefit estimate -->
 
+## Verification
+<!-- How will we know this worked? Tests, smoke-check, validation run, manual steps —
+     or an explicit recorded "no verification needed because…". -->
+
 ## Operator Decision
 <!-- Filled in by operator during review -->

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1399,6 +1399,12 @@ class TestKillMetricsContract(unittest.TestCase):
                       'PROPOSAL.md.template is missing the tags field — '
                       'brainstorm origin can never be preserved in proposal frontmatter')
 
+    def test_proposal_template_has_verification_section(self):
+        """PROPOSAL.md.template must carry a Verification section so the success check is a recorded decision rather than a silent default."""
+        self.assertIn('## Verification', self._proposal_template,
+                      'PROPOSAL.md.template is missing the Verification section — '
+                      'proposals ship with no defined success check')
+
     def test_proposal_create_triage_verdict_has_evidence_source(self):
         """proposal-create triage-verdict event must include evidence_source."""
         self.assertIn(


### PR DESCRIPTION
## Summary
Proposals shipped through claude-code-hermit had no structured place to record how success would be confirmed. The omission was silent — proposals could be accepted and resolved without ever stating (or consciously skipping) a verification step. This surfaces the question at authoring time and enforces it at accept time.

## Changes
- **`state-templates/PROPOSAL.md.template`** — adds `## Verification` section between Impact and Operator Decision with a domain-agnostic prompt
- **`skills/proposal-create/SKILL.md`** — extends the body-writing instruction to enumerate Verification alongside the other sections (so the authoring agent never leaves it blank)
- **`skills/proposal-act/SKILL.md`** — adds step e.6 (after the quality gate, before resolve) that performs defined verification steps and blocks on failure; rewrites the now-contradicted "No post-apply test gate" comment to correctly describe the cleanup/correctness split
- **`tests/run-contracts.py`** — adds a contract test asserting the template carries the Verification section

## Test plan
- All 346 tests pass: `bash plugins/claude-code-hermit/tests/run-all.sh` from inside `plugins/claude-code-hermit/`
- Manually verified: `## Verification` appears between Impact and Operator Decision in the template; proposal-create line 84 lists it; proposal-act e.6 gate exists after e.5; old "No post-apply test gate" text is replaced

Closes #281