### PR TITLE
fix(claude-code-hermit): bump min_claude_code_version to >=2.1.172 (#389)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ On-demand skills — pullable from the Claude app, your terminal, or a DM:
 
 ## Quick Start
 
-> **Prerequisites:** [Claude Code](https://code.claude.com) v2.1.150+, a Claude plan (Pro, Max, Teams, or Enterprise), and [Bun](https://bun.sh) 1.3+. Linux, macOS, and Windows via WSL2 — see [FAQ](plugins/claude-code-hermit/docs/faq.md).
+> **Prerequisites:** [Claude Code](https://code.claude.com) v2.1.172+, a Claude plan (Pro, Max, Teams, or Enterprise), and [Bun](https://bun.sh) 1.3+. Linux, macOS, and Windows via WSL2 — see [FAQ](plugins/claude-code-hermit/docs/faq.md).
 
 ### 1. Install
 

--- a/plugins/claude-code-hermit/.claude-plugin/hermit-meta.json
+++ b/plugins/claude-code-hermit/.claude-plugin/hermit-meta.json
@@ -1,4 +1,4 @@
 {
-  "min_claude_code_version": ">=2.1.150",
+  "min_claude_code_version": ">=2.1.172",
   "required_bun_version": ">=1.3.0"
 }

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **min CC version: floor bumped to 2.1.172 (#389)** — nested-subagent dispatch (used by the shipped `daily-auto-close: haiku` default) requires it; on older versions the nested `session-mgr` call fails silently, preventing auto-close. Prerequisite docs updated.
+
 ## [1.2.3] - 2026-06-13
 
 ### Added

--- a/plugins/claude-code-hermit/README.md
+++ b/plugins/claude-code-hermit/README.md
@@ -92,7 +92,7 @@ On-demand skills — pullable from the Claude app, your terminal, or a DM:
 
 ## Quick Start
 
-> **Prerequisites:** [Claude Code](https://code.claude.com) v2.1.150+, a Claude plan (Pro, Max, Teams, or Enterprise), and [Bun](https://bun.sh) 1.3+. Linux, macOS, and Windows via WSL2 — see [FAQ](docs/faq.md).
+> **Prerequisites:** [Claude Code](https://code.claude.com) v2.1.172+, a Claude plan (Pro, Max, Teams, or Enterprise), and [Bun](https://bun.sh) 1.3+. Linux, macOS, and Windows via WSL2 — see [FAQ](docs/faq.md).
 
 ### 1. Install
 

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -12,7 +12,7 @@ For skill details, see [Skills Reference](skills.md).
 | ------------------------ | ------------ | ------------------------------------------ |
 | **tmux**                 | Boot scripts | `brew install tmux` / `apt install tmux`   |
 | **Node.js 22+**          | Hooks        | Cost tracking, session evaluation          |
-| **Claude Code v2.1.150+** | Channels, sandbox | Minimum supported version |
+| **Claude Code v2.1.172+** | Channels, sandbox | Minimum supported version |
 
 tmux is required. Channels are optional.
 

--- a/plugins/claude-code-hermit/docs/always-on.md
+++ b/plugins/claude-code-hermit/docs/always-on.md
@@ -19,7 +19,7 @@ You get four things at once: config isolation, crash recovery, a reproducible en
 | **Docker**               | Container    | `docker compose` v2 (Docker Desktop or modern Docker Engine) |
 | **Node.js 22+**          | Hooks        | Inside the container — handled by the Dockerfile |
 | **Bun**                  | Plugins      | Inside the container — always included          |
-| **Claude Code v2.1.150+** | Channels, sandbox | Minimum supported version |
+| **Claude Code v2.1.172+** | Channels, sandbox | Minimum supported version |
 
 ---
 

--- a/plugins/claude-code-hermit/docs/how-to-use.md
+++ b/plugins/claude-code-hermit/docs/how-to-use.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-[Claude Code](https://code.claude.com) v2.1.150+ and a paid Claude plan (Pro, Max, Teams, or Enterprise). Node.js 22+ for hooks. Optional: **tmux** for always-on mode, **Bun** for phone channels (Discord, Telegram).
+[Claude Code](https://code.claude.com) v2.1.172+ and a paid Claude plan (Pro, Max, Teams, or Enterprise). Node.js 22+ for hooks. Optional: **tmux** for always-on mode, **Bun** for phone channels (Discord, Telegram).
 
 ---
 


### PR DESCRIPTION
## Summary

Bumps the Claude Code minimum version floor from `>=2.1.150` to `>=2.1.172`. Nested-subagent dispatch — required by the already-shipped `daily-auto-close: haiku` default — only works in CC >=2.1.172. Operators on the 22-patch gap (2.1.150–2.1.171) experience silent auto-close failure: the nested `session-mgr` call returns nothing, sessions never archive, and there is no error signal because the skill is intentionally silent.

## Changes

- `.claude-plugin/hermit-meta.json` — `min_claude_code_version` `>=2.1.150` → `>=2.1.172` (authoritative install-gate, read by `hermit-evolve`)
- `CHANGELOG.md` — new `## [Unreleased]` section with one `### Changed` bullet
- `README.md` (root + plugin), `docs/how-to-use.md`, `docs/always-on.md`, `docs/always-on-ops.md` — prerequisite version strings updated to `v2.1.172+`

Intentionally left as-is: `docs/security.md` (feature-availability facts for `auto` mode / sandbox that genuinely required 2.1.150), historical CHANGELOG entries.

## Test plan

- `bun test` in `plugins/claude-code-hermit/` — 997 pass, 0 fail (no test asserts the old literal)
- Nested dispatch (`main → Agent(general-purpose) → Agent(child)`) verified live in 2.1.177 this session
- On current CC (2.1.177) the bump is a no-op; protection applies only to operators on the gap versions

Closes #389