### PR TITLE
fix(claude-code-hermit): anchor brief proposal-count to frontmatter block

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **brief: anchor proposal-count status read to frontmatter** — resolved proposals quoting `status: proposed` in their body no longer inflate the morning-brief pending count. Closes #287.
+
 ### Added
 
 - **hatch: git init on fresh dirs** — when hatching in an empty, non-git directory (e.g. a dedicated ops-hermit workspace), offers a local `git init` so the hermit's build artifacts are versioned from day one. Existing projects and re-inits are untouched. Closes #282.

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -85,7 +85,7 @@ Next: description of next action (or "Session complete" if all done)
 - For the "Done" line: list completed task subjects from `TaskList`, comma-separated. If too many, show first 3 and "+ N more"
 - For the "Next" line: show the first pending or in_progress task from `TaskList`. If blocked, show "Blocked: reason"
 - If summarizing a completed report: "Next" becomes the report's "Next Start Point" content
-- After composing the 5-line output: scan `.claude-code-hermit/proposals/` for files with `source: auto-detected` and `status: proposed` (read from YAML frontmatter if present, fall back to bullet metadata). **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction).** If any exist, append a 6th line: `Proposals: N auto-detected proposal(s) pending review`
+- After composing the 5-line output: scan `.claude-code-hermit/proposals/` for files with `source: auto-detected` and `status: proposed` (read `status:` and `source:` from the **leading `---` YAML frontmatter block only** — do not count files where those phrases appear in the proposal body text; fall back to bullet metadata for pre-frontmatter proposals). **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction).** If any exist, append a 6th line: `Proposals: N auto-detected proposal(s) pending review`
 
 ## Daily Summary Format
 


### PR DESCRIPTION
## Summary

The morning brief's pending-proposal count could over-report when a resolved proposal's **body** quoted the phrase `status: proposed` (common in meta-proposals about the brief/proposal system). The scan instruction already said "read from YAML frontmatter if present," but the parenthetical was loose enough that a model could naive-grep the whole file instead.

This tightens the prose to explicitly scope the `status:` and `source:` reads to the leading `---` frontmatter block and exclude body-text matches.

## Changes

- `skills/brief/SKILL.md` line 88 — parenthetical reworded to anchor the status/source read to the leading YAML frontmatter block; body-text matches explicitly excluded
- `CHANGELOG.md` — `### Fixed` bullet under `[Unreleased]`

## Test plan

- All 406 contract/hook/static tests pass: `bash plugins/claude-code-hermit/tests/run-all.sh` (0 failures)
- No `### Upgrade Instructions` needed — skill files re-ship on `/plugin update`; no operator-editable state files changed

Closes #287.