### PR TITLE
feat(claude-code-hermit): default daily-auto-close to haiku + Opus-wake warning

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - **doctor-check: `runtime` check (bun)** — verifies bun presence and version against `required_bun_version` in `hermit-meta.json` (report grows to 13 checks); `hermit-start` preflight hard-errors when bun is missing or below 1.3.0.
 
+- **doctor-check + cost-summary: Opus automated-wake warning** — new 14th doctor check (`opus-wake`) and a `## This Week` line surface automated-source turns (`heartbeat` / `routine:*`) running on Opus over the trailing 7 days; soft warn, no block. Closes the silent $529-Opus-spend failure mode (#342).
+
 - **reflect: observations ledger with mechanical graduation** — sub-threshold observations (cost spikes, quick-mode deferrals, failed three-condition candidates) append to `state/observations.jsonl` instead of project memory; step 3b prunes (30-day TTL, recurrence keeps a pattern's history) and promotes patterns seen in ≥2 distinct sessions to candidates carrying a ledger `Artifact:` citation. New `scripts/prune-observations.js`.
 - **reflection-judge: ledger artifact verification + covered-by-memory exemption** — §1.4 verifies `state/observations.jsonl` citations directly (sub-threshold patterns live only in the ledger); ledger-graduated candidates are never suppressed `covered-by-memory`. Closes the lifecycle bug where recording a pattern to memory got it suppressed at graduation.
 - **reflect: ephemerality exception for procedure capture** — single-session eligibility when the procedure's artifacts are ephemeral (outside repo/state, e.g. `/tmp`) and the cost is already quantified in session content; Tier 3, kill criteria still apply.
@@ -22,6 +24,8 @@
 - **doctor-check: hooks check now verifies exec-form hooks** — `checkHooks` only parsed string-form `command` paths, silently skipping every real hook (all use `command` + `args`); it now resolves `args` entries too, so a missing hook script actually fails the check.
 
 ### Changed
+
+- **daily-auto-close defaults to Haiku** — the silent, stateless midnight close routine ships `model: "haiku"`; near-zero risk on Sonnet fleets, insures against session-model tier-drift cost on Opus fleets (#342).
 
 - **bun is now a required runtime (>=1.3)** — first step of the bun migration (#18): declared in `hermit-meta.json`, gated by `hermit-evolve` Step 0b (upgrade refuses to proceed without it), pinned in the Docker template (`BUN_VERSION` arg, native installer; the Claude Code CLI stays on npm).
 - **hooks and test harnesses run on bun** — every hooks.json command string, `heartbeat-monitor.sh`, and all test suites invoke `bun` instead of `node`; hook scripts stay stdlib `.js` at this step. `run-with-profile` spawns `process.execPath` so inner hooks inherit the outer runtime.
@@ -47,6 +51,7 @@ Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
 4. Refresh ALL on-disk boot wrappers (Step 5b's byte-compare will list every `bin/` file as changed — copy each from `state-templates/bin/`). The old wrappers exec `python3` directly and break when the Python scripts are removed from the plugin.
 5. Note for Docker operators: `hermit-status`, `hermit-attach`, and `hermit-docker` run on the HOST and now use bun there — install bun on the host even when the hermit itself runs in the container.
 6. Docker operators: refresh the on-disk `docker-entrypoint.hermit.sh` from the template (re-run `/docker-setup` or let this skill patch it) BEFORE running `hermit-docker update` — `update` rebuilds with the on-disk entrypoint, and the old one shells `python3`, which the new image no longer has. Then `hermit-docker update` rebuilds the image (drops Python, keeps Node for the Claude Code CLI).
+7. **Set the Haiku default on `daily-auto-close`.** Read `config.routines`, find the entry with `id: "daily-auto-close"`. If it has **no** `model` key, set `"model": "haiku"`. If a `model` is already present, leave it unchanged. (Revert: remove the `model` field from that entry to return it to the session model.)
 
 ## [1.1.12] - 2026-06-10
 

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -12,7 +12,7 @@ import { calculateCost } from './lib/pricing';
 import { readTasks, taskProgress } from './lib/tasks';
 import { kStr, formatTokens } from './lib/format';
 import { sessionId as ccSessionId, transcriptPath as ccTranscriptPath, entryText, isToolResult, extractUsage, costLogPath } from './lib/cc-compat';
-import { costIndexPath, updateCostIndex, readCostIndex } from './lib/cost-log';
+import { costIndexPath, updateCostIndex, readCostIndex, scanAutomatedOpus } from './lib/cost-log';
 
 type Json = any;
 
@@ -305,6 +305,11 @@ function writeCostSummary(index: Json): void {
   const weekSessionCount = weekSessionIds.size;
   const weekAvg = weekSessionCount > 0 ? weekCost / weekSessionCount : 0;
 
+  const opusWake = scanAutomatedOpus(COST_LOG, weekAgo);
+  const opusWakeLine = opusWake.count > 0
+    ? `\n- ⚠ ${opusWake.count} automated wake(s) on Opus this week ($${opusWake.cost.toFixed(2)}) — consider a lower session model`
+    : '';
+
   let trendTable = '| Date | Sessions | Cost | Tokens |\n|------|----------|------|--------|\n';
   for (let i = 0; i < 7; i++) {
     const d = new Date(Date.now() - i * 86400000).toISOString().slice(0, 10);
@@ -336,7 +341,7 @@ avg_session_tokens: ${Math.round(avgSessionTokens)}
 - Sessions: ${weekSessionCount}
 - Cost: $${weekCost.toFixed(2)}
 - Tokens: ${kStr(weekTokens)}K
-- Avg per session: $${weekAvg.toFixed(2)}
+- Avg per session: $${weekAvg.toFixed(2)}${opusWakeLine}
 
 ## All Time
 - Sessions: ${totalSessions}

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -630,7 +630,7 @@ function checkWatchdog() {
 
 function checkOpusWake() {
   try {
-    const since = new Date(Date.now() - 6 * MS_PER_DAY).toISOString().slice(0, 10);
+    const since = new Date(Date.now() - 7 * MS_PER_DAY).toISOString().slice(0, 10);
     const { count, cost } = scanAutomatedOpus(costLog, since);
     if (count > 0) {
       return { id: 'opus-wake', status: 'warn',

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -8,7 +8,7 @@ import { execFileSync } from 'node:child_process';
 import { globDir, readFrontmatter } from './lib/frontmatter';
 import { validate } from './validate-config';
 import { kStr } from './lib/format';
-import { costIndexPath, readCostIndex } from './lib/cost-log';
+import { costIndexPath, readCostIndex, scanAutomatedOpus } from './lib/cost-log';
 
 type Json = any;
 
@@ -628,6 +628,20 @@ function checkWatchdog() {
   }
 }
 
+function checkOpusWake() {
+  try {
+    const since = new Date(Date.now() - 6 * MS_PER_DAY).toISOString().slice(0, 10);
+    const { count, cost } = scanAutomatedOpus(costLog, since);
+    if (count > 0) {
+      return { id: 'opus-wake', status: 'warn',
+        detail: `${count} automated wake(s) on Opus in last 7d ($${cost.toFixed(2)}) — lower the session model to cut tier-drift cost` };
+    }
+    return { id: 'opus-wake', status: 'ok', detail: 'no Opus automated wakes in last 7d' };
+  } catch (e: any) {
+    return { id: 'opus-wake', status: 'fail', detail: `check failed: ${e.message}` };
+  }
+}
+
 // ----------------- Orchestration -----------------
 
 function runAllChecks() {
@@ -645,6 +659,7 @@ function runAllChecks() {
     checkReflectLoop(),
     checkScheduler(),
     checkWatchdog(),
+    checkOpusWake(),
   ];
 }
 
@@ -666,7 +681,7 @@ export {
   checkRuntime, checkConfig, checkHooks, checkStateFiles,
   checkCost, checkProposals, checkDependencies, checkPermissions,
   checkDockerSecurity, checkArchival, checkReflectLoop, checkScheduler,
-  checkWatchdog,
+  checkWatchdog, checkOpusWake,
   satisfiesRange, cidrOverlap,
   runAllChecks, writeReport,
 };

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -741,7 +741,6 @@ function runAllChecks() {
     checkReflectLoop(),
     checkScheduler(),
     checkWatchdog(),
-    checkWatchdog(),
     checkOpusWake(),
     checkHeartbeat(),
   ];

--- a/plugins/claude-code-hermit/scripts/lib/cost-log.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cost-log.ts
@@ -191,4 +191,25 @@ function updateCostIndex(logPath: string, indexPath: string): Json {
   return _writeIndex(indexPath, index);
 }
 
-export { costIndexPath, readCostIndex, updateCostIndex, rebuildCostIndex };
+// Warn-only: surfaces tier-drift cost without a hard block.
+function scanAutomatedOpus(costLogFile: string, sinceDateInclusive: string): { count: number; cost: number } {
+  let count = 0;
+  let cost = 0;
+  if (!fs.existsSync(costLogFile)) return { count, cost };
+  for (const line of fs.readFileSync(costLogFile, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const e = JSON.parse(line);
+      const date = (e.timestamp || '').slice(0, 10);
+      const src = e.source || 'other';
+      const automated = src === 'heartbeat' || src.startsWith('routine:');
+      if (date >= sinceDateInclusive && e.model === 'opus' && automated) {
+        count += 1;
+        cost += e.estimated_cost_usd || 0;
+      }
+    } catch { /* skip corrupt lines — checkCost already surfaces corruption */ }
+  }
+  return { count, cost };
+}
+
+export { costIndexPath, readCostIndex, updateCostIndex, rebuildCostIndex, scanAutomatedOpus };

--- a/plugins/claude-code-hermit/state-templates/config.json.template
+++ b/plugins/claude-code-hermit/state-templates/config.json.template
@@ -20,7 +20,7 @@
     {"id": "reflect",             "schedule": "0 9 * * *",  "skill": "claude-code-hermit:reflect",                     "enabled": true},
     {"id": "scheduled-checks",    "schedule": "5 9 * * *",  "skill": "claude-code-hermit:reflect-scheduled-checks",    "run_during_waiting": true, "enabled": true},
     {"id": "weekly-review",       "schedule": "0 23 * * 0", "skill": "claude-code-hermit:weekly-review",                "enabled": true},
-    {"id": "daily-auto-close",    "schedule": "0 0 * * *",  "skill": "claude-code-hermit:daily-auto-close",             "run_during_waiting": true, "enabled": true}
+    {"id": "daily-auto-close",    "schedule": "0 0 * * *",  "skill": "claude-code-hermit:daily-auto-close", "model": "haiku", "run_during_waiting": true, "enabled": true}
   ],
   "monitors": [],
   "env": {

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -762,13 +762,13 @@ describe('channel-reply-reminder', () => {
 // -------------------------------------------------------
 
 describe('doctor-check', () => {
-  test('doctor-check (minimal install, 13 checks)', withDir(async (dir) => {
+  test('doctor-check (minimal install, 14 checks)', withDir(async (dir) => {
     seedDoctor(dir,
       '{"agent_name":"test","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true,"active_hours":{"start":"08:00","end":"23:00"}},"routines":[]}');
     const report = await doctorReport(dir);
     expect(report.checks.map((c: any) => c.id)).toEqual([
       'runtime', 'config', 'hooks', 'state', 'cost', 'proposals', 'dependencies',
-      'permissions', 'docker-security', 'archive', 'reflect', 'scheduler', 'watchdog',
+      'permissions', 'docker-security', 'archive', 'reflect', 'scheduler', 'watchdog', 'opus-wake',
     ]);
   }));
 
@@ -831,6 +831,37 @@ describe('doctor-check', () => {
     fs.rmSync(hermit(dir, 'config.json'), { force: true });
     const c = checkById(await doctorReport(dir), 'config');
     expect(c.status).toBe('fail');
+  }));
+
+  test('doctor-check (opus-wake — ok when no cost-log)', withDir(async (dir) => {
+    seedDoctor(dir);
+    const c = checkById(await doctorReport(dir), 'opus-wake');
+    expect(c.status).toBe('ok');
+  }));
+
+  test('doctor-check (opus-wake — ok when only sonnet automated turns)', withDir(async (dir) => {
+    seedDoctor(dir);
+    const today = new Date().toISOString().slice(0, 10);
+    write(path.join(dir, '.claude', 'cost-log.jsonl'),
+      `{"timestamp":"${today}T10:00:00.000Z","session_id":"s1","source":"heartbeat","model":"sonnet","total_tokens":100000,"estimated_cost_usd":0.05}\n`);
+    const c = checkById(await doctorReport(dir), 'opus-wake');
+    expect(c.status).toBe('ok');
+  }));
+
+  test('doctor-check (opus-wake — warn when automated turn runs on opus)', withDir(async (dir) => {
+    seedDoctor(dir);
+    const today = new Date().toISOString().slice(0, 10);
+    write(path.join(dir, '.claude', 'cost-log.jsonl'), [
+      `{"timestamp":"${today}T10:00:00.000Z","session_id":"s1","source":"heartbeat","model":"opus","total_tokens":100000,"estimated_cost_usd":7.50}`,
+      `{"timestamp":"${today}T11:00:00.000Z","session_id":"s1","source":"routine:daily-auto-close","model":"opus","total_tokens":5000,"estimated_cost_usd":1.00}`,
+      `{"timestamp":"${today}T12:00:00.000Z","session_id":"s1","source":"other","model":"opus","total_tokens":5000,"estimated_cost_usd":0.50}`,
+      '',
+    ].join('\n'));
+    const c = checkById(await doctorReport(dir), 'opus-wake');
+    expect(c.status).toBe('warn');
+    // Only the heartbeat + routine rows count — "other" is not automated
+    expect(c.detail).toContain('2');
+    expect(c.detail).toContain('8.50');
   }));
 });
 

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -25,7 +25,7 @@ import {
   extractUsage, costLogPath, ccVersion,
 } from '../scripts/lib/cc-compat';
 import * as costLog from '../scripts/lib/cost-log';
-import { costIndexPath, readCostIndex, updateCostIndex } from '../scripts/lib/cost-log';
+import { costIndexPath, readCostIndex, updateCostIndex, scanAutomatedOpus } from '../scripts/lib/cost-log';
 import * as pricing from '../scripts/lib/pricing';
 import { calculateCost, costByType } from '../scripts/lib/pricing';
 import { search } from '../scripts/lib/search';
@@ -1227,6 +1227,51 @@ describe('cost-log', () => {
     const idx = updateCostIndex(corruptLog, corruptIndex);
     expect(idx.byte_offset).not.toBe(999999);
     expect(idx.total_cost_usd).toBeLessThanOrEqual(10);
+  });
+
+  // scanAutomatedOpus: counts only heartbeat/routine:* rows with model=opus
+  // within the given date window. Used by cost-summary and doctor-check.
+  describe('scanAutomatedOpus', () => {
+    test('returns zero count when log absent', () => {
+      const result = scanAutomatedOpus('/tmp/no-such-cost-log.jsonl', '2020-01-01');
+      expect(result.count).toBe(0);
+      expect(result.cost).toBe(0);
+    });
+
+    test('counts heartbeat+routine opus rows, excludes other/sonnet/haiku', withDir((dir) => {
+      const logFile = path.join(dir, '.claude', 'cost-log.jsonl');
+      const inWindow = localDate(new Date());        // today
+      const outWindow = '2020-01-01';                // old date — outside window
+      write(logFile, [
+        // counted: automated + opus + in window
+        `{"timestamp":"${inWindow}T10:00:00.000Z","source":"heartbeat","model":"opus","total_tokens":100,"estimated_cost_usd":5.00}`,
+        `{"timestamp":"${inWindow}T11:00:00.000Z","source":"routine:daily-auto-close","model":"opus","total_tokens":50,"estimated_cost_usd":2.50}`,
+        // excluded: not automated
+        `{"timestamp":"${inWindow}T12:00:00.000Z","source":"other","model":"opus","total_tokens":50,"estimated_cost_usd":0.50}`,
+        // excluded: wrong model
+        `{"timestamp":"${inWindow}T13:00:00.000Z","source":"heartbeat","model":"sonnet","total_tokens":50,"estimated_cost_usd":0.10}`,
+        `{"timestamp":"${inWindow}T14:00:00.000Z","source":"routine:reflect","model":"haiku","total_tokens":50,"estimated_cost_usd":0.01}`,
+        // excluded: out of date window
+        `{"timestamp":"${outWindow}T10:00:00.000Z","source":"heartbeat","model":"opus","total_tokens":100,"estimated_cost_usd":8.50}`,
+        '',
+      ].join('\n'));
+      const result = scanAutomatedOpus(logFile, inWindow);
+      expect(result.count).toBe(2);
+      expect(result.cost).toBeCloseTo(7.50, 9);
+    }));
+
+    test('skips corrupt lines silently', withDir((dir) => {
+      const logFile = path.join(dir, '.claude', 'cost-log.jsonl');
+      const today = localDate(new Date());
+      write(logFile, [
+        `{"timestamp":"${today}T10:00:00.000Z","source":"heartbeat","model":"opus","estimated_cost_usd":3.00}`,
+        'NOT VALID JSON',
+        '',
+      ].join('\n'));
+      const result = scanAutomatedOpus(logFile, today);
+      expect(result.count).toBe(1);
+      expect(result.cost).toBeCloseTo(3.00, 9);
+    }));
   });
 });
 

--- a/plugins/claude-code-hermit/tests/template-skill-sync.test.ts
+++ b/plugins/claude-code-hermit/tests/template-skill-sync.test.ts
@@ -83,3 +83,24 @@ describe('sandbox templates', () => {
     expect(d.sandbox.filesystem).toHaveProperty('denyRead');
   });
 });
+
+// -------------------------------------------------------
+// Routine model defaults
+// -------------------------------------------------------
+describe('routine model defaults', () => {
+  let routines: any[] = [];
+  try {
+    routines = JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf-8')).routines || [];
+  } catch {}
+
+  test('daily-auto-close has model: haiku', () => {
+    const entry = routines.find((r: any) => r.id === 'daily-auto-close');
+    expect(entry).toBeTruthy();
+    expect(entry.model).toBe('haiku');
+  });
+
+  test('no other default routine carries a model field', () => {
+    const withModel = routines.filter((r: any) => r.id !== 'daily-auto-close' && r.model !== undefined);
+    expect(withModel).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Model tier on automated wakes is the biggest cost lever in the fleet — an Opus session model can turn a \$0.07 heartbeat into a \$8.50 one. This PR closes that gap on two fronts: (1) the one routine that is genuinely safe to run on Haiku now defaults to it, and (2) Opus-tier automated turns are surfaced as a visible warning before they compound.

`heartbeat-restart` is intentionally excluded — the dispatcher ignores its `model` field and the validator warns on it (re-arm must run in the session model). Only `daily-auto-close` is targeted: stateless, intentionally silent, field-tested on Haiku by two fleet hermits.

Closes #342.

## Changes

- **`state-templates/config.json.template`** — `model: "haiku"` on `daily-auto-close`; no other routine touched.
- **`scripts/lib/cost-log.ts`** — export `scanAutomatedOpus(logFile, since)`: scans raw cost-log for `source ∈ {heartbeat, routine:*} && model === 'opus'` in a date window. Single source of truth for both consumers.
- **`scripts/cost-tracker.ts`** — `## This Week` section in cost-summary.md gets a `⚠` line when automated Opus wakes are found.
- **`scripts/doctor-check.ts`** — new 14th check `checkOpusWake` returns `warn` on automated Opus turns in the last 7 days; soft, no hard block.
- **`CHANGELOG.md`** — `[Unreleased]` Added + Changed entries; Upgrade Instructions step 7 (set-if-absent on existing installs via `hermit-evolve`).

## Test plan

```
cd plugins/claude-code-hermit
bun test                    # 877 pass, 0 fail
bun run scripts/validate-config.ts state-templates/config.json.template
                            # zero output = no warnings (heartbeat-restart trap avoided)
```

New tests:
- `template-skill-sync.test.ts` — `daily-auto-close` has `model: haiku`; no other default routine carries a `model` field.
- `scripts.test.ts` (`describe('scanAutomatedOpus')`) — counts heartbeat+routine Opus rows, excludes other/sonnet/haiku, respects date window, skips corrupt lines.
- `hooks.contract.test.ts` — 13→14 check count; 3 `opus-wake` cases (no log → ok, sonnet-only → ok, automated Opus rows → warn with correct count and cost).