### PR TITLE
fix(hermit-watchdog): auto-clear bloated context to cut routine cost spikes

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- **watchdog: context-size auto-clear** — sends `/clear` when a hermit-owned turn's prompt-side tokens (`input + cache_write + cache_read`) exceed `watchdog.context_clear_tokens` (default 700 000), preventing scheduled routines from re-reading a bloated context at 5–22× normal cost. Fires independently of `watchdog.enabled`; gated on always-on mode, operator silence ≥ 10 min, and 2-tick pane-hash quiescence. Fixes #373.
+
+### Upgrade Instructions
+
+Add `context_clear_tokens: 700000` to the `watchdog` block in `.claude-code-hermit/config.json`:
+
+```json
+"watchdog": {
+  "enabled": false,
+  "stale_factor": 2,
+  "escalate_after": 3,
+  "operator_grace": "15m",
+  "context_clear_tokens": 700000
+}
+```
+
+To disable: set `"context_clear_tokens": null` (or `0`).
+
 ### Fixed
 
 - **reflect, hermit-evolution: name the `event` field in routine-metrics fire counts** — prevents silent zero counts when a model confuses `routine-metrics.jsonl`'s `event` field with `proposal-metrics.jsonl`'s `type` field; both skills now explicitly say `event == "fired"` (#375).

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -103,19 +103,22 @@ Out-of-session supervisor that detects dead or wedged sessions and restarts them
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable the watchdog. No-op if false; `bin/hermit-watchdog run` exits immediately. |
+| `enabled` | boolean | `false` | Enable restart/nudge/re-arm machinery. `enabled: false` disables the wedge-detection and restart path only — `context_clear_tokens` and `post_close_clear` still run on every scheduler tick regardless. |
 | `stale_factor` | number | `2` | Heartbeat staleness multiplier. Session is considered stale when `now - mtime(state/.heartbeat) > stale_factor × heartbeat.every`. |
 | `escalate_after` | integer | `3` | Number of consecutive stale watchdog cycles before escalating from nudge to restart. |
 | `operator_grace` | string | `"15m"` | If `last-operator-action.json` shows activity within this window, the watchdog backs off (operator is mid-conversation). Duration format: `"15m"`, `"1h"`. |
+| `context_clear_tokens` | number \| null | `700000` | Auto-send `/clear` when the last hermit-owned turn's prompt-side tokens (`input + cache_write + cache_read`) exceed this threshold. Prevents scheduled routines from re-reading a bloated context on every wake. Set to `null` or `0` to disable. Only fires on always-on hermits (not interactive), when the session is quiescent (pane unchanged across two scheduler ticks) and the operator has been silent ≥ 10 min. |
 
 **Decision flow (one `run` cycle):**
-1. If `enabled: false` → exit (no-op).
-2. Read `runtime.json` shutdown fields. If operator stopped the hermit intentionally (`shutdown_requested_at`/`shutdown_completed_at` set or `session_state == idle`) → exit.
-3. If the tmux session is gone → restart.
-4. If the heartbeat is stale and the operator is quiet and the pane is frozen for `escalate_after` cycles → restart. Before that threshold: nudge (`/claude-code-hermit:heartbeat run`).
-5. If the in-session 4am `heartbeat-restart` routine missed its fire (last fired > 26h ago) → send-keys re-arm fallback.
+1. If `post_close_clear: true` and session-close marker present → send `/clear`, exit.
+2. If context-clear conditions met (prompt tokens over threshold, always-on, quiescent, operator silent) → send `/clear`, exit.
+3. If `enabled: false` → exit (restart/nudge machinery disabled).
+4. Read `runtime.json` shutdown fields. If operator stopped the hermit intentionally (`shutdown_requested_at`/`shutdown_completed_at` set or `session_state == idle`) → exit.
+5. If the tmux session is gone → restart.
+6. If the heartbeat is stale and the operator is quiet and the pane is frozen for `escalate_after` cycles → restart. Before that threshold: nudge (`/claude-code-hermit:heartbeat run`).
+7. If the in-session 4am `heartbeat-restart` routine missed its fire (last fired > 26h ago) → send-keys re-arm fallback.
 
-Every nudge, restart, and re-arm is appended to `state/watchdog-events.jsonl`. Restarts also set `runtime.json.watchdog_restart_reason`; `session-start` announces the restart to the operator channel.
+Every context-clear, post-close-clear, nudge, restart, and re-arm is appended to `state/watchdog-events.jsonl`. Restarts also set `runtime.json.watchdog_restart_reason`; `session-start` announces the restart to the operator channel.
 
 **Install:** `bin/hermit-watchdog install` — systemd user timer on Linux/WSL2, LaunchAgent on macOS, cron line printed as fallback. Docker hermits don't need `install` — the entrypoint already runs the watchdog on its own ~5 min cycle.
 

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -95,6 +95,7 @@ const DEFAULT_CONFIG: Json = {
     stale_factor: 2,
     escalate_after: 3,
     operator_grace: '15m',
+    context_clear_tokens: 700000,
   },
   post_close_clear: true,
 };

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -25,6 +25,7 @@ import { acquireLock, releaseLock } from './lib/lockfile';
 import { utcISOStamp as utcStamp, currentHHMM } from './lib/time';
 import { writeRuntimeJson, readRuntimeJson, STATE_DIR, LIFECYCLE_LOCK } from './lib/runtime';
 import { tmuxSessionAlive, getSessionName as deriveSessionName } from './lib/tmux';
