### PR TITLE
feat(claude-code-hermit): per-routine model override via subagent dispatch

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **hatch: git init on fresh dirs** — when hatching in an empty, non-git directory (e.g. a dedicated ops-hermit workspace), offers a local `git init` so the hermit's build artifacts are versioned from day one. Existing projects and re-inits are untouched. Closes #282.
+- **hermit-routines: optional per-routine `model` override** — run lightweight routines (URL checks, threshold comparisons) on Haiku via subagent dispatch to cut idle cost. Ignored on `heartbeat-restart`; not for routines whose value is chat/transcript output. Closes #289.
 
 ### Files affected
 

--- a/plugins/claude-code-hermit/agents/hermit-config-validator.md
+++ b/plugins/claude-code-hermit/agents/hermit-config-validator.md
@@ -46,6 +46,7 @@ For each routine in `routines[]`:
 - `enabled` (boolean)
 - `run_during_waiting` (boolean, optional) — if present, must be `true` or `false`
 - `reflect_after` (boolean, optional) — if present, must be `true` or `false`
+- `model` (string|null, optional) — if present and non-null, must be one of `opus`, `sonnet`, `haiku` (else error); if set on `heartbeat-restart`, emit a warning (ignored at load — re-arm must run in the session)
 
 ### 4. Channel structure
 

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -169,6 +169,7 @@ Routines live in `config.json` as a `routines` array:
 - `schedule`: 5-field cron expression (`minute hour dom month dow`), written in `config.timezone` — converted to machine local time at load before CronCreate registration (see [Config reference — routines.schedule](../docs/config-reference.md#cron-schedule-rules))
 - `skill`: full slash-command name (e.g. `claude-code-hermit:brief --morning` for plugin skills, `ha-refresh-context` for local project skills)
 - `run_during_waiting`: optional — if `true`, fires even when session status is `waiting` (default: `false`)
+- `model`: optional — one of `opus`, `sonnet`, `haiku`. Runs the skill in a subagent at that model to save cost on lightweight routines (e.g. URL checks, threshold comparisons). Subagents run in isolated context and return only a one-line status, so only use it on stateless routines — not ones whose value is chat/transcript output, and not `heartbeat-restart` (ignored there). See [config-reference](config-reference.md#idle-agency--routines) for details.
 - `enabled`: toggle without removing
 
 Manage with `/claude-code-hermit:hermit-settings routines`. Changes take effect immediately — `hermit-settings` auto-runs `/claude-code-hermit:hermit-routines load` after writing config. If you edit `config.json` by hand, run `/claude-code-hermit:hermit-routines load` to apply.

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -104,7 +104,7 @@ Modify with `/hermit-settings heartbeat`.
 |-----|------|---------|-------------|
 | `idle_behavior` | string | `"discover"` | What to do when idle: `"wait"` (check tasks/channels only) or `"discover"` (also run idle tasks, reflection, and priority alignment). |
 | `idle_budget` | string | `"$0.50"` | Maximum cost per idle task from `IDLE-TASKS.md`. |
-| `routines` | array | `[]` | Scheduled routines. Each entry: `{id, schedule, skill, run_during_waiting?, enabled}`. `schedule` is a 5-field cron expression (`minute hour dom month dow`) interpreted in `config.timezone`. |
+| `routines` | array | `[]` | Scheduled routines. Each entry: `{id, schedule, skill, run_during_waiting?, reflect_after?, model?, enabled}`. `schedule` is a 5-field cron expression (`minute hour dom month dow`) interpreted in `config.timezone`. `model` (optional, one of `opus`/`sonnet`/`haiku`) runs the skill in a subagent at that model to save cost on lightweight routines; omit to use the session model. Subagents run in isolated context and return only a one-line status — only use `model` on stateless routines (not ones whose primary value is chat/transcript output). Ignored on `heartbeat-restart`. |
 | `monitors` | array | `[]` | Declared background watches. Each entry: `{id, description, command, class?, persistent?, enabled, timeout_ms?}`. Auto-registered at session start via `/watch start`. `class` is `"stream"` or `"poll"` (documentation label only). Runtime state in `state/monitors.runtime.json`. |
 
 Modify with `/hermit-settings routines`, `/hermit-settings idle`.

--- a/plugins/claude-code-hermit/scripts/validate-config.js
+++ b/plugins/claude-code-hermit/scripts/validate-config.js
@@ -27,6 +27,7 @@ const REQUIRED_KEYS = {
 
 const VALID_ESCALATION = ['conservative', 'balanced', 'autonomous'];
 const VALID_QUALITY_GATE_TIER = ['budget', 'balanced', 'quality'];
+const VALID_ROUTINE_MODEL = ['opus', 'sonnet', 'haiku'];
 const TIME_RE = /^\d{2}:\d{2}$/;
 
 // --- Cron validation (5-field: minute hour dom month dow) ---
@@ -135,6 +136,13 @@ function validate(config) {
         warnings.push(`routines[${i}]: duplicate id "${r.id}"`);
       }
       if (r.id) ids.add(r.id);
+      if (r.model !== undefined && r.model !== null) {
+        if (typeof r.model !== 'string' || !VALID_ROUTINE_MODEL.includes(r.model)) {
+          errors.push(`routines[${i}]: model "${r.model}" not in [${VALID_ROUTINE_MODEL.join(', ')}] (omit to use session model)`);
+        } else if (r.id === 'heartbeat-restart') {
+          warnings.push(`routines[${i}]: model on "heartbeat-restart" is ignored — re-arm must run in the session`);
+        }
+      }
     });
   }
 

--- a/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
@@ -41,7 +41,7 @@ Called automatically by `hermit-start.py` on always-on launches. Can also be cal
 
 Use `run_during_waiting` (rdw) from the config entry to select the template. Default `run_during_waiting` is `false` when the field is absent.
 
-**Model-override substitution.** Read the routine's optional `model` field. First, if `id === "heartbeat-restart"`, treat `model` as absent regardless of its value — its re-arm append must run in the session, so it is never dispatched to a subagent. Then: if `model` is absent/null, use the literal clause `invoke /<skill>` in the templates below (current behavior). If set to a non-null `<model>`, replace that clause with the **Agent-dispatch clause**:
+**Model-override substitution.** Read the routine's optional `model` field. First, if `id === "heartbeat-restart"`, treat `model` as absent regardless of its value — its re-arm append must run in the session, so it is never dispatched to a subagent. Then: if `model` is absent/null, use the literal `invoke /<skill>` clause in the templates below (current behavior). If set to a non-null `<model>`, replace that clause — `invoke /<skill>` in the rdw=false template, `Invoke /<skill>` (capitalized) in the rdw=true template — with the **Agent-dispatch clause**:
 
 ```
 dispatch the skill via the Agent tool: subagent_type "general-purpose", model "<model>", prompt "Invoke the skill /<skill> to completion in this project, following its instructions exactly, including any reads/writes to .claude-code-hermit/ state files. Return only a one-line status."

--- a/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
@@ -41,6 +41,14 @@ Called automatically by `hermit-start.py` on always-on launches. Can also be cal
 
 Use `run_during_waiting` (rdw) from the config entry to select the template. Default `run_during_waiting` is `false` when the field is absent.
 
+**Model-override substitution.** Read the routine's optional `model` field. First, if `id === "heartbeat-restart"`, treat `model` as absent regardless of its value — its re-arm append must run in the session, so it is never dispatched to a subagent. Then: if `model` is absent/null, use the literal clause `invoke /<skill>` in the templates below (current behavior). If set to a non-null `<model>`, replace that clause with the **Agent-dispatch clause**:
+
+```
+dispatch the skill via the Agent tool: subagent_type "general-purpose", model "<model>", prompt "Invoke the skill /<skill> to completion in this project, following its instructions exactly, including any reads/writes to .claude-code-hermit/ state files. Return only a one-line status."
+```
+
+The Agent runs in isolated context (no live session conversation, but full filesystem access) and returns only a one-line status to the session. The waiting-check, `log-routine-event.sh` call, and any `heartbeat-restart`/`reflect_after` appends stay in the session turn and run at the session model.
+
 **rdw=true** — routine fires even when `session_state` is `waiting`:
 ```
 [hermit-routine:<id>] Invoke /<skill>. After it completes, run:
@@ -70,11 +78,11 @@ Show configured routines from `config.json` (not from CronList — this is the c
 3. Display table:
 ```
 Routines (config.json):
-  #  ID                 Schedule      Skill                                    RDW    RA     Status
-  1. heartbeat-restart  0 4 * * *     claude-code-hermit:heartbeat start       true   false  enabled
-  2. weekly-review      0 23 * * 0    claude-code-hermit:weekly-review         false  false  disabled
+  #  ID                 Schedule      Skill                                    RDW    RA     Model   Status
+  1. heartbeat-restart  0 4 * * *     claude-code-hermit:heartbeat start       true   false  -       enabled
+  2. weekly-review      0 23 * * 0    claude-code-hermit:weekly-review         false  false  -       disabled
 ```
-`RA` is `true` when `reflect_after: true` is set on the routine entry, `false` otherwise.
+`RA` is `true` when `reflect_after: true` is set on the routine entry, `false` otherwise. `Model` is the value of `model` if set, otherwise `-`.
 
 ### status
 
@@ -117,3 +125,4 @@ Extract the routine ID from the `[hermit-routine:<id>]` prefix in the prompt.
 - **CronCreate is idle-gated.** Routines only fire between REPL turns — never mid-task.
 - **`durable: false` (default).** CronCreates die with the session. `hermit-start.py` re-registers on every always-on launch.
 - **7-day auto-expiry depends on `heartbeat-restart`.** `load` resets the 7-day clock unconditionally on each call. The `heartbeat-restart` routine fires daily and re-invokes `/claude-code-hermit:hermit-routines load`, so entries never reach expiry. **If you disable `heartbeat-restart`, routine CronCreates expire after 7 days** — re-enable it, or run `/claude-code-hermit:hermit-routines load` weekly by hand.
+- **`model` (optional) runs a routine's skill in a subagent at the named model** (`opus`, `sonnet`, or `haiku`) to save cost on lightweight routines. Subagents run in **isolated context** and return only a one-line status to the session — only set `model` on self-contained, stateless routines (file/threshold/URL checks). Do **not** set it on `heartbeat-restart` (re-arm must run in the session — `load` ignores it), avoid it on `reflect`/`weekly-review` (live-session-dependent or already cheap), and **do not use it for routines whose value is chat/transcript output** (the rich output is collapsed to one line and lost). Validated by `scripts/validate-config.js`.

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1463,5 +1463,114 @@ class TestBootstrapSkills(unittest.TestCase):
                          f'Bootstrap skills must stay model-invocable; offenders: {offenders}')
 
 
+class TestRoutineModelValidation(unittest.TestCase):
+    """validate-config.js routine model field — validation rules."""
+
+    BASE_CONFIG = {
+        "agent_name": None, "language": None, "timezone": None,
+        "escalation": "balanced", "channels": {}, "env": {},
+        "heartbeat": {"enabled": True, "active_hours": {"start": "08:00", "end": "23:00"}},
+        "routines": [],
+        "quality_gate": {"tier": "budget"},
+    }
+
+    BASE_ROUTINE = {"id": "check", "schedule": "0 9 * * *", "skill": "claude-code-hermit:knowledge", "enabled": True}
+    HB_ROUTINE = {"id": "heartbeat-restart", "schedule": "0 4 * * *", "skill": "claude-code-hermit:heartbeat start", "run_during_waiting": True, "enabled": True}
+
+    def _run_validate(self, config_dict):
+        """Call validate-config.js validate() via node -e; return {errors, warnings}."""
+        config_json = json.dumps({**self.BASE_CONFIG, **config_dict})
+        js = f"""
+        const v = require('{SCRIPTS}/validate-config.js');
+        const result = v.validate({config_json});
+        process.stdout.write(JSON.stringify(result));
+        """
+        result = subprocess.run(
+            ['node', '-e', js], capture_output=True, text=True, timeout=5,
+        )
+        self.assertEqual(result.returncode, 0, f'node exited non-zero: {result.stderr}')
+        return json.loads(result.stdout)
+
+    def test_routine_model_valid_values(self):
+        """Each valid model value on a routine produces no errors."""
+        for model in ['haiku', 'sonnet', 'opus']:
+            out = self._run_validate({"routines": [{**self.BASE_ROUTINE, "model": model}]})
+            self.assertEqual(out['errors'], [], f'unexpected errors for model={model!r}: {out}')
+
+    def test_routine_model_absent_ok(self):
+        """Routine without model field produces no model-related error."""
+        out = self._run_validate({"routines": [self.BASE_ROUTINE]})
+        self.assertFalse(
+            any('model' in e for e in out['errors']),
+            f'unexpected model error for absent field: {out}',
+        )
+
+    def test_routine_model_null_ok(self):
+        """model: null is treated as absent — no error."""
+        out = self._run_validate({"routines": [{**self.BASE_ROUTINE, "model": None}]})
+        self.assertFalse(
+            any('model' in e for e in out['errors']),
+            f'unexpected model error for null: {out}',
+        )
+
+    def test_routine_model_invalid_rejected(self):
+        """model: haik (typo) is an error."""
+        out = self._run_validate({"routines": [{**self.BASE_ROUTINE, "model": "haik"}]})
+        self.assertTrue(
+            any('not in' in e for e in out['errors']),
+            f'expected "not in" error for invalid model, got {out}',
+        )
+
+    def test_routine_model_non_string_rejected(self):
+        """model: 5 (non-string) is an error."""
+        out = self._run_validate({"routines": [{**self.BASE_ROUTINE, "model": 5}]})
+        self.assertTrue(
+            any('not in' in e for e in out['errors']),
+            f'expected "not in" error for non-string model, got {out}',
+        )
+
+    def test_heartbeat_restart_model_warns_not_errors(self):
+        """model on heartbeat-restart produces a warning (ignored), not an error."""
+        out = self._run_validate({"routines": [{**self.HB_ROUTINE, "model": "haiku"}]})
+        self.assertEqual(out['errors'], [], f'unexpected errors: {out}')
+        self.assertTrue(
+            any('ignored' in w for w in out['warnings']),
+            f'expected "ignored" warning for heartbeat-restart model, got {out}',
+        )
+
+
+class TestHermitRoutinesModelContract(unittest.TestCase):
+    """Structural contract for the model-override substitution in hermit-routines SKILL.md.
+
+    Guards against the template change being reverted while the validator keeps
+    accepting the model field (which would leave the field accepted-but-inert),
+    and against the heartbeat-restart short-circuit guard being silently dropped.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        path = REPO / 'skills' / 'hermit-routines' / 'SKILL.md'
+        if not path.exists():
+            raise FileNotFoundError('skills/hermit-routines/SKILL.md missing')
+        cls._skill_content = path.read_text()
+
+    def test_skill_documents_model_override_substitution(self):
+        """SKILL.md must document the model-override substitution rule."""
+        self.assertIn('Model-override substitution', self._skill_content,
+                      'hermit-routines SKILL.md is missing the Model-override substitution section')
+
+    def test_skill_documents_agent_dispatch(self):
+        """SKILL.md must reference Agent tool dispatch for model overrides."""
+        self.assertIn('via the Agent tool', self._skill_content,
+                      'hermit-routines SKILL.md is missing the Agent tool dispatch clause')
+
+    def test_skill_documents_heartbeat_restart_guard(self):
+        """SKILL.md must document the heartbeat-restart short-circuit in the substitution rule."""
+        self.assertIn('heartbeat-restart', self._skill_content,
+                      'hermit-routines SKILL.md missing heartbeat-restart reference')
+        self.assertIn('treat `model` as absent', self._skill_content,
+                      'hermit-routines SKILL.md is missing the heartbeat-restart short-circuit guard phrase')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Adds an optional `model` field to `config.json` routine entries so operators can run lightweight routines (URL checks, threshold comparisons, schema validation) on Haiku instead of the global session model. On always-on deployments running 14+ routines, this can cut cache_read cost by ~73% on eligible routines (Haiku $0.08/MTok vs Sonnet $0.30/MTok).

## Why subagent dispatch

`CronCreate` has no `model` parameter (schema: `cron`/`prompt`/`recurring`/`durable` only). The other evaluated mechanism — mid-session `/model` switching — is broken: it doesn't re-model the in-flight turn (session model is launch-fixed), and an error before restore strands the whole session on the downgraded model. Subagent dispatch via the Agent tool is the only viable lever, confirmed by a live probe (a `general-purpose` subagent has the `Skill` tool, sees `claude-code-hermit:*` skills, and faithfully executes them).

When `model` is set, `hermit-routines load` bakes an Agent-dispatch clause into the CronCreate prompt instead of a direct `/<skill>` invocation. The wrapper (waiting-check, logging, `reflect_after`/`heartbeat-restart` appends) stays in the session; only the skill body runs in the subagent at the chosen model.

## Changes

- **`skills/hermit-routines/SKILL.md`** — Model-override substitution rule in the load prompt-template section; `heartbeat-restart` explicitly short-circuited (treat `model` as absent — re-arm must run in the session); `Model` column in the `list` table; Notes bullet covering isolation caveat and unsafe targets
- **`scripts/validate-config.js`** — `VALID_ROUTINE_MODEL` enum + per-routine validation: bad value → error, `heartbeat-restart` + model → warning (ignored at load)
- **`agents/hermit-config-validator.md`** — Routine validation section updated to include `model` field rules, matching the script
- **`docs/config-reference.md`** + **`docs/always-on-ops.md`** — `model` field documented in both routine field lists with isolation + output-collapse caveat
- **`tests/run-contracts.py`** — `TestRoutineModelValidation` (6 tests: valid values, absent/null no-op, typo error, non-string error, heartbeat-restart warning) + `TestHermitRoutinesModelContract` (3 SKILL-text contract tests guarding substitution rule and heartbeat-restart guard)

## Caveats

Subagents run in isolated context (no live session conversation, shared filesystem). Default routines ship `model`-free — zero behavior change on existing installs. Unsafe targets (`reflect`, `weekly-review`, routines whose value is chat/transcript output) are documented as such. `heartbeat-restart` is enforced-safe at both the validator and load levels.

## Test plan

```
cd plugins/claude-code-hermit && bash tests/run-all.sh
```

All 16 test suites passed (100 contract tests). Validator smoke-check:
- `model: "haiku"` on a routine → no errors
- `model: "haik"` → error containing "not in"
- `model: "haiku"` on `heartbeat-restart` → warning containing "ignored", no error

Closes #289