### PR TITLE
fix(hooks): resolve .cch paths via walk-up resolver, not cwd (#384)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -8,6 +8,10 @@
   and documents the channel shape, starter message, starter threads, moderation
   notes, and invite publishing checklist.
 
+### Fixed
+
+- **hooks: cwd-drift bug class resolved** — `hermitDir()` added to `scripts/lib/cc-compat.ts` resolves `.claude-code-hermit/` via `AGENT_DIR` (absolute only) → `CLAUDE_PROJECT_DIR`+`existsSync` → cwd walk-up → fail-open, surviving any `cd` that leaves shell cwd inside `.claude-code-hermit/`. All 10 affected hook scripts updated; payload-anchored hooks (`validate-config`, `generate-summary`) anchor on the absolute `file_path` from the hook payload instead. Fixes #384.
+
 ## [1.2.2] - 2026-06-13
 
 ### Added

--- a/plugins/claude-code-hermit/docs/plugin-hermit-storage.md
+++ b/plugins/claude-code-hermit/docs/plugin-hermit-storage.md
@@ -121,3 +121,18 @@ When reviewing a plugin hermit for storage compliance, run these checks:
 4. Update `knowledge-schema.md` to declare the types.
 5. Delete the empty old folders.
 6. Run a final checklist pass to confirm nothing points at the old paths.
+
+## Hook cwd and project-root resolution
+
+Claude Code hooks fire with the session's shell cwd, which can drift away from the project root (a persisted `cd` into a subdirectory, for example). Hook scripts must **never** resolve `.claude-code-hermit/...` paths relative to cwd.
+
+All core hook scripts use `hermitDir()` from `scripts/lib/cc-compat.ts` instead. Resolution order:
+
+1. `AGENT_DIR` if **absolute** — operator override via `config.env`, points directly at the `.cch` dir.
+2. `CLAUDE_PROJECT_DIR`/`.claude-code-hermit` if that directory exists — CC-authoritative root.
+3. cwd walk-up looking for `.claude-code-hermit/config.json` — drift recovery.
+4. `path.resolve('.claude-code-hermit')` — fail-open, preserves today's behavior.
+
+Hooks that receive an absolute `file_path` in their payload (`validate-config`, `generate-summary`) anchor directly on that path instead of using the resolver — they have a guaranteed absolute source.
+
+When adding a new hook script, import `hermitDir` from `./lib/cc-compat` and compute all `.claude-code-hermit/...` paths against its return value.

--- a/plugins/claude-code-hermit/scripts/channel-hook.ts
+++ b/plugins/claude-code-hermit/scripts/channel-hook.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { safe } from './lib/sanitize';
+import { hermitDir } from './lib/cc-compat';
 
 type Json = any;
 
@@ -15,9 +16,10 @@ type Json = any;
  * Only acts when the channel is already configured in config.json.
  */
 
-const CONFIG_PATH = path.resolve('.claude-code-hermit/config.json');
-const ACTIVITY_PATH = path.resolve('.claude-code-hermit/state/channel-activity.json');
-const REPLIES_PATH = path.resolve('.claude-code-hermit/state/channel-replies.jsonl');
+const HERMIT_DIR = hermitDir();
+const CONFIG_PATH = path.join(HERMIT_DIR, 'config.json');
+const ACTIVITY_PATH = path.join(HERMIT_DIR, 'state', 'channel-activity.json');
+const REPLIES_PATH = path.join(HERMIT_DIR, 'state', 'channel-replies.jsonl');
 const MAX_STDIN = 64 * 1024;
 
 const SERVER_TO_CHANNEL: Record<string, string> = {

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -11,21 +11,22 @@ import path from 'node:path';
 import { calculateCost } from './lib/pricing';
 import { readTasks, taskProgress } from './lib/tasks';
 import { kStr, formatTokens } from './lib/format';
-import { sessionId as ccSessionId, transcriptPath as ccTranscriptPath, entryText, isToolResult, extractUsage, costLogPath } from './lib/cc-compat';
+import { sessionId as ccSessionId, transcriptPath as ccTranscriptPath, entryText, isToolResult, extractUsage, costLogPath, hermitDir } from './lib/cc-compat';
 import { costIndexPath, updateCostIndex, readCostIndex, scanAutomatedOpus } from './lib/cost-log';
 
 type Json = any;
 
 const MAX_STDIN = 1024 * 1024; // 1MB safety limit
-const COST_LOG = costLogPath('.claude-code-hermit');
-const COST_INDEX = costIndexPath('.claude-code-hermit');
-const SHELL_SESSION = path.resolve('.claude-code-hermit/sessions/SHELL.md');
-const STATUS_JSON = path.resolve('.claude-code-hermit/sessions/.status.json');
-const STATUS_JSON_TMP = path.resolve('.claude-code-hermit/sessions/.status.json.tmp');
-const RUNTIME_JSON = path.resolve('.claude-code-hermit/state/runtime.json');
-const HEARTBEAT_FILE = path.resolve('.claude-code-hermit/state/.heartbeat');
-const COST_SUMMARY = path.resolve('.claude-code-hermit/cost-summary.md');
-const TASK_SNAPSHOT = path.resolve('.claude-code-hermit/tasks-snapshot.md');
+const HERMIT_DIR = hermitDir();
+const COST_LOG = costLogPath(HERMIT_DIR);
+const COST_INDEX = costIndexPath(HERMIT_DIR);
+const SHELL_SESSION = path.join(HERMIT_DIR, 'sessions', 'SHELL.md');
+const STATUS_JSON = path.join(HERMIT_DIR, 'sessions', '.status.json');
+const STATUS_JSON_TMP = path.join(HERMIT_DIR, 'sessions', '.status.json.tmp');
+const RUNTIME_JSON = path.join(HERMIT_DIR, 'state', 'runtime.json');
+const HEARTBEAT_FILE = path.join(HERMIT_DIR, 'state', '.heartbeat');
+const COST_SUMMARY = path.join(HERMIT_DIR, 'cost-summary.md');
+const TASK_SNAPSHOT = path.join(HERMIT_DIR, 'tasks-snapshot.md');
 
 let _runtimeCache: Json;
 function readRuntimeJsonCached(): Json {

--- a/plugins/claude-code-hermit/scripts/evaluate-session.ts
+++ b/plugins/claude-code-hermit/scripts/evaluate-session.ts
@@ -9,12 +9,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { readTasks } from './lib/tasks';
+import { hermitDir } from './lib/cc-compat';
 
 type Json = any;
 
-const SHELL_SESSION = path.resolve('.claude-code-hermit/sessions/SHELL.md');
-const HASH_FILE = path.resolve('.claude-code-hermit/sessions/.eval-hash');
-const RUNTIME_JSON = path.resolve('.claude-code-hermit/state/runtime.json');
+const HERMIT_DIR = hermitDir();
+const SHELL_SESSION = path.join(HERMIT_DIR, 'sessions', 'SHELL.md');
+const HASH_FILE = path.join(HERMIT_DIR, 'sessions', '.eval-hash');
+const RUNTIME_JSON = path.join(HERMIT_DIR, 'state', 'runtime.json');
 
 function evaluateSession(content: Json, tasks: Json[]): Json {
   const results: Json = {

--- a/plugins/claude-code-hermit/scripts/generate-summary.ts
+++ b/plugins/claude-code-hermit/scripts/generate-summary.ts
@@ -198,8 +198,10 @@ process.stdin.on('end', () => {
     if (!raw.includes(STATE_SUBDIR)) process.exit(0);
     const event = JSON.parse(raw);
     const filePath = (event.tool_input || {}).file_path || (event.tool_input || {}).path || '';
-    if (!filePath.includes(STATE_SUBDIR)) process.exit(0);
-    run(STATE_SUBDIR);
+    // Anchor on the absolute path from the payload — immune to cwd drift (#384)
+    const idx = filePath.indexOf(STATE_SUBDIR);
+    if (idx === -1) process.exit(0);
+    run(filePath.slice(0, idx + STATE_SUBDIR.length));
   } catch {
     // Never block the agent
   }

--- a/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
@@ -18,10 +18,42 @@
 //   - Cron grammar (5-field POSIX, stable; CronCreate semantics are doc)
 //   - Monitor sentinel constants (HEARTBEAT_EVALUATE is hermit's own protocol)
 
+import fs from 'node:fs';
 import path from 'node:path';
 
 type Json = any;
 type TriState = { state: string; count: number; entries: Json[] };
+
+// ---------------------------------------------------------------------------
+// Project-root resolution (robust to drifted hook cwd — fix for #384)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fleet resolver — one of three; same walk-up logic, different return and fallback:
+ *   core hermitDir    (scripts/lib/cc-compat.ts)              → the .cch dir (this file)
+ *   HA   projectRoot  (homeassistant-hermit/src/config.ts)    → the project root (parent)
+ *   dev  findHermitDir(dev-hermit/scripts/git-push-guard.ts)  → the .cch dir or null
+ * INVARIANT: hermitDir() === path.join(projectRoot(), '.claude-code-hermit').
+ * Fix one (env-var precedence, iteration cap) → check the other two.
+ *
+ * Robust to a drifted hook cwd (#384). A *relative* AGENT_DIR (the legacy
+ * drift-prone default, e.g. `AGENT_DIR=".claude-code-hermit"`) is intentionally
+ * NOT honored — it falls through to CLAUDE_PROJECT_DIR, then walk-up, then fail-open.
+ */
+function hermitDir(): string {
+  const agent = process.env.AGENT_DIR;
+  if (agent && path.isAbsolute(agent)) return path.resolve(agent);
+  const proj = process.env.CLAUDE_PROJECT_DIR;
+  if (proj) { const d = path.join(proj, '.claude-code-hermit'); if (fs.existsSync(d)) return d; }
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i++) {
+    if (fs.existsSync(path.join(dir, '.claude-code-hermit', 'config.json'))) return path.join(dir, '.claude-code-hermit');
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve('.claude-code-hermit'); // fail-open: preserves today's behavior
+}
 
 // ---------------------------------------------------------------------------
 // Hook-payload accessors (pure, null-safe)
@@ -201,6 +233,8 @@ function ccVersion(payload?: Json): string | null {
 // ---------------------------------------------------------------------------
 
 export {
+  // Project-root resolution
+  hermitDir,
   // Hook-payload accessors
   sessionId,
   transcriptPath,

--- a/plugins/claude-code-hermit/scripts/prompt-context.ts
+++ b/plugins/claude-code-hermit/scripts/prompt-context.ts
@@ -5,10 +5,11 @@ process.stdout.on('error', () => {});
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { hermitDir } from './lib/cc-compat';
 
 type Json = any;
 
-const AGENT_DIR = process.env.AGENT_DIR || '.claude-code-hermit';
+const AGENT_DIR = hermitDir();
 
 // Drain stdin (fail-open contract — broken pipe if unread)
 process.stdin.resume();

--- a/plugins/claude-code-hermit/scripts/record-operator-action.ts
+++ b/plugins/claude-code-hermit/scripts/record-operator-action.ts
@@ -21,10 +21,11 @@ process.stdout.on('error', () => {});
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { hermitDir } from './lib/cc-compat';
 
-const AGENT_DIR = process.env.AGENT_DIR || '.claude-code-hermit';
-const STATE_PATH = path.resolve(AGENT_DIR, 'state', 'last-operator-action.json');
-const TMP_PATH   = path.resolve(AGENT_DIR, 'state', '.last-operator-action.json.tmp');
+const AGENT_DIR = hermitDir();
+const STATE_PATH = path.join(AGENT_DIR, 'state', 'last-operator-action.json');
+const TMP_PATH   = path.join(AGENT_DIR, 'state', '.last-operator-action.json.tmp');
 
 function write() {
   try {

--- a/plugins/claude-code-hermit/scripts/session-diff.ts
+++ b/plugins/claude-code-hermit/scripts/session-diff.ts
@@ -94,7 +94,7 @@ function writeSidecar(changedFiles: { file: string; status: string }[]): void {
   fs.renameSync(SIDECAR_TMP, SIDECAR_PATH);
 }
 
-const RUNTIME_JSON = path.resolve(".claude-code-hermit/state/runtime.json");
+const RUNTIME_JSON = path.join(HERMIT_DIR, "state", "runtime.json");
 const DEBOUNCE_MS = 60 * 1000; // 60 seconds
 
 // Exported run() function for use by stop-pipeline.ts.

--- a/plugins/claude-code-hermit/scripts/session-diff.ts
+++ b/plugins/claude-code-hermit/scripts/session-diff.ts
@@ -14,12 +14,14 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { hermitDir } from "./lib/cc-compat";
 
 type Json = any;
 
 const MAX_STDIN = 1024 * 1024; // 1MB safety limit
-const SIDECAR_PATH = path.resolve(".claude-code-hermit/state/session-diff.json");
-const SIDECAR_TMP = path.resolve(".claude-code-hermit/state/.session-diff.json.tmp");
+const HERMIT_DIR = hermitDir();
+const SIDECAR_PATH = path.join(HERMIT_DIR, "state", "session-diff.json");
+const SIDECAR_TMP = path.join(HERMIT_DIR, "state", ".session-diff.json.tmp");
 
 const STATUS_LABELS: Record<string, string> = { A: "added", M: "modified", D: "deleted" };
 

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -11,10 +11,11 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { readFrontmatter, readFileWithFrontmatter, globDir } from './lib/frontmatter';
 import { parseSchema } from './knowledge-lint';
+import { hermitDir } from './lib/cc-compat';
 
 type Json = any;
 
-const AGENT_DIR = process.env.AGENT_DIR || '.claude-code-hermit';
+const AGENT_DIR = hermitDir();
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(import.meta.dir, '..');
 const HARD_CAP = 9000;
 

--- a/plugins/claude-code-hermit/scripts/stop-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/stop-pipeline.ts
@@ -7,14 +7,15 @@ import { run as costTracker } from './cost-tracker';
 import { run as suggestCompact } from './suggest-compact';
 import { run as sessionDiff } from './session-diff';
 import { run as evaluateSession } from './evaluate-session';
-import { sessionCrons, backgroundTasks, ccVersion } from './lib/cc-compat';
+import { sessionCrons, backgroundTasks, ccVersion, hermitDir } from './lib/cc-compat';
 import fs from 'node:fs';
 import path from 'node:path';
 
 type Json = any;
 
-const HEARTBEAT_FILE = path.resolve('.claude-code-hermit/state/.heartbeat');
-const SNAPSHOT_FILE = path.resolve('.claude-code-hermit/state/cc-stop-snapshot.json');
+const HERMIT_DIR = hermitDir();
+const HEARTBEAT_FILE = path.join(HERMIT_DIR, 'state', '.heartbeat');
+const SNAPSHOT_FILE = path.join(HERMIT_DIR, 'state', 'cc-stop-snapshot.json');
 
 async function main(): Promise<void> {
   // Read stdin once

--- a/plugins/claude-code-hermit/scripts/validate-config.ts
+++ b/plugins/claude-code-hermit/scripts/validate-config.ts
@@ -10,7 +10,6 @@ type Json = any;
  * Exit 2 = validation failed, surface errors to agent.
  */
 
-const CONFIG_PATH = path.resolve('.claude-code-hermit/config.json');
 const MAX_STDIN = 64 * 1024;
 
 const REQUIRED_KEYS: Record<string, string[]> = {
@@ -303,7 +302,7 @@ function main() {
 
       let config: Json;
       try {
-        config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+        config = JSON.parse(fs.readFileSync(filePath, 'utf8'));
       } catch (e: any) {
         process.stderr.write(`[config-validate] FAIL: config.json is not valid JSON — ${safeForLLM(e.message)}\n`);
         process.exit(2);

--- a/plugins/claude-code-hermit/tests/cc-compat-hermitdir.test.ts
+++ b/plugins/claude-code-hermit/tests/cc-compat-hermitdir.test.ts
@@ -1,0 +1,135 @@
+// Unit tests for hermitDir() — the project-root resolver added in #384.
+//
+// IMPORTANT: each case explicitly controls CLAUDE_PROJECT_DIR and AGENT_DIR before
+// importing the module, because the test process inherits the real env when run
+// inside a CC session. An ambient CLAUDE_PROJECT_DIR would silently satisfy
+// branch (2) and hide cwd-drift bugs the tests are meant to catch.
+//
+// Strategy: dynamically re-import cc-compat.ts for each case so the module-level
+// `process.env` reads happen fresh. Bun re-evaluates dynamic imports per module
+// instance only when the module hasn't been cached — so we manipulate env before
+// each call and restore it after.
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+function makeTmpHermit(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-test-'));
+  fs.mkdirSync(path.join(tmp, '.claude-code-hermit', 'state'), { recursive: true });
+  fs.writeFileSync(path.join(tmp, '.claude-code-hermit', 'config.json'), '{}');
+  return tmp;
+}
+
+// Save + restore env vars per test
+let savedEnv: Record<string, string | undefined> = {};
+function saveEnv(...keys: string[]) {
+  for (const k of keys) savedEnv[k] = process.env[k];
+}
+function restoreEnv() {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  savedEnv = {};
+}
+
+// hermitDir() reads process.env at call time (not module load time), so we can
+// import once and control env per-call.
+const { hermitDir } = await import('../scripts/lib/cc-compat');
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+describe('hermitDir()', () => {
+  let tmp: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmp = makeTmpHermit();
+    origCwd = process.cwd();
+    saveEnv('AGENT_DIR', 'CLAUDE_PROJECT_DIR');
+    // Clear both so tests start from a clean slate
+    delete process.env.AGENT_DIR;
+    delete process.env.CLAUDE_PROJECT_DIR;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    try { process.chdir(origCwd); } catch {}
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('(a) absolute AGENT_DIR wins over CLAUDE_PROJECT_DIR and drifted cwd', () => {
+    const agentDir = path.join(tmp, '.claude-code-hermit');
+    // Set a conflicting CLAUDE_PROJECT_DIR pointing somewhere else
+    const other = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-other-'));
+    try {
+      fs.mkdirSync(path.join(other, '.claude-code-hermit'), { recursive: true });
+      fs.writeFileSync(path.join(other, '.claude-code-hermit', 'config.json'), '{}');
+      process.env.AGENT_DIR = agentDir;
+      process.env.CLAUDE_PROJECT_DIR = other;
+      // cwd is unrelated
+      expect(hermitDir()).toBe(agentDir);
+    } finally {
+      fs.rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it('(b) relative AGENT_DIR is ignored — falls through to CLAUDE_PROJECT_DIR', () => {
+    // This is the legacy registration shape that CAUSED #384: AGENT_DIR=".claude-code-hermit"
+    process.env.AGENT_DIR = '.claude-code-hermit'; // relative — must be ignored
+    process.env.CLAUDE_PROJECT_DIR = tmp;
+    expect(hermitDir()).toBe(path.join(tmp, '.claude-code-hermit'));
+  });
+
+  it('(c) CLAUDE_PROJECT_DIR set, cwd drifted — env branch wins', () => {
+    // Simulate the #384 trigger: cwd drifted inside .claude-code-hermit/
+    delete process.env.AGENT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = tmp;
+    process.chdir(path.join(tmp, '.claude-code-hermit', 'state'));
+    expect(hermitDir()).toBe(path.join(tmp, '.claude-code-hermit'));
+  });
+
+  it('(d) no env vars, cwd drifted into subdir — walk-up recovers', () => {
+    delete process.env.AGENT_DIR;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    process.chdir(path.join(tmp, '.claude-code-hermit', 'state'));
+    expect(hermitDir()).toBe(path.join(tmp, '.claude-code-hermit'));
+  });
+
+  it('(e) no env vars, unrelated cwd — fail-open returns resolved .claude-code-hermit', () => {
+    delete process.env.AGENT_DIR;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    // Use a tmpdir with no hermit (walk-up finds nothing)
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-bare-'));
+    try {
+      process.chdir(bare);
+      const result = hermitDir();
+      // Should be path.resolve('.claude-code-hermit') from the bare dir
+      expect(result).toBe(path.join(bare, '.claude-code-hermit'));
+    } finally {
+      fs.rmSync(bare, { recursive: true, force: true });
+    }
+  });
+
+  it('(b2) CLAUDE_PROJECT_DIR set but .claude-code-hermit subdir absent — falls to walk-up', () => {
+    // existsSync guard: if CLAUDE_PROJECT_DIR doesn't actually have a .cch dir, skip it
+    delete process.env.AGENT_DIR;
+    const noHermit = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-noh-'));
+    try {
+      process.env.CLAUDE_PROJECT_DIR = noHermit; // no .claude-code-hermit inside
+      process.chdir(path.join(tmp, '.claude-code-hermit', 'state'));
+      // Walk-up from drifted cwd finds tmp's hermit dir
+      expect(hermitDir()).toBe(path.join(tmp, '.claude-code-hermit'));
+    } finally {
+      fs.rmSync(noHermit, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/claude-code-hermit/tests/hook-cwd-drift.test.ts
+++ b/plugins/claude-code-hermit/tests/hook-cwd-drift.test.ts
@@ -14,7 +14,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { runScript } from './helpers/run';
+import { runScript, PLUGIN_ROOT } from './helpers/run';
+import { setupGitWorkdir } from './helpers/workdir';
 
 // -------------------------------------------------------------------------
 // Fixture
@@ -157,5 +158,51 @@ describe('generate-summary with drifted cwd', () => {
 
     const wrongSummary = path.join(driftedCwd, '.claude-code-hermit', 'state', 'state-summary.md');
     expect(fs.existsSync(wrongSummary)).toBe(false);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Tier 2: session-diff (debounce reads state/runtime.json — driven via stop-pipeline)
+// -------------------------------------------------------------------------
+//
+// session-diff's run() debounce reads state/runtime.json to decide whether to
+// skip the sidecar rewrite. Before the fix that path resolved via cwd, so a
+// drifted cwd made the read ENOENT → forceRefresh=true → the sidecar was rewritten
+// even when the debounce should have skipped. run() is only reachable through
+// stop-pipeline (the import.meta.main entry bypasses the debounce), so we drive it
+// there with a git-backed workdir (setupGitWorkdir seeds an uncommitted file, so
+// the bug path's captureDiff is non-empty and the rewrite is observable).
+
+describe('session-diff debounce with drifted cwd (#384 regression)', () => {
+  it('skips the sidecar rewrite when cwd is inside .claude-code-hermit/ (runtime.json resolved via hermitDir)', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const cch = path.join(wd.dir, '.claude-code-hermit');
+      // walk-up anchor: hermitDir() recovers the root via config.json
+      fs.writeFileSync(path.join(cch, 'config.json'), '{}');
+      fs.writeFileSync(path.join(cch, 'state', 'runtime.json'), '{"session_state":"in_progress"}');
+      const sidecar = path.join(cch, 'state', 'session-diff.json');
+      fs.writeFileSync(sidecar, '{"changed_files":[],"captured_at":"2026-01-01T00:00:00Z"}');
+      // Backdate 5s — still inside the 60s debounce window, so a rewrite is detectable.
+      const past = new Date(Date.now() - 5000);
+      fs.utimesSync(sidecar, past, past);
+      const before = fs.statSync(sidecar).mtimeMs;
+
+      await runScript('stop-pipeline.ts', {
+        stdin: '{}',
+        cwd: path.join(cch, 'state'),              // drifted: inside .claude-code-hermit/
+        env: {
+          ...driftEnv(),                           // force walk-up (relative AGENT_DIR + nonexistent CLAUDE_PROJECT_DIR)
+          AGENT_HOOK_PROFILE: 'standard',
+          CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
+        },
+      });
+
+      // After fix: in_progress + fresh sidecar → debounce skip → mtime unchanged.
+      // Before fix: runtime.json unreadable → forceRefresh → captureDiff rewrites it.
+      expect(fs.statSync(sidecar).mtimeMs).toBe(before);
+    } finally {
+      wd.cleanup();
+    }
   });
 });

--- a/plugins/claude-code-hermit/tests/hook-cwd-drift.test.ts
+++ b/plugins/claude-code-hermit/tests/hook-cwd-drift.test.ts
@@ -1,0 +1,161 @@
+// Regression tests for #384 — hook cwd-drift bug class.
+//
+// Each test simulates the exact failure mode: hook fires with cwd pinned inside
+// .claude-code-hermit/ (the paulinho field-report trigger). Before the fix,
+// validate-config would read .claude-code-hermit/.claude-code-hermit/config.json
+// (ENOENT → exit 2). The others would silently write to wrong paths.
+//
+// Env discipline: opts.env overrides process.env in run.ts (spread order is
+// { ...process.env, ...opts.env }), so setting a key here wins over the ambient
+// CC session value. To force walk-up (branch 3 of hermitDir), we point
+// CLAUDE_PROJECT_DIR at a nonexistent path and AGENT_DIR to a relative value.
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript } from './helpers/run';
+
+// -------------------------------------------------------------------------
+// Fixture
+// -------------------------------------------------------------------------
+
+let tmpRoot: string;       // project root — contains .claude-code-hermit/
+let hermitDir: string;     // tmpRoot/.claude-code-hermit
+let driftedCwd: string;    // tmpRoot/.claude-code-hermit/state  (the bug's cwd)
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'drift-test-'));
+  hermitDir = path.join(tmpRoot, '.claude-code-hermit');
+  driftedCwd = path.join(hermitDir, 'state');
+  fs.mkdirSync(driftedCwd, { recursive: true });
+  // Minimal config.json
+  fs.writeFileSync(path.join(hermitDir, 'config.json'), JSON.stringify({
+    agent_name: null, language: null, timezone: null,
+    escalation: 'conservative', channels: {}, env: {},
+    heartbeat: { enabled: false }, routines: [], quality_gate: { tier: 'balanced' },
+  }));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// Force hermitDir() walk-up branch: CLAUDE_PROJECT_DIR nonexistent, AGENT_DIR relative
+function driftEnv(): Record<string, string> {
+  return {
+    AGENT_DIR: '.claude-code-hermit',           // relative — ignored by hermitDir()
+    CLAUDE_PROJECT_DIR: '/nonexistent-path',    // existsSync fails — falls to walk-up
+  };
+}
+
+// -------------------------------------------------------------------------
+// Tier 1: validate-config (the reported bug)
+// -------------------------------------------------------------------------
+
+describe('validate-config with drifted cwd (#384 regression)', () => {
+  it('exits 0 for valid config when cwd is inside .claude-code-hermit/', async () => {
+    // Before fix: readFileSync(path.resolve('.claude-code-hermit/config.json')) from
+    // driftedCwd = .../state → read .../state/.claude-code-hermit/config.json → ENOENT → exit 2
+    // After fix: reads filePath (absolute from payload) directly → exit 0
+    const payload = JSON.stringify({
+      tool: 'Edit',
+      tool_input: { file_path: path.join(hermitDir, 'config.json') },
+    });
+    const result = await runScript('validate-config.ts', {
+      stdin: payload,
+      cwd: driftedCwd,    // drifted: inside .claude-code-hermit/state
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('[config-validate] OK');
+  });
+
+  it('still exits 2 for invalid config (double-path fix does not break validation)', async () => {
+    const badConfig = JSON.stringify({ escalation: 'bad-value', channels: {}, env: {}, heartbeat: {}, routines: [], quality_gate: {} });
+    const badConfigPath = path.join(hermitDir, 'config-bad.json');
+    fs.writeFileSync(badConfigPath, badConfig);
+    const payload = JSON.stringify({
+      tool: 'Edit',
+      // Spoof basename as config.json so the basename gate passes
+      tool_input: { file_path: path.join(path.dirname(badConfigPath), 'config.json') },
+    });
+    // Write bad config to the path the hook will read
+    fs.writeFileSync(path.join(hermitDir, 'config.json'), badConfig);
+    try {
+      const result = await runScript('validate-config.ts', {
+        stdin: payload,
+        cwd: driftedCwd,
+      });
+      expect(result.exitCode).toBe(2);
+    } finally {
+      // Restore valid config
+      fs.writeFileSync(path.join(hermitDir, 'config.json'), JSON.stringify({
+        agent_name: null, language: null, timezone: null,
+        escalation: 'conservative', channels: {}, env: {},
+        heartbeat: { enabled: false }, routines: [], quality_gate: { tier: 'balanced' },
+      }));
+    }
+  });
+});
+
+// -------------------------------------------------------------------------
+// Tier 2: record-operator-action (payload-less hook, uses hermitDir)
+// -------------------------------------------------------------------------
+
+describe('record-operator-action with drifted cwd', () => {
+  it('writes last-operator-action.json to the correct hermit dir via walk-up', async () => {
+    const statePath = path.join(hermitDir, 'state', 'last-operator-action.json');
+    // Remove if exists from a previous run
+    try { fs.unlinkSync(statePath); } catch {}
+
+    const payload = JSON.stringify({ prompt: 'hello' });
+    const result = await runScript('record-operator-action.ts', {
+      stdin: payload,
+      cwd: driftedCwd,
+      env: driftEnv(),   // force walk-up: no absolute AGENT_DIR, no valid CLAUDE_PROJECT_DIR
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(fs.existsSync(statePath)).toBe(true);
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    expect(typeof written.at).toBe('string');
+
+    // Sanity: confirm the wrong doubled path was NOT created
+    const wrongPath = path.join(driftedCwd, '.claude-code-hermit', 'state', 'last-operator-action.json');
+    expect(fs.existsSync(wrongPath)).toBe(false);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Tier 2: generate-summary (has file_path — anchors on payload)
+// -------------------------------------------------------------------------
+
+describe('generate-summary with drifted cwd', () => {
+  it('regenerates state-summary.md in the correct state dir from absolute filePath', async () => {
+    // Seed the state files generate-summary reads
+    const stateDir = path.join(hermitDir, 'state');
+    fs.writeFileSync(path.join(stateDir, 'alert-state.json'), JSON.stringify({}));
+
+    const editedFile = path.join(stateDir, 'alert-state.json');
+    const payload = JSON.stringify({
+      tool: 'Edit',
+      tool_input: { file_path: editedFile },
+    });
+
+    const summaryPath = path.join(stateDir, 'state-summary.md');
+    // Remove if exists from a previous run
+    try { fs.unlinkSync(summaryPath); } catch {}
+
+    const result = await runScript('generate-summary.ts', {
+      stdin: payload,
+      cwd: driftedCwd,
+    });
+
+    expect(result.exitCode).toBe(0);
+    // Confirm it wrote to the correct absolute path (not doubled)
+    expect(fs.existsSync(summaryPath)).toBe(true);
+
+    const wrongSummary = path.join(driftedCwd, '.claude-code-hermit', 'state', 'state-summary.md');
+    expect(fs.existsSync(wrongSummary)).toBe(false);
+  });
+});

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **mcp-safety-gate: operator-defined sensitivity restored under drifted cwd** — `projectRoot()` added to `src/config.ts` resolves the project root via `CLAUDE_PROJECT_DIR`+`existsSync` → cwd walk-up → fail-open, so `HA_EXTRA_SENSITIVE_*` overrides in `.env` are found even when hook cwd has drifted inside `.claude-code-hermit/`. Before this fix the gate failed open for those operator-configured domains. Fixes #384.
+
 ## [0.2.0] - 2026-06-12
 
 ### Fixed

--- a/plugins/claude-code-homeassistant-hermit/hooks/mcp-safety-gate.ts
+++ b/plugins/claude-code-homeassistant-hermit/hooks/mcp-safety-gate.ts
@@ -30,6 +30,7 @@
 import { readFileSync, writeSync } from 'node:fs';
 
 import { Severity, classifyEntity } from '../src/policy';
+import { projectRoot } from '../src/config';
 
 /** Pull entity_id values from MCP tool parameters. */
 export function extractEntityIds(toolInput: Record<string, unknown>): string[] {
@@ -169,9 +170,10 @@ function main(): void {
       );
     }
 
+    const root = projectRoot();
     const hits: Array<[string, Severity]> = [];
     for (const eid of entityIds) {
-      const [sev] = classifyEntity(eid);
+      const [sev] = classifyEntity(eid, root);
       if (sev !== Severity.ALLOW) hits.push([eid, sev]);
     }
 

--- a/plugins/claude-code-homeassistant-hermit/src/cli.ts
+++ b/plugins/claude-code-homeassistant-hermit/src/cli.ts
@@ -27,7 +27,7 @@ import {
 } from './artifacts';
 import { auditAutomations, auditScripts } from './audits';
 import { bootStatus, saveBootPreferences } from './boot';
-import { AppConfig, loadConfig, normalizedContextPath } from './config';
+import { AppConfig, loadConfig, normalizedContextPath, projectRoot } from './config';
 import { HomeAssistantClient, HomeAssistantError } from './ha-api';
 import { fetchHistorySnapshot } from './history';
 import {
@@ -473,7 +473,7 @@ export async function main(argv: string[], overrides: Partial<CliDeps> = {}): Pr
     throw exc;
   }
 
-  const config = deps.loadConfig();
+  const config = deps.loadConfig(projectRoot());
   const root = config.root;
 
   if (args.command === 'ha' && args.sub === 'policy-check') {

--- a/plugins/claude-code-homeassistant-hermit/src/config.ts
+++ b/plugins/claude-code-homeassistant-hermit/src/config.ts
@@ -6,9 +6,39 @@
 //   process env var > .env file > operator context file > fallback.
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 import { dumpFrontmatter, loadFrontmatter } from './markdown';
+
+// ---------------------------------------------------------------------------
+// Project-root resolution (robust to drifted hook/CLI cwd — fix for #384)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fleet resolver — one of three; same walk-up logic, different return and fallback:
+ *   core hermitDir    (core/scripts/lib/cc-compat.ts)              → the .cch dir
+ *   HA   projectRoot  (homeassistant-hermit/src/config.ts)         → project root (this file)
+ *   dev  findHermitDir(dev-hermit/scripts/git-push-guard.ts)       → the .cch dir or null
+ * INVARIANT: hermitDir() === join(projectRoot(), '.claude-code-hermit').
+ * Fix one (env-var precedence, iteration cap) → check the other two.
+ *
+ * Returns the project ROOT (the dir containing .claude-code-hermit), NOT the
+ * .cch dir itself — callers append paths themselves. Does NOT honor AGENT_DIR
+ * (core-only signal pointing AT the .cch dir; honoring it here would break the
+ * return-value contract).
+ */
+export function projectRoot(): string {
+  const proj = process.env.CLAUDE_PROJECT_DIR;
+  if (proj && existsSync(join(proj, '.claude-code-hermit'))) return proj;
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(dir, '.claude-code-hermit', 'config.json'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return process.cwd(); // fail-open: preserves today's behavior
+}
 
 export class AppConfig {
   constructor(

--- a/plugins/claude-code-homeassistant-hermit/tests/config.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/config.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { loadConfig, parseEnvText, saveEnvFile } from '../src/config';
+import { loadConfig, parseEnvText, projectRoot, saveEnvFile } from '../src/config';
 import { Severity, classifyEntity, clearPolicyCaches } from '../src/policy';
 
 const tmpDirs: string[] = [];
@@ -102,5 +102,74 @@ describe('parseEnvText (python-dotenv parity)', () => {
 
   test('quoted values may span lines', () => {
     expect(parseEnvText('M="line1\nline2"\n')).toEqual({ M: 'line1\nline2' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projectRoot() — cwd-drift regression (#384)
+// ---------------------------------------------------------------------------
+
+describe('projectRoot()', () => {
+  const ORIG_CWD = process.cwd();
+  let savedClaudeProjectDir: string | undefined;
+  const driftDirs: string[] = [];
+
+  function makeTmpHermit() {
+    const { mkdirSync, writeFileSync } = require('node:fs') as typeof import('node:fs');
+    const dir = mkdtempSync(join(tmpdir(), 'ha-root-test-'));
+    driftDirs.push(dir);
+    mkdirSync(join(dir, '.claude-code-hermit', 'state'), { recursive: true });
+    writeFileSync(join(dir, '.claude-code-hermit', 'config.json'), '{}');
+    return dir;
+  }
+
+  afterEach(() => {
+    process.chdir(ORIG_CWD);
+    if (savedClaudeProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = savedClaudeProjectDir;
+    savedClaudeProjectDir = undefined;
+    clearPolicyCaches();
+    const { rmSync } = require('node:fs') as typeof import('node:fs');
+    for (const d of driftDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  test('CLAUDE_PROJECT_DIR wins when .claude-code-hermit exists there', () => {
+    savedClaudeProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    const root = makeTmpHermit();
+    process.env.CLAUDE_PROJECT_DIR = root;
+    // Drift cwd elsewhere
+    process.chdir(join(root, '.claude-code-hermit', 'state'));
+    expect(projectRoot()).toBe(root);
+  });
+
+  test('walk-up recovers from drifted cwd when CLAUDE_PROJECT_DIR is absent/invalid', () => {
+    savedClaudeProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    const root = makeTmpHermit();
+    process.env.CLAUDE_PROJECT_DIR = '/nonexistent-path';
+    process.chdir(join(root, '.claude-code-hermit', 'state'));
+    expect(projectRoot()).toBe(root);
+  });
+
+  test('HA_EXTRA_SENSITIVE_DOMAINS blocks under drifted cwd (the #384 safety hole)', () => {
+    // Without fix: classifyEntity(eid) no root arg → resolve(process.cwd()) →
+    // drifted path → .env not found → HA_EXTRA_SENSITIVE_DOMAINS empty → ALLOW (fail-open).
+    // With fix: classifyEntity(eid, projectRoot()) → walk-up finds root → .env loads → BLOCK.
+    savedClaudeProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    const { writeFileSync } = require('node:fs') as typeof import('node:fs');
+    const root = makeTmpHermit();
+    // Set extra sensitive domain in .env
+    writeFileSync(join(root, '.env'), 'HA_EXTRA_SENSITIVE_DOMAINS=sprinkler\n');
+    // Set ha_safety_mode=strict (default, but be explicit)
+    writeFileSync(join(root, '.claude-code-hermit', 'config.json'), '{"ha_safety_mode":"strict"}');
+
+    process.env.CLAUDE_PROJECT_DIR = '/nonexistent-path'; // force walk-up
+    process.chdir(join(root, '.claude-code-hermit', 'state')); // drift
+
+    const resolvedRoot = projectRoot();
+    expect(resolvedRoot).toBe(root); // walk-up succeeded
+
+    // classifyEntity with the resolved root must see the .env override
+    const [sev] = classifyEntity('sprinkler.front_yard', resolvedRoot);
+    expect(sev).toBe(Severity.BLOCK); // would be ALLOW without the fix
   });
 });


### PR DESCRIPTION
## Summary

Claude Code persists shell cwd across tool calls (documented in the repo CLAUDE.md). When a multi-step Bash `cd` lands inside `.claude-code-hermit/`, subsequent hook fires inherit that cwd and any cwd-relative `.claude-code-hermit/...` base produces a doubled path — `ENOENT` on read, silent wrong-path writes elsewhere.

The field trigger was captured in a `paulinho` session: a `cd watchdog && ... && cd ..` sequence left the shell pinned one level too high (inside `.claude-code-hermit/`), and the next `Edit` hook fired from there.

## Changes

**Commit A — `claude-code-hermit` core:**
- Added `hermitDir()` to `scripts/lib/cc-compat.ts` — resolution order: absolute `AGENT_DIR` → `CLAUDE_PROJECT_DIR`+`existsSync` → cwd walk-up → fail-open. Relative `AGENT_DIR` (the legacy drift-prone default) is intentionally not honored.
- `validate-config` and `generate-summary` anchor directly on the absolute `file_path` from the hook payload — no resolver needed, most correct-by-construction.
- 8 payload-less hooks (`channel-hook`, `prompt-context`, `record-operator-action`, `startup-context`, `stop-pipeline`, `cost-tracker`, `session-diff`, `evaluate-session`) switched from cwd-relative bases to `hermitDir()`.
- 6 new unit tests for `hermitDir()` (all precedence branches including the relative-AGENT_DIR regression guard).
- 4 integration regression tests with cwd pinned inside `.claude-code-hermit/state`.

**Commit B — `claude-code-homeassistant-hermit`:**
- Added `projectRoot()` to `src/config.ts` — same walk-up, but returns the project root (not the `.cch` dir) since HA callers append `.env`/`.claude-code-hermit/config.json` themselves.
- `mcp-safety-gate.ts` now passes `projectRoot()` into `classifyEntity()` — without this, `HA_EXTRA_SENSITIVE_*` overrides from `.env` were silently lost under drift, allowing actuations the operator had blocked.
- `cli.ts` `loadConfig()` → `loadConfig(projectRoot())` for consistency.
- 3 new `projectRoot()` tests including the safety regression case.

## Test plan

```
cd plugins/claude-code-hermit && bun test     # 996 pass, 0 fail
cd plugins/claude-code-homeassistant-hermit && bun test  # 480 pass, 1 todo, 0 fail
```

Closes #384