### PR TITLE
fix: fully-qualify plugin skill names in autonomous invocation directives

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **CLAUDE-APPEND: fully-qualify dev-quality and dev-pr back-references** — short-form `/dev-quality` and `/dev-pr` in prose left the model with an ambiguous name; updated all occurrences in §Implementation Flow, §Tests Before PR, and §Dev Quick Reference to the namespaced form so injected templates are internally consistent.
+
 ## [0.4.0] - 2026-06-12
 
 ### Changed

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -46,7 +46,7 @@ After making code changes:
 1. Run the configured test command (`claude-code-dev-hermit.commands.test`, set via `/claude-code-dev-hermit:hatch`). If unset, ask the operator for the command and offer to save it via `hatch`.
 2. If tests fail, fix the failures or surface them in the response — **do not declare the task done with broken tests**.
 3. If the task is non-trivial and `/feature-dev:feature-dev` is installed, run it first when the code path is unfamiliar (framework lifecycle hooks, ORM internals, build-tool plugins, auth middleware). The trigger is **unfamiliarity, not urgency**. Skip for: doc/prompt/config edits, single-line fixes, code paths you've already read end-to-end.
-4. Before declaring the task done: run `/claude-code-dev-hermit:dev-quality`. It runs `/claude-code-hermit:simplify` on the working tree (cleanup pass) and re-runs `commands.test` if configured. If tests regress, investigate before committing. The skill will suggest the native `/code-review` to the operator for deeper correctness review — do not invoke it autonomously. **Nested git repo?** If your work is happening inside a nested git repo (true submodule, Composer path package, npm/pnpm path workspace, vendored dep edited in place), pass `--cwd <relative/path>` so `/dev-quality` scopes git ops, `/claude-code-hermit:simplify`, and the test re-run to that repo. State still lives under the parent's `.claude-code-hermit/`, but the captured SHA is the child's HEAD.
+4. Before declaring the task done: run `/claude-code-dev-hermit:dev-quality`. It runs `/claude-code-hermit:simplify` on the working tree (cleanup pass) and re-runs `commands.test` if configured. If tests regress, investigate before committing. The skill will suggest the native `/code-review` to the operator for deeper correctness review — do not invoke it autonomously. **Nested git repo?** If your work is happening inside a nested git repo (true submodule, Composer path package, npm/pnpm path workspace, vendored dep edited in place), pass `--cwd <relative/path>` so `/claude-code-dev-hermit:dev-quality` scopes git ops, `/claude-code-hermit:simplify`, and the test re-run to that repo. State still lives under the parent's `.claude-code-hermit/`, but the captured SHA is the child's HEAD.
 
 ## Tests Before PR
 
