### PR TITLE
feat(claude-code-hermit): surface observations.jsonl count in weekly-review Reflect vital-signs

### DIFF
--- a/plugins/claude-code-hermit/scripts/weekly-review.ts
+++ b/plugins/claude-code-hermit/scripts/weekly-review.ts
@@ -257,6 +257,23 @@ try {
   }
 } catch {}
 
+// observations.jsonl is the reflect ledger's kill signal: empty everywhere =
+// graduation never fires.
+let reflectObsTotal = 0;
+let reflectObsWeek = 0;
+try {
+  const lines = fs.readFileSync(path.join(hermitDir, 'state', 'observations.jsonl'), 'utf-8').split('\n');
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    reflectObsTotal++;
+    try {
+      const e = JSON.parse(line);
+      const d = new Date(e.ts);
+      if (d >= weekStart && d < weekEnd) reflectObsWeek++;
+    } catch {}
+  }
+} catch {}
+
 // --- Build report ---
 
 const frontmatter = [
@@ -281,6 +298,7 @@ const frontmatter = [
   `reflect_surfaced: ${reflectSurfaced}`,
   `reflect_accepted: ${reflectAccepted}`,
   `reflect_cost_usd: ${reflectCost.toFixed(2)}`,
+  `reflect_observations: ${reflectObsTotal}`,
   '---',
 ].join('\n');
 
@@ -348,9 +366,10 @@ if (openLoops.length > 0) {
 // Reflect vital-signs — makes healthy-quiet distinguishable from dead: a week
 // of runs with zero surfaced/accepted while cost accumulates is the loop
 // telling the operator to prune it.
-if (reflectRuns > 0) {
+if (reflectRuns > 0 || reflectObsTotal > 0) {
   body += `### Reflect\n`;
   let line = `reflect: ${reflectRuns} run${reflectRuns !== 1 ? 's' : ''}, ${reflectCandidates} candidates, ${reflectSurfaced} surfaced, ${reflectAccepted} accepted, ~$${reflectCost.toFixed(2)}`;
+  line += `; obs: ${reflectObsTotal} ledger${reflectObsWeek > 0 ? ` (+${reflectObsWeek} this week)` : ''}`;
   if (reflectSuppressed.size > 0) {
     const list = [...reflectSuppressed];
     const more = list.length > 5 ? `, +${list.length - 5} more` : '';

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -1823,3 +1823,85 @@ describe('proposal-metrics-report', () => {
     expect(await runReport(dir, '--source=nonexistent')).toContain('Unknown source key');
   }));
 });
+
+// -------------------------------------------------------
+// weekly-review.ts (subprocess — argv/file-write CLI contract)
+// -------------------------------------------------------
+
+describe('weekly-review', () => {
+  const runWeeklyReview = (dir: string) =>
+    runScript('weekly-review.ts', { args: [hermit(dir)] });
+
+  function seedWeeklyReview(dir: string) {
+    // Minimal hermit layout weekly-review.ts needs to not crash
+    fs.mkdirSync(hermit(dir, 'sessions'), { recursive: true });
+    fs.mkdirSync(hermit(dir, 'state'), { recursive: true });
+    fs.mkdirSync(hermit(dir, 'proposals'), { recursive: true });
+  }
+
+  // weekly-review: observations.jsonl entries surface in ### Reflect
+  test('weekly-review (observations.jsonl count in Reflect line)', withDir(async (dir) => {
+    seedWeeklyReview(dir);
+    // Session report requires id + date (weekly-review filters on fm.id && fm.date)
+    const now = new Date();
+    const dateStr = utcDate(now);
+    const hhmm = now.toISOString().slice(11, 16);
+    write(hermit(dir, 'sessions', 'S-001-REPORT.md'), [
+      '---',
+      'id: S-001',
+      'type: report',
+      `date: ${dateStr}`,
+      'operator_turns: 0',
+      '---',
+      '## Progress Log',
+      `- [${hhmm}] reflect (adult) — 1 candidates; verdicts: accept=1 downgrade=0 suppress=0; outcomes: none`,
+    ].join('\n'));
+    // Seed 2 observations entries timestamped in the current week
+    const ts = now.toISOString();
+    write(hermit(dir, 'state', 'observations.jsonl'), [
+      JSON.stringify({ ts, pattern: 'p1', session_id: 'S-000', source: 'reflect' }),
+      JSON.stringify({ ts, pattern: 'p2', session_id: 'S-001', source: 'reflect' }),
+      '',
+    ].join('\n'));
+    const r = await runWeeklyReview(dir);
+    expect(r.exitCode).toBe(0);
+    // Report written to compiled/
+    const compiledDir = hermit(dir, 'compiled');
+    const files = fs.readdirSync(compiledDir);
+    const reportFile = files.find(f => f.startsWith('review-weekly-'));
+    expect(reportFile).toBeTruthy();
+    const content = fs.readFileSync(path.join(compiledDir, reportFile!), 'utf-8');
+    // Frontmatter counter
+    expect(content).toContain('reflect_observations: 2');
+    // Body line: obs count + this-week increment
+    expect(content).toContain('obs: 2 ledger (+2 this week)');
+  }));
+
+  // weekly-review: missing observations.jsonl fails open (obs: 0)
+  test('weekly-review (missing observations.jsonl shows obs: 0)', withDir(async (dir) => {
+    seedWeeklyReview(dir);
+    const now = new Date();
+    const dateStr = utcDate(now);
+    const hhmm = now.toISOString().slice(11, 16);
+    write(hermit(dir, 'sessions', 'S-001-REPORT.md'), [
+      '---',
+      'id: S-001',
+      'type: report',
+      `date: ${dateStr}`,
+      'operator_turns: 0',
+      '---',
+      '## Progress Log',
+      `- [${hhmm}] reflect (adult) — 0 candidates; verdicts: accept=0 downgrade=0 suppress=0; outcomes: none`,
+    ].join('\n'));
+    // No observations.jsonl seeded
+    const r = await runWeeklyReview(dir);
+    expect(r.exitCode).toBe(0);
+    const compiledDir = hermit(dir, 'compiled');
+    const files = fs.readdirSync(compiledDir);
+    const reportFile = files.find(f => f.startsWith('review-weekly-'));
+    expect(reportFile).toBeTruthy();
+    const content = fs.readFileSync(path.join(compiledDir, reportFile!), 'utf-8');
+    expect(content).toContain('reflect_observations: 0');
+    expect(content).toContain('obs: 0 ledger');
+  }));
+});


### PR DESCRIPTION
## Summary

Installs the dashboard instrument for the #343 reflect-yield kill-criteria decision. Fleet telemetry shows `observations.jsonl` empty everywhere — the primary kill signal — but it was never surfaced in weekly-review, so the +30-day decision would require manual fleet inspection rather than reading a dashboard line.

## Changes

- **`scripts/weekly-review.ts`**: reads `state/observations.jsonl` (fail-open, matching existing JSONL pattern), adds `reflect_observations` frontmatter counter, appends `; obs: N ledger (+M this week)` to the `### Reflect` body line, and widens the Reflect section guard to `reflectRuns > 0 || reflectObsTotal > 0` so the signal renders even when the precheck emits EMPTY (the starvation case).
- **`tests/scripts.test.ts`**: adds two `weekly-review` CLI contract tests — one verifying obs count + week increment render correctly, one verifying missing file fails open to `obs: 0 ledger`.

## What this does NOT do

Items 1, 2, and 4 from #343 are explicitly deferred: no SKILL.md branch deletion (30-day calendar decision), no precheck/ledger wiring changes ("no new investment in reflect mechanics now"), no domain-discovery re-point (separate proposal).

## Test plan

- `cd plugins/claude-code-hermit && bun test` — 871 pass, 0 fail (verified).

Closes #343