### PR TITLE
feat(claude-code-hermit): auto-enable watchdog for Docker hermits

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
+
+1. **Auto-enable the watchdog on Docker hermits.** If `docker-entrypoint.hermit.sh` exists in the project root (the artifact `/docker-setup` leaves behind), the watchdog scheduler is already wired into the entrypoint loop, so enable it:
+
+   ```
+   if [ -f docker-entrypoint.hermit.sh ]; then
+     jq '.watchdog.enabled = true' .claude-code-hermit/config.json > .claude-code-hermit/config.json.tmp \
+       && mv .claude-code-hermit/config.json.tmp .claude-code-hermit/config.json
+   fi
+   ```
+
+   Non-Docker hermits: `watchdog.enabled` stays `false`; opt in via `config.watchdog.enabled: true` + `bin/hermit-watchdog install`. To opt a Docker hermit back out, set `watchdog.enabled: false` via `/hermit-settings`.
+
 ## [1.1.11] - 2026-06-10
 
 ### Added

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -99,7 +99,7 @@ Modify with `/hermit-settings heartbeat`.
 
 ## `watchdog`
 
-Out-of-session supervisor that detects dead or wedged sessions and restarts them. Default disabled — opt in by setting `enabled: true`, then run `bin/hermit-watchdog install` to register the OS timer.
+Out-of-session supervisor that detects dead or wedged sessions and restarts them. Default disabled — opt in by setting `enabled: true`, then run `bin/hermit-watchdog install` to register the OS timer. **Docker hermits:** `/docker-setup` sets `enabled: true` automatically at the end of setup; the entrypoint loop already runs the watchdog, so no `install` step is needed.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -118,6 +118,8 @@ Out-of-session supervisor that detects dead or wedged sessions and restarts them
 Every nudge, restart, and re-arm is appended to `state/watchdog-events.jsonl`. Restarts also set `runtime.json.watchdog_restart_reason`; `session-start` announces the restart to the operator channel.
 
 **Install:** `bin/hermit-watchdog install` — systemd user timer on Linux/WSL2, LaunchAgent on macOS, cron line printed as fallback.
+
+Modify with `/hermit-settings watchdog`.
 
 ---
 

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -536,6 +536,15 @@ Why not `hermit-docker restart`: Docker's default stop_grace_period is 10s, whic
 
 ### 9. Verify
 
+**Enable the Docker watchdog.** Docker hermits run the watchdog from the entrypoint loop, so turn it on now:
+
+```
+jq '.watchdog.enabled = true' .claude-code-hermit/config.json > .claude-code-hermit/config.json.tmp \
+  && mv .claude-code-hermit/config.json.tmp .claude-code-hermit/config.json
+```
+
+This only flips `.watchdog.enabled` — the other watchdog tuning keys (`stale_factor`, `escalate_after`, `operator_grace`) are preserved.
+
 Run `.claude-code-hermit/bin/hermit-status` and show output. `no session` is the expected output on a fresh setup — it means the container is up and will start its first session on the next cron routine or channel message. Do **not** add `sleep` before `hermit-status`; if you need to wait for a session to appear, use `Monitor` with an `until`-loop (not chained sleeps).
 
 If healthy:

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -205,9 +205,9 @@ Update `permission_mode` in config.json.
   Watchdog (config.json watchdog)
 
     enabled         false
-    stale_factor    2       (wedge detection: tolerated missed-cycle multiplier)
-    escalate_after  3       (consecutive stale cycles before operator alert)
-    operator_grace  15m     (silence window before escalation fires)
+    stale_factor    2
+    escalate_after  3
+    operator_grace  15m
   ```
 - Ask: "Enable watchdog? (yes / no) [current: <value>]"
 - If yes: show the configurable sub-fields before asking each one:
@@ -219,7 +219,7 @@ Update `permission_mode` in config.json.
   ```
   Then ask each field in sequence.
 - Update `watchdog` object in config.json.
-- Note: "Changes take effect on the next watchdog run. To register or remove the OS timer: `bin/hermit-watchdog install` / `bin/hermit-watchdog uninstall`. Docker hermits run the watchdog from the entrypoint loop — no install step needed."
+  - Note: "Changes take effect on the next watchdog run. To register or remove the OS timer: `bin/hermit-watchdog install` / `bin/hermit-watchdog uninstall`. Docker hermits run the watchdog from the entrypoint loop — no install step needed."
 
 **If argument is "routines":**
 - Show current routines from `config.routines` array:

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -22,6 +22,7 @@ View or modify the hermit configuration for this project.
 /claude-code-hermit:hermit-settings brief          — configure morning brief
 /claude-code-hermit:hermit-settings permissions    — configure unattended mode
 /claude-code-hermit:hermit-settings heartbeat      — enable/disable, interval, quiet mode, active hours
