### PR TITLE
feat(proposal-act): dismissal learning

### DIFF
--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -184,7 +184,8 @@ Deferred proposals still appear in `/proposal-list` but are sorted below open pr
    ```
    Dismissed on 2026-04-06T14:30:00+01:00. Reason: [operator's reason]
    ```
-5. Respond: "PROP-NNN dismissed."
+4b. **Dismissal learning** — only when a reason was provided in step 3. Judge whether the reason states a durable preference, rule, or taste that applies to a *family* of future proposals (e.g. "don't propose process changes for things I do twice a year", "stop suggesting test-coverage proposals on docs-only changes") versus a one-off or proposal-specific response ("not now", "already did this manually", "the analysis is wrong", "duplicate of last week"). If generalizable, issue the standard "remember it" reflection framed as a `feedback`-type entry: state the preference as a rule, add a brief `Why:` and `How to apply:` so proposal-triage and reflection-judge can match it in their memory cross-check. Apply auto-memory discipline: respect `WHAT_NOT_TO_SAVE` (no file paths, no debugging recipes, no facts derivable from grep), keep it concise. The native auto-memory flow writes `feedback_<slug>.md` and updates the `MEMORY.md` index — do not write those files directly. If the reason is one-off or sub-threshold, skip — save nothing.
+5. Respond: "PROP-NNN dismissed." If step 4b saved a preference, add: "Remembered that as a standing preference (future similar proposals may be filtered)."
 
 Dismissed proposals are hidden from the default `/proposal-list` view. Use "show all" with `/proposal-list` to see them.
 


### PR DESCRIPTION
## Summary

When an operator dismisses a proposal with a reason that generalizes beyond the single proposal (a durable preference or rule), the Dismiss Flow now issues the standard \"remember it\" reflection as a `feedback`-type auto-memory entry. The triage and reflection-judge agents already cross-check `MEMORY.md` and emit `SUPPRESS — covered-by-memory` — so once the preference is recorded, the whole family of future similar proposals is suppressed with no changes needed in either agent.

The feature was designed in the architecture review (§17.2): \"taste-learning for roughly ten lines of skill prose.\"

## Changes

- **`skills/proposal-act/SKILL.md`** (Dismiss Flow): added step `4b` between the existing step 4 (write reason to Operator Decision) and the response step 5. The new step gates on a reason existing, judges generalizability (durable preference vs. one-off), and if generalizable issues the \"remember it\" reflection using auto-memory discipline (`WHAT_NOT_TO_SAVE`, `feedback_<slug>.md` written by native flow, not directly). One-off reasons ("not now", "already done", "analysis is wrong") produce no write.

## Test plan

- Unit test suite: 475 tests, 0 failures (`bash tests/run-all.sh` in `plugins/claude-code-hermit/`).
- Manual verification (interactive session): dismiss a proposal with a generalizable reason, confirm `feedback_*.md` appears under `~/.claude/projects/<path-key>/memory/` and a pointer is added to `MEMORY.md`. Dismiss another with a one-off reason, confirm no memory write. On next reflect/triage cycle, confirm the saved preference triggers `SUPPRESS — covered-by-memory` on a matching candidate.