### PR TITLE
fix(heartbeat): suppress first-iteration EVALUATE to avoid cold-start double-fire

### DIFF
--- a/plugins/claude-code-hermit/scripts/heartbeat-monitor.sh
+++ b/plugins/claude-code-hermit/scripts/heartbeat-monitor.sh
@@ -6,18 +6,26 @@
 # LLM needs to wake up (EVALUATE or AUTO_CLOSE verdict). --peek means the
 # polling itself is read-only; the mutating tick happens once when
 # /heartbeat run re-runs precheck inside the EVALUATE handler.
+# First-iteration EVALUATE is suppressed: at cold boot the monitor fires
+# within seconds of session-start (alerts{} empty, checklist unseen), which
+# would trigger a redundant /heartbeat run. AUTO_CLOSE is never suppressed —
+# a queued drain must fire immediately regardless of boot state.
 set -u
 INTERVAL="${1:?usage: heartbeat-monitor.sh <interval_seconds> <hermit_state_dir>}"
 HB_DIR="${2:?usage: heartbeat-monitor.sh <interval_seconds> <hermit_state_dir>}"
 PRECHECK="${HEARTBEAT_PRECHECK:-$(dirname "$0")/heartbeat-precheck.js}"
+first=1
 while true; do
   verdict="$(node "$PRECHECK" --peek "$HB_DIR" 2>/dev/null || echo "ERROR")"
   case "$verdict" in
-    EVALUATE*|AUTO_CLOSE*) echo "HEARTBEAT_EVALUATE" ;;
-    OK|SKIP\|*)            : ;;  # silent — designed no-op
-    ERROR*)                echo "HEARTBEAT_ERROR: precheck failed" ;;
-    *)                     echo "HEARTBEAT_ERROR: unknown verdict: $verdict" ;;
+    EVALUATE*)
+      [[ -n "$first" ]] || echo "HEARTBEAT_EVALUATE" ;;
+    AUTO_CLOSE*)          echo "HEARTBEAT_EVALUATE" ;;
+    OK|SKIP\|*)           : ;;  # silent — designed no-op
+    ERROR*)               echo "HEARTBEAT_ERROR: precheck failed" ;;
+    *)                    echo "HEARTBEAT_ERROR: unknown verdict: $verdict" ;;
   esac
+  first=""
   [[ -n "${HEARTBEAT_MONITOR_ONCE:-}" ]] && break
   sleep "$INTERVAL"
 done

--- a/plugins/claude-code-hermit/tests/run-scripts.sh
+++ b/plugins/claude-code-hermit/tests/run-scripts.sh
@@ -482,18 +482,18 @@ cleanup
 
 MONITOR_SH="$REPO_ROOT/scripts/heartbeat-monitor.sh"
 
-# 20b. EVALUATE → HEARTBEAT_EVALUATE
+# 20b. EVALUATE on iter-1 → silent (cold-start suppression)
 stub="$(mktemp /tmp/hb-stub-XXXXX.js)"
 printf 'process.stdout.write("EVALUATE\\n");\n' > "$stub"
 out="$(HEARTBEAT_MONITOR_ONCE=1 HEARTBEAT_PRECHECK="$stub" bash "$MONITOR_SH" 60 /tmp 2>/dev/null)"
-run_test "heartbeat-monitor (EVALUATE → HEARTBEAT_EVALUATE)" bash -c "[ '$out' = 'HEARTBEAT_EVALUATE' ]"
+run_test "heartbeat-monitor (iter-1 EVALUATE → silent, cold-start suppressed)" bash -c "[ -z '$out' ]"
 rm -f "$stub"
 
-# 20c. EVALUATE with suffix (prefix match) → HEARTBEAT_EVALUATE
+# 20c. EVALUATE with suffix on iter-1 → silent (prefix match still suppressed)
 stub="$(mktemp /tmp/hb-stub-XXXXX.js)"
 printf 'process.stdout.write("EVALUATE|micro-pending\\n");\n' > "$stub"
 out="$(HEARTBEAT_MONITOR_ONCE=1 HEARTBEAT_PRECHECK="$stub" bash "$MONITOR_SH" 60 /tmp 2>/dev/null)"
-run_test "heartbeat-monitor (EVALUATE|micro-pending → HEARTBEAT_EVALUATE)" bash -c "[ '$out' = 'HEARTBEAT_EVALUATE' ]"
+run_test "heartbeat-monitor (iter-1 EVALUATE|micro-pending → silent)" bash -c "[ -z '$out' ]"
 rm -f "$stub"
 
 # 20d. AUTO_CLOSE → HEARTBEAT_EVALUATE
@@ -532,6 +532,16 @@ out="$(HEARTBEAT_MONITOR_ONCE=1 HEARTBEAT_PRECHECK="$stub" bash "$MONITOR_SH" 60
 run_test "heartbeat-monitor (unknown verdict → HEARTBEAT_ERROR: unknown verdict)" bash -c \
   "echo '$out' | grep -q 'HEARTBEAT_ERROR: unknown verdict'"
 rm -f "$stub"
+
+# 20i. EVALUATE on iter-2 → HEARTBEAT_EVALUATE (suppression is first-iteration-only)
+# Runs without HEARTBEAT_MONITOR_ONCE so the loop can reach iter-2.
+stub="$(mktemp /tmp/hb-stub-XXXXX.js)"
+printf 'process.stdout.write("EVALUATE\\n");\n' > "$stub"
+tmp_out="$(mktemp /tmp/hb-out-XXXXX.txt)"
+HEARTBEAT_PRECHECK="$stub" timeout 3 bash "$MONITOR_SH" 1 /tmp >"$tmp_out" 2>/dev/null || true
+run_test "heartbeat-monitor (iter-2 EVALUATE → HEARTBEAT_EVALUATE, suppression not permanent)" bash -c \
+  "grep -q 'HEARTBEAT_EVALUATE' '$tmp_out'"
+rm -f "$stub" "$tmp_out"
 
 # -------------------------------------------------------
 # reflect-precheck.js


### PR DESCRIPTION
## Summary

On cold boot (and on every daily `heartbeat-restart` re-arm), the monitor's first `--peek` fires within seconds of `session-start` while `alerts{}` is still empty. Every checklist item returns `EVALUATE`, which triggers a redundant full `/heartbeat run` (~5–6k tokens) on top of the session that just ran. This adds a `first` flag to `heartbeat-monitor.sh` that silently swallows the first-iteration `EVALUATE*`; `AUTO_CLOSE` is never suppressed (queued drains must fire immediately).

Closes #333

## Changes

- `scripts/heartbeat-monitor.sh`: split `EVALUATE*|AUTO_CLOSE*` case arm; gate `EVALUATE*` on a `first` flag that clears after the first iteration; header comment explains the suppression and the AUTO_CLOSE exception.
- `tests/run-scripts.sh`: rewrote cases 20b/20c to assert iteration-1 EVALUATE is silent; added case 20i (bounded `timeout 3` run without `HEARTBEAT_MONITOR_ONCE`) proving suppression is first-iteration-only.

## Test plan

```bash
cd plugins/claude-code-hermit && bash tests/run-all.sh
```

All monitor cases pass (20b/20c now assert silent; 20d AUTO_CLOSE still notifies; new 20i asserts iter-2 emits `HEARTBEAT_EVALUATE`). Full suite clean.