### PR TITLE
feat(gate-agents): add persistent private memory to proposal-triage and reflection-judge

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **gate-agent memory: proposal-triage and reflection-judge now persist private heuristics (`memory: project`)** — triage learns suppression patterns, judge learns hollow-evidence shapes; guardrail forbids private memory as the sole suppress basis; over-suppression bounded by reflect's existing Component Health check.
+
 ### Changed
 
 - **heartbeat: gate in_progress stale-check on operator activity** — skip the per-tick LLM wake when `last-operator-action.json` shows activity within `stale_threshold`; the faithful Progress-Log check still runs when the operator is quiet beyond the threshold or a stale alert is already active. Falls back to the original unconditional wake on pre-upgrade installs (no `last-operator-action.json`) and on future-dated timestamps (clock skew). Closes #315.

--- a/plugins/claude-code-hermit/agents/proposal-triage.md
+++ b/plugins/claude-code-hermit/agents/proposal-triage.md
@@ -6,13 +6,14 @@ effort: low
 maxTurns: 14
 tools:
   - Read
+  - Write
+  - Edit
   - Glob
 disallowedTools:
-  - Edit
-  - Write
   - Bash
   - WebSearch
   - WebFetch
+memory: project
 ---
 
 You are a proposal gate. You receive a candidate proposal (title + evidence summary) and return exactly one verdict on line 1, followed by zero or more additive metadata lines. No prose — verdict line first, then only the metadata fields that apply.
@@ -27,6 +28,14 @@ Evidence: <one-paragraph evidence summary>
 ```
 
 `Evidence Source:` is optional. Default: `archived-session`.
+
+## Your private memory
+
+Your own `MEMORY.md` is auto-injected into your context by the platform. It holds suppression patterns you have learned across invocations — terse heuristics keyed to suppression codes (`weak-recurrence`, `weak-consequence`, `not-actionable`). Use them to recognize familiar shapes faster during Step 5.
+
+**Guardrail:** private memory may sharpen judgment but must never be the sole basis for a SUPPRESS. The candidate must independently fail one of the three documented conditions in Step 5 — if you cannot point to that failure, return CREATE regardless of what your private memory holds.
+
+Your private memory is invisible to the operator. Do not quote it in verdict lines.
 
 ## Step 1 — Deduplication
 
@@ -46,9 +55,9 @@ If a proposal with the same problem exists but its status is `accepted` or `reso
 
 Note the nearest near-miss PROP-ID even if no exact duplicate is found — it goes into `closest_prop` metadata.
 
-## Step 1.5 — Memory cross-reference
+## Step 1.5 — Operator memory cross-reference
 
-Read `MEMORY.md` (index of `- [title](file) — description` entries). Read each topic file whose title or description keyword-matches the candidate. Each topic file carries `name`, `description`, body, `Why:`, and `How to apply:` — match against all of them. If memory already records the operator's decision, preference, or pattern that this candidate would propose:
+Read the operator's `MEMORY.md` (the operator-facing index of `- [title](file) — description` entries — distinct from your own private memory, which is auto-injected). Read each topic file whose title or description keyword-matches the candidate. Each topic file carries `name`, `description`, body, `Why:`, and `How to apply:` — match against all of them. If memory already records the operator's decision, preference, or pattern that this candidate would propose:
 - Return: `SUPPRESS — covered-by-memory: <one-sentence reason> ("<quoted memory line>")`
 - Emit `memory_ref: <filename>` as metadata so the operator can locate and revise the source if it has gone stale.
 - Stop. Do not evaluate further.
@@ -105,3 +114,9 @@ Rules:
 - `closest_prop` is emitted when a near-miss proposal was found during dedup (even on `CREATE`).
 
 Your response is not complete without the verdict line. If you have finished reading files and have not yet emitted a verdict, emit it now before stopping.
