### PR TITLE
fix(claude-code-hermit): source Started and Status from runtime.json in hermit-stop and hermit-status

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,11 +2,26 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **hermit-stop: `Started` and `Status` read from wrong source** — `read_active_session()` now reads `session_state` and `created_at` from `runtime.json` (the documented single source of truth). The `**Status:**` field was removed from SHELL.md and always fell back to `unknown`; `**Started:**` could show the raw template placeholder `YYYY-MM-DD HH:MM` if session-mgr missed the substitution. SHELL.md `**Started:**` is still preferred when it contains a real date.
+- **hermit-status: `Status` fallback read from runtime.json** — the no-cost-data fallback branch now reads `session_state` from `state/runtime.json` instead of grepping `**Status:**` from SHELL.md (which no longer exists in that file).
+- **session-mgr/session-start: `Started` placeholder now explicitly named** — `session-mgr.md` step 5 and `session-start` fast-path step now name the literal placeholder `YYYY-MM-DD HH:MM` so substitution is unambiguous, matching the precision already applied to the `**ID:**` field.
+
 ### Upgrade Instructions
 
 Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
 
-1. **Auto-enable the watchdog on Docker hermits.** If `docker-entrypoint.hermit.sh` exists in the project root (the artifact `/docker-setup` leaves behind), the watchdog scheduler is already wired into the entrypoint loop, so enable it:
+1. **Refresh `bin/hermit-status` from the updated template.** The fallback branch that printed `Status: unknown` has been fixed to read from `state/runtime.json`. Overwrite the script if it has not been locally modified:
+
+   ```
+   if [ -f .claude-code-hermit/bin/hermit-status ]; then
+     cp "$(claude plugin path claude-code-hermit)"/state-templates/bin/hermit-status \
+       .claude-code-hermit/bin/hermit-status
+   fi
+   ```
+
+2. **Auto-enable the watchdog on Docker hermits.** If `docker-entrypoint.hermit.sh` exists in the project root (the artifact `/docker-setup` leaves behind), the watchdog scheduler is already wired into the entrypoint loop, so enable it:
 
    ```
    if [ -f docker-entrypoint.hermit.sh ]; then

--- a/plugins/claude-code-hermit/agents/session-mgr.md
+++ b/plugins/claude-code-hermit/agents/session-mgr.md
@@ -54,7 +54,7 @@ This file is the **single source of truth** for lifecycle decisions. All scripts
    - After recovery, clear transition fields in runtime.json
 4. If SHELL.md exists: read it and present the current task status to the main session
 5. If SHELL.md does not exist: create a new one from `.claude-code-hermit/templates/SHELL.md.template`
-   - Fill in the current date/time for "Started"
+   - Replace the placeholder `YYYY-MM-DD HH:MM` on the `**Started:**` line with the current date/time (e.g., `2026-06-10 21:59`).
    - Leave Task blank — the main session will provide it
 6. **Pre-compute session ID:** List all `.claude-code-hermit/sessions/S-*-REPORT.md` files, extract the highest NNN, increment by 1. If none exist, use `S-001`. Write this to runtime.json `session_id` field. Update SHELL.md `**ID:**` field with this session ID (replace the placeholder `S-NNN (assigned on close)` with the actual value, e.g., `S-009`).
 7. Update runtime.json: set `session_state` to `in_progress`. If `session_id` is null or missing, pre-compute it now (same sequential S-NNN logic as step 6) and write it in the same update.

--- a/plugins/claude-code-hermit/scripts/hermit-stop.py
+++ b/plugins/claude-code-hermit/scripts/hermit-stop.py
@@ -59,19 +59,28 @@ def find_latest_report():
 
 
 def read_active_session():
-    """Read SHELL.md for session stats."""
-    if not SHELL_PATH.exists():
-        return None
-    content = SHELL_PATH.read_text()
+    """Read session stats from runtime.json (status, started) and SHELL.md (tasks)."""
     stats = {}
-    for line in content.split('\n'):
-        if '**Status:**' in line:
-            stats['status'] = line.split('**Status:**')[1].strip()
-        elif '**Tasks Completed:**' in line:
-            stats['tasks_completed'] = line.split('**Tasks Completed:**')[1].strip()
-        elif '**Started:**' in line:
-            stats['started'] = line.split('**Started:**')[1].strip()
-    return stats
+
+    # Status and started come from runtime.json — the documented single source of truth.
+    # SHELL.md has no **Status:** field (removed; see session-mgr.md).
+    runtime = read_runtime_json()
+    if runtime:
+        stats['status'] = runtime.get('session_state', 'unknown')
+        stats['started'] = runtime.get('created_at', 'unknown')
+
+    # Prefer SHELL.md's **Started:** over runtime.json's only when it has been substituted
+    # (i.e. does not still contain the template placeholder YYYY-MM-DD HH:MM).
+    if SHELL_PATH.exists():
+        for line in SHELL_PATH.read_text().split('\n'):
+            if '**Tasks Completed:**' in line:
+                stats['tasks_completed'] = line.split('**Tasks Completed:**')[1].strip()
+            elif '**Started:**' in line:
+                value = line.split('**Started:**')[1].strip()
+                if 'YYYY' not in value:
+                    stats['started'] = value
+
+    return stats if stats else None
 
 
 def save_config(config):

--- a/plugins/claude-code-hermit/skills/session-start/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-start/SKILL.md
@@ -42,7 +42,7 @@ All state lives under `.claude-code-hermit/` in the project root.
    - `last_error` is null
    - `.claude-code-hermit/sessions/SHELL.md` exists
 
-   If all five are true: SHELL.md content is already available from the startup hook injection. Proceed directly to step 4b with the data already in hand. Do **not** spawn session-mgr. Read `session_id` from runtime.json — if set and SHELL.md `**ID:**` still contains the placeholder `S-NNN`, update it to the actual session ID (e.g., `S-009`) in-context without spawning session-mgr.
+   If all five are true: SHELL.md content is already available from the startup hook injection. Proceed directly to step 4b with the data already in hand. Do **not** spawn session-mgr. Read `session_id` from runtime.json — if set and SHELL.md `**ID:**` still contains the placeholder `S-NNN`, update it to the actual session ID (e.g., `S-009`) in-context without spawning session-mgr. Similarly, if `**Started:**` still contains the placeholder `YYYY-MM-DD HH:MM`, replace it with `created_at` from runtime.json (or the current date/time if `created_at` is absent), in-context without spawning session-mgr.
 
    **Slow path (spawn session-mgr) — any condition above fails:**
    - `runtime.json` is missing or malformed → first run or corrupted state

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-status
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-status
@@ -8,8 +8,6 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 AGENT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 STATUS_FILE="$AGENT_DIR/sessions/.status.json"
 CONFIG_FILE="$AGENT_DIR/config.json"
-SHELL_FILE="$AGENT_DIR/sessions/SHELL.md"
-
 PROJECT_DIR="$(cd "$AGENT_DIR/../.." && pwd)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 
@@ -55,10 +53,17 @@ if command -v docker &>/dev/null && [ -f "$COMPOSE" ] && docker info &>/dev/null
   fi
 fi
 
-# If no status data, try basic info from SHELL.md
+# If no status data, source session_state from runtime.json (SHELL.md has no **Status:** field)
 if [ -z "$STATUS" ]; then
-  if [ -f "$SHELL_FILE" ]; then
-    STATUS=$(grep -oP '\*\*Status:\*\*\s*\K\S+' "$SHELL_FILE" 2>/dev/null || echo "unknown")
+  RUNTIME_FILE="$AGENT_DIR/state/runtime.json"
+  if [ -f "$RUNTIME_FILE" ]; then
+    STATUS=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get('session_state', 'unknown'))
+except Exception: print('unknown')
+" "$RUNTIME_FILE" 2>/dev/null || echo "unknown")
     echo "$AGENT_NAME ($PROJECT_NAME) | $STATUS | no cost data yet${DOCKER_STATE:+ | $DOCKER_STATE}"
   else
     echo "$AGENT_NAME ($PROJECT_NAME) | no session${DOCKER_STATE:+ | $DOCKER_STATE}"


### PR DESCRIPTION
## Summary

`hermit-stop` and `hermit-status` were reading `**Status:**` from `SHELL.md`, a field that was deliberately removed when lifecycle state moved exclusively to `runtime.json`. Reads always fell back to `unknown`. `**Started:**` could display the raw template placeholder `YYYY-MM-DD HH:MM` when `session-mgr` missed the substitution step, breaking the stop banner and silently degrading duration computation and staleness checks in two other consumers.

## Changes

- **`scripts/hermit-stop.py`**: `read_active_session()` now reads `session_state` and `created_at` from `runtime.json`. SHELL.md `**Started:**` is still preferred when it contains a real date (guard: skip if value contains `YYYY`).
- **`state-templates/bin/hermit-status`**: fallback branch (no `.status.json` data) now reads `session_state` from `state/runtime.json` instead of grepping the nonexistent `**Status:**` field. Dead `SHELL_FILE` variable removed.
- **`agents/session-mgr.md`**: step 5 now names the literal placeholder `YYYY-MM-DD HH:MM` explicitly so substitution is unambiguous — mirrors the precision already applied to the `**ID:**` field.
- **`skills/session-start/SKILL.md`**: fast-path step adds a `Started` repair alongside the existing `**ID:**` repair.

## Test plan

- `bash plugins/claude-code-hermit/tests/run-all.sh` — all green (no direct hermit-stop test, checks no collateral breakage).
- Smoke-tested `read_active_session()` directly: with a SHELL.md containing `YYYY-MM-DD HH:MM`, returns `created_at` from `runtime.json`; with a real date in SHELL.md, prefers that value.