+import { costLogPath } from './lib/cc-compat';
 
 type Json = any;
 
@@ -282,6 +283,97 @@ function maybePostCloseClear(config: Json): void {
   process.exit(0);
 }
 
+// --- Context-size clear ---
+
+/**
+ * Runs before the watchdog.enabled gate — independent of watchdog restart behavior.
+ * Sends /clear when the last hermit-owned turn exceeded a prompt-side token threshold
+ * and the session is quiescent (pane unchanged across two consecutive ticks).
+ * Guards: always-on only, no in-flight transition, operator silent ≥10 min, no shutdown.
+ */
+function maybeContextClear(config: Json): void {
+  const threshold = config.watchdog?.context_clear_tokens;
+  if (typeof threshold !== 'number' || threshold <= 0) return;
+
+  const runtime = readRuntimeJson();
+  if (!runtime) return;
+
+  // Always-on gate: interactive sessions must never be auto-cleared
+  if (runtime.runtime_mode === 'interactive') return;
+
+  // Transition gate: archiving/cleaning recovery is mid-flight — never interfere
+  if (runtime.transition) return;
+
+  // State gate (exclusion model): only bail on watchdog-internal suspect_process
+  const sessionState: string = runtime.session_state ?? '';
+  if (sessionState === 'suspect_process') return;
+
+  // Shutdown gate
+  if (runtime.shutdown_requested_at || runtime.shutdown_completed_at) return;
+
+  const sessionName: string = runtime.tmux_session ?? '';
+  if (!sessionName) return;
+  if (!tmuxSessionAlive(sessionName)) return;
+
+  // Operator-recency backoff: if operator was active < 10 min, skip
+  const opAge = getOperatorLastActionAgeSecs();
+  if (opAge !== null && opAge < 10 * 60) return;
+
+  // Token check: find the last cost-log entry for this hermit session
+  const sessionId: string = runtime.session_id ?? '';
+  if (!sessionId) return;
+
+  const logPath = costLogPath();
+  let lastEntry: Json = null;
+  try {
+    const lines = fs.readFileSync(logPath, 'utf-8').split('\n');
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line) continue;
+      try {
+        const e = JSON.parse(line);
+        if (e && e.session_id === sessionId) lastEntry = e;
+      } catch {}
+    }
+  } catch {
+    return; // cost-log absent — fail safe
+  }
+  if (!lastEntry) return;
+
+  const prompt =
+    (lastEntry.input_tokens ?? 0) +
+    (lastEntry.cache_write_tokens ?? 0) +
+    (lastEntry.cache_read_tokens ?? 0);
+  if (prompt <= threshold) return;
+
+  // Idempotence: bail if this entry was already cleared
+  const watchdogState = readWatchdogState();
+  if (watchdogState.last_cleared_cost_ts && watchdogState.last_cleared_cost_ts === lastEntry.timestamp) return;
+
+  // Quiescence guard: require pane unchanged across two consecutive ticks
+  const currentHash = getPaneHash(sessionName);
+  const prevHash = watchdogState.last_pane_hash_ctx ?? null;
+  if (currentHash === null || currentHash !== prevHash) {
+    // First qualifying tick — record hash and wait for next tick
+    watchdogState.last_pane_hash_ctx = currentHash;
+    writeWatchdogState(watchdogState);
+    return;
+  }
+
+  // Pane stable across two ticks — safe to clear
+  if (!tryAcquireLifecycleLock()) return;
+  try {
+    sendKeys(sessionName, '/clear');
+    watchdogState.last_cleared_cost_ts = lastEntry.timestamp;
+    watchdogState.last_pane_hash_ctx = null; // reset so next bloat cycle re-arms
+    writeWatchdogState(watchdogState);
+    appendEvent('context-clear', `prompt tokens ${prompt} over threshold ${threshold}`);
+  } finally {
+    releaseLock(LIFECYCLE_LOCK);
+  }
+  process.exit(0);
+}
+
 // --- Main decision loop ---
 
 function main(): void {
@@ -294,8 +386,11 @@ function main(): void {
     process.exit(0);
   }
 
-  // 0. Post-close clear — independent of watchdog.enabled; runs on any hermit with a scheduler
+  // 0a. Post-close clear — independent of watchdog.enabled; runs on any hermit with a scheduler
   maybePostCloseClear(config);
+
+  // 0b. Context-size clear — independent of watchdog.enabled; runs on any always-on hermit
+  maybeContextClear(config);
 
   // 1. Config gate
   const watchdogCfg = config?.watchdog ?? {};

--- a/plugins/claude-code-hermit/scripts/validate-config.ts
+++ b/plugins/claude-code-hermit/scripts/validate-config.ts
@@ -208,6 +208,11 @@ function validate(config: Json): { errors: string[]; warnings: string[] } {
     if (wd.operator_grace !== undefined && typeof wd.operator_grace !== 'string') {
       warnings.push('watchdog.operator_grace: should be a duration string (e.g. "15m")');
     }
+    if (wd.context_clear_tokens !== undefined && wd.context_clear_tokens !== null) {
+      if (typeof wd.context_clear_tokens !== 'number' || wd.context_clear_tokens < 0) {
+        warnings.push('watchdog.context_clear_tokens: should be a non-negative number or null (0 or null disables)');
+      }
+    }
   }
 
   if (config.env && typeof config.env === 'object') {

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -204,18 +204,20 @@ Update `permission_mode` in config.json.
   ```
   Watchdog (config.json watchdog)
 
-    enabled         false
-    stale_factor    2
-    escalate_after  3
-    operator_grace  15m
+    enabled                false
+    stale_factor           2
+    escalate_after         3
+    operator_grace         15m
+    context_clear_tokens   700000
   ```
 - Ask: "Enable watchdog? (yes / no) [current: <value>]"
 - If yes: show the configurable sub-fields before asking each one:
   ```
   Watchdog sub-fields (press Enter to keep current value):
-    stale_factor    — missed-cycle tolerance multiplier (e.g. 2)          [current]
-    escalate_after  — consecutive stale cycles before escalation (e.g. 3) [current]
-    operator_grace  — silence window before alert fires (e.g. 15m, 1h)    [current]
+    stale_factor           — missed-cycle tolerance multiplier (e.g. 2)                   [current]
+    escalate_after         — consecutive stale cycles before escalation (e.g. 3)          [current]
+    operator_grace         — silence window before alert fires (e.g. 15m, 1h)             [current]
+    context_clear_tokens   — auto-clear context when prompt tokens exceed this (e.g. 700000, 0=off) [current]
   ```
   Then ask each field in sequence.
 - Update `watchdog` object in config.json.

--- a/plugins/claude-code-hermit/state-templates/config.json.template
+++ b/plugins/claude-code-hermit/state-templates/config.json.template
@@ -65,7 +65,8 @@
     "enabled": false,
     "stale_factor": 2,
     "escalate_after": 3,
-    "operator_grace": "15m"
+    "operator_grace": "15m",
+    "context_clear_tokens": 700000
   },
   "post_close_clear": true
 }

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -584,6 +584,234 @@ test('post_close_clear: flag false → no send even with marker',
     expect(fs.existsSync(state(h, 'clear-requested.json'))).toBe(true);
   }));
 
