### PR TITLE
fix(claude-code-hermit): cost instrumentation multi-call undercount, report double-count, api_calls/context_usage

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -14,7 +14,14 @@
 - **weekly-review: reflect vital-signs line** — review gains `reflect_runs/candidates/surfaced/accepted/cost_usd` frontmatter and a `### Reflect` section with a suppression digest (slug:code), computed week-scoped from session-report Progress Log lines and proposal-metrics.jsonl events; evolution block relays it. Makes a healthy-quiet reflect loop distinguishable from a dead one.
 - **session-close: close debrief in Lessons** — step 1 asks what was built ad-hoc this session (throwaway scripts, manual procedures, long waits a tool would remove) and what had to be re-derived that a compiled note should have covered; persists one quantified Lesson line per item (substantial re-derived knowledge goes to `compiled/`); arms procedure-capture recurrence upstream.
 
+### Added
+
+- **cost-tracker: `api_calls` and `context_usage` per log entry** — each cost-log.jsonl entry now records the number of API calls summed for that turn and the context-window fill fraction from the Stop payload (null when absent); enables per-turn call-count analysis and context/cost correlation (#341).
+
 ### Fixed
+
+- **cost-tracker: sums all API calls in a turn** (#341) — the previous code returned usage from the last API call only; multi-step tool-calling turns (each billed separately) were undercounted. The `sumTurnUsage` helper now sums every billed entry back to the turn boundary. **Reported costs will rise — this is not a regression.** A `schema: 2` marker entry is written to `cost-log.jsonl` at upgrade so operators see the boundary clearly.
+- **session reports: cost derived from immutable cost-log** (#341) — `cost_usd` and `tokens` in session report frontmatter are now summed from cost-log.jsonl per session-id by the main session before passing to session-mgr (via `session-cost.ts`), eliminating the double-count caused by the skippable per-task `.status.json` reset. Session-mgr falls back to `.status.json` only when the payload value is absent. The redundant prose reset steps are removed from session-mgr.
 
 - **hermit-watchdog: active_hours evaluated in the configured timezone** (#347) — `inActiveHours()` read the host wall clock (`new Date().getHours()`) while its sibling `heartbeat-precheck` already evaluated the same window through `currentHHMM(config.timezone)`; on any host where system TZ differed from `config.timezone` (headless Docker pinned to UTC) the watchdog fired in the wrong window. It now delegates to `currentHHMM`, fails open on an unparseable tz or malformed `HH:MM` bounds, and treats the window end as exclusive to match `heartbeat-precheck`.
 - **hermit-watchdog: reads runtime.json through lib/runtime** (code-review cleanup) — the watchdog wrote runtime.json via the shared `writeRuntimeJson` but still read it through a local `readJson`; it now uses `lib/runtime.readRuntimeJson` so the read/write semantics for that file live in one place.
@@ -41,12 +48,13 @@
 
 Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
 
-1. Create `.claude-code-hermit/state/observations.jsonl` as an empty file if it does not exist (append-only ledger; `append-metrics.js` also creates it lazily on first write, so pre-upgrade hermits fail open).
-2. No migration of existing sub-threshold memory entries is performed — future observations land in the ledger. Stale pattern-label notes in operator MEMORY.md can be pruned manually at the operator's convenience.
-3. Verify bun is installed before anything else (Step 0b is the hard gate): `bun --version` must be >= 1.3.0. If missing: `curl -fsSL https://bun.sh/install | bash`.
-4. Refresh ALL on-disk boot wrappers (Step 5b's byte-compare will list every `bin/` file as changed — copy each from `state-templates/bin/`). The old wrappers exec `python3` directly and break when the Python scripts are removed from the plugin.
-5. Note for Docker operators: `hermit-status`, `hermit-attach`, and `hermit-docker` run on the HOST and now use bun there — install bun on the host even when the hermit itself runs in the container.
-6. Docker operators: refresh the on-disk `docker-entrypoint.hermit.sh` from the template (re-run `/docker-setup` or let this skill patch it) BEFORE running `hermit-docker update` — `update` rebuilds with the on-disk entrypoint, and the old one shells `python3`, which the new image no longer has. Then `hermit-docker update` rebuilds the image (drops Python, keeps Node for the Claude Code CLI).
+1. Append a schema-marker line to `.claude/cost-log.jsonl`: `{"schema": 2, "timestamp": "<ISO now>", "note": "api_calls + context_usage added; pre-marker entries undercount multi-step turns"}`. This stamps the upgrade boundary so operators do not read the post-upgrade cost jump as a regression. Backfill of pre-marker entries is not performed.
+2. Create `.claude-code-hermit/state/observations.jsonl` as an empty file if it does not exist (append-only ledger; `append-metrics.js` also creates it lazily on first write, so pre-upgrade hermits fail open).
+3. No migration of existing sub-threshold memory entries is performed — future observations land in the ledger. Stale pattern-label notes in operator MEMORY.md can be pruned manually at the operator's convenience.
+4. Verify bun is installed before anything else (Step 0b is the hard gate): `bun --version` must be >= 1.3.0. If missing: `curl -fsSL https://bun.sh/install | bash`.
+5. Refresh ALL on-disk boot wrappers (Step 5b's byte-compare will list every `bin/` file as changed — copy each from `state-templates/bin/`). The old wrappers exec `python3` directly and break when the Python scripts are removed from the plugin.
+6. Note for Docker operators: `hermit-status`, `hermit-attach`, and `hermit-docker` run on the HOST and now use bun there — install bun on the host even when the hermit itself runs in the container.
+7. Docker operators: refresh the on-disk `docker-entrypoint.hermit.sh` from the template (re-run `/docker-setup` or let this skill patch it) BEFORE running `hermit-docker update` — `update` rebuilds with the on-disk entrypoint, and the old one shells `python3`, which the new image no longer has. Then `hermit-docker update` rebuilds the image (drops Python, keeps Node for the Claude Code CLI).
 
 ## [1.1.12] - 2026-06-10
 

--- a/plugins/claude-code-hermit/agents/session-mgr.md
+++ b/plugins/claude-code-hermit/agents/session-mgr.md
@@ -73,14 +73,14 @@ This file is the **single source of truth** for lifecycle decisions. All scripts
      - `status`: from the `Status:` line in the invocation prompt payload (e.g., `completed`, `partial`, `blocked`)
      - `date`: current ISO 8601 timestamp with timezone offset (e.g., `2026-04-06T14:30:00+01:00`). Use the timezone from `config.json` if set, otherwise UTC.
      - `duration`: compute from `**Started:**` timestamp to now (e.g., `2h 15m`, `45m`)
-     - `cost_usd`: read `cost_usd` from `.claude-code-hermit/sessions/.status.json`. Fall back to parsing `## Cost` section from SHELL.md (strip `$`, take the number before `(`). Use `0.00` if neither is available.
+     - `cost_usd`: from the `Cost:` line in the invocation prompt payload (e.g. `$0.4231 (152689 tokens)` — strip `$`, take the number before the space). Fall back to `cost_usd` from `.claude-code-hermit/sessions/.status.json`, then to parsing `## Cost` from SHELL.md. Use `0.00` if none is available.
      - `tags`: from `**Tags:**` field, split on comma, trim whitespace, output as YAML array. E.g., `refactor, frontend` → `[refactor, frontend]`. Use `[]` if empty.
      - `proposals_created`: scan `## Proposals Created` section for proposal IDs matching the regex `/PROP-[a-z0-9][a-z0-9-]*/gi` (captures legacy `PROP-006`, short `PROP-006-103612`, and full `PROP-006-capability-brainstorm-103612` / collision `PROP-006-capability-brainstorm-103612a` forms). Output the matched IDs verbatim as a YAML array. Use `[]` if none.
      - `task`: extract the first non-comment, non-empty line from `## Task` in SHELL.md. Trim to 120 characters max. Use `""` if blank.
      - `status`: must be one of `completed`, `partial`, `blocked`. Use the `Status:` value from the invocation prompt payload. If the value is anything else, normalize to `partial` and add a line to `## Blockers` in the report: `Status normalized: original value \`<value>\` coerced to \`partial\`.`
      - `escalation`: read `escalation` from `.claude-code-hermit/config.json`. If the field is missing or empty, default to `"balanced"`. Allowed values: `conservative`, `balanced`, `autonomous`.
      - `operator_turns`: read `operator_turns` from `.claude-code-hermit/sessions/.status.json`. Use `0` if the field is missing or the file doesn't exist. This is the count of human-type transcript entries for this session, maintained by the cost-tracker hook.
-     - `tokens`: read `tokens` from `.claude-code-hermit/sessions/.status.json`. Use `0` if the field is missing or the file doesn't exist.
+     - `tokens`: from the `Cost:` line in the invocation prompt payload (the number in parentheses). Fall back to `tokens` from `.claude-code-hermit/sessions/.status.json`. Use `0` if neither is available.
      - `closed_via`: from the `Closed Via:` line in the invocation prompt payload. Default to `operator` if not provided.
    - **Write `## Overview`** with the one-line task description from `## Task`
    - **If a task table was provided in the invocation prompt**, include it as `## Plan` in the report
@@ -121,7 +121,6 @@ This file is the **single source of truth** for lifecycle decisions. All scripts
    - Carry forward blockers from the closed session
    - If unfinished tasks remain in the native task list, note: "Unfinished tasks remain in the task list."
 8. **Clear transition and update runtime.json**: `transition: null`, `transition_target: null`, `transition_started_at: null`, `session_state: "idle"`, `session_id: null`, `shutdown_completed_at: <now>` (if this is a full shutdown close)
-   **Reset per-session counters in `.status.json`**: write `{"cost_usd": 0, "tokens": 0, "operator_turns": 0}` (merging into existing keys). Same atomic write pattern as On Task Complete step 10.
 
 ## On Task Complete (Idle Transition)
 
@@ -151,7 +150,6 @@ When the main session requests an idle transition (not a full close):
      `**S-NNN** (YYYY-MM-DD): [one-line task summary] — [status] ($X.XX)`
 8. **Transition clear (single atomic runtime.json write).** Set all of: `transition: null`, `transition_target: null`, `transition_started_at: null`, `session_state: "idle"`. Pre-compute next `session_id` (for the next task).
 9. If cost data is available, preserve the cumulative total in the Cost section
-10. **Reset per-session counters in `.status.json`**: write `{"cost_usd": 0, "tokens": 0, "operator_turns": 0}` (merging into existing keys, preserving `session_id`, `status`, etc.). This ensures the next task's cost-tracker readings start from zero rather than carrying over this task's totals. Use atomic write: write to `sessions/.status.json.tmp`, rename to `sessions/.status.json`.
 
 ## On Progress Update
 

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -104,8 +104,38 @@ function classifySource(triggerText: string): string {
   return 'other';
 }
 
+// Limitation: a turn spanning more than TAIL_BYTES is summed from buffer start, not the real boundary — same bleed as scanTriggerMarkers.
+function sumTurnUsage(lines: string[], billedIndex: number): {
+  inputTokens: number; cacheWriteTokens: number; cacheReadTokens: number;
+  outputTokens: number; model: string; apiCalls: number;
+} {
+  let inputTokens = 0, cacheWriteTokens = 0, cacheReadTokens = 0, outputTokens = 0;
+  let model = 'sonnet';
+  let apiCalls = 0;
+
+  for (let j = billedIndex; j >= 0; j--) {
+    try {
+      const entry = JSON.parse(lines[j]);
+      const usage = extractUsage(entry);
+      if (usage) {
+        inputTokens += usage.inputTokens;
+        cacheWriteTokens += usage.cacheWriteTokens;
+        cacheReadTokens += usage.cacheReadTokens;
+        outputTokens += usage.outputTokens;
+        apiCalls++;
+        // Model is constant within a turn; capture it once from the outermost call.
+        if (apiCalls === 1) model = usage.model;
+      }
+      // Turn boundary: the first non-tool_result user entry (same rule as scanTriggerMarkers).
+      if (entry.type === 'user' && !isToolResult(entry)) break;
+    } catch {}
+  }
+
+  return { inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens, model, apiCalls };
+}
+
 function readLastTurnUsage(transcriptPath: string): Json {
-  const TAIL_BYTES = 131072; // 128KB — read from end, avoid loading full transcript
+  const TAIL_BYTES = 524288; // 512KB — covers most multi-step agentic turns
   try {
     const stat = fs.statSync(transcriptPath);
     const readFrom = Math.max(0, stat.size - TAIL_BYTES);
@@ -121,23 +151,26 @@ function readLastTurnUsage(transcriptPath: string): Json {
     for (let i = lines.length - 1; i >= 0; i--) {
       try {
         const entry = JSON.parse(lines[i]);
-        const usage = extractUsage(entry);
-        if (usage) {
-          // Detect operator interaction for operator_turns tracking.
-          // Note: real transcripts use type:'user', not type:'human', so this is
-          // effectively always false in production — left intact for future correctness.
-          let hadHumanTurn = false;
-          for (let j = i - 1; j >= 0; j--) {
-            try {
-              const prev = JSON.parse(lines[j]);
-              hadHumanTurn = prev.type === 'human';
-              break; // stop at first valid entry before this assistant turn
-            } catch {}
-          }
-          const triggerText = scanTriggerMarkers(lines, i);
-          const source = classifySource(triggerText);
-          return { ...usage, hadHumanTurn, source };
+        if (!extractUsage(entry)) continue;
+
+        // Found the last billed entry — sum the whole turn.
+        const summed = sumTurnUsage(lines, i);
+
+        // Detect operator interaction for operator_turns tracking.
+        // Note: real transcripts use type:'user', not type:'human', so this is
+        // effectively always false in production — left intact for future correctness.
+        let hadHumanTurn = false;
+        for (let j = i - 1; j >= 0; j--) {
+          try {
+            const prev = JSON.parse(lines[j]);
+            hadHumanTurn = prev.type === 'human';
+            break;
+          } catch {}
         }
+
+        const triggerText = scanTriggerMarkers(lines, i);
+        const source = classifySource(triggerText);
+        return { ...summed, hadHumanTurn, source };
       } catch {}
     }
   } catch {}
@@ -386,7 +419,7 @@ async function run(data: Json): Promise<string | null> {
       return null;
     }
 
-    const { inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens, model: rawModel, hadHumanTurn, source } = turn;
+    const { inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens, model: rawModel, hadHumanTurn, source, apiCalls } = turn;
     const model = detectModel(rawModel);
 
     const totalTokens = inputTokens + cacheWriteTokens + cacheReadTokens + outputTokens;
@@ -411,6 +444,8 @@ async function run(data: Json): Promise<string | null> {
       cache_read_tokens: cacheReadTokens,
       output_tokens: outputTokens,
       total_tokens: totalTokens,
+      api_calls: apiCalls,
+      context_usage: data.context_usage ?? data.contextUsage ?? null,
       estimated_cost_usd: roundedCost,
     };
 
@@ -443,7 +478,7 @@ async function run(data: Json): Promise<string | null> {
   }
 }
 
-export { run, getCumulativeCost, classifySource, scanTriggerMarkers };
+export { run, getCumulativeCost, classifySource, scanTriggerMarkers, sumTurnUsage };
 
 if (import.meta.main) {
   (async () => {

--- a/plugins/claude-code-hermit/scripts/session-cost.ts
+++ b/plugins/claude-code-hermit/scripts/session-cost.ts
@@ -1,0 +1,29 @@
+// Sums cost-log.jsonl entries for a given session_id and prints the result.
+// Usage: bun session-cost.ts <session_id>
+// Output: JSON {"cost_usd": <number>, "tokens": <number>}
+// Fails open: missing log or unknown session_id prints {"cost_usd": 0, "tokens": 0}.
+
+import fs from 'node:fs';
+import { costLogPath } from './lib/cc-compat';
+
+const COST_LOG = costLogPath('.claude-code-hermit');
+
+const sessionId = process.argv[2] || '';
+
+let cost = 0;
+let tokens = 0;
+
+try {
+  for (const line of fs.readFileSync(COST_LOG, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const e = JSON.parse(line);
+      if (e.session_id === sessionId) {
+        cost += e.estimated_cost_usd || 0;
+        tokens += e.total_tokens || 0;
+      }
+    } catch {}
+  }
+} catch {}
+
+process.stdout.write(JSON.stringify({ cost_usd: Math.round(cost * 10000) / 10000, tokens }) + '\n');

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -58,13 +58,16 @@ If the archive in step 8 fails, leave `pending-close.json` in place so the next 
    If reflect returns `reflect: no candidates`, scan this session's `## Findings` and `## Progress Log` for non-obvious discoveries not already in memory and issue the standard "remember it" reflection for any that clear the auto-memory threshold. Apply WHAT_NOT_TO_SAVE as normal.
 6. **Stop always-on services (`shutdown_skill`).** Read `shutdown_skill` from `.claude-code-hermit/config.json`. If non-null, invoke it as a skill command (the value may include arguments, e.g. `/serve stop`) via the Skill tool. **Best-effort:** on error or if the skill does not return, log a Monitoring line and continue to archival — never abort the close. Runs on both operator and `--auto` paths.
 7. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for completed tasks only — pending/in_progress tasks persist for next session.
-8. Archive the session via `claude-code-hermit:session-mgr` (full close — finalize SHELL.md and replace with fresh template in one operation). Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
+8. Archive the session via `claude-code-hermit:session-mgr` (full close — finalize SHELL.md and replace with fresh template in one operation).
+   Before invoking session-mgr: read `session_id` from `.claude-code-hermit/state/runtime.json`. Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-cost.ts <session_id>` via Bash and parse the JSON output to get `cost_usd` and `tokens` for this session. If the script fails or returns zeros, omit the `Cost:` line (session-mgr will fall back to `.status.json`).
+   Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
    ```
    Status: <completed|partial|blocked>
    Blockers: <one line each, or none>
    Lessons: <one line each, or none>
    Changed: <file list, or none>
    Artifacts: <wikilinks to compiled/ outputs produced this session, or none>
+   Cost: $X.XXXX (N tokens)
    Closed Via: <operator|auto>
    Next Start Point: <one line>
    ```

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -62,12 +62,15 @@ When the work is done, or the operator decides to move on (even if partial or bl
 4. **Reflect (with debounce).** Read `state/reflection-state.json` for `last_reflection`. Only invoke the `claude-code-hermit:reflect` skill if `last_reflection` is null or older than 4 hours. For quick tasks (no tasks created, under 5 minutes), skip entirely — progress log is sufficient.
 4b. **Session-triggered scheduled checks.** For each `scheduled_checks` entry (from config already loaded) with `trigger: "session"` and `enabled: true`, invoke the skill. If a skill is unavailable or errors, skip it and continue — never block session finalization on a scheduled check failure. For each check that completed successfully, read-modify-write `state/reflection-state.json`: update only `scheduled_checks.<id>.last_run` to today's ISO date, preserving all other keys. Do not update `last_run` for failed checks.
 5. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for all tasks (idle = clean slate).
-6. Use `claude-code-hermit:session-mgr` to perform an **idle transition** (finalize SHELL.md, archive report, reset task-scoped sections, set `session_state` to `idle`). session-mgr updates `state/runtime.json` (lifecycle truth) and resets the task-scoped sections of SHELL.md. Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
+6. Use `claude-code-hermit:session-mgr` to perform an **idle transition** (finalize SHELL.md, archive report, reset task-scoped sections, set `session_state` to `idle`). session-mgr updates `state/runtime.json` (lifecycle truth) and resets the task-scoped sections of SHELL.md.
+   Before invoking session-mgr: read `session_id` from `.claude-code-hermit/state/runtime.json`. Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-cost.ts <session_id>` via Bash and parse the JSON output to get `cost_usd` and `tokens` for this session. If the script fails or returns zeros, omit the `Cost:` line (session-mgr will fall back to `.status.json`).
+   Pass the following compact structured payload in the prompt — keep it brief, no freeform prose:
    ```
    Status: <completed|partial|blocked>
    Blockers: <one line each, or none>
    Lessons: <one line each, or none>
    Changed: <file list, or none>
+   Cost: $X.XXXX (N tokens)
    ```
    Also include the task table (if native Tasks were created).
 7. If `heartbeat.enabled` is true in config and heartbeat is not already running: start it (`/claude-code-hermit:heartbeat start`)

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -98,6 +98,10 @@ describe('hook outputs', () => {
     expect(typeof entry.estimated_cost_usd).toBe('number');
     expect(typeof entry.timestamp).toBe('string');
     expect(entry.estimated_cost_usd).toBeGreaterThan(0);
+    // schema v2 fields
+    expect(typeof entry.api_calls).toBe('number');
+    expect(entry.api_calls).toBeGreaterThanOrEqual(1);
+    if (entry.context_usage !== null) { expect(typeof entry.context_usage).toBe('number'); }
   }), 15000);
 
   test('standard profile produces structured JSON with criteria', withTmpdir(async (dir) => {

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -1476,6 +1476,75 @@ describe('cost-tracker classifySource / scanTriggerMarkers', () => {
 });
 
 // -------------------------------------------------------
+// cost-tracker: sumTurnUsage unit tests (in-process)
+// -------------------------------------------------------
+
+describe('cost-tracker sumTurnUsage', () => {
+  let sumTurnUsage: typeof import('../scripts/cost-tracker').sumTurnUsage;
+
+  beforeAll(async () => {
+    const mod = (await import(
+      '../scripts/cost-tracker' + '?scripts-test-sumTurnUsage'
+    )) as typeof import('../scripts/cost-tracker');
+    ({ sumTurnUsage } = mod);
+  });
+
+  test('cost-tracker: sumTurnUsage exported', () => {
+    expect(typeof sumTurnUsage).toBe('function');
+  });
+
+  // Single-call turn — baseline: result equals what the old code returned
+  test('cost-tracker: sumTurnUsage single billed entry', () => {
+    const lines = [
+      JSON.stringify({ type: 'user', message: { content: 'hello' } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }, model: 'claude-sonnet-4-6' } }),
+    ];
+    const r = sumTurnUsage(lines, 1);
+    expect(r.inputTokens).toBe(100);
+    expect(r.outputTokens).toBe(50);
+    expect(r.apiCalls).toBe(1);
+    expect(r.model).toBe('claude-sonnet-4-6');
+  });
+
+  // Three-call turn — the core undercount fix
+  test('cost-tracker: sumTurnUsage sums three billed entries in one turn', () => {
+    const lines = [
+      // Prior turn (must NOT be included)
+      JSON.stringify({ type: 'user', message: { content: 'prior turn prompt' } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 999, output_tokens: 999 } } }),
+      // Current turn
+      JSON.stringify({ type: 'user', message: { content: '[hermit-routine:reflect] go' } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 10 }, content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }] } }),
+      JSON.stringify({ type: 'user', message: { content: [{ tool_use_id: 't1', type: 'tool_result', content: 'ok' }] } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 200, output_tokens: 20 }, content: [{ type: 'tool_use', id: 't2', name: 'Write', input: {} }] } }),
+      JSON.stringify({ type: 'user', message: { content: [{ tool_use_id: 't2', type: 'tool_result', content: 'written' }] } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 300, output_tokens: 30, cache_read_input_tokens: 150 }, model: 'claude-sonnet-4-6' } }),
+    ];
+    const billedIndex = lines.length - 1; // last assistant entry
+    const r = sumTurnUsage(lines, billedIndex);
+    expect(r.apiCalls).toBe(3);
+    expect(r.inputTokens).toBe(100 + 200 + 300);
+    expect(r.outputTokens).toBe(10 + 20 + 30);
+    expect(r.cacheReadTokens).toBe(150);
+    // Prior turn's 999 tokens must not bleed in
+    expect(r.inputTokens).not.toBeGreaterThanOrEqual(999);
+  });
+
+  // Boundary respected: prior turn's billed entries are excluded
+  test('cost-tracker: sumTurnUsage stops at turn boundary (prior-turn tokens excluded)', () => {
+    const lines = [
+      JSON.stringify({ type: 'user', message: { content: 'turn 1 prompt' } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 500, output_tokens: 500 } } }),
+      JSON.stringify({ type: 'user', message: { content: 'turn 2 prompt' } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 10, output_tokens: 5 } } }),
+    ];
+    const r = sumTurnUsage(lines, 3);
+    expect(r.apiCalls).toBe(1);
+    expect(r.inputTokens).toBe(10);
+  });
+});
+
+// -------------------------------------------------------
 // cost-reflect.ts: source attribution tests (subprocess)
 // -------------------------------------------------------
 

