### PR TITLE
fix(claude-code-hermit): raw/.archive/ purge policy + raw/ size doctor check

### DIFF
--- a/plugins/claude-code-hermit/scripts/archive-raw.ts
+++ b/plugins/claude-code-hermit/scripts/archive-raw.ts
@@ -25,7 +25,8 @@ try {
       retentionDays = config.knowledge.raw_retention_days;
     }
     const arc = config.knowledge.archive_retention_days;
-    if (arc === null || typeof arc === 'number') archiveRetentionDays = arc;
+    // Guard against a hand-edited 0/negative, which would purge the whole archive.
+    if (typeof arc === 'number' && arc > 0) archiveRetentionDays = arc;
   }
 } catch {}
 

--- a/plugins/claude-code-hermit/scripts/archive-raw.ts
+++ b/plugins/claude-code-hermit/scripts/archive-raw.ts
@@ -17,10 +17,15 @@ const compiledDir = path.join(hermitDir, 'compiled');
 
 // --- Read retention from config ---
 let retentionDays = 14;
+let archiveRetentionDays: number | null = null;
 try {
   const config = JSON.parse(fs.readFileSync(path.join(hermitDir, 'config.json'), 'utf8'));
-  if (config.knowledge && typeof config.knowledge.raw_retention_days === 'number') {
-    retentionDays = config.knowledge.raw_retention_days;
+  if (config.knowledge) {
+    if (typeof config.knowledge.raw_retention_days === 'number') {
+      retentionDays = config.knowledge.raw_retention_days;
+    }
+    const arc = config.knowledge.archive_retention_days;
+    if (arc === null || typeof arc === 'number') archiveRetentionDays = arc;
   }
 } catch {}
 
@@ -42,18 +47,20 @@ for (const fullPath of globDir(compiledDir, /^[^.].*\.md$/)) {
 // --- Scan raw/ ---
 const rawFullPaths = globDir(rawDir, /^[^.].*\.(md|json)$/);
 if (rawFullPaths.length === 0) {
-  console.log('raw/ does not exist or is empty — nothing to archive.');
-  process.exit(0);
+  if (archiveRetentionDays === null) {
+    console.log('raw/ does not exist or is empty — nothing to archive.');
+    process.exit(0);
+  }
+  // archiveRetentionDays configured: skip moves, fall through to purge.
 }
-
-// Ensure .archive/ exists
-fs.mkdirSync(archiveDir, { recursive: true });
 
 let archived = 0;
 let retained = 0;
 let pinned = 0;
 const skippedFiles: { file: string; reason: string }[] = []; // surfaced by name so operators can fix the root cause
 
+// Ensure .archive/ exists before moving files
+fs.mkdirSync(archiveDir, { recursive: true });
 for (const filePath of rawFullPaths) {
   const filename = path.basename(filePath);
 
@@ -117,7 +124,39 @@ for (const filePath of rawFullPaths) {
   }
 }
 
-console.log(`archive-raw: ${archived} archived, ${retained} retained, ${skippedFiles.length} skipped, ${pinned} pinned (-latest).`);
+// --- Purge expired .archive/ entries (only when archive_retention_days is set) ---
+let purged = 0;
+if (archiveRetentionDays !== null) {
+  const archiveCutoffMs = archiveRetentionDays * 24 * 60 * 60 * 1000;
+  try {
+    for (const filename of fs.readdirSync(archiveDir).filter(f => /^[^.].*\.(md|json)$/.test(f))) {
+      if (/-latest\.(md|json)$/.test(filename)) continue;
+      const filePath = path.join(archiveDir, filename);
+      const fm = readFrontmatter(filePath);
+      const m = filename.match(/(\d{4}-\d{2}-\d{2})/);
+      const fileDate = m ? new Date(m[1]) : null;
+      let created: Date | null = null;
+      if (fm?.created) {
+        const d = new Date(fm.created);
+        created = isNaN(d.getTime()) ? fileDate : d;
+      } else {
+        created = fileDate;
+      }
+      if (!created || isNaN(created.getTime())) continue; // can't date → keep
+      if (now - created.getTime() >= archiveCutoffMs) {
+        try {
+          fs.unlinkSync(filePath);
+          purged++;
+          process.stderr.write(`archive-raw: purged ${filename} (${created.toISOString().slice(0, 10)})\n`);
+        } catch (err: any) {
+          process.stderr.write(`archive-raw: purge failed ${filename} — ${err.message}\n`);
+        }
+      }
+    }
+  } catch { /* .archive/ may not exist yet */ }
+}
+
+console.log(`archive-raw: ${archived} archived, ${retained} retained, ${skippedFiles.length} skipped, ${pinned} pinned (-latest), ${purged} purged.`);
 if (archived > 0) {
   console.log(`Archived to ${archiveDir}`);
 }

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -710,6 +710,58 @@ function checkHeartbeat() {
   }
 }
 
+function checkRawSize() {
+  try {
+    const rawDir = path.join(hermitDir, 'raw');
+    if (!fs.existsSync(rawDir)) {
+      return { id: 'raw-size', status: 'ok', detail: 'raw/ absent' };
+    }
+
+    let bytes = 0;
+    let rawFileCount = 0;
+    for (const entry of fs.readdirSync(rawDir, { withFileTypes: true })) {
+      if (entry.isFile()) {
+        if (/^[^.].*\.(md|json)$/.test(entry.name)) rawFileCount++;
+        try { bytes += fs.statSync(path.join(rawDir, entry.name)).size; } catch {}
+      }
+    }
+    const archiveDir = path.join(rawDir, '.archive');
+    if (fs.existsSync(archiveDir)) {
+      for (const entry of fs.readdirSync(archiveDir, { withFileTypes: true })) {
+        if (entry.isFile()) {
+          try { bytes += fs.statSync(path.join(archiveDir, entry.name)).size; } catch {}
+        }
+      }
+    }
+
+    const mb = bytes / (1024 * 1024);
+    const WARN_MB = 50;
+
+    let lastRawArchive: string | null = null;
+    try {
+      const rt = JSON.parse(fs.readFileSync(path.join(stateDir, 'runtime.json'), 'utf8'));
+      lastRawArchive = rt.last_raw_archive_at ?? null;
+    } catch {}
+    const archiveDays = daysSince(lastRawArchive);
+    const sizeWarn = mb > WARN_MB;
+    const staleWarn = rawFileCount > 0 && (archiveDays === null || archiveDays > 14);
+
+    if (sizeWarn || staleWarn) {
+      const parts: string[] = [];
+      if (sizeWarn) parts.push(`${mb.toFixed(1)} MB (>${WARN_MB} MB threshold)`);
+      if (staleWarn) parts.push(archiveDays === null ? 'archive-raw has never run' : `archive-raw last ran ${archiveDays.toFixed(0)}d ago`);
+      return { id: 'raw-size', status: 'warn', detail: `raw/: ${parts.join('; ')}` };
+    }
+
+    return {
+      id: 'raw-size', status: 'ok',
+      detail: `raw/ ${mb.toFixed(1)} MB, archive-raw ${archiveDays !== null ? `${archiveDays.toFixed(0)}d ago` : 'never run'}`,
+    };
+  } catch (e: any) {
+    return { id: 'raw-size', status: 'fail', detail: `check failed: ${e.message}` };
+  }
+}
+
 // ----------------- Orchestration -----------------
 
 function runAllChecks() {
@@ -728,6 +780,7 @@ function runAllChecks() {
     checkScheduler(),
     checkWatchdog(),
     checkHeartbeat(),
+    checkRawSize(),
   ];
 }
 
@@ -749,7 +802,7 @@ export {
   checkRuntime, checkConfig, checkHooks, checkStateFiles,
   checkCost, checkProposals, checkDependencies, checkPermissions,
   checkDockerSecurity, checkArchival, checkReflectLoop, checkScheduler,
-  checkWatchdog, checkHeartbeat,
+  checkWatchdog, checkHeartbeat, checkRawSize,
   satisfiesRange, cidrOverlap,
   runAllChecks, writeReport,
 };

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -88,6 +88,7 @@ const DEFAULT_CONFIG: Json = {
     raw_retention_days: 14,
     compiled_budget_chars: 2500,
     working_set_warn: 20,
+    archive_retention_days: null,
   },
   watchdog: {
     enabled: false,

--- a/plugins/claude-code-hermit/scripts/reflect-precheck.ts
+++ b/plugins/claude-code-hermit/scripts/reflect-precheck.ts
@@ -223,6 +223,28 @@ if (archiveDue) {
 const onlyArchive = archiveDue && Object.keys(phases).length === 0;
 if (archiveTaken && !onlyArchive) phases.archive_due = true;
 
+// Run archive-raw.ts on a 7-day debounce so raw/.archive/ is bounded on every hermit
+// regardless of whether weekly-review is configured.
+if (pluginRoot && daysSince(runtime.last_raw_archive_at) >= 7) {
+  try {
+    execFileSync(process.execPath, [
+      path.join(pluginRoot, 'scripts', 'archive-raw.ts'),
+      stateDir,
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    // Re-read before writing — archive-shell may have updated runtime.json concurrently.
+    const runtimePath = path.join(stateDir, 'state', 'runtime.json');
+    const freshRuntime = readJSON(runtimePath) ?? runtime;
+    freshRuntime.last_raw_archive_at = new Date().toISOString();
+    try {
+      fs.writeFileSync(
+        runtimePath,
+        JSON.stringify(freshRuntime, null, 2) + '\n',
+        'utf-8',
+      );
+    } catch { /* fail-open */ }
+  } catch { /* fail-open */ }
+}
+
 if (Object.keys(phases).length > 0) emit('RUN|' + JSON.stringify(phases));
 
 // EMPTY path: update reflection-state.json and append Progress Log line.

--- a/plugins/claude-code-hermit/scripts/validate-config.ts
+++ b/plugins/claude-code-hermit/scripts/validate-config.ts
@@ -238,6 +238,11 @@ function validate(config: Json): { errors: string[]; warnings: string[] } {
           errors.push('knowledge.working_set_warn: must be a positive integer');
         }
       }
+      if (k.archive_retention_days !== undefined) {
+        if (k.archive_retention_days !== null && (!Number.isInteger(k.archive_retention_days) || k.archive_retention_days <= 0)) {
+          errors.push('knowledge.archive_retention_days: must be a positive integer or null');
+        }
+      }
     }
   }
 

--- a/plugins/claude-code-hermit/state-templates/config.json.template
+++ b/plugins/claude-code-hermit/state-templates/config.json.template
@@ -58,7 +58,8 @@
   "knowledge": {
     "raw_retention_days": 14,
     "compiled_budget_chars": 2500,
-    "working_set_warn": 20
+    "working_set_warn": 20,
+    "archive_retention_days": null
   },
   "watchdog": {
     "enabled": false,

--- a/plugins/claude-code-hermit/tests/archive-raw.test.ts
+++ b/plugins/claude-code-hermit/tests/archive-raw.test.ts
@@ -349,3 +349,95 @@ test('fail-open: exit 0 with missing state dir', async () => {
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
   }
 });
+
+// -------------------------------------------------------
+// 13. Purge: archive_retention_days set → deletes old .archive entries
+// -------------------------------------------------------
+describe('purge: archive_retention_days set, expired .archive entry deleted', () => {
+  let h: Hermit;
+  let out: string;
+
+  beforeAll(async () => {
+    h = makeHermit();
+    // Seed config with archive_retention_days: 90
+    fs.writeFileSync(
+      path.join(h.dir, '.claude-code-hermit', 'config.json'),
+      '{"knowledge":{"raw_retention_days":14,"archive_retention_days":90}}\n',
+    );
+    // Place an already-archived file older than 90d
+    fs.mkdirSync(raw(h.dir, '.archive'), { recursive: true });
+    fs.writeFileSync(
+      raw(h.dir, '.archive', `note-${PAST}.md`),
+      `---\ncreated: ${PAST}\n---\nold archive entry`,
+    );
+    out = await runArchive(h.dir);
+  });
+  afterAll(() => h.cleanup());
+
+  test('purge: expired .archive entry deleted', () => {
+    expect(fs.existsSync(raw(h.dir, '.archive', `note-${PAST}.md`))).toBe(false);
+  });
+  test('purge: output says 1 purged', () => {
+    expect(out).toMatch(/1 purged/);
+  });
+  test('purge: deletion logged to stderr', () => {
+    expect(out).toContain(`purged note-${PAST}.md`);
+  });
+});
+
+// -------------------------------------------------------
+// 14. Purge: archive_retention_days null → nothing deleted
+// -------------------------------------------------------
+describe('purge: archive_retention_days null → no deletion', () => {
+  let h: Hermit;
+  let out: string;
+
+  beforeAll(async () => {
+    h = makeHermit();
+    // Default config has archive_retention_days: null (implicit — key absent is treated as null)
+    fs.mkdirSync(raw(h.dir, '.archive'), { recursive: true });
+    fs.writeFileSync(
+      raw(h.dir, '.archive', `note-${PAST}.md`),
+      `---\ncreated: ${PAST}\n---\nold archive entry`,
+    );
+    out = await runArchive(h.dir);
+  });
+  afterAll(() => h.cleanup());
+
+  test('purge: null retention keeps the .archive entry', () => {
+    expect(fs.existsSync(raw(h.dir, '.archive', `note-${PAST}.md`))).toBe(true);
+  });
+});
+
+// -------------------------------------------------------
+// 15. Purge: -latest pin survives even with archive_retention_days set
+// -------------------------------------------------------
+describe('purge: -latest pin in .archive survives purge', () => {
+  let h: Hermit;
+
+  beforeAll(async () => {
+    h = makeHermit();
+    fs.writeFileSync(
+      path.join(h.dir, '.claude-code-hermit', 'config.json'),
+      '{"knowledge":{"raw_retention_days":14,"archive_retention_days":1}}\n',
+    );
+    fs.mkdirSync(raw(h.dir, '.archive'), { recursive: true });
+    fs.writeFileSync(
+      raw(h.dir, '.archive', `snapshot-${PAST}-latest.md`),
+      `---\ncreated: ${PAST}\n---\nlatest alias`,
+    );
+    fs.writeFileSync(
+      raw(h.dir, '.archive', `note-${PAST}.md`),
+      `---\ncreated: ${PAST}\n---\nregular old entry`,
+    );
+    await runArchive(h.dir);
+  });
+  afterAll(() => h.cleanup());
+
+  test('purge: -latest alias in .archive is not deleted', () => {
+    expect(fs.existsSync(raw(h.dir, '.archive', `snapshot-${PAST}-latest.md`))).toBe(true);
+  });
+  test('purge: regular expired .archive entry is deleted', () => {
+    expect(fs.existsSync(raw(h.dir, '.archive', `note-${PAST}.md`))).toBe(false);
+  });
+});

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -762,13 +762,14 @@ describe('channel-reply-reminder', () => {
 // -------------------------------------------------------
 
 describe('doctor-check', () => {
-  test('doctor-check (minimal install, 14 checks)', withDir(async (dir) => {
+  test('doctor-check (minimal install, 15 checks)', withDir(async (dir) => {
     seedDoctor(dir,
       '{"agent_name":"test","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true,"active_hours":{"start":"08:00","end":"23:00"}},"routines":[]}');
     const report = await doctorReport(dir);
     expect(report.checks.map((c: any) => c.id)).toEqual([
       'runtime', 'config', 'hooks', 'state', 'cost', 'proposals', 'dependencies',
       'permissions', 'docker-security', 'archive', 'reflect', 'scheduler', 'watchdog', 'heartbeat',
+      'raw-size',
     ]);
   }));
 


### PR DESCRIPTION
## Summary

Operators can now configure `knowledge.archive_retention_days` (default `null` — keep forever) to automatically delete old `.archive/` entries. `reflect-precheck` runs `archive-raw` on a 7-day debounce so archival runs on every hermit regardless of whether `weekly-review` is configured. `hermit-doctor` gains a `raw-size` check that warns when `raw/` exceeds 50 MB or `archive-raw` has not run in 14+ days with raw files present.

This is Part B of issue #344.

## Changes

- **`archive-raw.ts`**: adds purge pass after the move loop — deletes `.archive/` entries older than `archive_retention_days` days; `-latest.*` pins are never purged; exits early only when retention is null and raw/ is empty (falls through to purge-only when raw/ is empty but retention is configured)
- **`reflect-precheck.ts`**: calls `archive-raw.ts` on a 7-day debounce via `runtime.last_raw_archive_at`; re-reads `runtime.json` before writing to avoid clobbering `last_shell_snapshot_at` set by the archive-shell subprocess
- **`doctor-check.ts`**: adds `checkRawSize()` (15th check) — warns on size >50 MB or stale archive-raw (>14d with raw files present)
- **`validate-config.ts`**: validates `knowledge.archive_retention_days` must be a positive integer or null
- **`hermit-start.ts`** + **`state-templates/config.json.template`**: adds `archive_retention_days: null` to defaults

## Test plan

- 887/887 tests pass (`bun test` in `plugins/claude-code-hermit/`)
- New purge tests: describe blocks 13–15 in `tests/archive-raw.test.ts` cover expired entry deletion, null-retention no-op, and `-latest` pin survival
- Existing `hooks.contract.test.ts` updated for 15-check count (was 14)

Closes #344