+// -------------------------------------------------------
+// context-clear tests
+// -------------------------------------------------------
+
+const SESSION_ID = 'S-001';
+
+/** Write a cost-log entry under <hermit.dir>/.claude/cost-log.jsonl. */
+function writeCostLog(h: Hermit, entries: { session_id: string; input_tokens: number; cache_write_tokens: number; cache_read_tokens: number; timestamp?: string }[]): void {
+  const dir = path.join(h.dir, '.claude');
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = entries.map(e => JSON.stringify({
+    timestamp: e.timestamp ?? new Date().toISOString(),
+    session_id: e.session_id,
+    input_tokens: e.input_tokens,
+    cache_write_tokens: e.cache_write_tokens,
+    cache_read_tokens: e.cache_read_tokens,
+    output_tokens: 500,
+    total_tokens: e.input_tokens + e.cache_write_tokens + e.cache_read_tokens + 500,
+    estimated_cost_usd: 1.0,
+  })).join('\n') + '\n';
+  fs.writeFileSync(path.join(dir, 'cost-log.jsonl'), lines);
+}
+
+/** Write config with context_clear_tokens enabled and watchdog.enabled: false (pre-enabled gate). */
+function writeContextClearConfig(h: Hermit, threshold = 700000): void {
+  fs.writeFileSync(path.join(h.dir, '.claude-code-hermit', 'config.json'), JSON.stringify({
+    watchdog: { enabled: false, context_clear_tokens: threshold },
+    heartbeat: { enabled: true, every: '2h', active_hours: { start: '00:00', end: '23:59' } },
+  }, null, 2) + '\n');
+}
+
+/** Write runtime.json for an always-on hermit with given session_state. */
+function writeAlwaysOnRuntime(h: Hermit, session_state = 'idle'): void {
+  patchRuntime(h, { session_state, runtime_mode: 'tmux', session_id: SESSION_ID });
+}
+
+/** Write watchdog-state with a specific last_pane_hash_ctx (simulates second tick). */
+function primeContextHash(h: Hermit, hash: string): void {
+  const p = state(h, 'watchdog-state.json');
+  const existing = fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf-8')) : {};
+  fs.writeFileSync(p, JSON.stringify({ ...existing, last_pane_hash_ctx: hash }) + '\n');
+}
+
+test('context_clear: bloated idle + quiescent + operator silent → /clear sent on 2nd tick',
+  withHermit(async (h) => {
+    writeContextClearConfig(h);
+    writeAlwaysOnRuntime(h, 'idle');
+    // Bloated: 850K prompt-side tokens
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    // Fake tmux returns deterministic pane content so hash matches across both ticks
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    // Tick 1: hash recorded, no /clear yet
+    const r1 = await watchdog(h, 'run');
+    expect(r1.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+
+    // Tick 2: same hash → /clear fires
+    const r2 = await watchdog(h, 'run');
+    expect(r2.exitCode).toBe(0);
+    const tmuxLog = fs.readFileSync(path.join(h.dir, 'tmux-calls.log'), 'utf-8');
+    expect(tmuxLog).toContain('/clear');
+    expect(fs.readFileSync(eventsFile(h), 'utf-8')).toContain('context-clear');
+  }));
+
+test('context_clear: fires for in_progress session (evolve case) when quiescent + bloated',
+  withHermit(async (h) => {
+    writeContextClearConfig(h);
+    writeAlwaysOnRuntime(h, 'in_progress');
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    await watchdog(h, 'run'); // tick 1 — prime hash
+    const r2 = await watchdog(h, 'run'); // tick 2 — should clear
+    expect(r2.exitCode).toBe(0);
+    const tmuxLog = fs.readFileSync(path.join(h.dir, 'tmux-calls.log'), 'utf-8');
+    expect(tmuxLog).toContain('/clear');
+  }));
+
+test('context_clear: fires with watchdog.enabled: false (independent of restart path)',
+  withHermit(async (h) => {
+    // config has enabled: false — verifies context-clear runs before the enabled gate
+    writeContextClearConfig(h);
+    writeAlwaysOnRuntime(h, 'idle');
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    await watchdog(h, 'run'); // tick 1
+    const r2 = await watchdog(h, 'run'); // tick 2
+    expect(r2.exitCode).toBe(0);
+    const tmuxLog = fs.readFileSync(path.join(h.dir, 'tmux-calls.log'), 'utf-8');
+    expect(tmuxLog).toContain('/clear');
+  }));
+
+test('context_clear: under threshold → no /clear',
+  withHermit(async (h) => {
+    writeContextClearConfig(h, 700000);
+    writeAlwaysOnRuntime(h, 'idle');
+    // Only 100K tokens — under threshold
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 50000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    primeContextHash(h, crypto.createHash('sha256').update('static pane content\n').digest('hex'));
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
+test('context_clear: threshold 0 → disabled, no /clear',
+  withHermit(async (h) => {
+    writeContextClearConfig(h, 0);
+    writeAlwaysOnRuntime(h, 'idle');
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    primeContextHash(h, crypto.createHash('sha256').update('static pane content\n').digest('hex'));
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
+test('context_clear: interactive mode → no /clear',
+  withHermit(async (h) => {
+    writeContextClearConfig(h);
+    patchRuntime(h, { session_state: 'idle', runtime_mode: 'interactive', session_id: SESSION_ID });
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    primeContextHash(h, crypto.createHash('sha256').update('static pane content\n').digest('hex'));
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
+test('context_clear: transition set → no /clear',
+  withHermit(async (h) => {
+    writeContextClearConfig(h);
+    patchRuntime(h, { session_state: 'idle', runtime_mode: 'tmux', session_id: SESSION_ID, transition: 'cleaning' });
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    primeContextHash(h, crypto.createHash('sha256').update('static pane content\n').digest('hex'));
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
+test('context_clear: operator active < 10 min → no /clear',
+  withHermit(async (h) => {
+    writeContextClearConfig(h);
+    writeAlwaysOnRuntime(h, 'idle');
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    // Operator was active 3 min ago
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(3 / 60) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    primeContextHash(h, crypto.createHash('sha256').update('static pane content\n').digest('hex'));
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
+test('context_clear: pane hash changed between ticks → no /clear (active turn)',
+  withHermit(async (h) => {
+    writeContextClearConfig(h);
+    writeAlwaysOnRuntime(h, 'idle');
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    // Store a hash that won't match (simulates pane animation between ticks)
+    primeContextHash(h, 'different-hash-from-prev-tick');
+    writeFakeTmux(h, 0, 'static pane content'); // returns a different hash than stored
+    writeFakePgrep(h, 1);
+
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
+test('context_clear: no matching session_id in cost-log → no /clear',
+  withHermit(async (h) => {
+    writeContextClearConfig(h);
+    writeAlwaysOnRuntime(h, 'idle');
+    // Cost-log has entries for a different session
+    writeCostLog(h, [{ session_id: 'S-999', input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000 }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    primeContextHash(h, crypto.createHash('sha256').update('static pane content\n').digest('hex'));
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
+test('context_clear: idempotence — same entry not re-cleared on subsequent ticks',
+  withHermit(async (h) => {
+    writeContextClearConfig(h);
+    writeAlwaysOnRuntime(h, 'idle');
+    const ts = new Date(Date.now() - 3600_000).toISOString(); // fixed timestamp
+    writeCostLog(h, [{ session_id: SESSION_ID, input_tokens: 50000, cache_write_tokens: 0, cache_read_tokens: 800000, timestamp: ts }]);
+    fs.writeFileSync(state(h, 'last-operator-action.json'), JSON.stringify({ at: isoAgo(1) }) + '\n');
+    writeFakeTmux(h, 0, 'static pane content');
+    writeFakePgrep(h, 1);
+
+    // Simulate that this entry was already cleared: last_cleared_cost_ts matches the ts
+    const wdState = { last_pane_hash_ctx: crypto.createHash('sha256').update('static pane content\n').digest('hex'), last_cleared_cost_ts: ts };
+    fs.writeFileSync(state(h, 'watchdog-state.json'), JSON.stringify(wdState) + '\n');
+
+    const r = await watchdog(h, 'run');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(h.dir, 'tmux-calls.log'))).toBe(false);
+  }));
+
 // ---------- inActiveHours unit tests ----------
 // 2026-06-11T03:00:00Z → 12:00 Asia/Tokyo (inside 09:00-17:00), 23:00 America/New_York (outside)
 const ACTIVE_WINDOW = { start: '09:00', end: '17:00' };


### PR DESCRIPTION
## Summary

Operators saw 5–22× cost spikes on Jun 12–13 ($7–8/day vs $0.4–1.4 baseline) after the auto-evolve chain shipped. Root cause: scheduled routines (heartbeat, daily-auto-close, morning brief) kept firing while the session's conversation context was bloated (1–3M tokens), re-reading an inflated prompt cache at $0.50–2.50/call instead of ~$0.03/call.

Adds `maybeContextClear()` to the watchdog — a single deterministic lever that sends `/clear` when the last hermit-owned turn's prompt-side tokens exceed `watchdog.context_clear_tokens` (default 700k). Runs before the `watchdog.enabled` gate (independent of restart machinery), so it fires on any always-on hermit without requiring the restart path to be enabled.

## Changes

- **`scripts/hermit-watchdog.ts`**: new `maybeContextClear(config)` function; called at step 0b in `main()` immediately after `maybePostCloseClear`. Guards: always-on only, no in-flight `transition`, operator silent ≥10 min, 2-tick pane-hash quiescence, idempotence key (`last_cleared_cost_ts`) prevents re-firing on the same cost-log entry.
- **`state-templates/config.json.template` + `scripts/hermit-start.ts`**: add `context_clear_tokens: 700000` to `watchdog` defaults (both mirrored sites required by contract test).
- **`scripts/validate-config.ts`**: validate `context_clear_tokens` — non-negative number or null; no warning on `0` (valid disable value) to avoid spurious `/hermit-doctor` warnings.
- **`skills/hermit-settings/SKILL.md`**: add field to watchdog display and prompt sequence.
- **`docs/config-reference.md`**: document new field; correct decision-flow (steps 1–2 now show context-clear and post-close-clear run before `enabled` gate); fix event-list sentence (adds `context-clear`, was missing `post-close-clear` too).
- **`CHANGELOG.md`**: `### Added` bullet + `### Upgrade Instructions` for `hermit-evolve`.
- **`tests/watchdog.test.ts`**: 11 new test cases (fires on idle/in_progress/waiting, fires with `enabled: false`, under threshold, threshold=0, interactive gate, transition gate, operator-recency gate, pane-hash change, no matching session_id, idempotence).

## Test plan

- `bun test` from `plugins/claude-code-hermit/` — 978 pass, 0 fail (includes 11 new context-clear cases).
- Core premise verified in tmux: `/clear` drops Messages from 36.4k → 110 tokens (conversation history wiped to baseline).
- Quiescence guard verified in tmux: REPL pane animates every ~1s during any active turn (spinner + elapsed counter + token counter), so 2-tick pane-hash stability reliably detects in-flight turns.
- `session_id` keying verified on 4 real hermits (homeassistant S-014, rex S-024, trending S-019 all match; extratus unset/UUID is correctly excluded by the existing `runtime === null` bail).

Closes #373