@@ -54,8 +54,8 @@ If the project defines its own pre-PR validation (e.g. a custom test runner, CI 
 
 1. Run `/claude-code-dev-hermit:dev-quality` — handles `/claude-code-hermit:simplify` + test re-run (see §Implementation Flow step 4). For nested-repo workflows, pass `--cwd <path>`.
 2. Commit.
-3. If you committed after `/dev-quality` ran and `commands.test` is configured, re-run it once — `/dev-pr` Gate 0 checks `last-test.json` against the current HEAD sha.
-4. Run `/claude-code-dev-hermit:dev-pr`. Gate 0 reads `last-test.json` and refuses if missing, on a stale sha, or with a non-pass status. Pass `--cwd <path>` if you used it for `/dev-quality` — the PR opens against the child repo's remote.
+3. If you committed after `/claude-code-dev-hermit:dev-quality` ran and `commands.test` is configured, re-run it once — `/claude-code-dev-hermit:dev-pr` Gate 0 checks `last-test.json` against the current HEAD sha.
+4. Run `/claude-code-dev-hermit:dev-pr`. Gate 0 reads `last-test.json` and refuses if missing, on a stale sha, or with a non-pass status. Pass `--cwd <path>` if you used it for `/claude-code-dev-hermit:dev-quality` — the PR opens against the child repo's remote.
 
 ## Technical Constraints
 
@@ -101,7 +101,7 @@ Tier mapping:
 - Mid-task test run + cache warm: `/claude-code-dev-hermit:dev-test` (supports `--cwd <path>`)
 - Pre-wrap quality gate: `/claude-code-dev-hermit:dev-quality` (supports `--cwd <path>`)
 - Open the PR: `/claude-code-dev-hermit:dev-pr` (supports `--cwd <path>`)
-- Cleanup pass: `/claude-code-hermit:simplify` (parallel reviewers, applies its own edits; `/dev-quality` wraps it)
+- Cleanup pass: `/claude-code-hermit:simplify` (parallel reviewers, applies its own edits; `/claude-code-dev-hermit:dev-quality` wraps it)
 - Parallel changes across many files: `/batch` (built-in)
 - Diagnostics: `/debug` (built-in)
 - High-stakes review: `/code-review` (built-in)

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **capability-brainstorm: use fully-qualified skill name for proposal-create** — short-form `/proposal-create` fails when the model autonomously invokes a skill; changed to `/claude-code-hermit:proposal-create` so the Skill tool resolves it correctly.
+
 ### Added
 
 - **Community Discord** — publishes the dev-community invite in both READMEs

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **capability-brainstorm: use fully-qualified skill name for proposal-create** — short-form `/proposal-create` fails when the model autonomously invokes a skill; changed to `/claude-code-hermit:proposal-create` so the Skill tool resolves it correctly.
+- **proposal-act/reflect/proposal-create: fully-qualify skill-creator invocations** — short-form `/skill-creator` fails when the model invokes the skill (procedure-capture install, skill-improvement, `NEXT-TASK.md` plan bullets); changed to `/skill-creator:skill-creator` so the Skill tool resolves it.
 
 ### Added
 

--- a/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
+++ b/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
@@ -42,9 +42,9 @@ Think across all four inputs simultaneously. For each candidate idea, apply both
 
 Cap at 2 ideas that pass both constraints. Emit-zero if none do. Record discarded ideas (one line each) for the artifact.
 
-## 3. Create proposals (single-pass via `/proposal-create`)
+## 3. Create proposals (single-pass via `/claude-code-hermit:proposal-create`)
 
-For each generated idea, invoke `/proposal-create` once with:
+For each generated idea, invoke `/claude-code-hermit:proposal-create` once with:
 
 ```
 Title: <short idea title>
@@ -57,12 +57,12 @@ Set the PROP frontmatter:
 - `category: capability`
 - `tags: [capability-brainstorm, ideation]`
 
-`/proposal-create` invokes `proposal-triage` internally. Parse its outcome:
+`/claude-code-hermit:proposal-create` invokes `proposal-triage` internally. Parse its outcome:
 - `CREATE` — PROP file written, note the assigned PROP-NNN.
 - `SUPPRESS — <code>` — record the suppression code. Don't retry.
 - `DUPLICATE:<PROP-ID>` — record the existing PROP-ID. Don't create.
 
-Do NOT invoke `proposal-triage` directly in this skill — `/proposal-create` already does it.
+Do NOT invoke `proposal-triage` directly in this skill — `/claude-code-hermit:proposal-create` already does it.
 
 ## 4. Emit batch message
 

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -83,7 +83,7 @@ When the operator accepts a proposal:
 4. Ask: **"How should this be implemented?"**
 
    - **"Start implementing now"** (default, typical answer): run the falsification gate, then handle session lifecycle, then execute in this turn.
-     **Falsification gate (runs first, before any session transition).** Verify the proposal is actionable as written with a read-only pass. Skip if the body contains `## Skill Improvement` (step (e) routes that to `/skill-creator`). Also skip if the body contains `## Skill Draft` — authoring is delegated to `/skill-creator` on accept, not a code-edit plan — but first check that the `source_artifact` path listed in `## Skill Draft` exists and is readable (if the file is missing or unreadable, REJECT with code `stale-paths` — the procedure brief was removed or archived; the operator should re-run reflect to generate a fresh brief).
+     **Falsification gate (runs first, before any session transition).** Verify the proposal is actionable as written with a read-only pass. Skip if the body contains `## Skill Improvement` (step (e) routes that to `/skill-creator:skill-creator`). Also skip if the body contains `## Skill Draft` — authoring is delegated to `/skill-creator:skill-creator` on accept, not a code-edit plan — but first check that the `source_artifact` path listed in `## Skill Draft` exists and is readable (if the file is missing or unreadable, REJECT with code `stale-paths` — the procedure brief was removed or archived; the operator should re-run reflect to generate a fresh brief).
 
        Agent selection — check the harness's available-skills list (never `claude plugin list` or disk checks):
        - `feature-dev:feature-dev` in available-skills → use `feature-dev:code-explorer` as the subagent.
@@ -104,12 +104,12 @@ When the operator accepts a proposal:
         - Yes: append `[HH:MM] switched to PROP-NNN: <title> (prior task: <prior task>)` to SHELL.md `## Progress Log`; overwrite SHELL.md `Task:` field with "Implement PROP-NNN: <title>"; `runtime.json session_state` stays `in_progress`. Proceed to (e).
         - No: fall back to "Create a session task" below.
      d. **Waiting:** fall back to "Create a session task" without asking, then notify: "PROP-NNN queued. Session is currently waiting."
-     e. Read the proposal body and execute the Proposed Solution as the active task. If the body contains `## Skill Improvement`, use `/skill-creator` for the implementation. If the body contains `## Skill Draft`, follow the procedure-capture install flow below. If the body is vague, ask the operator for clarification before proceeding — unless the falsification gate already returned `PROCEED` with a file list, in which case actionability is confirmed and this check is skipped.
+     e. Read the proposal body and execute the Proposed Solution as the active task. If the body contains `## Skill Improvement`, use `/skill-creator:skill-creator` for the implementation. If the body contains `## Skill Draft`, follow the procedure-capture install flow below. If the body is vague, ask the operator for clarification before proceeding — unless the falsification gate already returned `PROCEED` with a file list, in which case actionability is confirmed and this check is skipped.
 
      **Procedure-capture install flow (when body contains `## Skill Draft`):**
      1. Parse `name`, `source_artifact`, `install_target`, and `triggers` from the `## Skill Draft` block.
      2. **Collision guard:** if `install_target` (`.claude/skills/<name>/SKILL.md`) already exists, do **not** overwrite. Ask the operator: "Skill `<name>` already exists at `<install_target>`. Overwrite / Rename / Cancel?" Default = **Cancel**.
-     3. Invoke `/skill-creator` using `source_artifact` (the procedure brief in `compiled/`) as input. Pass the proposed `name` and `triggers` so it can author the correct frontmatter and trigger phrases. `/skill-creator` outputs a proposed SKILL.md.
+     3. Invoke `/skill-creator:skill-creator` using `source_artifact` (the procedure brief in `compiled/`) as input. Pass the proposed `name` and `triggers` so it can author the correct frontmatter and trigger phrases. `/skill-creator:skill-creator` outputs a proposed SKILL.md.
      4. **Second confirmation gate:** present the full authored SKILL.md to the operator and require an explicit yes/no before installing. An installed skill auto-loads into every future session, so the operator approves the artifact, not just the intent. Record the operator's verdict (confirmed / declined) in the PROP's `## Operator Decision` section.
         - Confirmed: proceed to install.
         - Declined: stop. Notify the operator that they can re-run `/proposal-act accept PROP-NNN` after revising the procedure brief.
@@ -172,8 +172,8 @@ When the operator accepts a proposal:
      ```
      If `NEXT-TASK.md` already exists: do **not** write. Status still flips to `accepted` (operator intent is recorded). Notify: "PROP-NNN accepted. NEXT-TASK is already pending another proposal. Run `/session-start` to consume it first, then re-run `/proposal-act accept PROP-NNN` and pick 'Start implementing now' or manual."
      Otherwise write the file. Then append any of the following bullets to the end of the Suggested Plan, in order, numbered sequentially from `4.` (quality-gate bullet is last so `/claude-code-hermit:simplify` reviews any skill-creator output):
-       - **(if the proposal contains `## Skill Improvement` AND `/skill-creator` is available)** `Use /skill-creator to build and validate the skill.`
-       - **(if the proposal contains `## Skill Draft`)** `Use /skill-creator to author the captured procedure from the source_artifact (see ## Skill Draft), present the final SKILL.md to the operator for confirmation, then install it to the install_target only on confirmation.`
+       - **(if the proposal contains `## Skill Improvement` AND `/skill-creator:skill-creator` is available)** `Use /skill-creator:skill-creator to build and validate the skill.`
+       - **(if the proposal contains `## Skill Draft`)** `Use /skill-creator:skill-creator to author the captured procedure from the source_artifact (see ## Skill Draft), present the final SKILL.md to the operator for confirmation, then install it to the install_target only on confirmation.`
        - **(if `quality_gate.tier` in `.claude-code-hermit/config.json` is not `"budget"` — i.e. `"balanced"` or `"quality"`)** `Run /claude-code-hermit:simplify on the touched files for a cleanup pass, then commit.`
      Confirm: "Task prepared. The next `/session-start` will offer this as the default task."
 

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -129,7 +129,7 @@ When the proposed solution involves creating a new agent, skill, heartbeat item,
 3. Verify it completes correctly
 
 **For a captured procedure (procedure-capture — called from reflect):**
-When `reflect` detects a recurring multi-step procedure (≥2 sessions, no existing skill covers it), it calls `proposal-create` with a `## Skill Draft` body block carrying the audit artifact path. Include this block verbatim in the PROP body as the dispatch signal for `proposal-act`. Set `category: capability`, `tags: [procedure-capture]`, `source: auto-detected`. Do not write the SKILL.md here — the accept flow delegates authoring to `/skill-creator` so the operator can review the final skill before install.
+When `reflect` detects a recurring multi-step procedure (≥2 sessions, no existing skill covers it), it calls `proposal-create` with a `## Skill Draft` body block carrying the audit artifact path. Include this block verbatim in the PROP body as the dispatch signal for `proposal-act`. Set `category: capability`, `tags: [procedure-capture]`, `source: auto-detected`. Do not write the SKILL.md here — the accept flow delegates authoring to `/skill-creator:skill-creator` so the operator can review the final skill before install.
 ```markdown
 ## Skill Draft
 - name: <skill-name>

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -189,7 +189,7 @@ Check whether any skill, agent, or hook is underperforming.
 Signal ladder (same for all three):
 - **Weak signal** (one-off or ambiguous): no action — not worth surfacing.
 - **Moderate signal** (pattern across 2-3 sessions): create a proposal via `/claude-code-hermit:proposal-create` with the evidence (subject to Three-Condition Rule).
-- **Strong signal** (clear, repeated pattern): create a proposal via `/claude-code-hermit:proposal-create` with the evidence and include a `## Skill Improvement` section (or `## Agent Improvement`) listing the component name, observed failures, and suggested eval criteria. When the proposal is accepted via `proposal-act`, use `/skill-creator eval` and `/skill-creator improve` to implement the changes. If `/skill-creator` is not available, apply the changes to the component's definition file directly.
+- **Strong signal** (clear, repeated pattern): create a proposal via `/claude-code-hermit:proposal-create` with the evidence and include a `## Skill Improvement` section (or `## Agent Improvement`) listing the component name, observed failures, and suggested eval criteria. When the proposal is accepted via `proposal-act`, use `/skill-creator:skill-creator eval` and `/skill-creator:skill-creator improve` to implement the changes. If `/skill-creator:skill-creator` is not available, apply the changes to the component's definition file directly.
 
 ### Procedure capture (new-skill creation)
 


### PR DESCRIPTION
## Summary

Plugin skills invoked **by the model** via the Skill tool require the fully-qualified `plugin:skill` form — short-form names like `/proposal-create` fail with \"skill not found\". This was reported for `/dev-quality` in the dev-hermit `CLAUDE-APPEND.md`.

The fix covers the only two sites where the failure actually happens:

1. **`capability-brainstorm/SKILL.md`** (`claude-code-hermit`) — §3 told the model to `invoke /proposal-create`, a genuine autonomous invocation directive using the short form.
2. **`CLAUDE-APPEND.md`** (`claude-code-dev-hermit`) — the actual directives were already namespaced, but back-reference prose still used `/dev-quality` and `/dev-pr`, creating an inconsistency that let the model pick up the failing short name.

## Changes

- `capability-brainstorm/SKILL.md`: all 4 occurrences of `` `/proposal-create` `` → `` `/claude-code-hermit:proposal-create` ``
- `CLAUDE-APPEND.md`: 5 short-form back-references in §Implementation Flow, §Tests Before PR, and §Dev Quick Reference updated to use the fully-qualified names

Operator-facing echo/NOTICE text (the skill prints \"re-run `/dev-pr`\" for a human to type) and quick-reference lists (operator-typed, CLI resolves short forms) are intentionally left as-is.

## Test plan

- `cd plugins/claude-code-dev-hermit && bash tests/run-all.sh` — 43+12+37+53+18 tests, all pass. The `hatch-mode.test.ts` assertion `no /dev-quality reference` (line 33) still passes because it checks the SAFETY template (untouched); the standard template now contains `:dev-quality`, not the substring `/dev-quality`.
- `cd plugins/claude-code-hermit && bun test` — 986 tests, all pass.