### PR TITLE
feat(claude-code-hermit): expand hermit-evolution into a full evolution report

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Changed
 
+- **hermit-evolution: merged into a full evolution report** — the skill now produces a unified 6-section digest (cost trend + 30d source split, autonomy, proposal velocity, routines/watches with cadence, top-3 produced (inferred), grown since hatch (approximated)) instead of the prior terse 4-section snapshot; trigger phrases extended to include "evolution report", "monthly report", "how have I grown", "what did I produce last month".
+
 - **bun is now a required runtime (>=1.3)** — first step of the bun migration (#18): declared in `hermit-meta.json`, gated by `hermit-evolve` Step 0b (upgrade refuses to proceed without it), pinned in the Docker template (`BUN_VERSION` arg, native installer; the Claude Code CLI stays on npm).
 - **hooks and test harnesses run on bun** — every hooks.json command string, `heartbeat-monitor.sh`, and all test suites invoke `bun` instead of `node`; hook scripts stay stdlib `.js` at this step. `run-with-profile` spawns `process.execPath` so inner hooks inherit the outer runtime.
 - **Docker layer is Python-free** — the image drops `python3/venv/pip` from apt; every inline `python3 -c` in the entrypoint template (cred expiry, mtime watch, init JSON, recommended-plugins) and `check-upgrade.sh` converts to `bun -e`/heredoc equivalents with byte-identical outputs; docker-security's host-side verify blocks likewise. The entrypoint PATH line now includes `~/.bun/bin`. Bun quirk hardened: `-e` mode exits 0 on uncaught fs errors, so snippets catch internally and the init block fail-louds explicitly.

--- a/plugins/claude-code-hermit/skills/hermit-evolution/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolution/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: hermit-evolution
-description: "Show cost trend, autonomy delta, and proposal-resolution times across recent weeks. Activates on messages like 'how am I trending', 'cost trend', 'autonomy', 'hermit evolution', 'show me my trajectory', 'am I improving', 'proposal velocity', 'weekly trends'."
+description: "Show how this hermit has evolved: cost trend and source split, routines and watches, top things produced, and what grew since hatch. Activates on messages like 'how am I trending', 'cost trend', 'autonomy', 'hermit evolution', 'show me my trajectory', 'am I improving', 'proposal velocity', 'weekly trends', 'evolution report', 'monthly report', 'how have I grown', 'what did I produce last month'."
 ---
 # Hermit Evolution
 
-Synthesize a compact analytical snapshot of the hermit's trajectory over recent weeks: cost trend, autonomy rate, and how fast proposals move through the pipeline.
+Synthesize a coherent evolution report: cost trend and source split, autonomy and proposal velocity, active routines and watches, top things produced last month, and what grew organically since hatch.
 
 ## Step 0 — Channel reply
 
@@ -12,44 +12,69 @@ If this skill was invoked from a channel-arrived message (the inbound prompt con
 
 ## Scope
 
-Read the following (gracefully skip any file that doesn't exist):
+Read the following (gracefully skip any file or glob that doesn't exist; steps are independent — read files and run scripts concurrently where possible):
 
 1. `.claude-code-hermit/compiled/review-weekly-*.md` — glob all, sort by `week` frontmatter descending, read the 8 most recent. Extract per-file: `week`, `total_cost_usd`, `self_directed_rate`, `proposals_created`, `proposals_resolved`.
-2. `.claude-code-hermit/cost-summary.md` — frontmatter `total_cost_usd` and `total_tokens` for the current (partial) week's running total if the review file for the current week doesn't exist yet.
-3. `.claude-code-hermit/state/proposal-metrics.jsonl` — if present, scan from the end (most recent entries first); stop once entries are older than 30 days. Use `resolved_at` and `created_at` to compute resolution days for recently resolved proposals.
-4. Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/proposal-metrics-report.ts .claude-code-hermit` and capture stdout. Skip gracefully if the script is unavailable.
+2. `.claude-code-hermit/cost-summary.md` — frontmatter `total_cost_usd` for the current partial week if the review file for it doesn't exist yet.
+3. `.claude-code-hermit/state/proposal-metrics.jsonl` — scan from the end (most recent first); stop at entries older than 30 days. Use `resolved_at` and `created_at` to compute resolution days.
+4. Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/proposal-metrics-report.ts .claude-code-hermit` and capture stdout. Skip gracefully if unavailable. (Steps 4 and 5 may run concurrently.)
+5. Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/cost-reflect.ts .claude-code-hermit 30` and capture stdout. This produces a 30-day cost breakdown including a `### Cost by source` section. Skip gracefully if unavailable.
+6. `.claude-code-hermit/config.json` — read `routines[]` (id, schedule, enabled), `monitors[]` (id, enabled), `heartbeat.every`.
+7. `.claude-code-hermit/state/routine-metrics.jsonl` — count `fired` events per `routine_id` where `ts` is within the last 30 days.
+8. `.claude-code-hermit/sessions/S-NNN-REPORT.md` files for the last 30 days — read Artifacts and Changed sections plus `proposals_created` and `operator_turns` frontmatter. List filenames in `.claude-code-hermit/compiled/` created in the last 30 days.
+9. `.claude-code-hermit/OPERATOR.md` and `${CLAUDE_PLUGIN_ROOT}/state-templates/OPERATOR.md` — read both.
+10. List dirs under `.claude/skills/` in the target project root and under `${CLAUDE_PLUGIN_ROOT}/skills/`.
 
 ## Analysis
 
-**Cost:** From review files, extract `total_cost_usd` per week. Show the 4 most recent weeks as a trend. Compute Δ% between the most recent and the preceding week. If fewer than 2 reviews exist, show "not enough data".
+**Cost:** From review files, extract `total_cost_usd` per week and show the 4 most recent as a trend with Δ% between the two most recent weeks. If fewer than 2 reviews exist, note "not enough data". From the step 5 output, locate the `### Cost by source` block and compute two buckets: **scheduled** (sum of all `routine:*` and `heartbeat` lines) vs **interactive** (the `other` line). Note that watches (Monitor tool) cost ~0 tokens when quiet and will not appear. If step 5 is unavailable, omit the split.
 
-**Autonomy:** From review files, extract `self_directed_rate` (fraction of sessions with no operator turns). Show latest value and Δ vs prior week. Higher = more self-directed. If fewer than 2 reviews exist, show "not enough data".
+**Autonomy:** From review files, `self_directed_rate` (fraction of sessions with no operator turns) for the latest week and Δ vs the prior week. If fewer than 2 reviews: "not enough data".
 
-**Proposal resolution:** From `proposal-metrics.jsonl`, compute median days between `created_at` and `resolved_at` for proposals resolved in the last 30 days. If no data: "no resolution data yet". (For specific stale proposal names, use `/hermit-brain`.)
+**Proposal velocity:** From `proposal-metrics.jsonl`, median days `created_at` → `resolved_at` for proposals resolved in the last 30 days. From step 4 output, show the acceptance-by-source table (rows with n>0 only). Note any triggered kill gates.
 
-**Proposal acceptance by source:** From the script output (step 4), show the table. Omit rows where `n=0`. If any source has reached the ≥8-sample gate, call out whether the kill gate is clear or triggered.
+**Routines & watches:** From config.json, list enabled routines with their `schedule` cron string. Cross-reference routine-metrics.jsonl to show fire counts for the last 30 days. List enabled monitors and heartbeat cadence. Omit disabled entries.
+
+**Top-3 produced (inferred):** From step 8, rank outputs by operator signal — prefer: (1) proposals accepted or resolved, (2) compiled outputs cited in sessions with `operator_turns > 0`, (3) sessions with Artifacts/Changed and `operator_turns = 0` (autonomous wins). Pick the top 3 and describe each in one line. Label: _inferred — no operator-used signal exists._
+
+**Grown since hatch (approximated):** From step 9, diff `.claude-code-hermit/OPERATOR.md` against the template and note sections the operator added or meaningfully filled in. From step 10, list skill names present under `.claude/skills/` but absent from `${CLAUDE_PLUGIN_ROOT}/skills/` — those are organically created. Label: _approximated — no hatch baseline stored._
 
 ## Output
 
-Reply in ≤1500 chars. Use exactly this section structure:
+Target ≤1500 chars. If data is abundant, drop to one line per section rather than letting it balloon. Use this structure:
 
 ```
 ### Cost
-- This week: $X.XX | Prior: $Y.YY (Δ +/-N%)
-- 4-week trend: $A → $B → $C → $X
-(or: Cost trend — not enough weekly reviews to compute (need ≥2).)
+- Trend (weekly): $A → $B → $C → $X (Δ +/-N%)
+- Last 30d: $X.XX total — scheduled (routines/heartbeat): $Y (N%), interactive: $Z (N%)
+(or if no weekly reviews: Cost trend — not enough data (need ≥2 reviews).)
+(or if no 30d data: Cost split — no source data available.)
 
 ### Autonomy
 - Self-directed: N% this week (vs M% prior, Δ +/-N pp)
-(or: Autonomy — not enough weekly reviews to compute (need ≥2).)
+(or: not enough weekly reviews to compute (need ≥2).)
 
-### Proposal resolution
-- Median resolution: Nd (from N proposals resolved last 30d)
-(or: Proposal resolution — no proposal-metrics data yet.)
+### Proposal velocity
+- Median resolution: Nd (N proposals, last 30d)
+[acceptance-by-source table, rows n>0 only; note triggered kill gates]
+(or: no proposal data yet.)
 
-### Proposal acceptance by source
-(table from proposal-metrics-report.ts, rows with n>0 only; note any triggered kill gates)
-(or: Proposal acceptance — no data yet.)
+### Routines & watches
+- heartbeat: every X
+- <routine-id>: <cron> · fired N× in last 30d
+- watch <monitor-id>: active
+(or: no active routines or watches.)
+
+### Top-3 produced (inferred)
+- <one-line description>
+- <one-line description>
+- <one-line description>
+(inferred — no operator-used signal exists)
+
+### Grown since hatch (approximated)
+- OPERATOR.md: <sections added, or "no additions vs template">
+- Skills: <project-local skill names, or "none">
+(approximated — no hatch baseline stored)
 ```
 
-Omit sections that have no data rather than showing a heading with an empty body. Keep each bullet to one line.
+Omit sections with no data rather than showing a heading with an empty body. Keep each bullet to one line.


### PR DESCRIPTION
## Summary

Extends `hermit-evolution` to produce a unified 6-section evolution report instead of the prior terse 4-section snapshot. The new sections cover cost trend + 30d source split (routine/heartbeat vs interactive), autonomy, proposal velocity, active routines and watches with cadence, top-3 things produced last month (inferred), and what grew since hatch (approximated). No new scripts — reuses `cost-reflect.ts`'s existing source-bucketing with a `--days 30` invocation.

Closes #345.

## Changes

- `skills/hermit-evolution/SKILL.md` — description frontmatter extended with report-style trigger phrases; Scope gains 6 new data-gather steps (cost-reflect 30d, config.json, routine-metrics.jsonl, session reports, OPERATOR.md + template, local vs plugin skills); Analysis gains 4 new sections (Routines & watches, Top-3 produced, Grown since hatch) alongside the existing cost/autonomy/proposal sections; Output template updated to match, with explicit per-condition `(or:)` fallbacks and a ≤1500-char target.
- `CHANGELOG.md` — `[Unreleased] ### Changed` entry for the skill expansion.

## Test plan

- `bun test` from `plugins/claude-code-hermit/` — 869 tests pass (includes the `each analytics skill declares the ≤1500-char channel budget` contract).
- Sections 3 and 4 (top-3 produced, grown since hatch) are model-synthesized from session reports and OPERATOR.md diff; labeled "inferred" and "approximated" respectively in the output template.