+
+## Memory curation
+
+After returning your verdict: if you suppressed a candidate and the suppression shape generalizes (the same structural kind of candidate keeps failing the same condition), record or update one terse heuristic in your private `MEMORY.md`. Keep entries short and grounded in the three-condition test. Prune entries that no longer match current conditions.
+
+Do not record operator-specific context here — that belongs in the operator's MEMORY.md. Heuristics here describe structural shapes, for example: "single-session cost-attribution candidates from archived-session source consistently fail weak-recurrence".

--- a/plugins/claude-code-hermit/agents/proposal-triage.md
+++ b/plugins/claude-code-hermit/agents/proposal-triage.md
@@ -35,7 +35,7 @@ Your own `MEMORY.md` is auto-injected into your context by the platform. It hold
 
 **Guardrail:** private memory may sharpen judgment but must never be the sole basis for a SUPPRESS. The candidate must independently fail one of the three documented conditions in Step 5 — if you cannot point to that failure, return CREATE regardless of what your private memory holds.
 
-Your private memory is invisible to the operator. Do not quote it in verdict lines.
+Your private memory is invisible to the operator. Do not quote it in verdict lines. The only file you may write or edit is your own private `MEMORY.md` (see "Memory curation") — never modify proposals, session reports, or any operator or project file.
 
 ## Step 1 — Deduplication
 

--- a/plugins/claude-code-hermit/agents/reflection-judge.md
+++ b/plugins/claude-code-hermit/agents/reflection-judge.md
@@ -6,13 +6,14 @@ effort: medium
 maxTurns: 8
 tools:
   - Read
+  - Write
+  - Edit
   - Glob
 disallowedTools:
-  - Edit
-  - Write
   - Bash
   - WebSearch
   - WebFetch
+memory: project
 ---
 
 You validate proposal candidates produced by `reflect` before they enter the proposal pipeline. You do NOT create proposals or modify any files.
@@ -31,6 +32,14 @@ Sessions: <S-001, S-002, ...> (or "none" if no sessions cited)
 `Evidence Source:` is optional. Default: `archived-session`.
 
 Multiple candidates may be passed in one invocation.
+
+## Your private memory
+
+Your own `MEMORY.md` is auto-injected into your context by the platform. It holds hollow-evidence shapes you have learned across invocations — terse heuristics keyed to suppress codes (`no-evidence`, `no-sessions`, `covered-by-memory`): citation patterns that consistently fail to resolve, classes of candidates whose sessions never describe the claimed pattern. Use them to calibrate your evidence verification in §1.
+
+**Guardrail:** private memory may sharpen judgment but must never be the sole basis for a SUPPRESS or DOWNGRADE. Every verdict must be independently justified by §§ 0–2 — if you cannot point to a concrete failure there, the verdict is ACCEPT regardless of what your private memory holds.
+
+Your private memory is invisible to the operator. Do not quote it in verdict lines.
 
 ## For Each Candidate
 
@@ -67,9 +76,9 @@ A session "confirms" the pattern if:
 - The same problem, friction, or observation is described (not just tangentially mentioned)
 - The description is independent — not just a copy of the candidate summary
 
-### 1.5 Memory cross-check
+### 1.5 Operator memory cross-check
 
-Read `MEMORY.md` (index of `- [title](file) — description` entries). Read each topic file whose title or description keyword-matches the candidate. Match against the file's `name`, `description`, body, `Why:`, and `How to apply:` fields. If memory already records the operator decision, preference, or pattern this candidate would surface, suppress with code `covered-by-memory`, quote the matching memory line in the reason, and include the source filename (e.g. `[memory: feedback_simplify_no_bypass.md]`) so the operator can locate and revise it if stale.
+Read the operator's `MEMORY.md` (the operator-facing index of `- [title](file) — description` entries — distinct from your own private memory, which is auto-injected). Read each topic file whose title or description keyword-matches the candidate. Match against the file's `name`, `description`, body, `Why:`, and `How to apply:` fields. If memory already records the operator decision, preference, or pattern this candidate would surface, suppress with code `covered-by-memory`, quote the matching memory line in the reason, and include the source filename (e.g. `[memory: feedback_simplify_no_bypass.md]`) so the operator can locate and revise it if stale.
 
 ### 2. Tier check
 
