### PR TITLE
fix(claude-code-hermit): compute today's cost live in brief

### DIFF
--- a/plugins/claude-code-hermit/scripts/today-cost.js
+++ b/plugins/claude-code-hermit/scripts/today-cost.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// Fails open: missing log or parse errors print $0.00 and exit 0.
+
+const fs = require('fs');
+const path = require('path');
+const { formatTokens } = require('./lib/format');
+
+const COST_LOG = path.resolve('.claude/cost-log.jsonl');
+
+try {
+  const today = new Date().toISOString().slice(0, 10);
+  let cost = 0;
+  let tokens = 0;
+  const sessions = new Set();
+
+  try {
+    for (const line of fs.readFileSync(COST_LOG, 'utf8').split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const e = JSON.parse(line);
+        if (e.timestamp && e.timestamp.startsWith(today)) {
+          cost += e.estimated_cost_usd || 0;
+          tokens += e.total_tokens || 0;
+          if (e.session_id) sessions.add(e.session_id);
+        }
+      } catch {}
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+
+  process.stdout.write(
+    `$${cost.toFixed(2)} (${formatTokens(tokens)}) across ${sessions.size} session(s)\n`
+  );
+} catch {
+  process.stdout.write('$0.00 (0K tokens) across 0 session(s)\n');
+}

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -39,7 +39,7 @@ After composing the morning brief, check `state/micro-proposals.json → pending
 
 Emphasize backward-looking content:
 - Sessions completed today (scan S-NNN reports with today's date in frontmatter `date` field, or `## Summary` for pre-Observatory reports, plus current SHELL.md progress log)
-- Read `.claude-code-hermit/cost-summary.md` for today's cost and token total. If the summary is stale (its frontmatter `updated` date is not today), the cost-tracker will regenerate it on the next interaction — use the trend table's today row (Cost and Tokens columns) or fall back to scanning reports.
+- Compute today's cost live: run `node "${CLAUDE_PLUGIN_ROOT}/scripts/today-cost.js"` and use its output for the today's cost and token total. Do not read `cost-summary.md` for the today figure — it is only updated once per day and will be stale throughout the day in always-on deployments.
 - Key findings or patterns noticed
 - What to look at tomorrow
 - After generating summary: if SHELL.md Status is `in_progress` or has progress entries since last report, note it in the brief (e.g., "Session still open — run /session-close to archive.") and let the operator close explicitly. Exception: if `config.always_on` is `true` AND `config.routines` contains an enabled entry with skill containing `daily-auto-close`, suppress the note — the auto-close routine archives it at midnight. Idle transitions are owned by the `session` skill and `session-mgr`; brief does not trigger them.
@@ -91,4 +91,4 @@ Next: description of next action (or "Session complete" if all done)
 
 When invoked with "brief today", "daily summary", or "what happened today":
 
-Scan all session reports archived today (match `date` in YAML frontmatter, or `Date` in `## Summary` for pre-Observatory reports) plus the current SHELL.md progress log. Read `.claude-code-hermit/cost-summary.md` for aggregated cost data. Format as a day-level summary covering: work done, cost, and proposals created/resolved.
+Scan all session reports archived today (match `date` in YAML frontmatter, or `Date` in `## Summary` for pre-Observatory reports) plus the current SHELL.md progress log. For today's cost and token total, run `node "${CLAUDE_PLUGIN_ROOT}/scripts/today-cost.js"`. Read `.claude-code-hermit/cost-summary.md` for week and all-time aggregates. Format as a day-level summary covering: work done, cost, and proposals created/resolved.


### PR DESCRIPTION
## Summary

`brief --evening` and "brief today" reported today's cost by reading `.claude-code-hermit/cost-summary.md`, which is regenerated at most once per calendar day (first Stop turn). In always-on deployments, the first turn happens just after midnight, so "Today: \$0.00" was shown all day even as `cost-log.jsonl` accumulated entries.

The issue filed this as a daily-auto-close problem, and proposed checking the `updated` frontmatter date before falling back. Both framings are off: the real cause is the once-per-day guard in `writeCostSummary()`, and the `updated` date is always today (written at the first turn), so that gate never fires.

## Changes

- **`scripts/today-cost.js`** (new): fail-open helper that scans `.claude/cost-log.jsonl`, filters entries by today's date, and prints a one-line summary (`$0.42 (12.3K tokens) across 2 session(s)`). Reuses the scan pattern from `doctor-check.js`. Called only when `brief` is invoked, not on every Stop turn (avoids O(n)/turn cost as the log grows).
- **`skills/brief/SKILL.md`**: `--evening` and daily-summary today-cost consumers now call `node "${CLAUDE_PLUGIN_ROOT}/scripts/today-cost.js"` instead of reading the stale Today row. `--morning` (yesterday's cost from the trend table) is unchanged — yesterday is a closed day and is accurately aggregated.

## Test plan

- `node plugins/claude-code-hermit/scripts/today-cost.js` with a seeded log containing today + yesterday entries: confirmed it sums only today's entries and ignores yesterday's.
- `node plugins/claude-code-hermit/scripts/today-cost.js` with no log file: prints `$0.00 (0K tokens) across 0 session(s)` and exits 0 (fail-open).
- `bash plugins/claude-code-hermit/tests/run-all.sh`: 75 hook + 84 script + 20 tz-shift + 18 docker + 11 docker-baseline + 36 template + 18 hatch-options + 36 archive-shell + 12 archive-compiled + 36 more = all passed, 0 failed.

Closes #296