### PR TITLE
feat(recall): surface auto-memory alongside hermit artifacts

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **recall: surfaces auto-memory alongside hermit artifacts** — drops `model: haiku` and adds a "From memory" step over the loaded memory index (#350). Zero-config; existing hermits pick it up on `/plugin update`.
+
 ### Added
 
 - **deny-patterns: block Edit/Write to installed plugin source** — a hermit can no longer modify its own files under `~/.claude/plugins/marketplaces/` (#351).

--- a/plugins/claude-code-hermit/skills/recall/SKILL.md
+++ b/plugins/claude-code-hermit/skills/recall/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: recall
-model: haiku
 description: "Full-text retrieval over session reports, compiled artifacts, and proposals by keyword. Activates on messages like 'recall X', 'what did I learn about X', 'when did we last touch X', 'what did we decide about X'."
 ---
 # Recall
@@ -33,7 +32,11 @@ Relay the script output to the operator. Each result shows:
 - Title (when it differs from the filename)
 - Matching line snippets with `:line` references
 
-If no results: report "Nothing found for '`<query>`' in sessions, compiled artifacts, or proposals."
+## Step 1b — Recall from auto-memory
+
+Also surface entries from your loaded `MEMORY.md` that relate to the query under a **From memory** heading, each tagged `memory/<file>.md`. Read the few that matter; don't chase cross-links or read the full corpus. Skip silently if no `MEMORY.md` is loaded.
+
+If neither the script nor auto-memory returned anything: report "Nothing found for '`<query>`' in sessions, compiled artifacts, proposals, or auto-memory."
 
 ## Step 2 — Orientation line (optional)
 
@@ -48,4 +51,4 @@ If the operator asks for more detail on a specific result, Read that file and su
 
 ## Scope
 
-Searches `.claude-code-hermit/sessions/`, `.claude-code-hermit/compiled/`, and `.claude-code-hermit/proposals/` only. Strictly read-only — does not move, delete, or modify any file.
+Searches `.claude-code-hermit/sessions/`, `.claude-code-hermit/compiled/`, and `.claude-code-hermit/proposals/` via `search.ts`, and the loaded auto-memory index + topic files. Strictly read-only — does not move, delete, or modify any file.


### PR DESCRIPTION
## Summary
`/recall` queried only hermit artifacts (sessions, compiled, proposals) and never consulted Claude's auto-memory, where durable preferences, feedback, and decisions live. This closes that gap by promoting the skill off `model: haiku` and adding a native auto-memory recall step.

## Changes
- `recall/SKILL.md`: remove `model: haiku` — semantic memory matching belongs to the main model, not haiku
- Add Step 1b: surface matching `MEMORY.md` entries under a **From memory** heading, each tagged `memory/<file>.md`; skip silently if no MEMORY.md is loaded
- Update no-results check to cover both sources before reporting nothing found
- Update Scope line to reflect the additional search surface

## Design notes
Two knowledge layers, two retrieval styles. Structured artifacts (sessions/compiled/proposals) stay on `search.ts`'s deterministic keyword+recency engine — unchanged. Behavioral memory (preferences, feedback, decisions) uses native model recall: the main model has MEMORY.md injected at session start and is trained to judge relevance and Read topic files. `capability-brainstorm` and `reflect` already follow this exact pattern; `recall` now does too.

A `search.ts --memory` keyword engine was considered but rejected: it's keyword-only (misses paraphrase), would couple the CLI to Claude Code's projects-dir path convention, and would still leave haiku making the relevance call — the actual problem. Removing the judgment requirement (by using the trained native mechanism on a capable model) is cleaner than trying to work around it.

Empirically verified: 3×3 test (verbose / terse / minimal instruction × literal / semantic / keyword queries) against this project's real auto-memory showed the model correctly surfaces the right file even on semantic queries (e.g. "how should I handle dashes" → `feedback_no_em_dashes.md`) at every instruction level. The prose was trimmed to only pin format consistency and breadth discipline — the model doesn't need to be told *how* to recall.

## Test plan
- Run `/recall worktree` in a project with `memory/feedback_stay_in_worktree.md` — expect a **From memory** section alongside artifact hits
- Run `/recall` on a topic not in hermit artifacts but present in memory — expect memory-only results, no false "nothing found"
- Run in a project with no auto-memory loaded — Step 1b skips silently, artifact results still returned

Closes #350