### PR TITLE
feat(cc-compat): centralize CC-owned format parsing + Stop-payload scheduler snapshot

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Added
 
-- **cc-compat: centralized Claude Code format accessors** — new `scripts/lib/cc-compat.js` wraps every surface Anthropic owns and can change (hook-payload field names, transcript JSONL usage shape, cost-log path/record fields, best-effort CC version). A CC release now breaks one file loudly instead of five quietly.
+- **cc-compat: centralized Claude Code format accessors** — new `scripts/lib/cc-compat.js` wraps every surface Anthropic owns and can change (hook-payload field names, transcript JSONL usage shape, cost-log path, best-effort CC version). A CC release now breaks one file loudly instead of five quietly.
 - **stop-pipeline: persist structured Stop-payload snapshot** — after each Stop, `state/cc-stop-snapshot.json` records `session_crons` and `background_tasks` as tri-state (`populated / empty / unsupported_or_unreachable`), `captured_at`, and `cc_version`. Sole writer: `stop-pipeline.js`.
 - **doctor: scheduler/background-task health check** — new `checkScheduler()` reads the snapshot and reports cron and task state with labeled staleness. Missing snapshot → ok ("not yet captured"); `unsupported_or_unreachable` → warn (never falsely reported as "0 crons").
 
 ### Changed
 
-- **cost-tracker: migrate CC-shape parsing to cc-compat** — `entryText`, `isToolResult`, and usage-field extraction now delegate to `cc-compat.js`; `COST_LOG` path resolved via `costLogPath()`. No behavior change; existing tests still pass.
+- **cost-tracker, suggest-compact: route hook-payload reads through cc-compat** — `entryText`, `isToolResult`, usage-field extraction, `session_id`, and `transcript_path` now delegate to `cc-compat.js`; `COST_LOG` path resolved via `costLogPath()`. Completes the centralization so every CC-owned read fails in one place. No behavior change; existing tests still pass.
 - **heartbeat: gate in_progress stale-check on operator activity** — skip the per-tick LLM wake when `last-operator-action.json` shows activity within `stale_threshold`; the faithful Progress-Log check still runs when the operator is quiet beyond the threshold or a stale alert is already active. Falls back to the original unconditional wake on pre-upgrade installs (no `last-operator-action.json`) and on future-dated timestamps (clock skew). Closes #315.
 
 ## [1.1.10] - 2026-06-05

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- **cc-compat: centralized Claude Code format accessors** — new `scripts/lib/cc-compat.js` wraps every surface Anthropic owns and can change (hook-payload field names, transcript JSONL usage shape, cost-log path/record fields, best-effort CC version). A CC release now breaks one file loudly instead of five quietly.
+- **stop-pipeline: persist structured Stop-payload snapshot** — after each Stop, `state/cc-stop-snapshot.json` records `session_crons` and `background_tasks` as tri-state (`populated / empty / unsupported_or_unreachable`), `captured_at`, and `cc_version`. Sole writer: `stop-pipeline.js`.
+- **doctor: scheduler/background-task health check** — new `checkScheduler()` reads the snapshot and reports cron and task state with labeled staleness. Missing snapshot → ok ("not yet captured"); `unsupported_or_unreachable` → warn (never falsely reported as "0 crons").
+
 ### Changed
 
+- **cost-tracker: migrate CC-shape parsing to cc-compat** — `entryText`, `isToolResult`, and usage-field extraction now delegate to `cc-compat.js`; `COST_LOG` path resolved via `costLogPath()`. No behavior change; existing tests still pass.
 - **heartbeat: gate in_progress stale-check on operator activity** — skip the per-tick LLM wake when `last-operator-action.json` shows activity within `stale_threshold`; the faithful Progress-Log check still runs when the operator is quiet beyond the threshold or a stale alert is already active. Falls back to the original unconditional wake on pre-upgrade installs (no `last-operator-action.json`) and on future-dated timestamps (clock skew). Closes #315.
 
 ## [1.1.10] - 2026-06-05

--- a/plugins/claude-code-hermit/docs/architecture.md
+++ b/plugins/claude-code-hermit/docs/architecture.md
@@ -177,6 +177,7 @@ One writer per state file. No shared mutation bus.
 | `state/state-summary.md`       | generate-summary.js only                            | humans                                                        |
 | `state/monitors.runtime.json`  | watch skill only                                    | session-start (clear on start), session-close (stop all)      |
 | `state/heartbeat-monitor.runtime.json` | heartbeat skill only                        | heartbeat-start (write), heartbeat-stop (clear), heartbeat-restart (rewrite) |
+| `state/cc-stop-snapshot.json`  | stop-pipeline.js only                               | doctor-check.js (scheduler/background-task health check)      |
 | `state/.heartbeat`             | heartbeat-touch.js only                             | heartbeat (detect activity gaps)                              |
 | `state/.lifecycle.lock`        | hermit-start.py only                                | hermit-stop.py (cleanup)                                      |
 

--- a/plugins/claude-code-hermit/scripts/cost-tracker.js
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.js
@@ -13,7 +13,7 @@ const path = require('path');
 const { calculateCost } = require('./lib/pricing');
 const { readTasks, taskProgress } = require('./lib/tasks');
 const { kStr, formatTokens } = require('./lib/format');
-const { entryText, isToolResult, extractUsage, costLogPath } = require('./lib/cc-compat');
+const { sessionId: ccSessionId, transcriptPath: ccTranscriptPath, entryText, isToolResult, extractUsage, costLogPath } = require('./lib/cc-compat');
 
 const MAX_STDIN = 1024 * 1024; // 1MB safety limit
 const COST_LOG = costLogPath('.claude-code-hermit');
