### PR TITLE
fix(claude-code-hermit): block edits to installed plugin source

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **deny-patterns: block Edit/Write to installed plugin source** — a hermit can no longer modify its own files under `~/.claude/plugins/marketplaces/` (#351).
+
 - **doctor-check: `runtime` check (bun)** — verifies bun presence and version against `required_bun_version` in `hermit-meta.json` (report grows to 13 checks); `hermit-start` preflight hard-errors when bun is missing or below 1.3.0.
 
 - **reflect: observations ledger with mechanical graduation** — sub-threshold observations (cost spikes, quick-mode deferrals, failed three-condition candidates) append to `state/observations.jsonl` instead of project memory; step 3b prunes (30-day TTL, recurrence keeps a pattern's history) and promotes patterns seen in ≥2 distinct sessions to candidates carrying a ledger `Artifact:` citation. New `scripts/prune-observations.js`.

--- a/plugins/claude-code-hermit/state-templates/deny-patterns.json
+++ b/plugins/claude-code-hermit/state-templates/deny-patterns.json
@@ -15,7 +15,9 @@
     "Bash(*API_KEY*)",
     "Bash(*SECRET*)",
     "Bash(*TOKEN*)",
-    "Bash(*> *.claude-code-hermit/OPERATOR.md*)"
+    "Bash(*> *.claude-code-hermit/OPERATOR.md*)",
+    "Edit(*/.claude/plugins/marketplaces/*)",
+    "Write(*/.claude/plugins/marketplaces/*)"
   ],
   "sandbox": {
     "filesystem": {

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -286,6 +286,22 @@ describe('enforce-deny-patterns', () => {
     expect(r.exitCode).toBe(0);
   }));
 
+  test('enforce-deny-patterns (block marketplaces path)', withDir(async (dir) => {
+    const r = await runScript('enforce-deny-patterns.ts', {
+      stdin: '{"tool_name":"Edit","tool_input":{"file_path":"/home/u/.claude/plugins/marketplaces/claude-code-hermit/plugins/claude-code-hermit/scripts/foo.ts"}}',
+      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(2);
+  }));
+
+  test('enforce-deny-patterns (allow normal project path)', withDir(async (dir) => {
+    const r = await runScript('enforce-deny-patterns.ts', {
+      stdin: '{"tool_name":"Edit","tool_input":{"file_path":"/home/u/project/src/foo.ts"}}',
+      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(0);
+  }));
+
   test('enforce-deny-patterns (empty stdin)', withDir(async (dir) => {
     const r = await runScript('enforce-deny-patterns.ts', {
       stdin: '', cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },


### PR DESCRIPTION
## Summary

A running hermit had no guard against editing the plugin files that define it, installed under `~/.claude/plugins/marketplaces/claude-code-hermit/`. Such edits are real self-modification — silently wiped on the next \`/plugin update\`, and an unbounded mutation surface during idle/autonomous runs. This closes that gap using the existing deny-pattern engine with no new hook script.

## Changes

- `state-templates/deny-patterns.json` — adds `Edit(*/.claude/plugins/marketplaces/*)` and `Write(*/.claude/plugins/marketplaces/*)` to the `default` array (always-on, every mode)
- `tests/hooks.contract.test.ts` — two new contract test cases: block on a marketplaces path (exit 2, no strict profile required), allow on a normal project path (exit 0)
- `CHANGELOG.md` — `### Added` bullet under `[Unreleased]`

Cache path (`.claude/plugins/cache/`) is intentionally left to the existing `cache-edit-guard.ts`; no duplication.

## Test plan

- `bun test` — 866/866 pass (two new cases added to `enforce-deny-patterns` describe block)
- Manual: `echo '{"tool_name":"Edit","tool_input":{"file_path":"/home/u/.claude/plugins/marketplaces/claude-code-hermit/plugins/claude-code-hermit/scripts/x.ts"}}' | CLAUDE_PLUGIN_ROOT=$PWD bun scripts/enforce-deny-patterns.ts; echo $?` → `2` + `BLOCKED by deny-patterns:` on stderr

Closes #351