### PR TITLE
fix(claude-code-hermit): disambiguate session-mgr as subagent in lifecycle skills

### DIFF
--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -17,6 +17,8 @@ If watches are registered (`state/monitors.runtime.json` has entries), stop all 
 
 session-mgr handles updating both SHELL.md (cosmetic) and `state/runtime.json` (lifecycle truth) during archiving. For full shutdown, session-mgr sets `shutdown_completed_at` in runtime.json.
 
+> **Tool note:** `claude-code-hermit:session-mgr` is a **subagent** — invoke it via the Agent tool, never the Skill tool. The `plugin:name` form it shares with skills does not imply the Skill tool.
+
 ---
 
 ## Full Shutdown

--- a/plugins/claude-code-hermit/skills/session-start/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-start/SKILL.md
@@ -4,6 +4,8 @@ description: Initializes or resumes a work session. Loads context from OPERATOR.
 ---
 # Session Start
 
+> **Tool note:** `claude-code-hermit:session-mgr` is a **subagent** — invoke it via the Agent tool, never the Skill tool. The `plugin:name` form it shares with skills does not imply the Skill tool.
+
 ## Operator Notification
 Notify the operator per the channel policy in CLAUDE.md (§ Operator Notification).
 

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -46,6 +46,8 @@ When the work is done, or the operator decides to move on (even if partial or bl
 
 **Completion notification is the final step of this flow, not a substitute for it.** Skipping the session-mgr idle transition (step 6 below) leaves the session `in_progress`, which triggers stale-session heartbeat alerts and delays report archival until the time-based backstops kick in.
 
+> **Tool note:** `claude-code-hermit:session-mgr` is a **subagent** — invoke it via the Agent tool, never the Skill tool. The `plugin:name` form it shares with skills does not imply the Skill tool.
+
 1. Compile final session data **in context** — do NOT write to SHELL.md at this point. session-mgr owns the final write. Gather:
    - `Status:` one of `completed` | `partial` | `blocked`
    - `Blockers:` one line each, enough context for a cold start


### PR DESCRIPTION
## Summary

The `plugin:name` token is syntactically identical for both skills and subagents. When session lifecycle skills (`session`, `session-start`, `session-close`) referenced `claude-code-hermit:session-mgr` without a tool qualifier, the model dispatched it via the Skill tool, producing `Unknown skill: claude-code-hermit:session-mgr` before self-correcting. This wastes a turn and surfaces a visible error to the operator on every slow-path close or start.

## Changes

- Added a `> **Tool note:**` blockquote to `session-close/SKILL.md`, `session/SKILL.md`, and `session-start/SKILL.md` clarifying that `session-mgr` is a subagent invoked via the Agent tool, not the Skill tool.

## Test plan

- `bun test` in `plugins/claude-code-hermit/` — 864 tests pass, no regressions.
- `grep -n "session-mgr.*subagent" plugins/claude-code-hermit/skills/{session,session-start,session-close}/SKILL.md` — note confirmed in all three.

Closes #348