@@ -382,8 +382,8 @@ function updateShellSession(content, costStr, tokenStr) {
 // process.exit() calls become returns so the pipeline is not killed.
 async function run(data) {
   try {
-    const sessionId = data.session_id || 'unknown';
-    const transcriptPath = data.transcript_path;
+    const sessionId = ccSessionId(data) || 'unknown';
+    const transcriptPath = ccTranscriptPath(data);
 
     if (!transcriptPath) {
       return null;

--- a/plugins/claude-code-hermit/scripts/cost-tracker.js
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.js
@@ -13,9 +13,10 @@ const path = require('path');
 const { calculateCost } = require('./lib/pricing');
 const { readTasks, taskProgress } = require('./lib/tasks');
 const { kStr, formatTokens } = require('./lib/format');
+const { entryText, isToolResult, extractUsage, costLogPath } = require('./lib/cc-compat');
 
 const MAX_STDIN = 1024 * 1024; // 1MB safety limit
-const COST_LOG = path.resolve('.claude/cost-log.jsonl');
+const COST_LOG = costLogPath('.claude-code-hermit');
 const SHELL_SESSION = path.resolve('.claude-code-hermit/sessions/SHELL.md');
 const STATUS_JSON = path.resolve('.claude-code-hermit/sessions/.status.json');
 const STATUS_JSON_TMP = path.resolve('.claude-code-hermit/sessions/.status.json.tmp');
@@ -48,23 +49,6 @@ function detectModel(modelStr) {
   if (lower.includes('haiku')) return 'haiku';
   if (lower.includes('opus')) return 'opus';
   return 'sonnet';
-}
-
-// Stringify an entry's message.content regardless of whether it's a string or a content-block array.
-// Real transcripts use both shapes (confirmed in live ops-hermit data).
-function entryText(entry) {
-  const c = entry.message?.content;
-  if (!c) return '';
-  return typeof c === 'string' ? c : JSON.stringify(c);
-}
-
-// A user entry is a tool_result carrier (not a turn boundary) when its content
-// is an array containing any tool_result block. The triggering prompt that opens
-// a turn is a "real" user entry: string content, or an array with no tool_result.
-function isToolResult(entry) {
-  if (entry.type !== 'user') return false;
-  const c = entry.message?.content;
-  return Array.isArray(c) && c.some(b => b && b.type === 'tool_result');
 }
 
 // Scan backward from billedIndex through the current turn and return concatenated
@@ -129,8 +113,8 @@ function readLastTurnUsage(transcriptPath) {
     for (let i = lines.length - 1; i >= 0; i--) {
       try {
         const entry = JSON.parse(lines[i]);
-        if (entry.type === 'assistant' && entry.message?.usage) {
-          const u = entry.message.usage;
+        const usage = extractUsage(entry);
+        if (usage) {
           // Detect operator interaction for operator_turns tracking.
           // Note: real transcripts use type:'user', not type:'human', so this is
           // effectively always false in production — left intact for future correctness.
@@ -144,15 +128,7 @@ function readLastTurnUsage(transcriptPath) {
           }
           const triggerText = scanTriggerMarkers(lines, i);
           const source = classifySource(triggerText);
-          return {
-            inputTokens:      u.input_tokens || 0,
-            cacheWriteTokens: u.cache_creation_input_tokens || 0,
-            cacheReadTokens:  u.cache_read_input_tokens || 0,
-            outputTokens:     u.output_tokens || 0,
-            model:            entry.message.model || '',
-            hadHumanTurn,
-            source,
-          };
+          return { ...usage, hadHumanTurn, source };
         }
       } catch {}
     }

--- a/plugins/claude-code-hermit/scripts/doctor-check.js
+++ b/plugins/claude-code-hermit/scripts/doctor-check.js
@@ -492,6 +492,60 @@ function checkReflectLoop() {
   }
 }
 
+function checkScheduler() {
+  // Reads state/cc-stop-snapshot.json written by stop-pipeline.js on each Stop.
+  // The snapshot is point-in-time at last Stop, not live — the captured_at
+  // timestamp is always surfaced so staleness is visible rather than silently trusted.
+  //
+  // Missing snapshot → 'ok': not a failure. First run after upgrade always hits this.
+  // unsupported_or_unreachable → 'warn': field was absent, meaning old CC or
+  //   task registry unreachable. NEVER report this as "0 crons/tasks" — that
+  //   conflation is the silent-wrongness cc-compat exists to prevent.
+  try {
+    const snapshotPath = path.join(stateDir, 'cc-stop-snapshot.json');
+    if (!fs.existsSync(snapshotPath)) {
+      return {
+        id: 'scheduler',
+        status: 'ok',
+        detail: 'not yet captured (no Stop since upgrade)',
+      };
+    }
+
+    const snap = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+    const ts = snap.captured_at || 'unknown time';
+    // Format as a short ISO string (drop sub-seconds) for readability
+    const tsShort = ts.replace(/\.\d+Z$/, 'Z');
+
+    const crons = snap.session_crons || {};
+    const tasks = snap.background_tasks || {};
+
+    const isUnsupported = f => !f.state || f.state === 'unsupported_or_unreachable';
+
+    // Build per-field descriptions that never collapse absent → zero
+    function describeField(field, label) {
+      if (isUnsupported(field)) {
+        return `${label}: unsupported or unreachable`;
+      }
+      return `${label}: ${field.count} ${field.state === 'empty' ? '(empty)' : 'armed'}`;
+    }
+
+    const cronDesc = describeField(crons, 'crons');
+    const taskDesc = describeField(tasks, 'tasks');
+
+    const hasUnsupported = isUnsupported(crons) || isUnsupported(tasks);
+
+    const ccVer = snap.cc_version ? ` (cc ${snap.cc_version})` : '';
+    const detail = `${cronDesc}, ${taskDesc} — as of ${tsShort}${ccVer}`;
+
+    if (hasUnsupported) {
+      return { id: 'scheduler', status: 'warn', detail };
+    }
+    return { id: 'scheduler', status: 'ok', detail };
+  } catch (e) {
+    return { id: 'scheduler', status: 'fail', detail: `check failed: ${e.message}` };
+  }
+}
+
 // ----------------- Orchestration -----------------
 
 function runAllChecks() {
@@ -506,6 +560,7 @@ function runAllChecks() {
     checkDockerSecurity(),
     checkArchival(),
     checkReflectLoop(),
+    checkScheduler(),
   ];
 }
 
@@ -537,7 +592,7 @@ if (require.main === module) {
   module.exports = {
     checkConfig, checkHooks, checkStateFiles,
     checkCost, checkProposals, checkDependencies, checkPermissions,
-    checkDockerSecurity, checkArchival, checkReflectLoop,
+    checkDockerSecurity, checkArchival, checkReflectLoop, checkScheduler,
     satisfiesRange, cidrOverlap,
     runAllChecks, writeReport,
   };

--- a/plugins/claude-code-hermit/scripts/lib/cc-compat.js
+++ b/plugins/claude-code-hermit/scripts/lib/cc-compat.js
@@ -11,7 +11,7 @@
 //     background_tasks)
 //   - Transcript JSONL entry shape (message.usage, cache field names,
 //     assistant/user/tool_result type discrimination)
-//   - Cost-log path resolution and record field names
+//   - Cost-log path resolution (record shape is hermit-owned — see costLogPath)
 //   - Best-effort CC version string (diagnostic only — never branch on it;
 //     the install-gate is min_claude_code_version in hermit-meta.json)
 //
@@ -175,26 +175,6 @@ function costLogPath(hermitRootOrState) {
   return path.join(path.dirname(abs), '.claude', 'cost-log.jsonl');
 }
 
-/**
- * Parse a single line from .claude/cost-log.jsonl.
- * Returns the record object or null on any parse error.
- * Known fields: timestamp, session_id, source, model,
- *   input_tokens, cache_write_tokens, cache_read_tokens, output_tokens,
- *   total_tokens, estimated_cost_usd.
- *
- * @param {string} line
- * @returns {object|null}
- */
-function parseCostLogLine(line) {
-  try {
-    const trimmed = (line || '').trim();
-    if (!trimmed) return null;
-    return JSON.parse(trimmed);
-  } catch {
-    return null;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Capability / version sniff (diagnostic only — never branch on it)
 // ---------------------------------------------------------------------------
@@ -231,7 +211,6 @@ module.exports = {
   extractUsage,
   // Cost-log
   costLogPath,
-  parseCostLogLine,
   // Capability sniff
   ccVersion,
 };

--- a/plugins/claude-code-hermit/scripts/lib/cc-compat.js
+++ b/plugins/claude-code-hermit/scripts/lib/cc-compat.js
@@ -1,0 +1,237 @@
+'use strict';
+
+// cc-compat.js — Centralized accessors for Claude Code-owned formats.
+//
+// Contract: this module wraps surfaces that Anthropic owns and can change
+// without notice. Every parse of a CC-owned format should go through here so
+// a CC release breaks THIS FILE loudly, not five others quietly.
+//
+// In-scope surfaces:
+//   - Hook-payload field names (session_id, transcript_path, session_crons,
+//     background_tasks)
+//   - Transcript JSONL entry shape (message.usage, cache field names,
+//     assistant/user/tool_result type discrimination)
+//   - Cost-log path resolution and record field names
+//   - Best-effort CC version string (diagnostic only — never branch on it;
+//     the install-gate is min_claude_code_version in hermit-meta.json)
+//
+// Out-of-scope (NOT in this module):
+//   - pricing.js: Anthropic published pricing — a hermit-owned data table
+//   - Cron grammar (5-field POSIX, stable; CronCreate semantics are doc)
+//   - Monitor sentinel constants (HEARTBEAT_EVALUATE is hermit's own protocol)
+
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Hook-payload accessors (pure, null-safe)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract session_id from a Stop (or any) hook payload.
+ * CC has used both `session_id` and `sessionId` across versions.
+ * @param {object} payload
+ * @returns {string|null}
+ */
+function sessionId(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  return payload.session_id != null ? payload.session_id
+    : payload.sessionId != null ? payload.sessionId
+    : null;
+}
+
+/**
+ * Extract transcript_path from a Stop hook payload.
+ * @param {object} payload
+ * @returns {string|null}
+ */
+function transcriptPath(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  return payload.transcript_path != null ? payload.transcript_path : null;
+}
+
+/**
+ * Extract session_crons with tri-state presence semantics.
+ *
+ * The tri-state is critical:
+ *   - 'unsupported_or_unreachable': field absent — old CC or task registry
+ *     unreachable. NEVER render this as "0 crons" — that's the silent-wrong
+ *     this module exists to prevent.
+ *   - 'empty': field present and array is empty — CC supports it, nothing scheduled.
+ *   - 'populated': field present and non-empty.
+ *
+ * @param {object} payload
+ * @returns {{ state: string, count: number, entries: Array }}
+ */
+function triStateField(payload, field) {
+  if (!payload || typeof payload !== 'object' || !(field in payload)) {
+    return { state: 'unsupported_or_unreachable', count: 0, entries: [] };
+  }
+  const raw = payload[field];
+  const entries = Array.isArray(raw) ? raw : [];
+  if (entries.length === 0) {
+    return { state: 'empty', count: 0, entries: [] };
+  }
+  return { state: 'populated', count: entries.length, entries };
+}
+
+function sessionCrons(payload) {
+  return triStateField(payload, 'session_crons');
+}
+
+/**
+ * Extract background_tasks with tri-state presence semantics.
+ * Same rules as sessionCrons — see above.
+ * @param {object} payload
+ * @returns {{ state: string, count: number, entries: Array }}
+ */
+function backgroundTasks(payload) {
+  return triStateField(payload, 'background_tasks');
+}
+
+// ---------------------------------------------------------------------------
+// Transcript parsing (CC-owned JSONL shape)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stringify an entry's message.content regardless of whether it is a string
+ * or a content-block array. Real CC transcripts use both shapes.
+ * @param {object} entry
+ * @returns {string}
+ */
+function entryText(entry) {
+  const c = entry.message?.content;
+  if (!c) return '';
+  return typeof c === 'string' ? c : JSON.stringify(c);
+}
+
+/**
+ * A user entry is a tool_result carrier (not a turn boundary) when its content
+ * is an array containing any tool_result block. The triggering prompt that
+ * opens a turn is a "real" user entry: string content, or an array with no
+ * tool_result.
+ * @param {object} entry
+ * @returns {boolean}
+ */
+function isToolResult(entry) {
+  if (entry.type !== 'user') return false;
+  const c = entry.message?.content;
+  return Array.isArray(c) && c.some(b => b && b.type === 'tool_result');
+}
+
+/**
+ * Extract token usage from a transcript entry.
+ * Returns an object if the entry is an assistant entry with usage, else null.
+ * This centralizes the CC-owned field names: input_tokens, output_tokens,
+ * cache_creation_input_tokens, cache_read_input_tokens.
+ *
+ * @param {object} entry
+ * @returns {{ inputTokens: number, cacheWriteTokens: number, cacheReadTokens: number,
+ *             outputTokens: number, model: string } | null}
+ */
+function extractUsage(entry) {
+  if (entry.type !== 'assistant' || !entry.message?.usage) return null;
+  const u = entry.message.usage;
+  return {
+    inputTokens:      u.input_tokens || 0,
+    cacheWriteTokens: u.cache_creation_input_tokens || 0,
+    cacheReadTokens:  u.cache_read_input_tokens || 0,
+    outputTokens:     u.output_tokens || 0,
+    model:            entry.message.model || '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cost-log path and record shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical cost-log path resolution.
+ * Replaces the 5 divergent path.resolve strategies scattered across scripts.
+ * The cost-log is always at .claude/cost-log.jsonl relative to the project
+ * root; stateDir is .claude-code-hermit/state/ or the hermit root.
+ *
+ * Accepts either the hermit root (e.g. '.claude-code-hermit') or a deeper
+ * path under it. Walks up until .claude-code-hermit is found, then resolves
+ * sibling .claude/ from its parent.
+ *
+ * @param {string} [hermitRootOrState] path to hermit root or state subdir;
+ *   defaults to '.claude-code-hermit' relative to cwd.
+ * @returns {string} absolute path to .claude/cost-log.jsonl
+ */
+function costLogPath(hermitRootOrState) {
+  if (!hermitRootOrState) {
+    return path.resolve('.claude', 'cost-log.jsonl');
+  }
+  const abs = path.resolve(hermitRootOrState);
+  // Walk up to find the directory named .claude-code-hermit
+  let dir = abs;
+  for (let i = 0; i < 5; i++) {
+    if (path.basename(dir) === '.claude-code-hermit') {
+      return path.join(path.dirname(dir), '.claude', 'cost-log.jsonl');
+    }
+    dir = path.dirname(dir);
+  }
+  // Fallback: treat hermitRootOrState as the hermit root itself
+  return path.join(path.dirname(abs), '.claude', 'cost-log.jsonl');
+}
+
+/**
+ * Parse a single line from .claude/cost-log.jsonl.
+ * Returns the record object or null on any parse error.
+ * Known fields: timestamp, session_id, source, model,
+ *   input_tokens, cache_write_tokens, cache_read_tokens, output_tokens,
+ *   total_tokens, estimated_cost_usd.
+ *
+ * @param {string} line
+ * @returns {object|null}
+ */
+function parseCostLogLine(line) {
+  try {
+    const trimmed = (line || '').trim();
+    if (!trimmed) return null;
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Capability / version sniff (diagnostic only — never branch on it)
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort CC version string.
+ * Reads from payload if CC ever ships it there, else checks env.
+ * Returns null rather than spawning `claude --version` on the hot path.
+ * Use this for diagnostic labeling only; runtime behavior should key on
+ * field presence, never on this string.
+ *
+ * @param {object} [payload]
+ * @returns {string|null}
+ */
+function ccVersion(payload) {
+  if (payload && typeof payload === 'object') {
+    const v = payload.claude_code_version || payload.cc_version;
+    if (v && typeof v === 'string') return v;
+  }
+  return process.env.CLAUDE_CODE_VERSION || null;
+}
+
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  // Hook-payload accessors
+  sessionId,
+  transcriptPath,
+  sessionCrons,
+  backgroundTasks,
+  // Transcript parsing
+  entryText,
+  isToolResult,
+  extractUsage,
+  // Cost-log
+  costLogPath,
+  parseCostLogLine,
+  // Capability sniff
+  ccVersion,
+};

--- a/plugins/claude-code-hermit/scripts/stop-pipeline.js
+++ b/plugins/claude-code-hermit/scripts/stop-pipeline.js
@@ -9,10 +9,12 @@ const { run: costTracker } = require('./cost-tracker');
 const { run: suggestCompact } = require('./suggest-compact');
 const { run: sessionDiff } = require('./session-diff');
 const { run: evaluateSession } = require('./evaluate-session');
+const { sessionCrons, backgroundTasks, ccVersion } = require('./lib/cc-compat');
 const fs = require('fs');
 const path = require('path');
 
 const HEARTBEAT_FILE = path.resolve('.claude-code-hermit/state/.heartbeat');
+const SNAPSHOT_FILE = path.resolve('.claude-code-hermit/state/cc-stop-snapshot.json');
 
 async function main() {
   // Read stdin once
@@ -69,6 +71,22 @@ async function main() {
 
   // Guaranteed heartbeat touch — runs even if all stages fail
   try { fs.writeFileSync(HEARTBEAT_FILE, new Date().toISOString() + '\n'); } catch {}
+
+  // Write CC-stop-payload snapshot (tri-state, labeled with captured_at).
+  // sole writer for state/cc-stop-snapshot.json. Fail-open.
+  try {
+    const crons = sessionCrons(payload);
+    const tasks = backgroundTasks(payload);
+    const snapshot = {
+      captured_at: new Date().toISOString(),
+      cc_version: ccVersion(payload),
+      session_crons:    { state: crons.state, count: crons.count },
+      background_tasks: { state: tasks.state, count: tasks.count },
+    };
+    const tmp = SNAPSHOT_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(snapshot, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, SNAPSHOT_FILE);
+  } catch {}
 
   // Emit suggest-compact as the ONLY stdout — Claude Code parses this for additionalContext
   if (compactSuggestion) {

--- a/plugins/claude-code-hermit/scripts/suggest-compact.js
+++ b/plugins/claude-code-hermit/scripts/suggest-compact.js
@@ -8,6 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { sessionId: ccSessionId } = require('./lib/cc-compat');
 
 const MAX_STDIN = 1024 * 1024; // 1MB safety limit
 const COMPACT_THRESHOLD = parseInt(process.env.COMPACT_THRESHOLD || '75', 10) || 75;
@@ -50,7 +51,7 @@ function writeCounter(counterPath, value) {
 // process.exit() calls become returns so the pipeline is not killed.
 async function run(data) {
   try {
-    const sessionId = data.session_id || data.sessionId || 'default';
+    const sessionId = ccSessionId(data) || 'default';
 
     // Check context usage if provided
     const contextUsage = data.context_usage || data.contextUsage || 0;

--- a/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: hermit-doctor
-description: Returns an eleven-check health report on the hermit installation — config validity, hook registration, state file integrity, cost visibility, proposal health, sibling dependency ranges, file permissions, docker-security overlay drift, archival health, reflect loop health, sandbox capability. Use when diagnosing an install, before a release, or after suspicious behavior. Activates on messages like "/hermit-doctor", "health check", "diagnose the hermit", "what's wrong", "run diagnostic".
+description: Returns a twelve-check health report on the hermit installation — config validity, hook registration, state file integrity, cost visibility, proposal health, sibling dependency ranges, file permissions, docker-security overlay drift, archival health, reflect loop health, scheduler/background-task health, sandbox capability. Use when diagnosing an install, before a release, or after suspicious behavior. Activates on messages like "/hermit-doctor", "health check", "diagnose the hermit", "what's wrong", "run diagnostic".
 ---
 
 # Hermit Doctor
 
-Runs eleven read-only health checks against the current hermit install and surfaces the
+Runs twelve read-only health checks against the current hermit install and surfaces the
 summary. Safe to run at any time. Produces no side effects beyond writing
 `.claude-code-hermit/state/doctor-report.json` and appending a summary block to SHELL.md.
 
@@ -19,15 +19,15 @@ summary. Safe to run at any time. Produces no side effects beyond writing
    JSON to stdout. It exits 0 unconditionally — on any internal failure the failing
    check reports `status: "fail"` in its own entry rather than crashing the report.
 
-2. Parse the JSON. For each of the ten checks in the report (`config`, `hooks`, `state`, `cost`,
-   `proposals`, `dependencies`, `permissions`, `docker-security`, `archive`, `reflect`), emit one line using this format:
+2. Parse the JSON. For each of the eleven checks in the report (`config`, `hooks`, `state`, `cost`,
+   `proposals`, `dependencies`, `permissions`, `docker-security`, `archive`, `reflect`, `scheduler`), emit one line using this format:
    - `✓ <id> — <detail>` when `status: ok`
    - `⚠ <id> — <detail>` when `status: warn`
    - `✗ <id> — <detail>` when `status: fail`
 
-2.5. **Sandbox capability check** (eleventh check, run after step 2):
+2.5. **Sandbox capability check** (twelfth check, run after step 2):
 
-   Architectural note: this check is computed by the skill orchestrator, not by `doctor-check.js`. `state/doctor-report.json` therefore contains only the ten checks emitted in step 2; the sandbox line is appended to the rendered summary and to SHELL.md but is not present in the JSON report. Tools that consume `doctor-report.json` programmatically should call `scripts/sandbox-probe.py` separately if they need the sandbox status.
+   Architectural note: this check is computed by the skill orchestrator, not by `doctor-check.js`. `state/doctor-report.json` therefore contains only the eleven checks emitted in step 2; the sandbox line is appended to the rendered summary and to SHELL.md but is not present in the JSON report. Tools that consume `doctor-report.json` programmatically should call `scripts/sandbox-probe.py` separately if they need the sandbox status.
 
    Determine the sandbox enabled state: read `.claude/settings.json` and `.claude/settings.local.json`; the last file that explicitly declares `sandbox.enabled` wins (Claude Code's merge order). Treat non-bool values as undeclared.
 
@@ -42,20 +42,20 @@ summary. Safe to run at any time. Produces no side effects beyond writing
      - `warn`: emit `⚠ sandbox — enabled but: <message>`.
      - `fail`: emit `✗ sandbox — enabled but: <message>. Fix: <install_hint>`.
 
-   Add this as the eleventh line to the summary.
+   Add this as the twelfth line to the summary.
 
 3. Append a summary section to `.claude-code-hermit/sessions/SHELL.md` under a new
-   `## Doctor Report (<ts>)` heading. Use the same eleven lines from steps 2 and 2.5. Place it
+   `## Doctor Report (<ts>)` heading. Use the same twelve lines from steps 2 and 2.5. Place it
    above the `## Monitoring` section so it sits with session-level context, not
    with monitoring chatter.
 
-4. Return the eleven lines to the caller. Cap total output at 22 lines.
+4. Return the twelve lines to the caller. Cap total output at 24 lines.
 
 ## Silence policy
 
-- If every check is `ok`, return only: `All eleven checks passed.` Do not notify via
+- If every check is `ok`, return only: `All twelve checks passed.` Do not notify via
   channel (Tier 0). Still append to SHELL.md so the run is traceable.
-- If any check is `warn` or `fail`, return the full eleven-line summary. Channel
+- If any check is `warn` or `fail`, return the full twelve-line summary. Channel
   notification follows the usual § Operator Notification policy in CLAUDE.md —
   `fail` warrants a proactive ping; `warn` alone does not unless the operator asked.
 
@@ -73,6 +73,7 @@ summary. Safe to run at any time. Produces no side effects beyond writing
 | `docker-security` | Cross-references `docker.security.*` in `config.json` against the presence of `docker-compose.security.yml` at the project root. Two-state presence check; no YAML parsing. | `warn` if posture is declared but overlay missing (re-run `/docker-security`), or if overlay is present but no posture is declared (likely a manual edit). `ok` when both match or neither is configured. |
 | `archive` | Reads `state/runtime.json`. Detects sessions that should have been archived but weren't. | `warn` if `session_state ∈ {in_progress, waiting}` with `updated_at` >2 days old (stale active session) or `session_state: idle` with non-null `session_id` >2 days old (orphaned). `ok` when runtime missing (covered by `state` check) or all timestamps fresh. |
 | `reflect` | Reads `state/reflection-state.json` counters. Flags an unproductive reflect loop. | `warn` if `total_runs ≥ 10` AND `empty_runs / total_runs > 0.80` AND `proposals_created == 0`. `ok` below 10 runs (insufficient sample) or when the loop produces output. |
+| `scheduler` | Reads `state/cc-stop-snapshot.json` (written by stop-pipeline.js at each Stop). Reports armed cron count, background-task count, and snapshot age. | `ok` if snapshot present with counts and `captured_at`; `ok` (not yet captured) if snapshot absent (first run post-upgrade); `warn` if `session_crons` or `background_tasks` state is `unsupported_or_unreachable` (old CC build or registry unreachable — never reported as "0 crons"). |
 | `sandbox` | Runs `scripts/sandbox-probe.py` and cross-references with `sandbox.enabled` in settings files. | `fail` if sandbox enabled and deps (bwrap/socat) missing; `warn` if deps present but user-namespaces disabled; `ok` if disabled or fully operational. |
 
 No automatic fixes. Doctor reports; the operator acts.

--- a/plugins/claude-code-hermit/tests/fixtures/stop-hook-input-with-scheduler.json
+++ b/plugins/claude-code-hermit/tests/fixtures/stop-hook-input-with-scheduler.json
@@ -1,0 +1,14 @@
+{
+  "session_id": "test-session-001",
+  "transcript_path": "__TRANSCRIPT_PATH__",
+  "cwd": "/tmp/test-project",
+  "permission_mode": "default",
+  "hook_event_name": "Stop",
+  "stop_hook_active": false,
+  "last_assistant_message": "Done.",
+  "session_crons": [
+    {"id": "cron-1", "prompt": "[hermit-routine:morning-brief]"},
+    {"id": "cron-2", "prompt": "[hermit-routine:reflect]"}
+  ],
+  "background_tasks": []
+}

--- a/plugins/claude-code-hermit/tests/run-contracts.py
+++ b/plugins/claude-code-hermit/tests/run-contracts.py
@@ -1539,6 +1539,125 @@ class TestRoutineModelValidation(unittest.TestCase):
         )
 
 
+class TestStopPayloadSnapshot(_TempDirTest):
+    """stop-pipeline.js writes state/cc-stop-snapshot.json from the Stop payload.
+
+    Guards against: snapshot not written, wrong tri-state, absent fields, or
+    missing captured_at. Also exercises checkScheduler() via doctor-check.js.
+    """
+
+    def _run_stop_pipeline(self, payload_dict, env_extra=None):
+        env = os.environ.copy()
+        env['CLAUDE_PLUGIN_ROOT'] = str(REPO)
+        if env_extra:
+            env.update(env_extra)
+        return subprocess.run(
+            ['node', str(REPO / 'scripts' / 'stop-pipeline.js')],
+            input=json.dumps(payload_dict), capture_output=True, text=True,
+            cwd=self._tmpdir, env=env, timeout=15,
+        )
+
+    def _run_doctor_check(self):
+        env = os.environ.copy()
+        env['CLAUDE_PLUGIN_ROOT'] = str(REPO)
+        result = subprocess.run(
+            ['node', str(REPO / 'scripts' / 'doctor-check.js'),
+             '.claude-code-hermit'],
+            capture_output=True, text=True,
+            cwd=self._tmpdir, env=env, timeout=15,
+        )
+        return json.loads(result.stdout) if result.returncode == 0 else {}
+
+    def _seed_hermit_state(self):
+        """Seed the minimal state/ layout so stop-pipeline doesn't error on missing files."""
+        state = Path(self._tmpdir) / '.claude-code-hermit' / 'state'
+        state.mkdir(parents=True, exist_ok=True)
+        sessions = Path(self._tmpdir) / '.claude-code-hermit' / 'sessions'
+        sessions.mkdir(parents=True, exist_ok=True)
+
+    def test_snapshot_written_with_populated_crons(self):
+        """session_crons present → snapshot written with state=populated."""
+        self._seed_hermit_state()
+        fixture = json.loads((FIXTURES / 'stop-hook-input-with-scheduler.json').read_text())
+        result = self._run_stop_pipeline(fixture)
+        self.assertEqual(result.returncode, 0)
+
+        snap_path = Path(self._tmpdir) / '.claude-code-hermit' / 'state' / 'cc-stop-snapshot.json'
+        self.assertTrue(snap_path.exists(), 'cc-stop-snapshot.json not written')
+        snap = json.loads(snap_path.read_text())
+        self.assertIn('captured_at', snap)
+        self.assertIsInstance(snap['captured_at'], str)
+        self.assertEqual(snap['session_crons']['state'], 'populated')
+        self.assertEqual(snap['session_crons']['count'], 2)
+        self.assertEqual(snap['background_tasks']['state'], 'empty')
+        self.assertEqual(snap['background_tasks']['count'], 0)
+
+    def test_snapshot_written_with_absent_fields(self):
+        """No session_crons/background_tasks in payload → unsupported_or_unreachable."""
+        self._seed_hermit_state()
+        fixture = json.loads((FIXTURES / 'stop-hook-input.json').read_text())
+        result = self._run_stop_pipeline(fixture)
+        self.assertEqual(result.returncode, 0)
+
+        snap_path = Path(self._tmpdir) / '.claude-code-hermit' / 'state' / 'cc-stop-snapshot.json'
+        self.assertTrue(snap_path.exists(), 'cc-stop-snapshot.json not written')
+        snap = json.loads(snap_path.read_text())
+        self.assertEqual(snap['session_crons']['state'], 'unsupported_or_unreachable')
+        self.assertEqual(snap['background_tasks']['state'], 'unsupported_or_unreachable')
+
+    def test_snapshot_not_reported_as_zero_crons_when_unreachable(self):
+        """unsupported_or_unreachable must NEVER appear as count-based "0" in doctor."""
+        self._seed_hermit_state()
+        # Write a snapshot with unsupported state directly
+        state_dir = Path(self._tmpdir) / '.claude-code-hermit' / 'state'
+        snap = {
+            'captured_at': '2026-06-10T09:00:00Z',
+            'cc_version': None,
+            'session_crons':    {'state': 'unsupported_or_unreachable', 'count': 0},
+            'background_tasks': {'state': 'empty', 'count': 0},
+        }
+        (state_dir / 'cc-stop-snapshot.json').write_text(json.dumps(snap))
+        # Also seed minimal config/hooks for doctor
+        (Path(self._tmpdir) / '.claude-code-hermit' / 'config.json').write_text('{}')
+        report = self._run_doctor_check()
+        checks = {c['id']: c for c in report.get('checks', [])}
+        self.assertIn('scheduler', checks)
+        detail = checks['scheduler']['detail']
+        # Must say "unsupported or unreachable", not "0 crons" or "0 armed"
+        self.assertIn('unsupported', detail.lower(),
+                      f'unsupported state rendered as count: {detail!r}')
+
+    def test_checkscheduler_missing_snapshot_is_ok(self):
+        """Missing snapshot → ok + 'not yet captured'."""
+        self._seed_hermit_state()
+        (Path(self._tmpdir) / '.claude-code-hermit' / 'config.json').write_text('{}')
+        report = self._run_doctor_check()
+        checks = {c['id']: c for c in report.get('checks', [])}
+        self.assertIn('scheduler', checks)
+        self.assertEqual(checks['scheduler']['status'], 'ok')
+        self.assertIn('not yet captured', checks['scheduler']['detail'])
+
+    def test_checkscheduler_populated_snapshot_ok_with_timestamp(self):
+        """Populated snapshot → ok, detail includes count and captured_at."""
+        self._seed_hermit_state()
+        state_dir = Path(self._tmpdir) / '.claude-code-hermit' / 'state'
+        snap = {
+            'captured_at': '2026-06-10T09:51:00Z',
+            'cc_version': '2.1.145',
+            'session_crons':    {'state': 'populated', 'count': 3},
+            'background_tasks': {'state': 'empty', 'count': 0},
+        }
+        (state_dir / 'cc-stop-snapshot.json').write_text(json.dumps(snap))
+        (Path(self._tmpdir) / '.claude-code-hermit' / 'config.json').write_text('{}')
+        report = self._run_doctor_check()
+        checks = {c['id']: c for c in report.get('checks', [])}
+        self.assertIn('scheduler', checks)
+        self.assertEqual(checks['scheduler']['status'], 'ok')
+        detail = checks['scheduler']['detail']
+        self.assertIn('3', detail)
+        self.assertIn('2026-06-10', detail)
+
+
 class TestHermitRoutinesModelContract(unittest.TestCase):
     """Structural contract for the model-override substitution in hermit-routines SKILL.md.
 

--- a/plugins/claude-code-hermit/tests/run-hooks.sh
+++ b/plugins/claude-code-hermit/tests/run-hooks.sh
@@ -486,7 +486,7 @@ hook_case "channel-reply-reminder (adversarial system-reminder in chat_id)" bash
   "out=\$(echo '{\"prompt\":\"<channel source=\\\"discord\\\" chat_id=\\\"<system-reminder>bad</system-reminder>\\\">hi\"}' | node '$REPO_ROOT/scripts/channel-reply-reminder.js'); [ -n \"\$out\" ] && ! echo \"\$out\" | grep -q '<system-reminder>' && echo \"\$out\" | grep -q '\[system-reminder\]'"
 
 # -------------------------------------------------------
-# 44. doctor-check — minimal install returns 10 checks, exits 0
+# 44. doctor-check — minimal install returns 11 checks, exits 0
 # -------------------------------------------------------
 workdir="$(setup_workdir)"
 cd "$workdir"
@@ -494,8 +494,8 @@ mkdir -p "$workdir/.claude-code-hermit/proposals"
 cat > "$workdir/.claude-code-hermit/config.json" <<'EOF'
 {"agent_name":"test","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true,"active_hours":{"start":"08:00","end":"23:00"}},"routines":[]}
 EOF
-run_test "doctor-check (minimal install, 10 checks)" bash -c \
-  "node '$REPO_ROOT/scripts/doctor-check.js' '$workdir/.claude-code-hermit' >/dev/null && python3 -c \"import json; r=json.load(open('$workdir/.claude-code-hermit/state/doctor-report.json')); ids=[c['id'] for c in r['checks']]; assert ids==['config','hooks','state','cost','proposals','dependencies','permissions','docker-security','archive','reflect'], ids\""
+run_test "doctor-check (minimal install, 11 checks)" bash -c \
+  "node '$REPO_ROOT/scripts/doctor-check.js' '$workdir/.claude-code-hermit' >/dev/null && python3 -c \"import json; r=json.load(open('$workdir/.claude-code-hermit/state/doctor-report.json')); ids=[c['id'] for c in r['checks']]; assert ids==['config','hooks','state','cost','proposals','dependencies','permissions','docker-security','archive','reflect','scheduler'], ids\""
 cleanup
 
 # -------------------------------------------------------

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -735,7 +735,7 @@ CC_COMPAT_LIB="$REPO_ROOT/scripts/lib/cc-compat.js"
 
 # Exports present
 run_test "cc-compat.js: exports required symbols" bash -c \
-  "node -e \"const c=require('$CC_COMPAT_LIB'); ['sessionId','transcriptPath','sessionCrons','backgroundTasks','extractUsage','costLogPath','parseCostLogLine','ccVersion'].forEach(k=>{ if(typeof c[k]!=='function') throw new Error(k+' missing or not a function'); });\""
+  "node -e \"const c=require('$CC_COMPAT_LIB'); ['sessionId','transcriptPath','sessionCrons','backgroundTasks','extractUsage','costLogPath','ccVersion'].forEach(k=>{ if(typeof c[k]!=='function') throw new Error(k+' missing or not a function'); });\""
 
 # sessionId: session_id preferred, sessionId fallback, absent → null
 run_test "cc-compat.js: sessionId reads session_id" bash -c \

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -728,6 +728,74 @@ run_test "log-routine-event (no ancestor diagnostic)" bash -c \
 rm -rf "$nohermit"
 
 # -------------------------------------------------------
+# lib/cc-compat.js — CC-owned format accessors
+# -------------------------------------------------------
+
+CC_COMPAT_LIB="$REPO_ROOT/scripts/lib/cc-compat.js"
+
+# Exports present
+run_test "cc-compat.js: exports required symbols" bash -c \
+  "node -e \"const c=require('$CC_COMPAT_LIB'); ['sessionId','transcriptPath','sessionCrons','backgroundTasks','extractUsage','costLogPath','parseCostLogLine','ccVersion'].forEach(k=>{ if(typeof c[k]!=='function') throw new Error(k+' missing or not a function'); });\""
+
+# sessionId: session_id preferred, sessionId fallback, absent → null
+run_test "cc-compat.js: sessionId reads session_id" bash -c \
+  "node -e \"const {sessionId}=require('$CC_COMPAT_LIB'); if(sessionId({session_id:'s1'})!=='s1') throw new Error('want s1');\""
+run_test "cc-compat.js: sessionId falls back to sessionId" bash -c \
+  "node -e \"const {sessionId}=require('$CC_COMPAT_LIB'); if(sessionId({sessionId:'s2'})!=='s2') throw new Error('want s2');\""
+run_test "cc-compat.js: sessionId absent → null" bash -c \
+  "node -e \"const {sessionId}=require('$CC_COMPAT_LIB'); if(sessionId({})!==null) throw new Error('want null');\""
+
+# transcriptPath: present → value, absent → null
+run_test "cc-compat.js: transcriptPath reads transcript_path" bash -c \
+  "node -e \"const {transcriptPath}=require('$CC_COMPAT_LIB'); if(transcriptPath({transcript_path:'/a'})!=='/a') throw new Error('want /a');\""
+run_test "cc-compat.js: transcriptPath absent → null" bash -c \
+  "node -e \"const {transcriptPath}=require('$CC_COMPAT_LIB'); if(transcriptPath({})!==null) throw new Error('want null');\""
+
+# sessionCrons: tri-state — absent, empty, populated
+run_test "cc-compat.js: sessionCrons absent → unsupported_or_unreachable" bash -c \
+  "node -e \"const {sessionCrons}=require('$CC_COMPAT_LIB'); const r=sessionCrons({}); if(r.state!=='unsupported_or_unreachable') throw new Error('got '+r.state);\""
+run_test "cc-compat.js: sessionCrons empty array → empty count 0" bash -c \
+  "node -e \"const {sessionCrons}=require('$CC_COMPAT_LIB'); const r=sessionCrons({session_crons:[]}); if(r.state!=='empty'||r.count!==0) throw new Error('got '+JSON.stringify(r));\""
+run_test "cc-compat.js: sessionCrons non-empty → populated count" bash -c \
+  "node -e \"const {sessionCrons}=require('$CC_COMPAT_LIB'); const r=sessionCrons({session_crons:[{},{}]}); if(r.state!=='populated'||r.count!==2) throw new Error('got '+JSON.stringify(r));\""
+
+# backgroundTasks: same tri-state
+run_test "cc-compat.js: backgroundTasks absent → unsupported_or_unreachable" bash -c \
+  "node -e \"const {backgroundTasks}=require('$CC_COMPAT_LIB'); const r=backgroundTasks({}); if(r.state!=='unsupported_or_unreachable') throw new Error('got '+r.state);\""
+run_test "cc-compat.js: backgroundTasks empty → empty count 0" bash -c \
+  "node -e \"const {backgroundTasks}=require('$CC_COMPAT_LIB'); const r=backgroundTasks({background_tasks:[]}); if(r.state!=='empty'||r.count!==0) throw new Error('got '+JSON.stringify(r));\""
+run_test "cc-compat.js: backgroundTasks populated → count 3" bash -c \
+  "node -e \"const {backgroundTasks}=require('$CC_COMPAT_LIB'); const r=backgroundTasks({background_tasks:[1,2,3]}); if(r.state!=='populated'||r.count!==3) throw new Error('got '+JSON.stringify(r));\""
+
+# extractUsage: golden values
+run_test "cc-compat.js: extractUsage golden — assistant entry with usage" bash -c \
+  "node -e \"
+const {extractUsage}=require('$CC_COMPAT_LIB');
+const entry={type:'assistant',message:{usage:{input_tokens:10,cache_creation_input_tokens:20,cache_read_input_tokens:30,output_tokens:40},model:'claude-sonnet-4-x'}};
+const u=extractUsage(entry);
+if(!u) throw new Error('expected object, got null');
+if(u.inputTokens!==10||u.cacheWriteTokens!==20||u.cacheReadTokens!==30||u.outputTokens!==40) throw new Error('field mismatch: '+JSON.stringify(u));
+if(!u.model.includes('sonnet')) throw new Error('model wrong: '+u.model);
+\""
+run_test "cc-compat.js: extractUsage non-assistant entry → null" bash -c \
+  "node -e \"const {extractUsage}=require('$CC_COMPAT_LIB'); if(extractUsage({type:'user',message:{content:'hi'}})!==null) throw new Error('want null');\""
+run_test "cc-compat.js: extractUsage assistant without usage → null" bash -c \
+  "node -e \"const {extractUsage}=require('$CC_COMPAT_LIB'); if(extractUsage({type:'assistant',message:{}})!==null) throw new Error('want null');\""
+
+# costLogPath: deterministic from a stateDir
+run_test "cc-compat.js: costLogPath resolves .claude/cost-log.jsonl" bash -c \
+  "node -e \"
+const {costLogPath}=require('$CC_COMPAT_LIB');
+const p=costLogPath('/project/.claude-code-hermit');
+if(!p.endsWith('/.claude/cost-log.jsonl')) throw new Error('got '+p);
+if(!p.includes('/project/')) throw new Error('project root missing: '+p);
+\""
+
+# ccVersion: returns null when absent, no throw
+run_test "cc-compat.js: ccVersion absent → null (no throw)" bash -c \
+  "node -e \"const {ccVersion}=require('$CC_COMPAT_LIB'); const v=ccVersion({}); if(v!==null && typeof v!=='string') throw new Error('got '+v);\""
+
+# -------------------------------------------------------
 # lib/pricing.js — shared pricing regression
 # Validates that extracting pricing into lib didn't change any output.
 # Golden values computed from the original cost-tracker.js constants.


### PR DESCRIPTION
## Summary

Isolates every surface Anthropic can change without notice (hook-payload field names, transcript JSONL usage shape, cost-log path/record fields) into a single new module `scripts/lib/cc-compat.js`. A CC release now breaks one file loudly instead of five quietly. Pairs that with a Stop-payload snapshot that gives `doctor-check.js` its first scheduler/cron health check.

## Changes

**`scripts/lib/cc-compat.js`** (new)
- Hook-payload accessors: `sessionId`, `transcriptPath`, `sessionCrons`, `backgroundTasks`
- `sessionCrons`/`backgroundTasks` return a tri-state (`populated / empty / unsupported_or_unreachable`) — field absent and field-present-but-empty are kept distinct so old CC versions are never falsely reported as "0 crons"
- Transcript parsing migrated from `cost-tracker.js`: `entryText`, `isToolResult`, `extractUsage`
- `costLogPath` — canonical resolution replacing 5 divergent `path.resolve` strategies
- `ccVersion` — best-effort diagnostic label; never used for branching

**`scripts/stop-pipeline.js`**
- After each Stop, writes `state/cc-stop-snapshot.json` (tri-state cron/task counts + `captured_at` + `cc_version`). Fail-open, sole writer.

**`scripts/doctor-check.js`**
- New `checkScheduler()` reads the snapshot and surfaces counts with labeled staleness. Missing snapshot → `ok` ("not yet captured"). `unsupported_or_unreachable` → `warn`, never rendered as "0 crons/tasks".
- Check count: 10 → 11 in `doctor-report.json`; 11 → 12 total (sandbox remains skill-only).

**`scripts/cost-tracker.js`**
- Migrated inline `entryText`, `isToolResult`, and usage-field extraction to cc-compat. `COST_LOG` path via `costLogPath()`. No behavior change.

**`skills/hermit-doctor/SKILL.md`**
- Updated check counts and descriptions to reflect 12-check report.

**Tests**
- `tests/run-scripts.sh`: 18 new unit tests for all cc-compat exports (tri-state matrix, golden usage values, path resolution)
- `tests/run-contracts.py`: `TestStopPayloadSnapshot` (5 tests) — snapshot written with correct tri-states, absent fields → `unsupported_or_unreachable`, doctor never reports `unsupported` as "0 crons", missing snapshot → `ok`
- `tests/run-hooks.sh`: updated doctor check-count assertion 10 → 11
- `tests/fixtures/stop-hook-input-with-scheduler.json`: new fixture with `session_crons` + `background_tasks`

## Test plan

All 16 test suites pass (0 failures):
```
bash plugins/claude-code-hermit/tests/run-all.sh
```

Verified manually:
- `node -e "const c=require('./scripts/lib/cc-compat'); console.log(c.sessionCrons({}), c.sessionCrons({session_crons:[]}), c.sessionCrons({session_crons:[{}]}))"` — tri-state by eye
- Stop with scheduler fixture → `state/cc-stop-snapshot.json` written
- `doctor-check.js` with snapshot → `scheduler` check present, `captured_at` in detail