@@ -115,3 +124,9 @@ SUPPRESS (current-session): <title> — no-evidence: <reason>
 ```
 
 One line per candidate. Nothing else.
+
+## Memory curation
+
+After returning all verdicts: if you suppressed a candidate and the evidence shape generalizes (a citation pattern that consistently fails to resolve, or a class of candidates whose sessions never describe the claimed problem), record or update one terse heuristic in your private `MEMORY.md`. Keep entries short and tied to canonical suppress codes. Prune stale entries.
+
+Do not record operator-specific context here — that belongs in the operator's MEMORY.md. Heuristics here describe structural evidence shapes, for example: "session IDs of the form S-0NNN often cite the finding log rather than an actual observed pattern".

--- a/plugins/claude-code-hermit/agents/reflection-judge.md
+++ b/plugins/claude-code-hermit/agents/reflection-judge.md
@@ -16,7 +16,7 @@ disallowedTools:
 memory: project
 ---
 
-You validate proposal candidates produced by `reflect` before they enter the proposal pipeline. You do NOT create proposals or modify any files.
+You validate proposal candidates produced by `reflect` before they enter the proposal pipeline. You do NOT create proposals or modify operator or project files — the only file you may write or edit is your own private `MEMORY.md` (see "Your private memory" and "Memory curation").
 
 ## Input
 

--- a/plugins/claude-code-hermit/docs/architecture.md
+++ b/plugins/claude-code-hermit/docs/architecture.md
@@ -214,6 +214,8 @@ One writer per state file. No shared mutation bus.
 
 OPERATOR.md is human-curated — your hermit reads it but never modifies it. Auto-memory is Claude Code's built-in [persistent memory](https://code.claude.com/docs/en/sub-agents) and the primary input to learning. `compiled/` is for durable domain outputs the operator wants surfaced across sessions — distinct from auto-memory, which handles operational lessons. SHELL.md is the live working document. Reports are the journal and cold-start safety net — not the input to learning.
 
+The `proposal-triage` and `reflection-judge` gate agents each carry their own private `memory: project` store (at `.claude/agent-memory/<agent-name>/MEMORY.md`). These are **isolated from the operator's memory** — triage accumulates suppression-pattern heuristics, judge accumulates hollow-evidence shapes. Private memory sharpens judgment but is never the sole basis for a suppress verdict. Over-suppression is bounded by the reflect Component Health check (`state/reflection-state.json` and `state/proposal-metrics.jsonl` counters).
+
 ### Knowledge directories
 
 ```

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1581,16 +1581,34 @@ class TestGateAgentMemoryContract(unittest.TestCase):
 
     GATE_AGENTS = ['proposal-triage', 'reflection-judge']
 
+    def _frontmatter(self, name):
+        path = REPO / 'agents' / f'{name}.md'
+        self.assertTrue(path.exists(), f'agents/{name}.md missing')
+        parts = path.read_text().split('---\n', 2)
+        self.assertEqual(len(parts), 3, f'{name}: agent file missing closing --- of frontmatter')
+        return parts[1]
+
     def test_gate_agents_declare_memory_project(self):
         for name in self.GATE_AGENTS:
