### PR TITLE
chore(hermit): extract tmuxSessionAlive/getSessionName into lib/tmux

### DIFF
--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -18,6 +18,7 @@ import { spawnSync } from 'node:child_process';
 import { acquireLock, releaseLock } from './lib/lockfile';
 import { writeRuntimeJson, readRuntimeJson, STATE_DIR, RUNTIME_JSON, RUNTIME_TMP, LIFECYCLE_LOCK } from './lib/runtime';
 import { localISOStamp } from './lib/time';
+import { tmuxSessionAlive, getSessionName } from './lib/tmux';
 
 type Json = any;
 
@@ -334,10 +335,6 @@ function checkSandboxCapability(): void {
   if (pyTruthy(hint)) console.log(`[hermit] Fix: ${hint}`);
 }
 
-function tmuxSessionAlive(sessionName: string): boolean {
-  return spawnSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore' }).status === 0;
-}
-
 /** Check for stale runtime state from a previous run and warn. */
 function checkStaleRuntime(config: Json, sessionName: string): void {
   const runtime = readRuntimeJson();
@@ -610,13 +607,6 @@ function buildClaudeCommand(config: Json, tools: Json): string[] {
   }
 
   return cmd;
-}
-
-/** Resolve tmux session name from config. */
-function getSessionName(config: Json): string {
-  const name = 'tmux_session_name' in config ? config.tmux_session_name : 'hermit-{project_name}';
-  const projectName = path.basename(process.cwd());
-  return name.replaceAll('{project_name}', projectName);
 }
 
 /**
@@ -975,7 +965,6 @@ export {
   checkSandboxCapability,
   writeRuntimeJson,
   readRuntimeJson,
-  tmuxSessionAlive,
   checkStaleRuntime,
   acquireLifecycleLock,
   fetchRegisteredMarketplaces,
@@ -983,7 +972,6 @@ export {
   getEnabledChannels,
   resolveStateDir,
   buildClaudeCommand,
-  getSessionName,
   writeSettingsEnv,
   shlexQuote,
   shlexJoin,

--- a/plugins/claude-code-hermit/scripts/hermit-stop.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-stop.ts
@@ -16,6 +16,7 @@ import { spawnSync } from 'node:child_process';
 import { acquireLock, releaseLock } from './lib/lockfile';
 import { localISOStamp } from './lib/time';
 import { readRuntimeJson, updateRuntimeField, STATE_DIR, LIFECYCLE_LOCK } from './lib/runtime';
+import { tmuxSessionAlive, getSessionName } from './lib/tmux';
 
 type Json = any;
 
@@ -32,15 +33,6 @@ function loadConfig(): Json {
     process.exit(1);
   }
   return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
-}
-
-function getSessionName(config: Json): string {
-  const name = config.tmux_session_name ?? 'hermit-{project_name}';
-  return name.replaceAll('{project_name}', path.basename(process.cwd()));
-}
-
-function tmuxSessionAlive(name: string): boolean {
-  return spawnSync('tmux', ['has-session', '-t', name], { stdio: 'ignore' }).status === 0;
 }
 
 function findLatestReport(): string | null {

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -24,6 +24,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { acquireLock, releaseLock } from './lib/lockfile';
 import { utcISOStamp as utcStamp } from './lib/time';
 import { writeRuntimeJson, readRuntimeJson, STATE_DIR, LIFECYCLE_LOCK } from './lib/runtime';
+import { tmuxSessionAlive, getSessionName as deriveSessionName } from './lib/tmux';
 
 type Json = any;
 
@@ -82,10 +83,6 @@ function ageSecs(ts: string): number | null {
 }
 
 // --- Tmux helpers ---
-
-function tmuxSessionAlive(sessionName: string): boolean {
-  return spawnSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore' }).status === 0;
-}
 
 /** Capture pane content and return its SHA-256 hash, or null on failure. */
 function getPaneHash(sessionName: string): string | null {
@@ -363,9 +360,7 @@ function main(): void {
 function getSessionName(): string {
   if (!fs.existsSync(CONFIG_PATH)) return 'hermit';
   try {
-    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
-    const name = cfg.tmux_session_name ?? 'hermit-{project_name}';
-    return String(name).replaceAll('{project_name}', path.basename(process.cwd()));
+    return deriveSessionName(JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8')));
   } catch {
     return 'hermit';
   }

--- a/plugins/claude-code-hermit/scripts/lib/tmux.ts
+++ b/plugins/claude-code-hermit/scripts/lib/tmux.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared tmux helpers for the lifecycle scripts
+ * (hermit-start, hermit-stop, hermit-watchdog).
+ */
+
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+type Json = any;
+
+/** Return true when the named tmux session exists. */
+export function tmuxSessionAlive(name: string): boolean {
+  return spawnSync('tmux', ['has-session', '-t', name], { stdio: 'ignore' }).status === 0;
+}
+
+/** Derive the tmux session name from config (CWD-relative project name). */
+export function getSessionName(config: Json): string {
+  const name = config.tmux_session_name ?? 'hermit-{project_name}';
+  return String(name).replaceAll('{project_name}', path.basename(process.cwd()));
+}


### PR DESCRIPTION
## Summary

Three lifecycle scripts (`hermit-start`, `hermit-stop`, `hermit-watchdog`) each carried their own copy of two small tmux helpers. This is the deferred half of code-review finding #10 from the bun migration (PR #349) — the runtime/lockfile helpers already moved to `lib/` then; these two were deferred because they touched all three scripts and their export contracts.

Adds `scripts/lib/tmux.ts` with canonical implementations of both helpers, imports them in all three scripts, and removes the local copies. The watchdog keeps a thin config-reading wrapper (zero-arg, reads disk, falls back to `'hermit'`) so its `install`/`uninstall` commands don't need to change signature. The shared `getSessionName(config)` uses `??` (safer than hermit-start's old `in` guard on explicit `null`). The two dead re-exports from `hermit-start`'s export block are dropped — nothing imports them.

## Changes
- `scripts/lib/tmux.ts` — new shared module exporting `tmuxSessionAlive(name)` and `getSessionName(config)`
- `hermit-start.ts` — import from lib, delete local defs, drop two unused re-exports
- `hermit-stop.ts` — import from lib, delete local defs
- `hermit-watchdog.ts` — import `tmuxSessionAlive` from lib; convert `getSessionName()` to a thin wrapper over the shared helper

## Test plan
- `bun test` from `plugins/claude-code-hermit/` — 864 tests, all pass

Closes #352