### PR TITLE
fix(claude-code-hermit): add stale-wake damper to heartbeat precheck

### DIFF
--- a/plugins/claude-code-hermit/scripts/heartbeat-precheck.ts
+++ b/plugins/claude-code-hermit/scripts/heartbeat-precheck.ts
@@ -5,7 +5,7 @@
 // With --peek: read-only — computes the same verdict without any state mutation.
 //
 // Owner contract (write-field split with SKILL.md):
-//   This script owns: alert-state.json total_ticks
+//   This script owns: alert-state.json total_ticks, last_stale_wake_at
 //   SKILL.md owns:    alert-state.json alerts{}, self_eval{}, last_digest_date
 
 import fs from 'node:fs';
@@ -164,14 +164,29 @@ if (sessionState === 'in_progress') {
       if ((now - mtime) / (1000 * 60 * 60) > 12) emit('AUTO_CLOSE');
     } catch { /* fail-open */ }
   }
-  // Stale-session check: skip the LLM wake when the operator is demonstrably present.
-  // Falls back to unconditional EVALUATE when last-operator-action.json is absent (pre-upgrade
-  // installs), mtime fallback was used, or timestamp is future-dated (clock skew / cross-machine).
-  // staleAlertActive: keep waking while an active alert exists so the LLM can track resolution.
+  // Stale-session check: wake once per stale_threshold, not every tick.
+  // Falls back to EVALUATE when last-operator-action.json is absent (pre-upgrade installs),
+  // mtime fallback was used, or timestamp is future-dated (clock skew / cross-machine).
+  // Damped by last_stale_wake_at: if the staleness condition is unchanged and stale_threshold
+  // hasn't elapsed since last wake, fall through to the digest/checklist gates instead of
+  // emitting EVALUATE — identical operator-visible behavior, 1 LLM wake per interval instead of N.
   const staleMs = parseDuration(hbConfig.stale_threshold, 2 * 3600000);
   const opQuiet = !usedActionFile || lastActionAt > now || (now - lastActionAt) > staleMs;
   const staleAlertActive = !!(alertState.alerts ?? {})['stale-session'];
-  if (opQuiet || staleAlertActive) emit('EVALUATE');
+  if (opQuiet || staleAlertActive) {
+    const lastStaleWakeAt = typeof alertState.last_stale_wake_at === 'string'
+      ? new Date(alertState.last_stale_wake_at).getTime()
+      : NaN;
+    const operatorAdvanced = usedActionFile && !isNaN(lastStaleWakeAt) && lastActionAt > lastStaleWakeAt;
+    const wakeDue = isNaN(lastStaleWakeAt) || operatorAdvanced || (now - lastStaleWakeAt) >= staleMs;
+    if (wakeDue) {
+      if (!peek) {
+        alertState.last_stale_wake_at = new Date(now).toISOString();
+        writeJSON(alertStatePath, alertState);
+      }
+      emit('EVALUATE');
+    }
+  }
 }
 
 // waiting-timeout check requires elapsed computation — delegate to LLM

--- a/plugins/claude-code-hermit/tests/auto-close.test.ts
+++ b/plugins/claude-code-hermit/tests/auto-close.test.ts
@@ -647,4 +647,96 @@ describe('stale-session gate: skip LLM wake when operator is present', () => {
     writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T21:30:00+00:00"}');
     expect(await precheck(dir, { now: NOW, peek: true })).toBe('EVALUATE');
   }));