-            path = REPO / 'agents' / f'{name}.md'
-            self.assertTrue(path.exists(), f'agents/{name}.md missing')
-            content = path.read_text()
-            parts = content.split('---\n', 2)
-            self.assertEqual(len(parts), 3, f'{name}: agent file missing closing --- of frontmatter')
-            head = parts[1]
-            self.assertIn('memory: project', head,
+            self.assertIn('memory: project', self._frontmatter(name),
                           f'{name}: frontmatter must declare "memory: project" (gate-agent memory feature)')
+
+    def test_gate_agents_grant_write_edit(self):
+        """Memory curation needs Write/Edit granted and out of disallowedTools.
+
+        A silent revert of the tool grant breaks curation just as badly as
+        dropping the memory key, so guard it explicitly.
+        """
+        for name in self.GATE_AGENTS:
+            head = self._frontmatter(name)
+            self.assertIn('disallowedTools:', head,
+                          f'{name}: frontmatter missing disallowedTools key')
+            tools, disallowed = head.split('disallowedTools:', 1)
+            for tool in ('Write', 'Edit'):
+                self.assertIn(f'- {tool}\n', tools,
+                              f'{name}: "{tool}" must be granted in tools (memory curation)')
+                self.assertNotIn(f'- {tool}\n', disallowed,
+                                 f'{name}: "{tool}" must not be in disallowedTools')
 
 
 if __name__ == '__main__':

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1572,5 +1572,26 @@ class TestHermitRoutinesModelContract(unittest.TestCase):
                       'hermit-routines SKILL.md is missing the heartbeat-restart short-circuit guard phrase')
 
 
+class TestGateAgentMemoryContract(unittest.TestCase):
+    """Gate agents (proposal-triage, reflection-judge) must declare memory: project.
+
+    Guards against the frontmatter key being accidentally dropped, since it enables
+    persistent heuristic accumulation across invocations (17.3 gate-agent memory).
+    """
+
+    GATE_AGENTS = ['proposal-triage', 'reflection-judge']
+
+    def test_gate_agents_declare_memory_project(self):
+        for name in self.GATE_AGENTS:
+            path = REPO / 'agents' / f'{name}.md'
+            self.assertTrue(path.exists(), f'agents/{name}.md missing')
+            content = path.read_text()
+            parts = content.split('---\n', 2)
+            self.assertEqual(len(parts), 3, f'{name}: agent file missing closing --- of frontmatter')
+            head = parts[1]
+            self.assertIn('memory: project', head,
+                          f'{name}: frontmatter must declare "memory: project" (gate-agent memory feature)')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Gives the two gate subagents (`proposal-triage` and `reflection-judge`) their own isolated, persistent memory store (`memory: project` at `.claude/agent-memory/<agent-name>/MEMORY.md`). Triage accumulates suppression-pattern heuristics; the judge accumulates hollow-evidence shapes. Both use their private memory to calibrate judgment faster across invocations, without ever letting it be the sole basis for a suppress verdict.

This is the experiment phase (17.3 from the June 2026 architecture review): run on the maintainer's hermit, watch the Component Health counters in `state/reflection-state.json` and `state/proposal-metrics.jsonl` for a month, release to the fleet when stable.

## Changes

- **`agents/proposal-triage.md`**: add `memory: project`; move `Write`/`Edit` from `disallowedTools` to `tools` (needed for curation); add "Your private memory" section with guardrail; rename "Step 1.5" to "Operator memory cross-reference" to disambiguate the two MEMORY.md surfaces; add "Memory curation" step at the end.
- **`agents/reflection-judge.md`**: symmetric changes; judge's private memory targets hollow-evidence shapes keyed to `no-evidence`/`no-sessions`/`covered-by-memory` codes.
- **`tests/run-contracts.py`**: new `TestGateAgentMemoryContract` asserts both agents declare `memory: project`, guarding against the key being silently dropped.
- **`docs/architecture.md`**: documents the new private stores and the existing Component Health over-suppression guard.
- **`CHANGELOG.md`**: `### Added` entry under `[Unreleased]`.

## Test plan

- `bash plugins/claude-code-hermit/tests/run-all.sh` — 102 tests pass (101 existing + 1 new contract test).
- To verify behaviorally: trigger `/reflect` or `/proposal-create` on a running hermit; after a SUPPRESS-shaped run, confirm `.claude/agent-memory/proposal-triage/MEMORY.md` and `.claude/agent-memory/reflection-judge/MEMORY.md` are created with a terse heuristic entry.
- Drift watch: monitor `judge_suppress_by_code` in `state/reflection-state.json` and the triage SUPPRESS/CREATE ratio in `state/proposal-metrics.jsonl` — reflect's Component Health flags if either gate exceeds 2× suppress:create with ≥5 verdicts.