--- a/plugins/claude-code-hermit/tests/session-cost.test.ts
+++ b/plugins/claude-code-hermit/tests/session-cost.test.ts
@@ -1,0 +1,86 @@
+// Tests for scripts/session-cost.ts: per-session cost summation from cost-log.jsonl.
+
+import { describe, test, expect } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript, PLUGIN_ROOT } from './helpers/run';
+
+function withTmpdir(fn: (dir: string) => Promise<void>) {
+  return async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-session-cost-'));
+    try {
+      await fn(dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  };
+}
+
+// Write a minimal cost-log.jsonl with entries for two different sessions.
+function seedCostLog(dir: string, entries: object[]): string {
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  const logPath = path.join(claudeDir, 'cost-log.jsonl');
+  const lines = entries.map(e => JSON.stringify(e)).join('\n') + '\n';
+  fs.writeFileSync(logPath, lines);
+  return logPath;
+}
+
+describe('session-cost.ts', () => {
+  test('sums cost and tokens for the target session_id only', withTmpdir(async (dir) => {
+    seedCostLog(dir, [
+      { timestamp: '2026-06-01T10:00:00Z', session_id: 'S-001', estimated_cost_usd: 0.1234, total_tokens: 10000, source: 'other', model: 'sonnet' },
+      { timestamp: '2026-06-01T10:05:00Z', session_id: 'S-001', estimated_cost_usd: 0.0500, total_tokens: 5000, source: 'heartbeat', model: 'sonnet' },
+      { timestamp: '2026-06-01T11:00:00Z', session_id: 'S-002', estimated_cost_usd: 0.9999, total_tokens: 99999, source: 'other', model: 'sonnet' },
+    ]);
+
+    const r = await runScript('session-cost.ts', {
+      args: ['S-001'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.cost_usd).toBeCloseTo(0.1734, 4);
+    expect(out.tokens).toBe(15000);
+  }));
+
+  test('returns zeros for unknown session_id', withTmpdir(async (dir) => {
+    seedCostLog(dir, [
+      { timestamp: '2026-06-01T10:00:00Z', session_id: 'S-001', estimated_cost_usd: 0.5, total_tokens: 50000, source: 'other', model: 'sonnet' },
+    ]);
+
+    const r = await runScript('session-cost.ts', {
+      args: ['S-999'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.cost_usd).toBe(0);
+    expect(out.tokens).toBe(0);
+  }));
+
+  test('returns zeros when cost-log is absent', withTmpdir(async (dir) => {
+    // no cost-log seeded
+    const r = await runScript('session-cost.ts', {
+      args: ['S-001'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.cost_usd).toBe(0);
+    expect(out.tokens).toBe(0);
+  }));
+
+  test('skips schema-marker lines (no session_id match)', withTmpdir(async (dir) => {
+    seedCostLog(dir, [
+      { schema: 2, timestamp: '2026-06-01T09:00:00Z', note: 'schema upgrade marker' },
+      { timestamp: '2026-06-01T10:00:00Z', session_id: 'S-001', estimated_cost_usd: 0.25, total_tokens: 25000, source: 'other', model: 'sonnet' },
+    ]);
+
+    const r = await runScript('session-cost.ts', {
+      args: ['S-001'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.cost_usd).toBe(0.25);
+    expect(out.tokens).toBe(25000);
+  }));
+});


### PR DESCRIPTION
## Summary

Three cost instrumentation defects from #341 (items 1, 2, 4a):

- **Multi-call undercount** (item 1): `readLastTurnUsage` returned only the last API call's usage in a turn; intermediate tool-calling steps were silently dropped. Turns with N agent calls were billed as if N=1. Cost totals were floors, not actuals.
- **Report double-count** (item 2): report `cost_usd` came from a mutable `.status.json` running counter whose per-task reset was skippable prose in `session-mgr.md`. Skipped resets caused carryover (fleet symptom: summed report costs 1.2-2.9x the cost-log). Fixed by deriving report cost from the immutable cost-log per session_id, eliminating the reset entirely.
- **context_usage not persisted** (item 4a): `suggest-compact.ts` read `context_usage` from the Stop payload and discarded it. Now written to cost-log entries.

Item 3 (source mis-tagging) was investigated and refuted. Items 4b/c/d (cross-source reporting) deferred.

## Changes

- `scripts/cost-tracker.ts`: `sumTurnUsage` helper walks backward from billed index to turn boundary, summing all API calls; `readLastTurnUsage` now calls it. `api_calls` + `context_usage` added to log entries. `TAIL_BYTES` raised 128KB to 512KB.
- `scripts/session-cost.ts` (new): sums cost-log.jsonl by `session_id`, prints `{cost_usd, tokens}`.
- `skills/session/SKILL.md` + `skills/session-close/SKILL.md`: run `session-cost.ts` before invoking session-mgr; pass `Cost:` line in payload.
- `agents/session-mgr.md`: read `cost_usd`/`tokens` from payload; removed prose reset steps.
- `CHANGELOG.md`: Fixed/Added bullets + Upgrade Instructions (schema-marker line for v2 boundary).

## Test plan

```
cd plugins/claude-code-hermit && bun test
```

New/extended tests:
- `tests/scripts.test.ts`: `sumTurnUsage` with 3-call synthetic turn returns summed tokens and `apiCalls: 3`; boundary stop excludes prior-turn entries.
- `tests/session-cost.test.ts`: sums target session only, zeros for unknown session_id, zeros on missing log, skips schema-marker lines.
- `tests/contracts.test.ts`: cost-log-entry contract extended for `api_calls` (number) and `context_usage` (number|null).

Manual post-merge check: for new sessions, `S-NNN-REPORT.md cost_usd` should approximate cost-log totals (the 1.2-2.9x gap closes).

Closes #341