+/claude-code-hermit:hermit-settings watchdog       — enable/disable, stale_factor, escalate_after, operator_grace
 /claude-code-hermit:hermit-settings routines        — manage scheduled routines (add/edit/remove/enable/disable)
 /claude-code-hermit:hermit-settings idle             — set idle behavior (wait or discover)
 /claude-code-hermit:hermit-settings env              — view/edit environment variables
@@ -61,6 +62,7 @@ Operational:
   Morning brief:   disabled       → run: /claude-code-hermit:hermit-settings brief
   Idle behavior:   discover       → discover | wait
   Heartbeat:       disabled       → yes | no  (interval, active hours, stale threshold)
+  Watchdog:        disabled       → yes | no  (stale_factor, escalate_after, operator_grace)
   Routines:        2 configured   → run: /claude-code-hermit:hermit-settings routines
   Quality gate:    budget         → budget | balanced | quality
   Permission mode: auto           → default | acceptEdits | auto | plan | dontAsk | bypassPermissions
@@ -196,6 +198,28 @@ Update `permission_mode` in config.json.
   Then ask each field in sequence.
 - Update `heartbeat` object in config.json.
   - Note: "Heartbeat changes take effect on next `/claude-code-hermit:heartbeat start` or `hermit-start.py` run."
+
+**If argument is "watchdog":**
+- Show current watchdog config from `config.json`:
+  ```
+  Watchdog (config.json watchdog)
+
+    enabled         false
+    stale_factor    2       (wedge detection: tolerated missed-cycle multiplier)
+    escalate_after  3       (consecutive stale cycles before operator alert)
+    operator_grace  15m     (silence window before escalation fires)
+  ```
+- Ask: "Enable watchdog? (yes / no) [current: <value>]"
+- If yes: show the configurable sub-fields before asking each one:
+  ```
+  Watchdog sub-fields (press Enter to keep current value):
+    stale_factor    — missed-cycle tolerance multiplier (e.g. 2)          [current]
+    escalate_after  — consecutive stale cycles before escalation (e.g. 3) [current]
+    operator_grace  — silence window before alert fires (e.g. 15m, 1h)    [current]
+  ```
+  Then ask each field in sequence.
+- Update `watchdog` object in config.json.
+- Note: "Changes take effect on the next watchdog run. To register or remove the OS timer: `bin/hermit-watchdog install` / `bin/hermit-watchdog uninstall`. Docker hermits run the watchdog from the entrypoint loop — no install step needed."
 
 **If argument is "routines":**
 - Show current routines from `config.routines` array:


### PR DESCRIPTION
## Summary

Docker hermits already have the watchdog wired into the entrypoint loop (`_wd_cycle` counter + `hermit-watchdog run`, added in v1.1.11). Enabling `watchdog.enabled` is immediately load-bearing there — no separate `bin/hermit-watchdog install` step required. This wires up the flip at the two right moments so Docker operators don't have to do it manually.

## Changes

- **`skills/docker-setup/SKILL.md`**: adds a watchdog-enable step at the start of Step 9 (Verify), the convergence point for both the "build now" and "No — manual" paths. Uses `jq` to set `.watchdog.enabled = true` while preserving the other tuning keys (`stale_factor`, `escalate_after`, `operator_grace`).
- **`CHANGELOG.md`**: adds `[Unreleased]` section with `### Upgrade Instructions` for existing Docker hermits. `hermit-evolve` detects `docker-entrypoint.hermit.sh` in the project root (the artifact `/docker-setup` leaves behind) and runs the same jq flip. Non-Docker hermits skip the step and keep `false`.

## Test plan

- `bash tests/run-all.sh` from `plugins/claude-code-hermit/` — all 19 suites pass (0 failures). No test asserts on docker-setup Step 9 content or the real CHANGELOG, so no test changes needed.
- jq idiom verified: `jq '.watchdog.enabled = true'` on a full watchdog config block flips only `enabled`, leaving `stale_factor`/`escalate_after`/`operator_grace`/other keys intact.