### PR TITLE
fix(claude-code-hermit): watchdog install/uninstall no longer crash on systemd-less Linux

### DIFF
--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -117,7 +117,7 @@ Out-of-session supervisor that detects dead or wedged sessions and restarts them
 
 Every nudge, restart, and re-arm is appended to `state/watchdog-events.jsonl`. Restarts also set `runtime.json.watchdog_restart_reason`; `session-start` announces the restart to the operator channel.
 
-**Install:** `bin/hermit-watchdog install` — systemd user timer on Linux/WSL2, LaunchAgent on macOS, cron line printed as fallback.
+**Install:** `bin/hermit-watchdog install` — systemd user timer on Linux/WSL2, LaunchAgent on macOS, cron line printed as fallback. Docker hermits don't need `install` — the entrypoint already runs the watchdog on its own ~5 min cycle.
 
 ---
 

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.py
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.py
@@ -407,9 +407,17 @@ def _find_templates_dir():
     return None
 
 
+def _print_cron_fallback(root):
+    cron_line = (f'*/5 * * * * cd {root} && .claude-code-hermit/bin/hermit-watchdog run '
+                 f'2>>.claude-code-hermit/state/watchdog.log')
+    print('[watchdog] Add the following line via `crontab -e`:')
+    print(f'  {cron_line}')
+
+
 def cmd_install():
     """Platform-dispatching install: systemd (Linux/WSL), launchd (macOS), cron fallback."""
     import platform
+    import shutil
     import subprocess as sp
 
     root = str(Path.cwd().resolve())
@@ -422,6 +430,13 @@ def cmd_install():
     system = platform.system()
 
     if system == 'Linux':
+        if not shutil.which('systemctl'):
+            print('[watchdog] systemctl not found — systemd is unavailable on this host.')
+            print('[watchdog] In the hermit Docker container the entrypoint already runs the '
+                  'watchdog on a ~5 min cycle; no install is needed there.')
+            _print_cron_fallback(root)
+            return
+
         systemd_dir = Path.home() / '.config' / 'systemd' / 'user'
         systemd_dir.mkdir(parents=True, exist_ok=True)
         service_name = f'hermit-watchdog@{name}'
@@ -470,21 +485,25 @@ def cmd_install():
         print(f'[watchdog] Installed LaunchAgent: {plist_name}')
 
     else:
-        cron_line = f'*/5 * * * * cd {root} && .claude-code-hermit/bin/hermit-watchdog run 2>>.claude-code-hermit/state/watchdog.log'
         print('[watchdog] systemd and launchd not available on this platform.')
-        print('[watchdog] Add the following line via `crontab -e`:')
-        print(f'  {cron_line}')
+        _print_cron_fallback(root)
 
 
 def cmd_uninstall():
     """Remove the installed OS timer for this project."""
     import platform
+    import shutil
     import subprocess as sp
 
     name = _get_session_name()
     system = platform.system()
 
     if system == 'Linux':
+        if not shutil.which('systemctl'):
+            print('[watchdog] systemctl not found — no systemd timer to remove.')
+            print('[watchdog] In Docker the watchdog runs via the entrypoint loop, not an OS timer.')
+            return
+
         service_name = f'hermit-watchdog@{name}'
         sp.run(['systemctl', '--user', 'disable', '--now', f'{service_name}.timer'], check=False)
         systemd_dir = Path.home() / '.config' / 'systemd' / 'user'

--- a/plugins/claude-code-hermit/tests/test-watchdog.sh
+++ b/plugins/claude-code-hermit/tests/test-watchdog.sh
@@ -415,4 +415,37 @@ assert w[0]['status']=='warn', 'status: '+w[0]['status']
 \""
 cleanup
 
+# -------------------------------------------------------
+# install / uninstall without systemctl (Linux-only path)
+# -------------------------------------------------------
+if [ "$(uname -s)" = "Linux" ]; then
+
+workdir="$(setup_hermit)"
+write_config "$workdir"
+# fake-bin has tmux/pgrep stubs but no systemctl — simulates systemd-less host
+write_fake_tmux "$workdir/fake-bin" 0
+write_fake_pgrep "$workdir/fake-bin" 1
+run_test "install without systemctl → exit 0, prints crontab, no traceback" bash -c "
+  cd '$workdir'
+  out=\$(PATH='$workdir/fake-bin' '$(command -v python3)' '$WATCHDOG' install 2>&1)
+  echo \"\$out\"
+  echo \"\$out\" | grep -q 'crontab' || { echo 'FAIL: expected crontab guidance'; exit 1; }
+  echo \"\$out\" | grep -q 'Traceback' && { echo 'FAIL: got traceback'; exit 1; }
+  true"
+cleanup
+
+workdir="$(setup_hermit)"
+write_config "$workdir"
+write_fake_tmux "$workdir/fake-bin" 0
+write_fake_pgrep "$workdir/fake-bin" 1
+run_test "uninstall without systemctl → exit 0, no traceback" bash -c "
+  cd '$workdir'
+  out=\$(PATH='$workdir/fake-bin' '$(command -v python3)' '$WATCHDOG' uninstall 2>&1)
+  echo \"\$out\"
+  echo \"\$out\" | grep -q 'Traceback' && { echo 'FAIL: got traceback'; exit 1; }
+  true"
+cleanup
+
+fi  # Linux-only
+
 print_results


### PR DESCRIPTION
## Summary
`hermit-watchdog install` and `uninstall` dispatched on `platform.system() == 'Linux'` but assumed systemd was always present, calling `systemctl` via `sp.run(..., check=False)`. `check=False` swallows non-zero exit codes but not `FileNotFoundError` when the binary is missing entirely — so on systemd-less Linux (Docker containers) both commands crashed with an uncaught traceback and gave no actionable guidance.

## Changes
- `scripts/hermit-watchdog.py`: guard both `cmd_install` and `cmd_uninstall` Linux branches with `shutil.which('systemctl')` (the established in-repo idiom from `hermit-start.py`). When systemd is absent: print a clear message noting the Docker entrypoint already runs the watchdog on its own ~5 min cycle, print the crontab fallback line for non-Docker hosts, return cleanly.
- Extracted `_print_cron_fallback(root)` helper so the cron line isn't duplicated between the new no-systemd path and the existing non-Linux `else` branch.
- `tests/test-watchdog.sh`: 2 new Linux-guarded cases — first-ever coverage of `cmd_install`/`cmd_uninstall`. 21/21 tests passing.
- `docs/config-reference.md`: one-line note that Docker hermits don't need `install`.

## Test plan
- `cd plugins/claude-code-hermit && bash tests/test-watchdog.sh` — 21 passed, 0 failed.
- Manual repro: `PATH=/nonexistent python3 scripts/hermit-watchdog.py install` → exit 0, prints crontab guidance, no traceback.
- `bash tests/run-all.sh` — full suite green.

Closes #332