### PR TITLE
fix: normalize strava-data-cruncher model alias and add checklist item

### DIFF
--- a/plugins/claude-code-fitness-hermit/agents/strava-data-cruncher.md
+++ b/plugins/claude-code-fitness-hermit/agents/strava-data-cruncher.md
@@ -1,7 +1,7 @@
 ---
 name: strava-data-cruncher
 description: Lightweight Haiku subagent for bulk Strava data aggregation — weekly load, zone distribution, efficiency trends. Returns compact structured output; no coaching judgment. Use when you need multi-week trend tables, zone distribution over time, or bulk activity metrics.
-model: claude-haiku-4-5-20251001
+model: haiku
 maxTurns: 10
 tools:
   - mcp__strava__check-strava-connection

--- a/plugins/claude-code-hermit/docs/creating-your-own-hermit.md
+++ b/plugins/claude-code-hermit/docs/creating-your-own-hermit.md
@@ -291,3 +291,4 @@ Skills should say "notify the operator" instead of referencing specific channels
 - [ ] Cadence-driven skills registered in `scheduled_checks` (not a bespoke scheduler)
 - [ ] Docker system packages (if any) declared in a `## Docker apt dependencies` section in the hatch SKILL.md or `DOCKER.md` at plugin root
 - [ ] Docker network requirements (if any) declared in a `## Docker network requirements` section so `/docker-security` can surface them — outbound domains and LAN-IP suggestions (use `ASK_OPERATOR_FOR_<NAME>_IP` if the IP is operator-specific)
+- [ ] Each agent's `model:` matches task complexity (Haiku for scanning, Sonnet for reasoning) — use the short alias, not a pinned ID


### PR DESCRIPTION
## Summary

`strava-data-cruncher` was the only agent in the fleet using a pinned full model ID (`claude-haiku-4-5-20251001`). All other agents use the short bare alias (`haiku`, `sonnet`). This normalizes it and encodes the convention in the authoring guide's publish checklist.

Closes #291

## Changes

- `plugins/claude-code-fitness-hermit/agents/strava-data-cruncher.md` — `model: claude-haiku-4-5-20251001` → `model: haiku`
- `plugins/claude-code-hermit/docs/creating-your-own-hermit.md` — new publish-checklist item: "Each agent's `model:` matches task complexity — use the short alias, not a pinned ID"

## Test plan

- `grep -rn "^model:" plugins/*/agents/` — confirm all 10 agents now use bare aliases, no pinned IDs.
- No behavioural tests cover agent frontmatter model values; the alias `haiku` is already validated in dispatch by 4 other agents in the fleet.