### PR TITLE
feat(hermit-watchdog): post-close context reset to eliminate cold cache-writes

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **post-close context reset via `/clear`** (#340) — after `daily-auto-close` archives a session, the watchdog sends `/clear` on the next tick when the session is idle and unattended. The next sparse wake (e.g. the 03:xx heartbeat) reads only the `startup-context.ts` injection (~9 KB) instead of the full stale conversation (~200–450 K), eliminating the cold cache-write (1.25× input cost) that made sparse autonomous wakes expensive. `/clear` preserves session-scoped `CronCreate` routines and `Monitor` tasks (process-scoped, not conversation-scoped — empirically verified on 2.1.173); no re-arm is needed. Enabled by default (`post_close_clear: true`). Only fires when the watchdog is invoked on a schedule (Docker hermits: automatic; bare-metal: requires `hermit-watchdog install`).
+- **post-close context reset via `/clear`** (#340) — after `daily-auto-close` archives a session, the watchdog sends `/clear` on the next tick when the session is idle and unattended, so the next sparse wake reads only the startup-context injection instead of the full stale conversation (drops the 1.25× cold cache-write). Preserves process-scoped `CronCreate` routines and `Monitor` tasks; no re-arm needed. Enabled by default (`post_close_clear: true`); only fires when the watchdog runs on a schedule (Docker: automatic; bare-metal: requires `hermit-watchdog install`).
 
 ### Changed
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **post-close context reset via `/clear`** (#340) — after `daily-auto-close` archives a session, the watchdog sends `/clear` on the next tick when the session is idle and unattended. The next sparse wake (e.g. the 03:xx heartbeat) reads only the `startup-context.ts` injection (~9 KB) instead of the full stale conversation (~200–450 K), eliminating the cold cache-write (1.25× input cost) that made sparse autonomous wakes expensive. `/clear` preserves session-scoped `CronCreate` routines and `Monitor` tasks (process-scoped, not conversation-scoped — empirically verified on 2.1.173); no re-arm is needed. Enabled by default (`post_close_clear: true`). Only fires when the watchdog is invoked on a schedule (Docker hermits: automatic; bare-metal: requires `hermit-watchdog install`).
+
 ### Changed
 
 - **recall: surfaces auto-memory alongside hermit artifacts** — drops `model: haiku` and adds a "From memory" step over the loaded memory index (#350). Zero-config; existing hermits pick it up on `/plugin update`.
@@ -60,6 +64,8 @@
 1. Run `/claude-code-hermit:heartbeat start` (or wait for the next session start) to restart the monitor so it begins writing `state/heartbeat-liveness.json`. An already-running monitor does not pick up the change automatically. Once the first iteration completes, `state/heartbeat-liveness.json` appears and `/hermit-doctor` can evaluate heartbeat liveness.
 2. `state/heartbeat-liveness.json` is runtime-created — no manual seeding required.
 3. To disable the heartbeat doctor check: set `heartbeat.enabled: false` in `config.json` (check returns `ok: disabled`).
+4. Add `"post_close_clear": true` to `.claude-code-hermit/config.json` (top-level, not nested under `watchdog`). This enables the post-close context reset that ships enabled by default in new hermits. To disable: set `"post_close_clear": false`.
+   Note: the reset only fires when `hermit-watchdog run` is invoked on a schedule. Docker hermits get this automatically (the entrypoint runs it every ~5 min). Bare-metal hermits need `hermit-watchdog install` to set up the systemd/launchd timer — without a timer the marker sits until the next watchdog invocation, which may never come on bare metal.
 
 Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
 

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -95,6 +95,7 @@ const DEFAULT_CONFIG: Json = {
     escalate_after: 3,
     operator_grace: '15m',
   },
+  post_close_clear: true,
 };
 
 const sleep = (s: number) => new Promise((r) => setTimeout(r, s * 1000));

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -253,14 +253,16 @@ function doRearm(sessionName: string): void {
  * fires on any hermit with post_close_clear: true and a running scheduler.
  * /clear preserves CronCreate routines and Monitor tasks (process-scoped, not
  * conversation-scoped), so no re-arm is needed after clearing.
+ * Takes the lifecycle lock around the send so it can't race a concurrent tick or restart.
  */
 function maybePostCloseClear(config: Json): void {
-  if (!config.post_close_clear) return;
+  if (config.post_close_clear !== true) return;
   if (!fs.existsSync(CLEAR_REQUESTED_JSON)) return;
 
   const runtime = readRuntimeJson();
   if (!runtime) return;
   if (runtime.session_state !== 'idle') return;
+  if (runtime.shutdown_requested_at || runtime.shutdown_completed_at) return; // never clear a stopping hermit
 
   const sessionName = runtime.tmux_session ?? '';
   if (!sessionName) return;
@@ -269,9 +271,14 @@ function maybePostCloseClear(config: Json): void {
   const opAge = getOperatorLastActionAgeSecs();
   if (opAge !== null && opAge < 10 * 60) return; // operator active < 10 min — back off
 
-  sendKeys(sessionName, '/clear');
-  try { fs.rmSync(CLEAR_REQUESTED_JSON); } catch {}
-  appendEvent('post-close-clear', 'daily-auto-close context reset');
+  if (!tryAcquireLifecycleLock()) return; // another lifecycle action in flight, retry next tick
+  try {
+    sendKeys(sessionName, '/clear');
+    try { fs.rmSync(CLEAR_REQUESTED_JSON); } catch {}
+    appendEvent('post-close-clear', 'daily-auto-close context reset');
+  } finally {
+    releaseLock(LIFECYCLE_LOCK);
+  }
   process.exit(0);
 }
 

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -34,6 +34,7 @@ const WATCHDOG_EVENTS_JSONL = path.join(STATE_DIR, 'watchdog-events.jsonl');
 const HEARTBEAT_FILE = path.join(STATE_DIR, '.heartbeat');
 const ROUTINE_METRICS_JSONL = path.join(STATE_DIR, 'routine-metrics.jsonl');
 const LAST_OPERATOR_ACTION = path.join(STATE_DIR, 'last-operator-action.json');
+const CLEAR_REQUESTED_JSON = path.join(STATE_DIR, 'clear-requested.json');
 
 // --- Utilities ---
 
@@ -245,6 +246,35 @@ function doRearm(sessionName: string): void {
   process.stderr.write(`[watchdog] re-armed "${sessionName}"\n`);
 }
 
+// --- Post-close context reset ---
+
+/**
+ * Runs before the watchdog.enabled gate — independent of watchdog restart behavior;
+ * fires on any hermit with post_close_clear: true and a running scheduler.
+ * /clear preserves CronCreate routines and Monitor tasks (process-scoped, not
+ * conversation-scoped), so no re-arm is needed after clearing.
+ */
+function maybePostCloseClear(config: Json): void {
+  if (!config.post_close_clear) return;
+  if (!fs.existsSync(CLEAR_REQUESTED_JSON)) return;
+
+  const runtime = readRuntimeJson();
+  if (!runtime) return;
+  if (runtime.session_state !== 'idle') return;
+
+  const sessionName = runtime.tmux_session ?? '';
+  if (!sessionName) return;
+  if (!tmuxSessionAlive(sessionName)) return;
+
+  const opAge = getOperatorLastActionAgeSecs();
+  if (opAge !== null && opAge < 10 * 60) return; // operator active < 10 min — back off
+
+  sendKeys(sessionName, '/clear');
+  try { fs.rmSync(CLEAR_REQUESTED_JSON); } catch {}
+  appendEvent('post-close-clear', 'daily-auto-close context reset');
+  process.exit(0);
+}
+
 // --- Main decision loop ---
 
 function main(): void {
@@ -256,6 +286,9 @@ function main(): void {
   } catch {
     process.exit(0);
   }
+
+  // 0. Post-close clear — independent of watchdog.enabled; runs on any hermit with a scheduler
+  maybePostCloseClear(config);
 
   // 1. Config gate
   const watchdogCfg = config?.watchdog ?? {};

--- a/plugins/claude-code-hermit/scripts/validate-config.ts
+++ b/plugins/claude-code-hermit/scripts/validate-config.ts
@@ -265,6 +265,10 @@ function validate(config: Json): { errors: string[]; warnings: string[] } {
     errors.push('push_notifications: must be a boolean');
   }
 
+  if (config.post_close_clear !== undefined && typeof config.post_close_clear !== 'boolean') {
+    errors.push('post_close_clear: must be a boolean');
+  }
+
   return { errors, warnings };
 }
 

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -405,7 +405,7 @@ For routines — if Yes: use the config defaults (`active_hours.start = 08:00`, 
 
 **Re-initialization merge**: read the existing `.claude-code-hermit/config.json`, then overlay only the fields the wizard asked about. Never strip unknown keys (operators may have added custom fields). Don't re-default fields the operator didn't touch this run.
 
-**Template-only fields** (the wizard never asks about these — they come straight from `config.json.template` and the operator can tune them via `/hermit-settings` later): `model`, `auto_session`, `always_on`, `chrome`, `monitors`, `compact`, `heartbeat`, `knowledge`, `env`, `quality_gate`, `watchdog`. The Quick branch and Advanced wizard both leave these at template defaults.
+**Template-only fields** (the wizard never asks about these — they come straight from `config.json.template` and the operator can tune them via `/hermit-settings` later): `model`, `auto_session`, `always_on`, `chrome`, `monitors`, `compact`, `heartbeat`, `knowledge`, `env`, `quality_gate`, `watchdog`, `post_close_clear`. The Quick branch and Advanced wizard both leave these at template defaults.
 
 If channels were configured in Phase 5, populate each channel's entry in the `channels` object using a **relative path** (relative to the project root):
 

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -27,7 +27,7 @@ Use this when the operator wants to end everything (via `hermit-stop` or explici
 
 ### Auto-close path (`--auto`)
 
-When invoked with `--auto` by heartbeat, skip steps 1–5 and jump directly to step 6 (shutdown_skill), step 7 (Tasks cleanup), step 8 (session-mgr archive), and step 9 (pending-close cleanup). Pass this templated payload to session-mgr:
+When invoked with `--auto` by heartbeat, skip steps 1–5 and jump directly to step 6 (shutdown_skill), step 7 (Tasks cleanup), step 8 (session-mgr archive), step 9 (pending-close cleanup), and step 10 (context-reset marker). Pass this templated payload to session-mgr:
 
 ```
 Status: completed
@@ -73,6 +73,11 @@ If the archive in step 8 fails, leave `pending-close.json` in place so the next 
    ```
    Also include the task table (if native Tasks were created).
 9. **Pending-close cleanup (both paths).** After the session-mgr archive returns success, delete `.claude-code-hermit/state/pending-close.json` if it exists (`rm -f` — ignore if absent). Any pending midnight-drain flag is invalidated by a successful close, regardless of trigger; without this step a flag queued before an operator-invoked close would survive and the next session's first heartbeat tick could fire `AUTO_CLOSE` against it.
+10. **Context-reset marker (`--auto` only, after step 9 success).** Write `.claude-code-hermit/state/clear-requested.json`:
+    ```json
+    { "requested_at": "<utc ISO>", "reason": "daily-auto-close" }
+    ```
+    Skip on archive failure (step 9 is skipped too — the marker inherits the archive-success precondition). Skip on operator-invoked closes entirely — only the `--auto` path writes this. The watchdog reads it on the next tick and sends `/clear` when the session is still alive + idle + unattended, resetting the stale conversation context before the next scheduled wake incurs a cold cache-write. `/clear` preserves CronCreate routines and Monitor tasks; no re-arm is needed.
 
 ---
 

--- a/plugins/claude-code-hermit/state-templates/config.json.template
+++ b/plugins/claude-code-hermit/state-templates/config.json.template
@@ -65,5 +65,6 @@
     "stale_factor": 2,
     "escalate_after": 3,
     "operator_grace": "15m"
-  }
+  },
+  "post_close_clear": true
 }

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -468,6 +468,109 @@ test.if(isLinux)('uninstall without systemctl → exit 0, no traceback', withHer
   expect(r.stdout + r.stderr).not.toContain('Traceback');
 }));
 
+// -------------------------------------------------------
+// post-close clear tests
+// -------------------------------------------------------
+
+function writeClearMarker(h: Hermit): void {
+  fs.writeFileSync(state(h, 'clear-requested.json'),
+    JSON.stringify({ requested_at: new Date().toISOString(), reason: 'daily-auto-close' }) + '\n');
+}
+
+// watchdog.enabled: false verifies clear fires independently of the watchdog restart path
+function writePostCloseClearConfig(h: Hermit): void {
+  fs.writeFileSync(path.join(h.dir, '.claude-code-hermit', 'config.json'), JSON.stringify({
+    post_close_clear: true,
+    watchdog: { enabled: false },
+    heartbeat: { enabled: true, every: '2h', active_hours: { start: '00:00', end: '23:59' } },
+  }, null, 2) + '\n');
+}
+
+test('post_close_clear: marker + idle + tmux alive + operator silent → /clear sent, marker deleted',
+  withHermit(async (h) => {
+    writePostCloseClearConfig(h);
+    // runtime: idle (as set by session-mgr after auto-close)
+    patchRuntime(h, { session_state: 'idle' });
+    writeClearMarker(h);
+    // operator idle 30 min ago
+    fs.writeFileSync(state(h, 'last-operator-action.json'),
+      JSON.stringify({ at: isoAgo(0.5) }) + '\n');
+    writeFakeTmux(h, 0); // tmux session alive
+    writeFakePgrep(h, 1);
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    const tmuxLog = fs.readFileSync(path.join(h.dir, 'tmux-calls.log'), 'utf-8');
+    expect(tmuxLog).toContain('/clear');
+    expect(fs.existsSync(state(h, 'clear-requested.json'))).toBe(false);
+    expect(fs.readFileSync(eventsFile(h), 'utf-8')).toContain('post-close-clear');
+  }));
+
+test('post_close_clear: operator active < 10 min → no send, marker kept',
+  withHermit(async (h) => {
+    writePostCloseClearConfig(h);
+    patchRuntime(h, { session_state: 'idle' });
+    writeClearMarker(h);
+    // operator active 3 min ago — within the 10-min grace
+    fs.writeFileSync(state(h, 'last-operator-action.json'),
+      JSON.stringify({ at: isoAgo(3 / 60) }) + '\n');
+    writeFakeTmux(h, 0);
+    writeFakePgrep(h, 1);
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+    expect(fs.existsSync(state(h, 'clear-requested.json'))).toBe(true);
+  }));
+
+test('post_close_clear: session not idle → no send, marker kept',
+  withHermit(async (h) => {
+    writePostCloseClearConfig(h);
+    // setupHermit() defaults to session_state: in_progress — no patchRuntime needed
+    writeClearMarker(h);
+    writeFakeTmux(h, 0);
+    writeFakePgrep(h, 1);
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+    expect(fs.existsSync(state(h, 'clear-requested.json'))).toBe(true);
+  }));
+
+test('post_close_clear: tmux session dead → no send, marker kept',
+  withHermit(async (h) => {
+    writePostCloseClearConfig(h);
+    patchRuntime(h, { session_state: 'idle' });
+    writeClearMarker(h);
+    writeFakeTmux(h, 1); // tmux session dead (hermit-stop ran)
+    writeFakePgrep(h, 1);
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+    expect(fs.existsSync(state(h, 'clear-requested.json'))).toBe(true);
+  }));
+
+test('post_close_clear: no marker → no send',
+  withHermit(async (h) => {
+    writePostCloseClearConfig(h);
+    patchRuntime(h, { session_state: 'idle' });
+    writeFakeTmux(h, 0);
+    writeFakePgrep(h, 1);
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
+test('post_close_clear: flag false → no send even with marker',
+  withHermit(async (h) => {
+    writeConfig(h); // standard config: watchdog.enabled true, no post_close_clear
+    patchRuntime(h, { session_state: 'idle' });
+    writeClearMarker(h);
+    writeFakeTmux(h, 0);
+    writeFakePgrep(h, 1);
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+    expect(fs.existsSync(state(h, 'clear-requested.json'))).toBe(true);
+  }));
+
 // ---------- inActiveHours unit tests ----------
 // 2026-06-11T03:00:00Z → 12:00 Asia/Tokyo (inside 09:00-17:00), 23:00 America/New_York (outside)
 const ACTIVE_WINDOW = { start: '09:00', end: '17:00' };

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -547,6 +547,19 @@ test('post_close_clear: tmux session dead → no send, marker kept',
     expect(fs.existsSync(state(h, 'clear-requested.json'))).toBe(true);
   }));
 
+test('post_close_clear: shutdown requested → no send, marker kept',
+  withHermit(async (h) => {
+    writePostCloseClearConfig(h);
+    patchRuntime(h, { session_state: 'idle', shutdown_requested_at: isoAgo(0.5) });
+    writeClearMarker(h);
+    writeFakeTmux(h, 0); // tmux still briefly alive mid-shutdown
+    writeFakePgrep(h, 1);
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+    expect(fs.existsSync(state(h, 'clear-requested.json'))).toBe(true);
+  }));
+
 test('post_close_clear: no marker → no send',
   withHermit(async (h) => {
     writePostCloseClearConfig(h);


### PR DESCRIPTION
## Summary

After `daily-auto-close` archives a session, the REPL stays alive but the conversation context sits stale. Sparse automated wakes (e.g. the 03:xx heartbeat) re-read that full context as a cold cache-write at 1.25× input cost — fleet telemetry shows this as 32–47% of lifetime spend on 4 of 5 hermits.

This PR adds a marker-driven `/clear` action in the watchdog: `session-close --auto` writes `state/clear-requested.json` on archive success, and the watchdog fires `/clear` on the next tick when all gates pass (idle session, live tmux, unattended for 10+ min). The next wake reads only the `startup-context.ts` injection (~9 KB) instead of the full stale conversation, eliminating the cold-write cost entirely.

**Mechanism validated empirically on CC 2.1.173:** `/clear` preserves `CronCreate` routines and `Monitor` tasks — they are process-scoped (die when the Claude process dies, not on `/clear`). No re-arm is needed. The `SessionStart` hook re-injects `startup-context.ts` automatically on the `/clear`-source session start.

Closes #340

## Changes

- **`hermit-watchdog.ts`** — `maybePostCloseClear()` runs at the top of `main()`, before the `watchdog.enabled` gate, so it fires on any hermit with a scheduler (not just those with `watchdog.enabled: true`). Gates: `post_close_clear: true` in config, marker file exists, `session_state === 'idle'`, tmux session alive, operator idle 10+ min.
- **`session-close/SKILL.md`** — step 10 (`--auto` only, after step 9 archive success): write `state/clear-requested.json`. Manual closes and `hermit-stop --shutdown` write nothing.
- **`config.json.template`** + **`hermit-start.ts`** — `post_close_clear: true` as a new top-level key (default on, independent of `watchdog.enabled`).
- **`validate-config.ts`** — accepts the new top-level boolean field.
- **`hatch/SKILL.md`** — `post_close_clear` added to the template-only fields list (contract test sync).
- **`tests/watchdog.test.ts`** — 6 new black-box tests covering the happy path and all gate inversions (operator active, session not idle, tmux dead, no marker, flag false).

## Test plan

- `bun test tests/watchdog.test.ts` — 30/30 pass (6 new tests, 24 pre-existing)
- `bun test` (full suite) — run to confirm no regressions
- Existing hermits: add `"post_close_clear": true` to `.claude-code-hermit/config.json` (or run `/hermit-evolve` after this ships). Docker hermits get the watchdog invocation for free; bare-metal needs `hermit-watchdog install` for the timer.