### PR TITLE
perf(heartbeat): skip per-tick LLM wake when operator is present

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **heartbeat: gate in_progress stale-check on operator activity** — skip the per-tick LLM wake when `last-operator-action.json` shows activity within `stale_threshold`; the faithful Progress-Log check still runs when the operator is quiet beyond the threshold or a stale alert is already active. Falls back to the original unconditional wake on pre-upgrade installs (no `last-operator-action.json`) and on future-dated timestamps (clock skew). Closes #315.
+
 ## [1.1.10] - 2026-06-05
 
 ### Fixed

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -88,7 +88,7 @@ Manage with `/hermit-settings channels` (subcommands include `primary <name>` an
 | `every` | string | `"2h"` | Heartbeat interval (e.g., `"15m"`, `"1h"`, `"2h"`). |
 | `active_hours.start` | string | `"08:00"` | Start of active window (heartbeat pauses outside). |
 | `active_hours.end` | string | `"23:00"` | End of active window. |
-| `stale_threshold` | string | `"2h"` | Alert if active session has no progress for this duration. |
+| `stale_threshold` | string | `"2h"` | Alert if active session has no operator activity and no progress for this duration. |
 | `waiting_timeout` | string/null | `null` | Auto-transition from `waiting` to `idle` after this duration (e.g., `"4h"`). `null` = no timeout. |
 
 > **Note:** The tick counter (`total_ticks`) lives in `state/alert-state.json`, not here. It is runtime state, not operator configuration.

--- a/plugins/claude-code-hermit/scripts/heartbeat-precheck.js
+++ b/plugins/claude-code-hermit/scripts/heartbeat-precheck.js
@@ -44,6 +44,15 @@ function normalizeItemKey(itemText) {
   return text ? `checklist:${text}` : null;
 }
 
+// Same unit set the heartbeat skill uses for `every`.
+function parseDuration(str, defaultMs) {
+  if (typeof str !== 'string') return defaultMs;
+  const m = str.trim().match(/^(\d+)\s*([smh])$/i);
+  if (!m) return defaultMs;
+  const mult = { s: 1000, m: 60000, h: 3600000 }[m[2].toLowerCase()];
+  return parseInt(m[1], 10) * mult;
+}
+
 // Resolve "now" once: real wall-clock, overridable by HERMIT_NOW for deterministic
 // tests. Shared by the pending-close drain and the in_progress 12h check below.
 let now = Date.now();
@@ -133,6 +142,7 @@ if (sessionState === 'in_progress') {
   // by routine writes (reflect, scheduled-checks, heartbeat alerts) that bump SHELL.md mtime.
   // Falls back to SHELL.md mtime for pre-upgrade installs that don't have the file yet.
   let usedActionFile = false;
+  let lastActionAt = NaN;
   try {
     const lastAction = readJSON(path.join(stateDir, 'state', 'last-operator-action.json'));
     if (lastAction && typeof lastAction.at === 'string') {
@@ -140,6 +150,7 @@ if (sessionState === 'in_progress') {
       if (!isNaN(t)) {
         if ((now - t) / (1000 * 60 * 60) > 12) emit('AUTO_CLOSE');
         usedActionFile = true; // valid timestamp — skip mtime fallback
+        lastActionAt = t;
       }
     }
   } catch { /* fail-open: fall through to mtime */ }
@@ -153,8 +164,14 @@ if (sessionState === 'in_progress') {
       if ((now - mtime) / (1000 * 60 * 60) > 12) emit('AUTO_CLOSE');
     } catch { /* fail-open */ }
   }
-  // stale-session check needs SHELL.md parsing — delegate to LLM
-  emit('EVALUATE');
+  // Stale-session check: skip the LLM wake when the operator is demonstrably present.
+  // Falls back to unconditional EVALUATE when last-operator-action.json is absent (pre-upgrade
+  // installs), mtime fallback was used, or timestamp is future-dated (clock skew / cross-machine).
+  // staleAlertActive: keep waking while an active alert exists so the LLM can track resolution.
+  const staleMs = parseDuration(hbConfig.stale_threshold, 2 * 3600000);
+  const opQuiet = !usedActionFile || lastActionAt > now || (now - lastActionAt) > staleMs;
+  const staleAlertActive = !!alertState.alerts['stale-session'];
+  if (opQuiet || staleAlertActive) emit('EVALUATE');
 }
 
 // waiting-timeout check requires elapsed computation — delegate to LLM

--- a/plugins/claude-code-hermit/scripts/heartbeat-precheck.js
+++ b/plugins/claude-code-hermit/scripts/heartbeat-precheck.js
@@ -170,7 +170,7 @@ if (sessionState === 'in_progress') {
   // staleAlertActive: keep waking while an active alert exists so the LLM can track resolution.
   const staleMs = parseDuration(hbConfig.stale_threshold, 2 * 3600000);
   const opQuiet = !usedActionFile || lastActionAt > now || (now - lastActionAt) > staleMs;
-  const staleAlertActive = !!alertState.alerts['stale-session'];
+  const staleAlertActive = !!(alertState.alerts ?? {})['stale-session'];
   if (opQuiet || staleAlertActive) emit('EVALUATE');
 }
 

--- a/plugins/claude-code-hermit/tests/test-auto-close.sh
+++ b/plugins/claude-code-hermit/tests/test-auto-close.sh
@@ -666,4 +666,105 @@ run_test "reflect-precheck: only empty 12h archive (operator_turns:0, closed_via
   bash -c "[ '$out' = 'EMPTY' ]"
 cleanup
 
+echo ""
+echo "=== stale-session gate: skip LLM wake when operator is present ==="
+echo ""
+
+# Shared setup: HEARTBEAT.md with one suppressed item (all OK for checklist gate),
+# last_digest_date = today so the digest gate doesn't fire, total_ticks = 1.
+TODAY_DATE="$(date -u +%Y-%m-%d)"
+SUPPRESSED_ALERT_STATE="{\"alerts\":{\"checklist:checksys\":{\"count\":6,\"consecutive_clean\":0,\"suppressed\":true,\"first_seen\":\"${TODAY_DATE}\",\"last_seen\":\"${TODAY_DATE}\",\"text\":\"Check system\"}},\"last_digest_date\":\"${TODAY_DATE}\",\"self_eval\":{},\"total_ticks\":1}"
+
+# -------------------------------------------------------
+# stale.1. in_progress + operator within stale_threshold + all items suppressed + digest ran → OK
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/sessions"
+mkdir -p "$workdir/.claude-code-hermit/state"
+printf '# Heartbeat\n\n- Check system\n' > "$workdir/.claude-code-hermit/HEARTBEAT.md"
+touch "$workdir/.claude-code-hermit/sessions/SHELL.md"
+echo '{"session_state":"in_progress","session_id":"S-001"}' > "$workdir/.claude-code-hermit/state/runtime.json"
+echo '{"at":"2026-05-20T21:30:00+00:00"}' > "$workdir/.claude-code-hermit/state/last-operator-action.json"
+echo "$SUPPRESSED_ALERT_STATE" > "$workdir/.claude-code-hermit/state/alert-state.json"
+out="$(cd "$workdir" && HERMIT_NOW="2026-05-20T22:00:00+00:00" node "$HEARTBEAT_PRECHECK" --peek .claude-code-hermit)"
+run_test "stale-gate: in_progress + operator 30min ago + suppressed checklist + digest done → OK" bash -c "[ '$out' = 'OK' ]"
+cleanup
+
+# -------------------------------------------------------
+# stale.2. in_progress + operator quiet beyond stale_threshold → EVALUATE (unchanged)
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/sessions"
+mkdir -p "$workdir/.claude-code-hermit/state"
+printf '# Heartbeat\n\n- Check system\n' > "$workdir/.claude-code-hermit/HEARTBEAT.md"
+touch "$workdir/.claude-code-hermit/sessions/SHELL.md"
+echo '{"session_state":"in_progress","session_id":"S-001"}' > "$workdir/.claude-code-hermit/state/runtime.json"
+echo '{"at":"2026-05-20T19:00:00+00:00"}' > "$workdir/.claude-code-hermit/state/last-operator-action.json"
+echo "$SUPPRESSED_ALERT_STATE" > "$workdir/.claude-code-hermit/state/alert-state.json"
+out="$(cd "$workdir" && HERMIT_NOW="2026-05-20T22:00:00+00:00" node "$HEARTBEAT_PRECHECK" --peek .claude-code-hermit)"
+run_test "stale-gate: in_progress + operator 3h ago (> 2h threshold) → EVALUATE" bash -c "[ '$out' = 'EVALUATE' ]"
+cleanup
+
+# -------------------------------------------------------
+# stale.3. in_progress + operator recent + stale-session alert active → EVALUATE (resolution tracking)
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/sessions"
+mkdir -p "$workdir/.claude-code-hermit/state"
+printf '# Heartbeat\n\n- Check system\n' > "$workdir/.claude-code-hermit/HEARTBEAT.md"
+touch "$workdir/.claude-code-hermit/sessions/SHELL.md"
+echo '{"session_state":"in_progress","session_id":"S-001"}' > "$workdir/.claude-code-hermit/state/runtime.json"
+echo '{"at":"2026-05-20T21:30:00+00:00"}' > "$workdir/.claude-code-hermit/state/last-operator-action.json"
+STALE_ACTIVE="{\"alerts\":{\"checklist:checksys\":{\"count\":6,\"consecutive_clean\":0,\"suppressed\":true,\"first_seen\":\"${TODAY_DATE}\",\"last_seen\":\"${TODAY_DATE}\",\"text\":\"Check system\"},\"stale-session\":{\"count\":1,\"consecutive_clean\":0,\"suppressed\":false,\"first_seen\":\"${TODAY_DATE}\",\"last_seen\":\"${TODAY_DATE}\",\"text\":\"Stale session\"}},\"last_digest_date\":\"${TODAY_DATE}\",\"self_eval\":{},\"total_ticks\":1}"
+echo "$STALE_ACTIVE" > "$workdir/.claude-code-hermit/state/alert-state.json"
+out="$(cd "$workdir" && HERMIT_NOW="2026-05-20T22:00:00+00:00" node "$HEARTBEAT_PRECHECK" --peek .claude-code-hermit)"
+run_test "stale-gate: operator recent + stale-session alert active → EVALUATE (resolution tracking)" bash -c "[ '$out' = 'EVALUATE' ]"
+cleanup
+
+# -------------------------------------------------------
+# stale.4. in_progress + future-dated last-operator-action (clock skew) → EVALUATE (fail-open)
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/sessions"
+mkdir -p "$workdir/.claude-code-hermit/state"
+printf '# Heartbeat\n\n- Check system\n' > "$workdir/.claude-code-hermit/HEARTBEAT.md"
+touch "$workdir/.claude-code-hermit/sessions/SHELL.md"
+echo '{"session_state":"in_progress","session_id":"S-001"}' > "$workdir/.claude-code-hermit/state/runtime.json"
+echo '{"at":"2026-05-20T23:00:00+00:00"}' > "$workdir/.claude-code-hermit/state/last-operator-action.json"
+echo "$SUPPRESSED_ALERT_STATE" > "$workdir/.claude-code-hermit/state/alert-state.json"
+out="$(cd "$workdir" && HERMIT_NOW="2026-05-20T22:00:00+00:00" node "$HEARTBEAT_PRECHECK" --peek .claude-code-hermit)"
+run_test "stale-gate: future-dated last-operator-action (clock skew) → EVALUATE (fail-open)" bash -c "[ '$out' = 'EVALUATE' ]"
+cleanup
+
+# -------------------------------------------------------
+# stale.5. in_progress + no last-operator-action.json → EVALUATE (no regression for pre-upgrade installs)
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/sessions"
+mkdir -p "$workdir/.claude-code-hermit/state"
+printf '# Heartbeat\n\n- Check system\n' > "$workdir/.claude-code-hermit/HEARTBEAT.md"
+touch "$workdir/.claude-code-hermit/sessions/SHELL.md"
+echo '{"session_state":"in_progress","session_id":"S-001"}' > "$workdir/.claude-code-hermit/state/runtime.json"
+echo "$SUPPRESSED_ALERT_STATE" > "$workdir/.claude-code-hermit/state/alert-state.json"
+out="$(cd "$workdir" && HERMIT_NOW="2026-05-20T22:00:00+00:00" node "$HEARTBEAT_PRECHECK" --peek .claude-code-hermit)"
+run_test "stale-gate: absent last-operator-action (pre-upgrade install) → EVALUATE (no regression)" bash -c "[ '$out' = 'EVALUATE' ]"
+cleanup
+
+# -------------------------------------------------------
+# stale.6. stale.1 variant WITHOUT last_digest_date=today → EVALUATE (digest gate fires correctly)
+# -------------------------------------------------------
+workdir="$(mktemp -d)"
+mkdir -p "$workdir/.claude-code-hermit/sessions"
+mkdir -p "$workdir/.claude-code-hermit/state"
+printf '# Heartbeat\n\n- Check system\n' > "$workdir/.claude-code-hermit/HEARTBEAT.md"
+touch "$workdir/.claude-code-hermit/sessions/SHELL.md"
+echo '{"session_state":"in_progress","session_id":"S-001"}' > "$workdir/.claude-code-hermit/state/runtime.json"
+echo '{"at":"2026-05-20T21:30:00+00:00"}' > "$workdir/.claude-code-hermit/state/last-operator-action.json"
+# Same suppressed item but last_digest_date is yesterday → digest gate fires
+STALE_NO_DIGEST="{\"alerts\":{\"checklist:checksys\":{\"count\":6,\"consecutive_clean\":0,\"suppressed\":true,\"first_seen\":\"2026-05-19\",\"last_seen\":\"2026-05-19\",\"text\":\"Check system\"}},\"last_digest_date\":\"2026-05-19\",\"self_eval\":{},\"total_ticks\":1}"
+echo "$STALE_NO_DIGEST" > "$workdir/.claude-code-hermit/state/alert-state.json"
+out="$(cd "$workdir" && HERMIT_NOW="2026-05-20T22:00:00+00:00" node "$HEARTBEAT_PRECHECK" --peek .claude-code-hermit)"
+run_test "stale-gate: operator recent + suppressed but digest not yet run today → EVALUATE (daily digest)" bash -c "[ '$out' = 'EVALUATE' ]"
+cleanup
+
 print_results


### PR DESCRIPTION
## Summary

Replaces the unconditional `emit('EVALUATE')` at `heartbeat-precheck.js:157` — which fired on every heartbeat tick while a session is `in_progress` — with an operator-presence gate. When `last-operator-action.json` shows activity within `stale_threshold`, the precheck falls through to the existing checklist/digest gates (possibly emitting silent `OK`) rather than always waking the main Sonnet session. The faithful Progress-Log-based stale check still runs when the operator has been quiet beyond the threshold.

Background: #315 proposed delegating the EVALUATE phase to a Haiku subagent, but the dominant per-tick cost is the full-context cache-read that occurs the moment the session wakes — Haiku delegation can't remove that. This change removes the wake itself in the common active-operator case.

## Changes

- `scripts/heartbeat-precheck.js` — added `parseDuration()` helper (parses `"2h"`/`"30m"`/`"90s"` → ms); replaced unconditional `emit('EVALUATE')` with operator-presence gate using `last-operator-action.json` (already trusted for the 12h AUTO_CLOSE decision)
- `docs/config-reference.md` — updated `stale_threshold` description to reflect the new operator-activity condition
- `tests/test-auto-close.sh` — 6 new test cases: silent OK when operator active + checklist suppressed + digest done; EVALUATE when operator quiet beyond threshold; EVALUATE when stale alert active (resolution tracking); fail-open on future-dated timestamp (clock skew); fail-open on absent file (pre-upgrade); EVALUATE when digest not yet run today

**Fail-open conditions (unconditional EVALUATE preserved):**
- `last-operator-action.json` absent (pre-upgrade installs without the file)
- Timestamp is `NaN` or malformed
- Timestamp is future-dated (clock skew / cross-machine state)
- `stale-session` alert already active in `alert-state.json` (resolution tracking)

**Behavior change:** in the `(operator acted recently) AND (Progress Log older than threshold)` edge, this suppresses a stale alert. A session the operator just touched is not abandoned — the new behavior is arguably more correct, but it is a change from the literal spec.

## Test plan

```bash
cd plugins/claude-code-hermit && bash tests/run-all.sh
```

All 6 new stale-gate cases pass; full suite green (no regressions).

Closes #315