### PR TITLE
feat(claude-code-hermit): add trigger-source attribution to cost-log and cost-reflect (#294)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **hatch: git init on fresh dirs** — when hatching in an empty, non-git directory (e.g. a dedicated ops-hermit workspace), offers a local `git init` so the hermit's build artifacts are versioned from day one. Existing projects and re-inits are untouched. Closes #282.
 - **cost-reflect: structural cost audit skill** — breaks 7-day spend into token-type drivers (cache_read / cache_write / output / input), flags cold-start overhead, and attributes cost per session. Read-only report; opt-in as a weekly routine via `/hermit-settings`. Closes #295.
+- **cost-tracker/cost-reflect: trigger-source attribution** — every `cost-log.jsonl` entry records its trigger source (`heartbeat`, `routine:<id>`, or `other`), and cost-reflect adds a **Cost by source** breakdown so idle spend can be traced to its origin. Closes #294.
 
 ### Changed
 

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -219,6 +219,26 @@ The `cost-tracker` hook tracks spend automatically. For detailed token optimizat
 
 Quick summary: set per-session budgets with `/hermit-settings budget` (warns at 80%, recommends closing at 100%) and project-level budgets in OPERATOR.md.
 
+### Cheap always-on
+
+Four levers, in rough order of impact:
+
+**1. Whole-session model** (`config.model: "haiku"`). The single highest-leverage cut. Every idle turn — heartbeat, routines, interactive — inherits the session model. Tradeoff: your interactive work and idle task pickup also drop to Haiku. It is whole-session, not heartbeat-only. Set via `/hermit-settings` or directly in `config.json`.
+
+**2. Per-routine model override** (since v1.0.20). Routines that are self-contained and stateless (URL checks, threshold comparisons, file audits) can run their skill in a subagent at a cheaper model:
+
+```json
+{"id": "cortex-refresh", "schedule": "0 6 * * *", "skill": "...", "model": "haiku"}
+```
+
+Not suitable for routines whose value is chat or transcript output (subagent output collapses to one line) or for `heartbeat-restart` (must run in-session). See the [Routines](#routines) section above and [config-reference](config-reference.md#idle-agency--routines).
+
+**3. Interval and active hours.** Cost is wakes/day × cost/wake. Widen `heartbeat.every` (default 5 min) or tighten `active_hours` in `config.json`. Only `EVALUATE`/`AUTO_CLOSE` wakes cost tokens — the `--peek` poll between them is free.
+
+**4. Checklist curation.** A shorter, sharper `HEARTBEAT.md` lets the free OK precheck path fire more often, skipping the full LLM eval. `/claude-code-hermit:heartbeat edit` warns when the list exceeds 10 items.
+
+**Measure before and after:** run `/claude-code-hermit:cost-reflect` to see spend broken down by trigger source (`heartbeat`, `routine:<id>`, `other`) and by token type. The `routine:<id>` rows are the ones a per-routine model override shrinks; `heartbeat` is the one that responds to interval/checklist changes; `other` covers interactive and unattributed turns.
+
 ---
 
 ## 5. Reconnecting After Disconnects

--- a/plugins/claude-code-hermit/scripts/cost-reflect.js
+++ b/plugins/claude-code-hermit/scripts/cost-reflect.js
@@ -117,7 +117,6 @@ function run() {
 
   // All source entries sorted desc by cost; tail count used for the '+N more' line
   const allSources = Object.entries(sourceMap).sort((a, b) => b[1] - a[1]);
-  const hasRoutineRow = allSources.some(([src]) => src.startsWith('routine:'));
 
   const header = `### Cost by token type (${days}d · ${formatCost(total)} · ${turns} turns / ${sessions} sessions)\n` +
     `- cache_read ${formatCost(totals.cacheRead)} (${pct(totals.cacheRead, total)})` +
@@ -129,19 +128,20 @@ function run() {
     ? `\n### Cold starts\n- ${coldStartTurns} turn${coldStartTurns === 1 ? '' : 's'} · ${formatCost(coldStartCost)} (${pct(coldStartCost, total)}) — cache-write, no cache-read, <${COLD_START_OUTPUT_MAX} output tokens\n`
     : '';
 
-  const subagentFootnote = hasRoutineRow
-    ? `\n_routines with a model override run their skill in a subagent; only the in-session dispatch cost is counted here_\n`
-    : '';
-
   function buildSourceSection(n) {
     if (n <= 0 || allSources.length === 0) return '';
     const rest = allSources.length - n;
-    const rows = allSources.slice(0, n).map(([src, cost]) => {
+    const shown = allSources.slice(0, n);
+    const rows = shown.map(([src, cost]) => {
       const label = src === 'other' ? `${src} _(non-scheduled)_` : src;
       return `- ${label}: ${formatCost(cost)} (${pct(cost, total)})`;
     });
     if (rest > 0) rows.push(`- +${rest} more sources`);
-    return `\n### Cost by source\n${rows.join('\n')}\n`;
+    // Footnote only when a routine row is actually displayed — otherwise it dangles.
+    const footnote = shown.some(([src]) => src.startsWith('routine:'))
+      ? `\n_routines with a model override run their skill in a subagent; only the in-session dispatch cost is counted here_\n`
+      : '';
+    return `\n### Cost by source\n${rows.join('\n')}\n${footnote}`;
   }
 
   function buildTopSection(n) {
@@ -152,16 +152,20 @@ function run() {
     return `\n### Top sessions\n${lines}\n`;
   }
 
-  // Enforce ≤1500 chars by dropping rows from both sections until it fits.
-  // Source rows shed first (lowest-value for operators with many routines),
-  // then top-sessions, mirroring the existing degradation pattern.
-  for (let m = MAX_TOP_SOURCES; m >= 0; m--) {
-    for (let n = MAX_TOP_SESSIONS; n >= 0; n--) {
-      const body = header + coldSection + buildSourceSection(m) + subagentFootnote + buildTopSection(n);
-      if (body.length <= MAX_CHARS || (m === 0 && n === 0)) {
-        process.stdout.write(body);
-        return;
-      }
+  // Enforce ≤1500 chars. Shed source rows first (lowest-value for operators with
+  // many routines) down to zero, then shed top-sessions — a single monotonic path.
+  for (let m = MAX_TOP_SOURCES; m >= 1; m--) {
+    const body = header + coldSection + buildSourceSection(m) + buildTopSection(MAX_TOP_SESSIONS);
+    if (body.length <= MAX_CHARS) {
+      process.stdout.write(body);
+      return;
+    }
+  }
+  for (let n = MAX_TOP_SESSIONS; n >= 0; n--) {
+    const body = header + coldSection + buildTopSection(n);
+    if (body.length <= MAX_CHARS || n === 0) {
+      process.stdout.write(body);
+      return;
     }
   }
 }

--- a/plugins/claude-code-hermit/scripts/cost-reflect.js
+++ b/plugins/claude-code-hermit/scripts/cost-reflect.js
@@ -12,6 +12,7 @@ const { costByType } = require('./lib/pricing');
 const COLD_START_OUTPUT_MAX = 1000; // tokens
 
 const MAX_TOP_SESSIONS = 3;
+const MAX_TOP_SOURCES = 5;
 const MAX_CHARS = 1500;
 
 function parseLogEntries(costLog) {
@@ -60,6 +61,7 @@ function run() {
   let coldStartTurns = 0;
   let coldStartCost = 0;
   const sessionMap = {}; // session_id -> { cost, turns, byType }
+  const sourceMap = {};
 
   for (const e of window) {
     const model = e.model || 'sonnet';
@@ -94,6 +96,10 @@ function run() {
       s.byType.cacheRead  += types.cacheRead;
       s.byType.output     += types.output;
     }
+
+    // Per-source attribution; legacy entries without 'source' bucket to 'other'
+    const src = e.source || 'other';
+    sourceMap[src] = (sourceMap[src] || 0) + entryCost;
   }
 
   const total = totals.input + totals.cacheWrite + totals.cacheRead + totals.output;
@@ -109,6 +115,10 @@ function run() {
       return { id: sid.slice(0, 8), cost: s.cost, turns: s.turns, dominant: label };
     });
 
+  // All source entries sorted desc by cost; tail count used for the '+N more' line
+  const allSources = Object.entries(sourceMap).sort((a, b) => b[1] - a[1]);
+  const hasRoutineRow = allSources.some(([src]) => src.startsWith('routine:'));
+
   const header = `### Cost by token type (${days}d · ${formatCost(total)} · ${turns} turns / ${sessions} sessions)\n` +
     `- cache_read ${formatCost(totals.cacheRead)} (${pct(totals.cacheRead, total)})` +
     ` · cache_write ${formatCost(totals.cacheWrite)} (${pct(totals.cacheWrite, total)})` +
@@ -119,6 +129,21 @@ function run() {
     ? `\n### Cold starts\n- ${coldStartTurns} turn${coldStartTurns === 1 ? '' : 's'} · ${formatCost(coldStartCost)} (${pct(coldStartCost, total)}) — cache-write, no cache-read, <${COLD_START_OUTPUT_MAX} output tokens\n`
     : '';
 
+  const subagentFootnote = hasRoutineRow
+    ? `\n_routines with a model override run their skill in a subagent; only the in-session dispatch cost is counted here_\n`
+    : '';
+
+  function buildSourceSection(n) {
+    if (n <= 0 || allSources.length === 0) return '';
+    const rest = allSources.length - n;
+    const rows = allSources.slice(0, n).map(([src, cost]) => {
+      const label = src === 'other' ? `${src} _(non-scheduled)_` : src;
+      return `- ${label}: ${formatCost(cost)} (${pct(cost, total)})`;
+    });
+    if (rest > 0) rows.push(`- +${rest} more sources`);
+    return `\n### Cost by source\n${rows.join('\n')}\n`;
+  }
+
   function buildTopSection(n) {
     if (n <= 0 || topSessions.length === 0) return '';
     const lines = topSessions.slice(0, n).map(s =>
@@ -127,12 +152,16 @@ function run() {
     return `\n### Top sessions\n${lines}\n`;
   }
 
-  // Enforce ≤1500 chars by dropping top-sessions entries until it fits
-  for (let n = MAX_TOP_SESSIONS; n >= 0; n--) {
-    const body = header + coldSection + buildTopSection(n);
-    if (body.length <= MAX_CHARS || n === 0) {
-      process.stdout.write(body);
-      return;
+  // Enforce ≤1500 chars by dropping rows from both sections until it fits.
+  // Source rows shed first (lowest-value for operators with many routines),
+  // then top-sessions, mirroring the existing degradation pattern.
+  for (let m = MAX_TOP_SOURCES; m >= 0; m--) {
+    for (let n = MAX_TOP_SESSIONS; n >= 0; n--) {
+      const body = header + coldSection + buildSourceSection(m) + subagentFootnote + buildTopSection(n);
+      if (body.length <= MAX_CHARS || (m === 0 && n === 0)) {
+        process.stdout.write(body);
+        return;
+      }
     }
   }
 }

--- a/plugins/claude-code-hermit/scripts/cost-tracker.js
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.js
@@ -58,18 +58,29 @@ function entryText(entry) {
   return typeof c === 'string' ? c : JSON.stringify(c);
 }
 
-// Scan backward from billedIndex through the current turn (stopping at the previous
-// assistant-with-usage entry or the tail start) and return concatenated entry text.
-// Turn-boundary is load-bearing: the 128KB tail often contains several stacked turns,
-// so without this bound a prior routine's marker can bleed into a later turn's source.
+// A user entry is a tool_result carrier (not a turn boundary) when its content
+// is an array containing any tool_result block. The triggering prompt that opens
+// a turn is a "real" user entry: string content, or an array with no tool_result.
+function isToolResult(entry) {
+  if (entry.type !== 'user') return false;
+  const c = entry.message?.content;
+  return Array.isArray(c) && c.some(b => b && b.type === 'tool_result');
+}
+
+// Scan backward from billedIndex through the current turn and return concatenated
+// entry text. The turn boundary is the triggering user prompt (the first non-tool_result
+// user entry) — we include it and stop. This passes over intermediate tool-calling
+// assistant steps (which each carry their own usage) so a multi-step heartbeat/routine
+// turn still reaches its marker, while stopping before the prior turn's prompt so an
+// earlier routine's marker can't bleed into a later turn's source.
 function scanTriggerMarkers(lines, billedIndex) {
   const parts = [];
   for (let j = billedIndex - 1; j >= 0; j--) {
     try {
       const prev = JSON.parse(lines[j]);
-      // Stop at the previous billed assistant turn — that's the turn boundary
-      if (prev.type === 'assistant' && prev.message?.usage) break;
       parts.push(entryText(prev));
+      // Reached this turn's triggering prompt — include it, then stop.
+      if (prev.type === 'user' && !isToolResult(prev)) break;
     } catch {}
   }
   return parts.join(' ');
@@ -82,6 +93,9 @@ function scanTriggerMarkers(lines, billedIndex) {
 // strict charset here ([A-Za-z0-9._-]+) is the classifier's own gate, and
 // it is confirmed to reject skill-template noise ([hermit-routine:*], <id> placeholders)
 // that appears in tool_result entries when routines register.
+// Limitation: scanning covers the whole turn (prompt + tool_results), so a turn that
+// merely surfaces a marker string in tool output (e.g. grepping these very sources)
+// can be misclassified. Accepted — the markers are stable and this is rare in practice.
 function classifySource(triggerText) {
   if (!triggerText) return 'other';
   if (triggerText.includes('HEARTBEAT_EVALUATE') ||

--- a/plugins/claude-code-hermit/scripts/cost-tracker.js
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.js
@@ -50,6 +50,54 @@ function detectModel(modelStr) {
   return 'sonnet';
 }
 
+// Stringify an entry's message.content regardless of whether it's a string or a content-block array.
+// Real transcripts use both shapes (confirmed in live ops-hermit data).
+function entryText(entry) {
+  const c = entry.message?.content;
+  if (!c) return '';
+  return typeof c === 'string' ? c : JSON.stringify(c);
+}
+
+// Scan backward from billedIndex through the current turn (stopping at the previous
+// assistant-with-usage entry or the tail start) and return concatenated entry text.
+// Turn-boundary is load-bearing: the 128KB tail often contains several stacked turns,
+// so without this bound a prior routine's marker can bleed into a later turn's source.
+function scanTriggerMarkers(lines, billedIndex) {
+  const parts = [];
+  for (let j = billedIndex - 1; j >= 0; j--) {
+    try {
+      const prev = JSON.parse(lines[j]);
+      // Stop at the previous billed assistant turn — that's the turn boundary
+      if (prev.type === 'assistant' && prev.message?.usage) break;
+      parts.push(entryText(prev));
+    } catch {}
+  }
+  return parts.join(' ');
+}
+
+// Classify a turn's trigger source from the scanned text of its entries.
+// Only the two marker-driven sources are claimed; everything else is 'other'
+// (the non-scheduled bucket, typically the largest row in practice).
+// Routine ids are validated only for presence/uniqueness in config — the
+// strict charset here ([A-Za-z0-9._-]+) is the classifier's own gate, and
+// it is confirmed to reject skill-template noise ([hermit-routine:*], <id> placeholders)
+// that appears in tool_result entries when routines register.
+function classifySource(triggerText) {
+  if (!triggerText) return 'other';
+  if (triggerText.includes('HEARTBEAT_EVALUATE') ||
+      triggerText.includes('/claude-code-hermit:heartbeat run')) {
+    return 'heartbeat';
+  }
+  // Strict charset — must match a real routine id, never a placeholder or glob
+  const routineMatch = triggerText.match(/\[hermit-routine:([A-Za-z0-9._-]+)\]/);
+  // Length-cap to 64 chars so ids can't overflow markdown table cells
+  if (routineMatch) return `routine:${routineMatch[1].slice(0, 64)}`;
+  // log-routine-event.sh fallback: present in tool_result when the skill fires the marker
+  const logMatch = triggerText.match(/log-routine-event\.sh\s+([A-Za-z0-9._-]+)/);
+  if (logMatch) return `routine:${logMatch[1].slice(0, 64)}`;
+  return 'other';
+}
+
 function readLastTurnUsage(transcriptPath) {
   const TAIL_BYTES = 131072; // 128KB — read from end, avoid loading full transcript
   try {
@@ -69,7 +117,9 @@ function readLastTurnUsage(transcriptPath) {
         const entry = JSON.parse(lines[i]);
         if (entry.type === 'assistant' && entry.message?.usage) {
           const u = entry.message.usage;
-          // Detect operator interaction for operator_turns tracking
+          // Detect operator interaction for operator_turns tracking.
+          // Note: real transcripts use type:'user', not type:'human', so this is
+          // effectively always false in production — left intact for future correctness.
           let hadHumanTurn = false;
           for (let j = i - 1; j >= 0; j--) {
             try {
@@ -78,6 +128,8 @@ function readLastTurnUsage(transcriptPath) {
               break; // stop at first valid entry before this assistant turn
             } catch {}
           }
+          const triggerText = scanTriggerMarkers(lines, i);
+          const source = classifySource(triggerText);
           return {
             inputTokens:      u.input_tokens || 0,
             cacheWriteTokens: u.cache_creation_input_tokens || 0,
@@ -85,6 +137,7 @@ function readLastTurnUsage(transcriptPath) {
             outputTokens:     u.output_tokens || 0,
             model:            entry.message.model || '',
             hadHumanTurn,
+            source,
           };
         }
       } catch {}
@@ -369,7 +422,7 @@ async function run(data) {
       return null;
     }
 
-    const { inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens, model: rawModel, hadHumanTurn } = turn;
+    const { inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens, model: rawModel, hadHumanTurn, source } = turn;
     const model = detectModel(rawModel);
 
     const totalTokens = inputTokens + cacheWriteTokens + cacheReadTokens + outputTokens;
@@ -387,6 +440,7 @@ async function run(data) {
     const logEntry = {
       timestamp: new Date().toISOString(),
       session_id: runtimeSessionId || sessionId,
+      source,
       model,
       input_tokens: inputTokens,
       cache_write_tokens: cacheWriteTokens,
@@ -424,7 +478,7 @@ async function run(data) {
   }
 }
 
-module.exports = { run, getCumulativeCost };
+module.exports = { run, getCumulativeCost, classifySource, scanTriggerMarkers };
 
 if (require.main === module) {
   (async () => {

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -915,6 +915,23 @@ const text=scanTriggerMarkers(lines,3);
 if(text.includes('[hermit-routine:old-routine]')) throw new Error('prior turn marker bled in: '+text.slice(0,200));
 \""
 
+# scanTriggerMarkers: reaches the marker past an intermediate tool-calling assistant
+# that ITSELF carries usage — the realistic transcript shape (every API round-trip is
+# billed). The scan must skip it and stop at the triggering user prompt, not truncate early.
+run_test "cost-tracker: scanTriggerMarkers passes intermediate billed assistant" bash -c \
+  "node -e \"
+const {scanTriggerMarkers,classifySource}=require('$TRACKER_LIB');
+const lines=[
+  JSON.stringify({type:'user',message:{content:'[hermit-routine:reflect] Invoke /reflect.'}}),
+  JSON.stringify({type:'assistant',message:{usage:{input_tokens:80,output_tokens:30},content:[{type:'tool_use',id:'t1',name:'Skill',input:{}}]}}),
+  JSON.stringify({type:'user',message:{content:[{tool_use_id:'t1',type:'tool_result',content:'ok'}]}}),
+  JSON.stringify({type:'assistant',message:{usage:{input_tokens:100,output_tokens:50},content:[{type:'text',text:'done'}]}})
+];
+const text=scanTriggerMarkers(lines,3);
+if(!text.includes('[hermit-routine:reflect]')) throw new Error('marker not reached past billed tool step: '+text.slice(0,200));
+if(classifySource(text)!=='routine:reflect') throw new Error('got '+classifySource(text));
+\""
+
 # -------------------------------------------------------
 # cost-reflect.js: source attribution tests
 # -------------------------------------------------------
@@ -952,6 +969,24 @@ run_test "cost-reflect: routine row triggers subagent footnote" bash -c \
 
 run_test "cost-reflect (source fixture): output ≤1500 chars" bash -c \
   "[ \$(echo '$REFLECT_SRC_OUT' | wc -c) -le 1500 ]"
+
+cleanup
+
+# No-routine fixture: footnote must be absent when no routine row is displayed (no dangling note)
+REFLECT_NOROUTINE_WORKDIR="$(setup_workdir)"
+REFLECT_NOROUTINE_DATE="$(date -u -d '1 day ago' +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d 2>/dev/null || echo "$(date -u +%Y-%m-%d)")"
+
+cat > "$REFLECT_NOROUTINE_WORKDIR/.claude/cost-log.jsonl" <<NOROUTEOF
+{"timestamp":"${REFLECT_NOROUTINE_DATE}T10:00:00.000Z","session_id":"s1","source":"heartbeat","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":100000,"output_tokens":0,"total_tokens":100000,"estimated_cost_usd":0.03}
+{"timestamp":"${REFLECT_NOROUTINE_DATE}T10:02:00.000Z","session_id":"s3","source":"other","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":50000,"output_tokens":5000,"total_tokens":55000,"estimated_cost_usd":0.09}
+NOROUTEOF
+
+REFLECT_NOROUTINE_OUT="$(cd "$REFLECT_NOROUTINE_WORKDIR" && node "$REPO_ROOT/scripts/cost-reflect.js" .claude-code-hermit 2>&1)"
+
+run_test "cost-reflect: no routine row → source section still present" bash -c \
+  "echo '$REFLECT_NOROUTINE_OUT' | grep -q 'Cost by source'"
+run_test "cost-reflect: no routine row → no subagent footnote" bash -c \
+  "! echo '$REFLECT_NOROUTINE_OUT' | grep -qi 'subagent'"
 
 cleanup
 

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -831,6 +831,151 @@ run_test "cost-reflect: missing log → 'No cost data' (exit 0)" bash -c \
 cleanup
 
 # -------------------------------------------------------
+# cost-tracker: classifySource / scanTriggerMarkers unit tests
+# -------------------------------------------------------
+
+TRACKER_LIB="$REPO_ROOT/scripts/cost-tracker.js"
+
+# Exports the new symbols
+run_test "cost-tracker: exports classifySource and scanTriggerMarkers" bash -c \
+  "node -e \"const t=require('$TRACKER_LIB'); ['classifySource','scanTriggerMarkers'].forEach(k=>{ if(typeof t[k]!=='function') throw new Error(k+' missing'); });\""
+
+# classifySource: heartbeat marker
+run_test "cost-tracker: classifySource(HEARTBEAT_EVALUATE) = heartbeat" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource('some prefix HEARTBEAT_EVALUATE rest'); if(r!=='heartbeat') throw new Error('got '+r);\""
+
+run_test "cost-tracker: classifySource(heartbeat run) = heartbeat" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource('/claude-code-hermit:heartbeat run'); if(r!=='heartbeat') throw new Error('got '+r);\""
+
+# classifySource: routine marker
+run_test "cost-tracker: classifySource([hermit-routine:daily]) = routine:daily" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource('[hermit-routine:daily]'); if(r!=='routine:daily') throw new Error('got '+r);\""
+
+run_test "cost-tracker: classifySource([hermit-routine:cortex-refresh]) = routine:cortex-refresh" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource('text [hermit-routine:cortex-refresh] more text'); if(r!=='routine:cortex-refresh') throw new Error('got '+r);\""
+
+# classifySource: no marker → other
+run_test "cost-tracker: classifySource(no marker) = other" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource('just a normal operator message'); if(r!=='other') throw new Error('got '+r);\""
+
+run_test "cost-tracker: classifySource(empty) = other" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource(''); if(r!=='other') throw new Error('got '+r);\""
+
+# classifySource: skill-template noise must NOT match (false-positive guard)
+# These strings appear as tool_result content when routines register
+run_test "cost-tracker: classifySource rejects [hermit-routine:*] (template glob)" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource('[hermit-routine:*]'); if(r!=='other') throw new Error('got '+r);\""
+
+run_test "cost-tracker: classifySource rejects [hermit-routine:<id>] (template placeholder)" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource('[hermit-routine:<id>]'); if(r!=='other') throw new Error('got '+r);\""
+
+# classifySource: unsanitized id with disallowed chars yields other (not a partial match)
+run_test "cost-tracker: classifySource rejects id with pipe/newline" bash -c \
+  "node -e \"const {classifySource}=require('$TRACKER_LIB'); const r=classifySource('[hermit-routine:foo|bar]'); if(r!=='other') throw new Error('got '+r);\""
+
+# classifySource: id length-capped at 64 chars
+run_test "cost-tracker: classifySource caps id at 64 chars" bash -c \
+  "node -e \"
+const {classifySource}=require('$TRACKER_LIB');
+const longId='a'.repeat(80);
+const r=classifySource('[hermit-routine:'+longId+']');
+if(!r.startsWith('routine:')) throw new Error('expected routine:..., got '+r);
+const id=r.slice('routine:'.length);
+if(id.length!==64) throw new Error('id length '+id.length+', want 64');
+\""
+
+# scanTriggerMarkers: backward scan finds routine marker past tool_result boundary
+# Simulates: human([hermit-routine:daily]) → assistant(tool_use) → user(tool_result) → assistant(usage)
+# The billed entry is the last assistant; scanTriggerMarkers should find the human entry's marker.
+run_test "cost-tracker: scanTriggerMarkers finds routine past tool_result" bash -c \
+  "node -e \"
+const {scanTriggerMarkers}=require('$TRACKER_LIB');
+const lines=[
+  JSON.stringify({type:'user',message:{content:'[hermit-routine:daily] Read runtime.json. Invoke /reflect.'}}),
+  JSON.stringify({type:'assistant',message:{content:[{type:'tool_use',id:'t1',name:'Read',input:{}}]}}),
+  JSON.stringify({type:'user',message:{content:[{tool_use_id:'t1',type:'tool_result',content:'ok'}]}}),
+  JSON.stringify({type:'assistant',message:{usage:{input_tokens:100,output_tokens:50}}})
+];
+const text=scanTriggerMarkers(lines,3);
+if(!text.includes('[hermit-routine:daily]')) throw new Error('marker not found in: '+text.slice(0,200));
+\""
+
+# scanTriggerMarkers: turn-boundary stops at prior billed assistant
+# Ensures a routine from a PREVIOUS turn can't bleed into the current turn's source
+run_test "cost-tracker: scanTriggerMarkers respects turn boundary" bash -c \
+  "node -e \"
+const {scanTriggerMarkers}=require('$TRACKER_LIB');
+const lines=[
+  JSON.stringify({type:'user',message:{content:'[hermit-routine:old-routine] prior turn'}}),
+  JSON.stringify({type:'assistant',message:{usage:{input_tokens:50,output_tokens:20}}}),
+  JSON.stringify({type:'user',message:{content:'operator message with no marker'}}),
+  JSON.stringify({type:'assistant',message:{usage:{input_tokens:100,output_tokens:50}}})
+];
+const text=scanTriggerMarkers(lines,3);
+if(text.includes('[hermit-routine:old-routine]')) throw new Error('prior turn marker bled in: '+text.slice(0,200));
+\""
+
+# -------------------------------------------------------
+# cost-reflect.js: source attribution tests
+# -------------------------------------------------------
+
+# Fixture log with known source values + legacy untagged entries
+REFLECT_SRC_WORKDIR="$(setup_workdir)"
+REFLECT_SRC_DATE="$(date -u -d '1 day ago' +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d 2>/dev/null || echo "$(date -u +%Y-%m-%d)")"
+
+cat > "$REFLECT_SRC_WORKDIR/.claude/cost-log.jsonl" <<SRCEOF
+{"timestamp":"${REFLECT_SRC_DATE}T10:00:00.000Z","session_id":"s1","source":"heartbeat","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":100000,"output_tokens":0,"total_tokens":100000,"estimated_cost_usd":0.03}
+{"timestamp":"${REFLECT_SRC_DATE}T10:01:00.000Z","session_id":"s2","source":"routine:reflect","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":100000,"output_tokens":2000,"total_tokens":102000,"estimated_cost_usd":0.06}
+{"timestamp":"${REFLECT_SRC_DATE}T10:02:00.000Z","session_id":"s3","source":"other","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":50000,"output_tokens":5000,"total_tokens":55000,"estimated_cost_usd":0.09}
+{"timestamp":"${REFLECT_SRC_DATE}T10:03:00.000Z","session_id":"s4","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":50000,"output_tokens":1000,"total_tokens":51000,"estimated_cost_usd":0.021}
+SRCEOF
+
+REFLECT_SRC_OUT="$(cd "$REFLECT_SRC_WORKDIR" && node "$REPO_ROOT/scripts/cost-reflect.js" .claude-code-hermit 2>&1)"
+
+run_test "cost-reflect: Cost by source section present" bash -c \
+  "echo '$REFLECT_SRC_OUT' | grep -q 'Cost by source'"
+
+run_test "cost-reflect: heartbeat source row present" bash -c \
+  "echo '$REFLECT_SRC_OUT' | grep -q 'heartbeat'"
+
+run_test "cost-reflect: routine:reflect source row present" bash -c \
+  "echo '$REFLECT_SRC_OUT' | grep -q 'routine:reflect'"
+
+run_test "cost-reflect: other (non-scheduled) label present" bash -c \
+  "echo '$REFLECT_SRC_OUT' | grep -q 'non-scheduled'"
+
+run_test "cost-reflect: legacy entry (no source) bucketed to other" bash -c \
+  "echo '$REFLECT_SRC_OUT' | grep -q 'other'"
+
+run_test "cost-reflect: routine row triggers subagent footnote" bash -c \
+  "echo '$REFLECT_SRC_OUT' | grep -qi 'subagent'"
+
+run_test "cost-reflect (source fixture): output ≤1500 chars" bash -c \
+  "[ \$(echo '$REFLECT_SRC_OUT' | wc -c) -le 1500 ]"
+
+cleanup
+
+# ~20-source cap fixture: verify ≤1500 chars with many distinct routine sources
+REFLECT_MANY_WORKDIR="$(setup_workdir)"
+REFLECT_MANY_DATE="$(date -u -d '1 day ago' +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d 2>/dev/null || echo "$(date -u +%Y-%m-%d)")"
+
+{
+  for i in $(seq 1 20); do
+    echo "{\"timestamp\":\"${REFLECT_MANY_DATE}T10:$(printf '%02d' "$i"):00.000Z\",\"session_id\":\"s${i}\",\"source\":\"routine:routine-${i}\",\"model\":\"sonnet\",\"input_tokens\":0,\"cache_write_tokens\":0,\"cache_read_tokens\":10000,\"output_tokens\":500,\"total_tokens\":10500,\"estimated_cost_usd\":0.01}"
+  done
+} > "$REFLECT_MANY_WORKDIR/.claude/cost-log.jsonl"
+
+REFLECT_MANY_OUT="$(cd "$REFLECT_MANY_WORKDIR" && node "$REPO_ROOT/scripts/cost-reflect.js" .claude-code-hermit 2>&1)"
+
+run_test "cost-reflect: 20-source fixture produces output" bash -c "[ -n '$REFLECT_MANY_OUT' ]"
+run_test "cost-reflect: 20-source fixture ≤1500 chars" bash -c \
+  "[ \$(echo '$REFLECT_MANY_OUT' | wc -c) -le 1500 ]"
+run_test "cost-reflect: 20-source fixture shows +N more sources line" bash -c \
+  "echo '$REFLECT_MANY_OUT' | grep -q 'more sources'"
+
+cleanup
+
+# -------------------------------------------------------
 # Summary
 # -------------------------------------------------------
 print_results


### PR DESCRIPTION
## Summary

Adds a `source` field to every `cost-log.jsonl` entry and a **Cost by source** section to `cost-reflect`, giving operators a clear breakdown of where idle spend originates. Closes #294.

The three source values are marker-driven and reliable: `heartbeat` (detected via `HEARTBEAT_EVALUATE` / `/claude-code-hermit:heartbeat run`), `routine:<id>` (detected via `[hermit-routine:<id>]` or `log-routine-event.sh <id>` in the turn's entries), and `other` (everything non-scheduled — the non-automation remainder, expected to be the largest row).

## Changes

- **`scripts/cost-tracker.js`**: adds `entryText()`, `scanTriggerMarkers()`, and `classifySource()` helpers; extends `readLastTurnUsage` to scan the current turn backward (turn-boundary-guarded to prevent prior routine markers bleeding into a later turn), and writes `source` into every `cost-log.jsonl` entry. Exports `classifySource` and `scanTriggerMarkers` for unit testing.
- **`scripts/cost-reflect.js`**: accumulates `sourceMap` in the entry loop, adds `buildSourceSection(n)` mirroring the existing `buildTopSection(n)` pattern, folds both into one nested char-cap loop (source rows shed first), and appends a subagent footnote when any `routine:` row is present (model-override routines run in a subagent; only dispatch overhead is counted).
- **`docs/always-on-ops.md`**: new **Cheap always-on** subsection covering the four cost levers (whole-session model, per-routine model override, interval/active-hours, checklist curation) with a pointer to `cost-reflect`'s source breakdown.
- **`tests/run-scripts.sh`**: 23 new tests — `classifySource` unit tests (heartbeat, routine, other, skill-template noise rejection, id length-cap), `scanTriggerMarkers` turn-boundary test, `cost-reflect` source section rendering, 20-source cap fixture.

## Test plan

All 464 tests pass (122 scripts tests, including the 23 new ones):

```
bash plugins/claude-code-hermit/tests/run-all.sh
```

Verified classification against live `ghost-army-ops-hermit` transcripts before implementation: `HEARTBEAT_EVALUATE` and `[hermit-routine:<id>]` markers confirmed present in real turns; strict charset `[A-Za-z0-9._-]+` confirmed to reject skill-template placeholder noise.

Closes #294