+
+  // stale.7. Damper: second tick within stale_threshold, unchanged condition → fall-through → OK
+  test('stale-gate: damper — stale condition unchanged within threshold → fall-through → OK', withTmp(async (dir) => {
+    const damped = JSON.stringify({
+      alerts: {
+        'checklist:checksys': {
+          count: 6, consecutive_clean: 0, suppressed: true,
+          first_seen: TODAY_DATE, last_seen: TODAY_DATE, text: 'Check system',
+        },
+      },
+      last_digest_date: TODAY_DATE, self_eval: {}, total_ticks: 1,
+      last_stale_wake_at: '2026-05-20T21:00:00+00:00', // 1h before NOW, < 2h threshold
+    });
+    seedStale(dir, damped);
+    writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T19:00:00+00:00"}'); // 3h ago (opQuiet)
+    expect(await precheck(dir, { now: NOW, peek: true })).toBe('OK');
+  }));
+
+  // stale.8. Damper: stale_threshold elapsed since last wake → EVALUATE again
+  test('stale-gate: damper — stale_threshold elapsed since last_stale_wake_at → EVALUATE', withTmp(async (dir) => {
+    const damped = JSON.stringify({
+      alerts: {
+        'checklist:checksys': {
+          count: 6, consecutive_clean: 0, suppressed: true,
+          first_seen: TODAY_DATE, last_seen: TODAY_DATE, text: 'Check system',
+        },
+      },
+      last_digest_date: TODAY_DATE, self_eval: {}, total_ticks: 1,
+      last_stale_wake_at: '2026-05-20T19:30:00+00:00', // 2.5h before NOW, > 2h threshold
+    });
+    seedStale(dir, damped);
+    writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T19:00:00+00:00"}'); // 3h ago (opQuiet)
+    expect(await precheck(dir, { now: NOW, peek: true })).toBe('EVALUATE');
+  }));
+
+  // stale.9. Damper: operator advances after damp period → EVALUATE (operatorAdvanced)
+  test('stale-gate: damper — operator advances after damp → EVALUATE', withTmp(async (dir) => {
+    const staleActive = JSON.stringify({
+      alerts: {
+        'checklist:checksys': {
+          count: 6, consecutive_clean: 0, suppressed: true,
+          first_seen: TODAY_DATE, last_seen: TODAY_DATE, text: 'Check system',
+        },
+        'stale-session': {
+          count: 1, consecutive_clean: 0, suppressed: false,
+          first_seen: TODAY_DATE, last_seen: TODAY_DATE, text: 'Stale session',
+        },
+      },
+      last_digest_date: TODAY_DATE, self_eval: {}, total_ticks: 1,
+      last_stale_wake_at: '2026-05-20T21:30:00+00:00', // 30min before NOW
+    });
+    seedStale(dir, staleActive);
+    // Operator acted at 21:45 — after last_stale_wake_at (21:30) → operatorAdvanced = true
+    writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T21:45:00+00:00"}');
+    expect(await precheck(dir, { now: NOW, peek: true })).toBe('EVALUATE');
+  }));
+
+  // stale.10. Regression: digest gate still fires when staleness is damped (fall-through must reach it)
+  test('stale-gate: damper — digest gate fires through the damp fall-through', withTmp(async (dir) => {
+    const dampedNoDigest = JSON.stringify({
+      alerts: {
+        'checklist:checksys': {
+          count: 6, consecutive_clean: 0, suppressed: true,
+          first_seen: '2026-05-19', last_seen: '2026-05-19', text: 'Check system',
+        },
+      },
+      last_digest_date: '2026-05-19', self_eval: {}, total_ticks: 1, // yesterday → digest due
+      last_stale_wake_at: '2026-05-20T21:00:00+00:00', // 1h ago (within threshold → damped)
+    });
+    seedStale(dir, dampedNoDigest);
+    writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T19:00:00+00:00"}'); // 3h ago (opQuiet)
+    expect(await precheck(dir, { now: NOW, peek: true })).toBe('EVALUATE');
+  }));
+
+  // stale.11. Non-peek: first stale wake writes last_stale_wake_at to alert-state.json
+  test('stale-gate: non-peek first stale wake writes last_stale_wake_at', withTmp(async (dir) => {
+    seedStale(dir);
+    writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T19:00:00+00:00"}'); // 3h ago (opQuiet)
+    expect(await precheck(dir, { now: NOW })).toBe('EVALUATE'); // non-peek
+    const state = JSON.parse(fs.readFileSync(hermit(dir, 'state', 'alert-state.json'), 'utf-8'));
+    expect(typeof state.last_stale_wake_at).toBe('string');
+    expect(new Date(state.last_stale_wake_at).toISOString()).toBe(new Date(NOW).toISOString());
+  }));
+
+  // stale.12. Peek: does NOT write last_stale_wake_at
+  test('stale-gate: peek does not write last_stale_wake_at', withTmp(async (dir) => {
+    seedStale(dir);
+    writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T19:00:00+00:00"}');
+    expect(await precheck(dir, { now: NOW, peek: true })).toBe('EVALUATE');
+    const state = JSON.parse(fs.readFileSync(hermit(dir, 'state', 'alert-state.json'), 'utf-8'));
+    expect(state.last_stale_wake_at).toBeUndefined();
+  }));
 });


### PR DESCRIPTION
## Summary

On short-interval heartbeats (e.g. 30 min), a stale-operator or active `stale-session` alert condition was firing EVALUATE every tick — the LLM would wake to re-confirm unchanged staleness 4x per 2h threshold. Alert dedup suppresses notifications after 5 fires but nothing suppressed the wakes.

Adds a `last_stale_wake_at` field (precheck-owned, same write-field partition as `total_ticks`) that records when the last staleness-driven EVALUATE fired. Subsequent ticks where the condition is unchanged and `stale_threshold` hasn't elapsed fall through to the existing digest/checklist gates instead of emitting EVALUATE, preserving daily digest delivery during long stale sessions.

## Changes

- `scripts/heartbeat-precheck.ts`: replace unconditional `emit('EVALUATE')` in the staleness branch with a `wakeDue` check gated on `last_stale_wake_at`; update owner-contract comment in header
- `tests/auto-close.test.ts`: extend `stale-session gate` describe with 6 new contract tests (stale.7–12): damped tick falls through to OK, threshold elapsed re-fires, operator advance re-fires, digest gate still reaches through the damp, non-peek writes the field, peek does not

## Test plan

```
bun test tests/auto-close.test.ts   # 57 pass
bun test                            # 875 pass, 0 fail
```

Closes #344 (Part A only — Part B raw/archival purge is a separate PR)