### PR TITLE
docs(claude-code-hermit): advise staggering co-scheduled routines

### DIFF
--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -129,6 +129,8 @@ DST transitions self-correct within 24h via the daily `heartbeat-restart` reload
 
 Schedules that cannot be expressed as a single CronCreate after shifting are passed through unchanged with a warning: mixed day-wrap on restricted-DOW schedules, and hour step patterns (`*/7`) that lose their structure. Avoid these in routines when `config.timezone` differs from the machine TZ; split into separate fixed-time entries instead.
 
+**Staggering routines.** When several routines run around the same time, offset them by a minute or two (the defaults do this: `reflect` at `0 9`, `scheduled-checks` at `5 9`). Co-scheduled routines fire as separate idle turns; a small stagger keeps each fire inside the prompt-cache window so they reuse warm context.
+
 ---
 
 ## `knowledge`


### PR DESCRIPTION
## Summary

Adds a one-paragraph note to the Cron schedule rules section of `docs/config-reference.md` advising operators to stagger heavy routines by a minute or two rather than stacking them on one exact cron minute. The defaults already model this pattern (`reflect` at `0 9`, `scheduled-checks` at `5 9`).

## Changes

- `docs/config-reference.md` — new **Staggering routines** paragraph appended to the cron rules section, explaining that co-scheduled routines fire as separate idle turns and a small offset keeps each fire inside the prompt-cache window.

## Context

Issue #297 proposed batching co-scheduled routines into a single `CronCreate` turn. Investigation found:
- The cited per-fire cold-cache cost is likely amortized already by the 5-min TTL for back-to-back idle fires in the same session.
- The default config co-schedules nothing; `reflect`/`scheduled-checks` are deliberately staggered.
- The batching machinery would add grouping + mixed-`run_during_waiting` merge + synthetic-id complexity to a bootstrap-critical SKILL.md.

The doc note captures the guidance value with zero complexity cost. Closes #297.

## Test plan

- Doc-only change; no test suite impact.
- Read the edited section: paragraph renders cleanly and matches surrounding style.