### PR TITLE
feat(claude-code-hermit): add falsifiable success signals on proposals (§17.1)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **proposal-act/reflect: falsifiable success signals** — optional cost-per-session predicate (`success_signal` frontmatter field) on a proposal auto-resolves it when met; reflect evaluates via `scripts/eval-success-signal.js` against session-report `cost_usd` anchored at `accepted_date`. Closes #317-adjacent (§17.1 of architecture review).
+
 ### Changed
 
 - **heartbeat: gate in_progress stale-check on operator activity** — skip the per-tick LLM wake when `last-operator-action.json` shows activity within `stale_threshold`; the faithful Progress-Log check still runs when the operator is quiet beyond the threshold or a stale alert is already active. Falls back to the original unconditional wake on pre-upgrade installs (no `last-operator-action.json`) and on future-dated timestamps (clock skew). Closes #315.

--- a/plugins/claude-code-hermit/scripts/eval-success-signal.js
+++ b/plugins/claude-code-hermit/scripts/eval-success-signal.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Evaluate or validate a success_signal predicate for a hermit proposal.
+//
+// Validate mode (grammar check only — no state reads):
+//   node eval-success-signal.js --validate "<predicate>"
+//   Exits 0 + prints "OK" if valid. Exits 1 + prints a reason if invalid.
+//
+// Evaluate mode (check predicate against session reports):
+//   node eval-success-signal.js <stateDir> "<accepted_date>" "<accepted_in_session|null>" "<predicate>"
+//   Prints one JSON line:
+//     {"verdict":"MET|UNMET|INSUFFICIENT_DATA","metric":"...","op":"...","threshold":N,"window":N,"observed":N,"sessions_counted":N}
+//   Never throws — any failure emits INSUFFICIENT_DATA.
+//
+// v1 grammar (one metric):
+//   avg_session_cost_usd <OP> <NUMBER> over <N> sessions
+//   OP in {<, <=, >, >=}; NUMBER positive float; N positive integer.
+
+'use strict';
+
+const path = require('path');
+const { readFrontmatter, globDir } = require('./lib/frontmatter.js');
+
+// ─── Grammar ──────────────────────────────────────────────────────────────────
+
+const GRAMMAR = /^(\w+)\s*(<=?|>=?)\s*(\d+(?:\.\d+)?)\s+over\s+(\d+)\s+sessions?$/;
+
+const SUPPORTED_METRICS = new Set(['avg_session_cost_usd']);
+
+function parseSignal(predicate) {
+  const m = GRAMMAR.exec(predicate.trim());
+  if (!m) return null;
+  const metric = m[1];
+  const op = m[2];
+  const threshold = parseFloat(m[3]);
+  const window = parseInt(m[4], 10);
+  if (!SUPPORTED_METRICS.has(metric)) return null;
+  if (threshold <= 0) return null;
+  if (window < 1) return null;
+  return { metric, op, threshold, window };
+}
+
+function applyOp(observed, op, threshold) {
+  switch (op) {
+    case '<':  return observed < threshold;
+    case '<=': return observed <= threshold;
+    case '>':  return observed > threshold;
+    case '>=': return observed >= threshold;
+    default:   return false;
+  }
+}
+
+// ─── Validate mode ────────────────────────────────────────────────────────────
+
+function runValidate(predicate) {
+  const parsed = parseSignal(predicate);
+  if (!parsed) {
+    // Give a specific reason.
+    const m = GRAMMAR.exec(predicate.trim());
+    if (!m) {
+      process.stdout.write(
+        `invalid grammar; expected: avg_session_cost_usd <OP> <NUMBER> over <N> sessions (OP: < <= > >=)\n`
+      );
+    } else if (!SUPPORTED_METRICS.has(m[1])) {
+      process.stdout.write(`unsupported metric '${m[1]}'; v1 supports: ${[...SUPPORTED_METRICS].join(', ')}\n`);
+    } else {
+      process.stdout.write(`invalid predicate values\n`);
+    }
+    process.exit(1);
+  }
+  process.stdout.write('OK\n');
+  process.exit(0);
+}
+
+// ─── Evaluate mode ────────────────────────────────────────────────────────────
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+function emitInsufficient(parsed) {
+  emit({
+    verdict: 'INSUFFICIENT_DATA',
+    metric: parsed ? parsed.metric : null,
+    op: parsed ? parsed.op : null,
+    threshold: parsed ? parsed.threshold : null,
+    window: parsed ? parsed.window : null,
+    observed: null,
+    sessions_counted: 0,
+  });
+}
+
+function runEvaluate(stateDir, acceptedDateStr, acceptedInSession, predicate) {
+  const parsed = parseSignal(predicate);
+  if (!parsed) {
+    emitInsufficient(null);
+    return;
+  }
+
+  let acceptedDate;
+  try {
+    acceptedDate = new Date(acceptedDateStr);
+    if (isNaN(acceptedDate.getTime())) throw new Error('bad date');
+  } catch {
+    emitInsufficient(parsed);
+    return;
+  }
+
+  const sessionsDir = path.join(stateDir, 'sessions');
+  const reportFiles = globDir(sessionsDir, /^S-\d+-REPORT\.md$/);
+
+  const candidates = [];
+  for (const file of reportFiles) {
+    try {
+      const fm = readFrontmatter(file);
+      if (!fm) continue;
+      const id = fm.id || path.basename(file).replace(/-REPORT\.md$/, '');
+      if (acceptedInSession && acceptedInSession !== 'null' && id === acceptedInSession) continue;
+      if (!fm.date) continue;
+      const reportDate = new Date(fm.date);
+      if (isNaN(reportDate.getTime())) continue;
+      if (reportDate < acceptedDate) continue;
+      candidates.push({ id, date: reportDate, cost_usd: parseFloat(fm.cost_usd || 0) });
+    } catch {
+      // readFrontmatter is fail-open, but downstream date/float parsing can still throw.
+    }
+  }
+
+  candidates.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  if (candidates.length < parsed.window) {
+    emit({
+      verdict: 'INSUFFICIENT_DATA',
+      metric: parsed.metric,
+      op: parsed.op,
+      threshold: parsed.threshold,
+      window: parsed.window,
+      observed: null,
+      sessions_counted: candidates.length,
+    });
+    return;
+  }
+
+  const sample = candidates.slice(0, parsed.window);
+  let observed;
+  switch (parsed.metric) {
+    case 'avg_session_cost_usd': {
+      const total = sample.reduce((sum, s) => sum + s.cost_usd, 0);
+      observed = Math.round((total / sample.length) * 10000) / 10000;
+      break;
+    }
+    default:
+      emitInsufficient(parsed);
+      return;
+  }
+
+  const met = applyOp(observed, parsed.op, parsed.threshold);
+  emit({
+    verdict: met ? 'MET' : 'UNMET',
+    metric: parsed.metric,
+    op: parsed.op,
+    threshold: parsed.threshold,
+    window: parsed.window,
+    observed,
+    sessions_counted: sample.length,
+  });
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+if (args[0] === '--validate') {
+  if (args.length < 2) {
+    process.stdout.write('usage: eval-success-signal.js --validate "<predicate>"\n');
+    process.exit(1);
+  }
+  runValidate(args.slice(1).join(' '));
+} else {
+  if (args.length < 4) {
+    process.stdout.write(
+      'usage: eval-success-signal.js <stateDir> "<accepted_date>" "<accepted_in_session|null>" "<predicate>"\n'
+    );
+    // Fail open — emit INSUFFICIENT_DATA so reflect doesn't crash.
+    emitInsufficient(null);
+    return;
+  }
+  const [stateDir, acceptedDate, acceptedInSession, ...rest] = args;
+  runEvaluate(stateDir, acceptedDate, acceptedInSession, rest.join(' '));
+}

--- a/plugins/claude-code-hermit/scripts/eval-success-signal.js
+++ b/plugins/claude-code-hermit/scripts/eval-success-signal.js
@@ -119,7 +119,14 @@ function runEvaluate(stateDir, acceptedDateStr, acceptedInSession, predicate) {
       const reportDate = new Date(fm.date);
       if (isNaN(reportDate.getTime())) continue;
       if (reportDate < acceptedDate) continue;
-      candidates.push({ id, date: reportDate, cost_usd: parseFloat(fm.cost_usd || 0) });
+      // cost_usd is populated only when the cost-tracker hook is active; the
+      // template default is 0.00. Treat <= 0 as unrecorded (not a real $0
+      // session) and skip it, so an install without cost tracking can't
+      // spuriously satisfy a cost-reduction predicate. The window simply takes
+      // longer to fill (INSUFFICIENT_DATA holds) until N recorded sessions exist.
+      const cost = parseFloat(fm.cost_usd || 0);
+      if (!(cost > 0)) continue;
+      candidates.push({ id, date: reportDate, cost_usd: cost });
     } catch {
       // readFrontmatter is fail-open, but downstream date/float parsing can still throw.
     }

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -62,6 +62,16 @@ When the operator accepts a proposal:
 
 3a. **Session tracking:** Read `state/runtime.json` for `session_id` and `session_state` (both are used below). If `session_id` is non-null, set `accepted_in_session` to that session ID in the proposal's YAML frontmatter. If no session is active (`session_id` is null), leave `accepted_in_session: null`.
 
+3c. **Success signal (optional).** Check whether the proposal body has a `## Success Signal` section with a non-empty predicate line (ignore comment lines starting with `<!--`).
+   - If a non-empty predicate line is found, validate it:
+     ```
+     node ${CLAUDE_PLUGIN_ROOT}/scripts/eval-success-signal.js --validate "<predicate line>"
+     ```
+   - Exit 0 → set `success_signal: <predicate line>` in the proposal's YAML frontmatter.
+   - Exit non-zero → log a one-line warning to SHELL.md Findings: `PROP-NNN success_signal ignored: <reason printed by the script>`. Leave `success_signal: null`.
+   - No `## Success Signal` section, or the section is empty / comment-only → leave `success_signal: null`.
+   - Never block accept regardless of outcome.
+
 3b. **Routine proposals.** If the proposal metadata contains `Type: routine` and a `## Config` section with a JSON block:
     - Parse the JSON block. Validate: must have `id`, `schedule`, `skill`, `enabled` fields.
     - Check for duplicate `id` in existing `config.json` routines array — if found, update the existing entry instead of appending.

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -62,6 +62,14 @@ When the operator accepts a proposal:
 
 3a. **Session tracking:** Read `state/runtime.json` for `session_id` and `session_state` (both are used below). If `session_id` is non-null, set `accepted_in_session` to that session ID in the proposal's YAML frontmatter. If no session is active (`session_id` is null), leave `accepted_in_session: null`.
 
+3b. **Routine proposals.** If the proposal metadata contains `Type: routine` and a `## Config` section with a JSON block:
+    - Parse the JSON block. Validate: must have `id`, `schedule`, `skill`, `enabled` fields.
+    - Check for duplicate `id` in existing `config.json` routines array — if found, update the existing entry instead of appending.
+    - If no duplicate found, append the routine entry to `config.json` routines array.
+    - Respond: "Routine '{id}' added to config. Run `/claude-code-hermit:hermit-routines load` to register it immediately."
+    - Notify the operator.
+    - Skip step 4 — no further implementation needed.
+
 3c. **Success signal (optional).** Check whether the proposal body has a `## Success Signal` section with a non-empty predicate line (ignore comment lines starting with `<!--`).
    - If a non-empty predicate line is found, validate it:
      ```
@@ -71,14 +79,6 @@ When the operator accepts a proposal:
    - Exit non-zero → log a one-line warning to SHELL.md Findings: `PROP-NNN success_signal ignored: <reason printed by the script>`. Leave `success_signal: null`.
    - No `## Success Signal` section, or the section is empty / comment-only → leave `success_signal: null`.
    - Never block accept regardless of outcome.
-
-3b. **Routine proposals.** If the proposal metadata contains `Type: routine` and a `## Config` section with a JSON block:
-    - Parse the JSON block. Validate: must have `id`, `schedule`, `skill`, `enabled` fields.
-    - Check for duplicate `id` in existing `config.json` routines array — if found, update the existing entry instead of appending.
-    - If no duplicate found, append the routine entry to `config.json` routines array.
-    - Respond: "Routine '{id}' added to config. Run `/claude-code-hermit:hermit-routines load` to register it immediately."
-    - Notify the operator.
-    - Skip step 4 — no further implementation needed.
 
 4. Ask: **"How should this be implemented?"**
 

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -46,7 +46,28 @@ If `$ARGUMENTS` contains `--quick` (invoked as `/claude-code-hermit:reflect --qu
    a. Read `state/reflection-state.json` → `last_resolution_check` (last PROP-NNN checked, or null if first run).
    b. Read all proposals with `status: accepted`. Sort by `accepted_date` ascending. Resume from the proposal after `last_resolution_check`, wrapping around. Take up to 5.
    c. If the accepted list from step b is empty, skip to step f.
-   d. For each proposal: read its `title` and Evidence section to understand the original pattern.
+   d. For each proposal: read its `title`, `success_signal`, `accepted_in_session`, and Evidence section.
+
+      **If `success_signal` is non-null** — skip the 3-session Explore fetch and cadence computation; the predicate is the resolution test:
+      ```
+      node ${CLAUDE_PLUGIN_ROOT}/scripts/eval-success-signal.js .claude-code-hermit "<accepted_date>" "<accepted_in_session|null>" "<success_signal>"
+      ```
+      Parse the one JSON line printed to stdout. Branch on `verdict`:
+      - `INSUFFICIENT_DATA` → skip; revisit next cycle (the window hasn't filled yet).
+      - `MET` → **auto-resolve**:
+        - Update frontmatter: `status: resolved`, `resolved_date: <now ISO>`.
+        - Append a `resolved` event:
+          ```
+          node ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.js .claude-code-hermit/state/proposal-metrics.jsonl '{"ts":"<now ISO>","type":"resolved","proposal_id":"PROP-NNN"}'
+          ```
+        - Note in SHELL.md Findings: `PROP-NNN resolved — success signal met: avg session cost $<observed> over <sessions_counted> sessions (target <op> $<threshold>).`
+      - `UNMET` → do **not** resolve. Surface once for operator judgment, debounced by the existing 7-day `last_sparse_nudge` guard:
+        - Check `state/reflection-state.json → last_sparse_nudge.<PROP-NNN>`. If present and fewer than 7 days have elapsed, skip.
+        - Otherwise, add to SHELL.md Findings: `PROP-NNN success signal NOT met: avg session cost $<observed> over <sessions_counted> sessions (target <op> $<threshold>). Run /claude-code-hermit:proposal-act resolve|dismiss PROP-NNN, or revise.`
+        - Record nudge: include `"last_sparse_nudge": {"<PROP-NNN>": "<now ISO>"}` in the State Update payload. The update script merges under `last_sparse_nudge`.
+
+      **If `success_signal` is null** — use the prose pattern-absence test below (existing behaviour).
+
       Delegate the session fetch to the built-in `Explore` subagent. Prompt: `Glob .claude-code-hermit/sessions/S-*-REPORT.md. Sort descending by filename. Read the 3 most recent and return: filename, date from frontmatter, and the full body verbatim — do not truncate, summarize, or excerpt (full body is required for pattern presence/absence detection). If a body exceeds your read window, say so explicitly per file rather than silently trimming.` If Explore returns truncated bodies for any of the 3 files, fall back to reading those files inline with the Read tool before evaluating step e.
    e. If the pattern is **absent** from all 3 checked sessions — apply the cadence-aware resolution rule:
 

--- a/plugins/claude-code-hermit/state-templates/PROPOSAL.md.template
+++ b/plugins/claude-code-hermit/state-templates/PROPOSAL.md.template
@@ -13,6 +13,7 @@ tags: []
 responded: false
 self_eval_key: null
 accepted_in_session: null
+success_signal: null
 ---
 # Proposal: PROP-NNN — [Title]
 
@@ -31,6 +32,13 @@ accepted_in_session: null
 ## Verification
 <!-- How will we know this worked? Tests, smoke-check, validation run, manual steps —
      or an explicit recorded "no verification needed because…". -->
+
+## Success Signal
+<!-- Optional. Machine-checkable predicate that AUTO-RESOLVES this proposal when met.
+     v1 grammar: avg_session_cost_usd <OP> <NUMBER> over <N> sessions   (OP: < <= > >=)
+     Example: avg_session_cost_usd < 0.30 over 10 sessions
+     Window: first N sessions after accepted_date, excluding the implementation session.
+     Leave empty → reflect's default prose pattern-absence resolution applies. -->
 
 ## Operator Decision
 <!-- Filled in by operator during review -->

--- a/plugins/claude-code-hermit/state-templates/PROPOSAL.md.template
+++ b/plugins/claude-code-hermit/state-templates/PROPOSAL.md.template
@@ -37,7 +37,8 @@ success_signal: null
 <!-- Optional. Machine-checkable predicate that AUTO-RESOLVES this proposal when met.
      v1 grammar: avg_session_cost_usd <OP> <NUMBER> over <N> sessions   (OP: < <= > >=)
      Example: avg_session_cost_usd < 0.30 over 10 sessions
-     Window: first N sessions after accepted_date, excluding the implementation session.
+     Window: first N sessions after accepted_date, excluding the implementation
+     session and any session without a recorded cost (cost-tracker hook inactive).
      Leave empty → reflect's default prose pattern-absence resolution applies. -->
 
 ## Operator Decision

--- a/plugins/claude-code-hermit/tests/run-all.sh
+++ b/plugins/claude-code-hermit/tests/run-all.sh
@@ -24,4 +24,5 @@ bash "$SCRIPT_DIR/test-simplify-totals-contract.sh"        || rc=$?
 bash "$SCRIPT_DIR/test-auto-close.sh"                      || rc=$?
 bash "$SCRIPT_DIR/test-evolve-plan.sh"                     || rc=$?
 bash "$SCRIPT_DIR/test-archive-raw.sh"                     || rc=$?
+bash "$SCRIPT_DIR/test-eval-success-signal.sh"             || rc=$?
 exit $rc

--- a/plugins/claude-code-hermit/tests/test-eval-success-signal.sh
+++ b/plugins/claude-code-hermit/tests/test-eval-success-signal.sh
@@ -124,7 +124,7 @@ run_test "evaluate: observed value in MET output" \
   bash -c '
     workdir="$(mktemp -d)"
     trap "rm -rf \"$workdir\"" EXIT
-    sdir="$workdir/.claire-code-hermit"
+    sdir="$workdir/.claude-code-hermit"
     mkdir -p "$sdir/sessions"
     '"$(declare -f write_report)"'
     write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.20
@@ -217,6 +217,41 @@ run_test "evaluate: missing sessions dir returns INSUFFICIENT_DATA (not crash)" 
     # No sessions/ directory.
     out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 3 sessions")
     echo "$out" | grep -q "INSUFFICIENT_DATA"
+  '
+
+# ── Unrecorded cost (cost_usd <= 0) excluded ──────────────────────────────────
+
+run_test "evaluate: cost_usd=0 sessions excluded (no spurious MET)" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    # cost_usd defaults to 0.00 when the cost-tracker hook is inactive. Three
+    # such sessions must NOT satisfy "< 0.30" — they are unrecorded, not $0.
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.00
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.00
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.00
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 3 sessions")
+    echo "$out" | grep -q "INSUFFICIENT_DATA"
+  '
+
+run_test "evaluate: unrecorded sessions skipped, recorded ones still count" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    # Two unrecorded + three recorded → window of 3 fills from the recorded ones.
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.00
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.00
+    write_report "$sdir/sessions" S-004 "2026-05-04T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-005 "2026-05-05T10:00:00Z" 0.20
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 3 sessions")
+    echo "$out" | node -e "const d=JSON.parse(require(\"fs\").readFileSync(\"/dev/stdin\",\"utf8\")); process.exit(d.verdict===\"MET\"&&d.sessions_counted===3&&d.observed===0.2?0:1)"
   '
 
 print_results

--- a/plugins/claude-code-hermit/tests/test-eval-success-signal.sh
+++ b/plugins/claude-code-hermit/tests/test-eval-success-signal.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/eval-success-signal.js
+# Validate mode (grammar) and evaluate mode (MET / UNMET / INSUFFICIENT_DATA).
+# Runs from inside plugins/claude-code-hermit/ (REPO_ROOT = that directory).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+EVAL="$REPO_ROOT/scripts/eval-success-signal.js"
+echo "=== eval-success-signal tests ==="
+echo ""
+
+# ── Validate mode ─────────────────────────────────────────────────────────────
+
+run_test "validate: canonical predicate accepted" \
+  node "$EVAL" --validate "avg_session_cost_usd < 0.30 over 10 sessions"
+
+run_test "validate: <= op accepted" \
+  node "$EVAL" --validate "avg_session_cost_usd <= 0.50 over 5 sessions"
+
+run_test "validate: > op accepted" \
+  node "$EVAL" --validate "avg_session_cost_usd > 0.10 over 3 sessions"
+
+run_test "validate: >= op accepted" \
+  node "$EVAL" --validate "avg_session_cost_usd >= 0.05 over 1 session"
+
+run_test "validate: integer threshold accepted" \
+  node "$EVAL" --validate "avg_session_cost_usd < 1 over 7 sessions"
+
+run_test "validate: bad op rejected (exit non-zero)" \
+  bash -c '! node "$1" --validate "avg_session_cost_usd ~ 0.30 over 10 sessions"' -- "$EVAL"
+
+run_test "validate: bad op prints reason" \
+  bash -c 'node "$1" --validate "avg_session_cost_usd ~ 0.30 over 10 sessions" 2>&1 | grep -q "invalid grammar"' -- "$EVAL"
+
+run_test "validate: unsupported metric rejected" \
+  bash -c '! node "$1" --validate "total_tokens < 1000 over 5 sessions"' -- "$EVAL"
+
+run_test "validate: unsupported metric prints reason" \
+  bash -c 'node "$1" --validate "total_tokens < 1000 over 5 sessions" 2>&1 | grep -q "unsupported metric"' -- "$EVAL"
+
+run_test "validate: missing 'over N sessions' rejected" \
+  bash -c '! node "$1" --validate "avg_session_cost_usd < 0.30"' -- "$EVAL"
+
+run_test "validate: missing window number rejected" \
+  bash -c '! node "$1" --validate "avg_session_cost_usd < 0.30 over sessions"' -- "$EVAL"
+
+# ── Evaluate mode — helper to build fixtures ──────────────────────────────────
+
+# Write a session report fixture with a given id, date, and cost_usd.
+write_report() {
+  local dir="$1" id="$2" date="$3" cost="$4"
+  cat >"$dir/$id-REPORT.md" <<EOF
+---
+id: $id
+status: completed
+date: $date
+duration: ~1h
+cost_usd: $cost
+tokens: 10000
+tags: []
+task: "test task"
+escalation: balanced
+operator_turns: 2
+closed_via: operator
+---
+# Session Report: $id
+## Completed
+Test.
+EOF
+}
+
+# ── INSUFFICIENT_DATA (window not filled) ─────────────────────────────────────
+
+run_test "evaluate: INSUFFICIENT_DATA when fewer sessions than window" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    # 3 sessions post-accept, window = 5 → not enough
+    '"$(declare -f write_report)"'
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.22
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.18
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 5 sessions")
+    echo "$out" | grep -q "INSUFFICIENT_DATA"
+  '
+
+run_test "evaluate: sessions_counted in INSUFFICIENT_DATA output" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.20
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 5 sessions")
+    echo "$out" | node -e "const d=JSON.parse(require(\"fs\").readFileSync(\"/dev/stdin\",\"utf8\")); process.exit(d.sessions_counted===1?0:1)"
+  '
+
+# ── MET ───────────────────────────────────────────────────────────────────────
+
+run_test "evaluate: MET when avg < threshold" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    # avg = (0.20+0.22+0.18+0.19+0.21) / 5 = 0.20 < 0.30
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.22
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.18
+    write_report "$sdir/sessions" S-004 "2026-05-04T10:00:00Z" 0.19
+    write_report "$sdir/sessions" S-005 "2026-05-05T10:00:00Z" 0.21
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 5 sessions")
+    echo "$out" | grep -q "\"verdict\":\"MET\""
+  '
+
+run_test "evaluate: observed value in MET output" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claire-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.20
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 3 sessions")
+    echo "$out" | node -e "const d=JSON.parse(require(\"fs\").readFileSync(\"/dev/stdin\",\"utf8\")); process.exit(d.observed===0.2?0:1)"
+  '
+
+# ── UNMET ─────────────────────────────────────────────────────────────────────
+
+run_test "evaluate: UNMET when avg >= threshold (< op)" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    # avg = 0.40 which is NOT < 0.30
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.40
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.40
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.40
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 3 sessions")
+    echo "$out" | grep -q "\"verdict\":\"UNMET\""
+  '
+
+# ── accepted_in_session exclusion ─────────────────────────────────────────────
+
+run_test "evaluate: accepted_in_session excluded from window" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    # S-001 is the implementation session (high cost); S-002..S-004 are under threshold.
+    # If S-001 were included, avg would be (1.50+0.20+0.20+0.20)/4 = 0.525 → UNMET.
+    # With exclusion, avg = (0.20+0.20+0.20)/3 = 0.20 → MET.
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 1.50
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-004 "2026-05-04T10:00:00Z" 0.20
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "S-001" "avg_session_cost_usd < 0.30 over 3 sessions")
+    echo "$out" | grep -q "\"verdict\":\"MET\""
+  '
+
+# ── Pre-accept sessions excluded ──────────────────────────────────────────────
+
+run_test "evaluate: sessions before accepted_date excluded" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    # S-001 is before accepted_date and should be excluded.
+    # Only S-002..S-003 are valid (< 3 needed) → INSUFFICIENT_DATA.
+    write_report "$sdir/sessions" S-001 "2026-04-01T10:00:00Z" 0.10
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.20
+    out=$(node "'"$EVAL"'" "$sdir" "2026-05-01T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 3 sessions")
+    echo "$out" | grep -q "INSUFFICIENT_DATA"
+  '
+
+# ── Fail-open on malformed report ─────────────────────────────────────────────
+
+run_test "evaluate: malformed report does not crash (fail-open)" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/sessions"
+    '"$(declare -f write_report)"'
+    # Write a non-YAML file that will fail frontmatter parse.
+    echo "not a frontmatter file" > "$sdir/sessions/S-BAD-REPORT.md"
+    write_report "$sdir/sessions" S-001 "2026-05-01T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-002 "2026-05-02T10:00:00Z" 0.20
+    write_report "$sdir/sessions" S-003 "2026-05-03T10:00:00Z" 0.20
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 3 sessions")
+    # Bad file is skipped; valid ones are evaluated normally.
+    echo "$out" | grep -q "\"verdict\":\"MET\""
+  '
+
+run_test "evaluate: missing sessions dir returns INSUFFICIENT_DATA (not crash)" \
+  bash -c '
+    workdir="$(mktemp -d)"
+    trap "rm -rf \"$workdir\"" EXIT
+    sdir="$workdir/.claude-code-hermit"
+    mkdir -p "$sdir/state"
+    # No sessions/ directory.
+    out=$(node "'"$EVAL"'" "$sdir" "2026-04-30T00:00:00Z" "null" "avg_session_cost_usd < 0.30 over 3 sessions")
+    echo "$out" | grep -q "INSUFFICIENT_DATA"
+  '
+
+print_results

--- a/plugins/claude-code-hermit/tests/test-proposal-act-accept-flow.sh
+++ b/plugins/claude-code-hermit/tests/test-proposal-act-accept-flow.sh
@@ -78,4 +78,27 @@ FRONTMATTER="$(awk '/^---$/{c++; next} c==1' "$SKILL")"
 run_test "frontmatter description mentions 'start implementing now'" \
   bash -c 'echo "$1" | grep -q "^description:.*start implementing now"' -- "$FRONTMATTER"
 
+# Step 3c: success_signal capture and validation.
+# Guards that the step exists, references eval-success-signal.js, and never blocks accept.
+run_test "step 3c: success_signal step present" \
+  grep -qF "3c." "$SKILL"
+
+run_test "step 3c: references eval-success-signal.js" \
+  grep -qF "eval-success-signal.js" "$SKILL"
+
+run_test "step 3c: never blocks accept" \
+  grep -qF "Never block accept" "$SKILL"
+
+run_test "step 3c: warns on invalid predicate (logs to SHELL.md Findings)" \
+  bash -c "grep -qF 'success_signal ignored' \"$SKILL\""
+
+# PROPOSAL.md.template: success_signal field present.
+TEMPLATE="$REPO_ROOT/state-templates/PROPOSAL.md.template"
+
+run_test "PROPOSAL.md.template: success_signal frontmatter key present" \
+  grep -qF "success_signal:" "$TEMPLATE"
+
+run_test "PROPOSAL.md.template: Success Signal section present" \
+  grep -qF "## Success Signal" "$TEMPLATE"
+
 print_results


### PR DESCRIPTION
## Summary

Closes the gap from §17.1 of the architecture review: proposals whose success is not visible as pattern-absence in session prose (cost-shaped outcomes like \"cost/session under \$0.30 for 10 sessions\") now support an optional machine-checkable predicate. Accepted proposals become measurable experiments — reflect evaluates the predicate each cycle and auto-resolves when met.

## Changes

- **`state-templates/PROPOSAL.md.template`**: adds `success_signal: null` frontmatter field and a `## Success Signal` body section with v1 grammar documentation
- **`scripts/eval-success-signal.js`** (new): deterministic evaluator — `--validate` mode checks grammar; evaluate mode scans session-report `cost_usd` anchored at `accepted_date`, returns `MET` / `UNMET` / `INSUFFICIENT_DATA` JSON; fail-open on any error
- **`skills/proposal-act/SKILL.md`**: new step 3c extracts and validates the `## Success Signal` predicate at accept time, writes `success_signal` to frontmatter; invalid predicate logs a warning and never blocks accept
- **`skills/reflect/SKILL.md`**: step 6d branches on `success_signal`; if set, runs the evaluator instead of the prose pattern-absence test; MET auto-resolves; UNMET surfaces once with 7-day nudge debounce via existing `last_sparse_nudge` machinery; null falls through to the unchanged cadence path
- **`tests/test-eval-success-signal.sh`** (new): 20 tests covering validate mode (grammar, bad op, unsupported metric, missing window) and evaluate mode (MET, UNMET, INSUFFICIENT_DATA, `accepted_in_session` exclusion, pre-accept exclusion, fail-open on malformed reports, missing sessions dir)
- **`tests/test-proposal-act-accept-flow.sh`**: 6 new assertions on step 3c and the template field

## v1 grammar

```
avg_session_cost_usd <OP> <NUMBER> over <N> sessions
```

`OP` in `< <= > >=`; window anchored at `accepted_date`; `accepted_in_session` excluded (implementation session cost is skewed). `INSUFFICIENT_DATA` until N post-accept sessions exist. Engagement metrics deliberately out of scope — they need a separate state change in channel-activity.json.

## Test plan

All run inside `plugins/claude-code-hermit/`:

- `bash tests/test-eval-success-signal.sh` — 20/20 passed
- `bash tests/test-proposal-act-accept-flow.sh` — 24/24 passed
- `bash tests/run-all.sh` — all 17 suites, 0 failures