### PR TITLE
reflection-judge: weight evidence by session provenance (closed_via)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- **reflection-judge: weight evidence by session provenance** — Tier 2/3 candidates backed only by auto-closed sessions lean toward DOWNGRADE; operator-supervised or mixed evidence is unaffected.
 - **heartbeat: gate in_progress stale-check on operator activity** — skip the per-tick LLM wake when `last-operator-action.json` shows activity within `stale_threshold`; the faithful Progress-Log check still runs when the operator is quiet beyond the threshold or a stale alert is already active. Falls back to the original unconditional wake on pre-upgrade installs (no `last-operator-action.json`) and on future-dated timestamps (clock skew). Closes #315.
 
 ## [1.1.10] - 2026-06-05

--- a/plugins/claude-code-hermit/agents/reflection-judge.md
+++ b/plugins/claude-code-hermit/agents/reflection-judge.md
@@ -71,6 +71,10 @@ A session "confirms" the pattern if:
 
 Read `MEMORY.md` (index of `- [title](file) — description` entries). Read each topic file whose title or description keyword-matches the candidate. Match against the file's `name`, `description`, body, `Why:`, and `How to apply:` fields. If memory already records the operator decision, preference, or pattern this candidate would surface, suppress with code `covered-by-memory`, quote the matching memory line in the reason, and include the source filename (e.g. `[memory: feedback_simplify_no_bypass.md]`) so the operator can locate and revise it if stale.
 
+### 1.6 Provenance weighting
+
+When reading each cited report in § 1, also read its `closed_via:` frontmatter field. Treat a missing `closed_via` as `operator` (legacy reports predate the field). Citations from **operator-supervised** sessions (`closed_via: operator`) carry stronger evidential weight than citations from **auto-closed idle** sessions (`closed_via: auto`) — two auto-closed sightings do not equal two supervised sightings. For **Tier 2 or Tier 3** candidates whose confirming recurrence rests *entirely* on auto-closed sessions, lean toward `DOWNGRADE:<N>` with reason `auto-closed-evidence`: the pattern may be real but its significance is unconfirmed under supervision. Mixed or operator-supervised evidence carries full weight. Tier 1 is reversible and low-stakes — provenance does not downgrade it. Never suppress on provenance alone; there is no suppress code for it.
+
 ### 2. Tier check
 
 Given confirmed evidence (or bypassed evidence for scheduled-check/operator-request), is the tier classification correct?
@@ -110,6 +114,7 @@ ACCEPT (current-session): <title>
 ACCEPT (scheduled-check): <title>
 ACCEPT (operator-request): <title>
 DOWNGRADE:2: <title> — <reason>
+DOWNGRADE:1: <title> — <reason>
 SUPPRESS: <title> — no-evidence: <reason>
 SUPPRESS (current-session): <title> — no-evidence: <reason>
 ```

--- a/plugins/claude-code-hermit/tests/recurrence-gate-matrix.sh
+++ b/plugins/claude-code-hermit/tests/recurrence-gate-matrix.sh
@@ -83,6 +83,13 @@ if ! grep -q "DOWNGRADE" "$judge"; then
   rc=1
 fi
 
+for term in "closed_via" "auto-closed-evidence"; do
+  if ! grep -q "$term" "$judge"; then
+    echo "FAIL [agents/reflection-judge.md]: missing '$term' provenance token"
+    rc=1
+  fi
+done
+
 # ── 4. Verdict-tag coverage in judge output examples ────────────────────────
 echo "=== Recurrence gate: verdict-tag coverage ==="
 


### PR DESCRIPTION
## Summary

The `reflection-judge` gate now reads the `closed_via` frontmatter field from every cited session report and weights evidence by supervision level. Operator-supervised sessions (`closed_via: operator`) carry stronger signal than auto-closed idle sessions (`closed_via: auto`). A Tier 2/3 candidate whose confirming recurrence rests entirely on auto-closed sessions now leans toward `DOWNGRADE` with reason `auto-closed-evidence` — the pattern may be real but its significance is unconfirmed without an operator present to curate it.

This is §17.8 from the hermit architecture review: "trivial, confirmed — no new state, no new reads beyond what the judge already does."

## Changes

- `agents/reflection-judge.md`: added §1.6 Provenance weighting after §1.5 Memory cross-check. Reads `closed_via` from each cited report's frontmatter; treats a missing field as `operator` (legacy reports predate it). Downgrades Tier 2/3 candidates only when all confirming sessions are auto-closed; Tier 1 and mixed/supervised evidence unaffected. No new suppress code.
- `tests/recurrence-gate-matrix.sh`: added static grep assertions for `closed_via` and `auto-closed-evidence` tokens, consolidated into the existing loop pattern to protect the new paragraph from silent removal.

## Test plan

- `bash tests/recurrence-gate-matrix.sh` from `plugins/claude-code-hermit/` — all checks pass including the two new provenance assertions
- `bash tests/run-all.sh` — 30 tests passed, 0 failed