### PR TITLE
feat(claude-code-hermit): add context-hygiene rule to session discipline

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **hatch: git init on fresh dirs** — when hatching in an empty, non-git directory (e.g. a dedicated ops-hermit workspace), offers a local `git init` so the hermit's build artifacts are versioned from day one. Existing projects and re-inits are untouched. Closes #282.
 - **cost-reflect: structural cost audit skill** — breaks 7-day spend into token-type drivers (cache_read / cache_write / output / input), flags cold-start overhead, and attributes cost per session. Read-only report; opt-in as a weekly routine via `/hermit-settings`. Closes #295.
+- **session-discipline: context-hygiene rule** — delegate broad scans/research to `Explore` subagent; keeps main context lean. Cost-neutral (`idle_budget` still gates).
 
 ### Changed
 
@@ -27,6 +28,7 @@
 | `scripts/cost-tracker.js` | consume lib/pricing.js |
 | `tests/run-scripts.sh` | pricing regression + cost-reflect fixture tests |
 | `docs/skills.md` | cost-reflect row in Channel-Friendly Summaries |
+| `state-templates/CLAUDE-APPEND.md` | New "Context hygiene" rule under § Rules |
 
 ## [1.1.9] - 2026-06-04
 

--- a/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
@@ -86,6 +86,7 @@ Auto-memory handles all learning. `compiled/` is for durable domain outputs and 
 
 - **Rate limits:** Log pause/resume in Progress Log. Never silently stall.
 - **Self-awareness:** If stuck — say so, log it, alert via channel. Don't push through silently.
+- **Context hygiene:** For broad file scans, archive traversals, or research where only the conclusion is needed, delegate to the built-in `Explore` subagent. Keeps context lean on long runs. Not a compute fan-out — `idle_budget` still gates.
 - **Calibration:** Before publishing specifics you didn't verify in this conversation (version-pinned behavior, external system state, recalled API/function signatures, menu paths, prices/dates/counts), either verify against a source (`WebSearch`, project docs, read the code, ask the operator) or label as recalled-not-verified. Trigger is specificity of the claim, not topic; general domain knowledge (principles, patterns, semantics) is fine to answer directly. `OPERATOR.md` can tighten or relax.
 - **Secrets:** Never log API keys, tokens, passwords, or credentials to SHELL.md, reports, or proposals. Session files may be committed to git.
 - **OPERATOR.md:** Never edit autonomously. If you notice stale or contradictory context, draft the minimal change, show a diff, and apply only after the operator confirms. In always-on mode, flag it via channel instead — the operator edits directly.


### PR DESCRIPTION
## Summary

Adds one session-discipline rule to the shipped hermit so it delegates broad file scans / archive traversals / research to the built-in `Explore` subagent instead of reading everything into the main session context. This is the single piece of Claude Code's default subagent guidance the hermit was genuinely missing — and it's framed as *context hygiene*, not "throw more compute at it," so it doesn't fight the hermit's cost spine (`idle_budget`, `cost-reflect`, `hermit-doctor`).

Context: we reviewed Claude Code's recommended CLAUDE.md (Boris's interactive-engineer baseline) against the hermit. Most items are already implemented in a stronger form (reflect/proposals, verification gates, cost machinery) or conflict with the hermit's unattended design (autonomous "just fix it" inverts the proposal gate; "use subagents liberally / more compute" collides with `idle_budget`). Only the context-hygiene half of the subagent strategy survived as a real gap.

## Changes

- **`state-templates/CLAUDE-APPEND.md`** — new **Context hygiene** bullet under § Rules, placed after **Self-awareness**. Reuses the `Explore`-subagent vocabulary already used in the `reflect` skill.
- **`CHANGELOG.md`** — `[Unreleased] → Added` entry + Files-affected row.

No `### Upgrade Instructions` needed: the change is non-config, so `hermit-evolve` Step 6's marker-aware diff applies it to existing hermits' `CLAUDE.md` / `CLAUDE.local.md` automatically (replace case).

## Test plan

- `bash plugins/claude-code-hermit/tests/run-all.sh` — full suite green (16/16 result blocks at 0 failed, exit 0).
- `evolve-plan (#211)` suite: 13/13 pass, including the three `CLAUDE-APPEND` marker-diff cases (confirms the new bullet flows through the upgrade replace path rather than triggering a re-append).