### PR TITLE
fix(cost-tracker): attribute dispatched-subagent tokens (#390)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **cost-tracker: attribute dispatched-subagent tokens (#390)** — Agent tool_result usage (model-override routines, heartbeat, ad-hoc Task) was silently dropped; now emitted as a per-subagent cost-log line at its resolved model, attributed to the dispatching source. Cost totals will rise to reflect previously-invisible spend; cost-reflect folds subagent cost into the dispatching source row automatically.
+
 ## [1.2.3] - 2026-06-13
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/cost-reflect.ts
+++ b/plugins/claude-code-hermit/scripts/cost-reflect.ts
@@ -77,7 +77,8 @@ function run() {
     totals.cacheRead  += types.cacheRead;
     totals.output     += types.output;
 
-    if (cw > 0 && cr === 0 && out < COLD_START_OUTPUT_MAX) {
+    // Subagent lines contribute to cost totals but not to turn counts or cold-start detection.
+    if (!e.subagent && cw > 0 && cr === 0 && out < COLD_START_OUTPUT_MAX) {
       coldStartTurns++;
       coldStartCost += entryCost;
     }
@@ -90,7 +91,7 @@ function run() {
       }
       const s = sessionMap[sid];
       s.cost += entryCost;
-      s.turns++;
+      if (!e.subagent) s.turns++;
       s.byType.input      += types.input;
       s.byType.cacheWrite += types.cacheWrite;
       s.byType.cacheRead  += types.cacheRead;
@@ -104,7 +105,7 @@ function run() {
 
   const total = totals.input + totals.cacheWrite + totals.cacheRead + totals.output;
   const sessions = Object.keys(sessionMap).length;
-  const turns = window.length;
+  const turns = window.filter(e => !e.subagent).length;
 
   const topSessions = Object.entries(sessionMap)
     .sort((a, b) => b[1].cost - a[1].cost)
@@ -139,7 +140,7 @@ function run() {
     if (rest > 0) rows.push(`- +${rest} more sources`);
     // Footnote only when a routine row is actually displayed — otherwise it dangles.
     const footnote = shown.some(([src]) => src.startsWith('routine:'))
-      ? `\n_routines with a model override run their skill in a subagent; only the in-session dispatch cost is counted here_\n`
+      ? `\n_routine model-override subagent cost is included, attributed to its dispatching source_\n`
       : '';
     return `\n### Cost by source\n${rows.join('\n')}\n${footnote}`;
   }

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -110,6 +110,9 @@ function classifySource(triggerText: string): string {
 // only the Agent tool_result (type:'user' with toolUseResult.usage) does. extractUsage
 // skips these because they aren't type:'assistant', so collect them explicitly or their
 // tokens vanish from the ledger.
+// Limitation: shares sumTurnUsage's TAIL_BYTES window — a turn larger than the 512KB tail
+// is scanned from buffer start, so a prior turn's dispatch can bleed in. Same rare
+// over-count as the main-turn sum, accepted for the same reason.
 function collectSubagentUsage(lines: string[], billedIndex: number): Array<{
   model: string; inputTokens: number; cacheWriteTokens: number;
   cacheReadTokens: number; outputTokens: number; agentType: string;
@@ -517,6 +520,7 @@ async function run(data: Json): Promise<string | null> {
         api_calls: 0,
         subagent: true,
         agent_type: sa.agentType,
+        model_resolved: !!sa.model,   // false → resolvedModel was absent; model is a sonnet-default guess
         context_usage: null,
         estimated_cost_usd: saCost,
       }) + '\n', 'utf-8');

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -105,6 +105,41 @@ function classifySource(triggerText: string): string {
   return 'other';
 }
 
+// Collect Agent tool_results from the current turn window.
+// Subagent assistant entries live in separate transcript files and never appear here;
+// only the Agent tool_result (type:'user' with toolUseResult.usage) does. extractUsage
+// skips these because they aren't type:'assistant', so collect them explicitly or their
+// tokens vanish from the ledger.
+function collectSubagentUsage(lines: string[], billedIndex: number): Array<{
+  model: string; inputTokens: number; cacheWriteTokens: number;
+  cacheReadTokens: number; outputTokens: number; agentType: string;
+}> {
+  const out: Array<{
+    model: string; inputTokens: number; cacheWriteTokens: number;
+    cacheReadTokens: number; outputTokens: number; agentType: string;
+  }> = [];
+  for (let j = billedIndex; j >= 0; j--) {
+    try {
+      const e = JSON.parse(lines[j]);
+      const r = e.toolUseResult;
+      if (e.type === 'user' && r && r.agentType && r.usage) {
+        const u = r.usage;
+        out.push({
+          model: r.resolvedModel || '',
+          inputTokens: u.input_tokens || 0,
+          cacheWriteTokens: u.cache_creation_input_tokens || 0,
+          cacheReadTokens: u.cache_read_input_tokens || 0,
+          outputTokens: u.output_tokens || 0,
+          agentType: r.agentType,
+        });
+      }
+      // Same turn boundary as sumTurnUsage: the first non-tool_result user entry.
+      if (e.type === 'user' && !isToolResult(e)) break;
+    } catch {}
+  }
+  return out;
+}
+
 // Limitation: a turn spanning more than TAIL_BYTES is summed from buffer start, not the real boundary — same bleed as scanTriggerMarkers.
 function sumTurnUsage(lines: string[], billedIndex: number): {
   inputTokens: number; cacheWriteTokens: number; cacheReadTokens: number;
@@ -171,7 +206,8 @@ function readLastTurnUsage(transcriptPath: string): Json {
 
         const triggerText = scanTriggerMarkers(lines, i);
         const source = classifySource(triggerText);
-        return { ...summed, hadHumanTurn, source };
+        const subagents = collectSubagentUsage(lines, i);
+        return { ...summed, hadHumanTurn, source, subagents };
       } catch {}
     }
   } catch {}
@@ -425,7 +461,7 @@ async function run(data: Json): Promise<string | null> {
       return null;
     }
 
-    const { inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens, model: rawModel, hadHumanTurn, source, apiCalls } = turn;
+    const { inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens, model: rawModel, hadHumanTurn, source, apiCalls, subagents } = turn;
     const model = detectModel(rawModel);
 
     const totalTokens = inputTokens + cacheWriteTokens + cacheReadTokens + outputTokens;
@@ -457,12 +493,44 @@ async function run(data: Json): Promise<string | null> {
 
     fs.appendFileSync(COST_LOG, JSON.stringify(logEntry) + '\n', 'utf-8');
 
+    // Emit one log line per dispatched subagent at its resolved model.
+    // Subagent assistant entries live in separate transcript files; only the Agent tool_result
+    // (type:'user' with toolUseResult.usage) appears here. collectSubagentUsage captured them;
+    // attribute them to the same source so cost-reflect folds them into the dispatching row.
+    let subTokens = 0, subCost = 0;
+    for (const sa of (subagents || [])) {
+      const saTotal = sa.inputTokens + sa.cacheWriteTokens + sa.cacheReadTokens + sa.outputTokens;
+      if (saTotal === 0) continue;
+      const saModel = detectModel(sa.model);
+      const saCostRaw = calculateCost(saModel, sa.inputTokens, sa.cacheWriteTokens, sa.cacheReadTokens, sa.outputTokens);
+      const saCost = Math.round(saCostRaw * 10000) / 10000;
+      fs.appendFileSync(COST_LOG, JSON.stringify({
+        timestamp: new Date().toISOString(),
+        session_id: runtimeSessionId || sessionId,
+        source,
+        model: saModel,
+        input_tokens: sa.inputTokens,
+        cache_write_tokens: sa.cacheWriteTokens,
+        cache_read_tokens: sa.cacheReadTokens,
+        output_tokens: sa.outputTokens,
+        total_tokens: saTotal,
+        api_calls: 0,
+        subagent: true,
+        agent_type: sa.agentType,
+        context_usage: null,
+        estimated_cost_usd: saCost,
+      }) + '\n', 'utf-8');
+      subTokens += saTotal;
+      subCost += saCost;
+    }
+
     // Update incremental index — O(1) in the common case; O(n) only on first run or log truncation.
-    // Must happen before getCumulativeCost so the index fallback sees this turn's line.
+    // Must happen before getCumulativeCost so the index fallback sees this turn's lines.
     const costIdx = updateCostIndex(COST_LOG, COST_INDEX);
 
-    // Running total from .status.json (O(1)), falls back to index (O(1)) on first run
-    const cumulative = getCumulativeCost(roundedCost, totalTokens, hadHumanTurn, runtimeSessionId || sessionId, costIdx);
+    // Running total from .status.json (O(1)), falls back to index (O(1)) on first run.
+    // Include subagent spend so .status.json stays consistent with the index.
+    const cumulative = getCumulativeCost(roundedCost + subCost, totalTokens + subTokens, hadHumanTurn, runtimeSessionId || sessionId, costIdx);
     const costStr = `$${cumulative.cost.toFixed(4)}`;
 
     // Read SHELL.md for task/blockers — do NOT write back (avoids race condition with Claude's edits)
@@ -484,7 +552,7 @@ async function run(data: Json): Promise<string | null> {
   }
 }
 
-export { run, getCumulativeCost, classifySource, scanTriggerMarkers, sumTurnUsage };
+export { run, getCumulativeCost, classifySource, scanTriggerMarkers, sumTurnUsage, collectSubagentUsage };
 
 if (import.meta.main) {
   (async () => {

--- a/plugins/claude-code-hermit/tests/cost-tracker.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-tracker.test.ts
@@ -46,7 +46,7 @@ async function runCollect(lines: string[], billedIndex: number): Promise<any[]> 
 // CC uses a hybrid representation: both toolUseResult (the subagent summary) and
 // message.content:[{type:'tool_result'}] (so isToolResult returns true and boundary
 // scanning doesn't stop here).
-function subagentEntry(resolvedModel: string, inputTokens: number, outputTokens: number): string {
+function subagentEntry(resolvedModel: string | undefined, inputTokens: number, outputTokens: number): string {
   return JSON.stringify({
     type: 'user',
     message: { content: [{ type: 'tool_result', tool_use_id: 'agent-1', content: 'done' }] },
@@ -207,6 +207,7 @@ describe('cost-tracker subagent log lines', () => {
     expect(entry.model).toBe('haiku');
     expect(entry.agent_type).toBe('general-purpose');
     expect(entry.api_calls).toBe(0);
+    expect(entry.model_resolved).toBe(true); // resolvedModel was present
   });
 
   test('cost-tracker: subagent entry inherits the dispatching source', () => {
@@ -225,5 +226,47 @@ describe('cost-tracker subagent log lines', () => {
 
   test('cost-tracker: stderr summary produced (exit 0)', () => {
     expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+// A subagent dispatch whose tool_result carries no resolvedModel must still be
+// logged (tokens stay visible), but flagged model_resolved:false so the sonnet
+// default is auditable rather than a silent mis-bill.
+describe('cost-tracker subagent with no resolvedModel', () => {
+  let dir: string;
+  let logPath: string;
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-cost-tracker-nomodel-'));
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+    logPath = path.join(dir, '.claude', 'cost-log.jsonl');
+    const stateDir = path.join(dir, '.claude-code-hermit', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'runtime.json'), JSON.stringify({ session_id: 'test-session', session_state: 'active' }));
+
+    const transcriptLines = [
+      triggerPrompt('[hermit-routine:demo] start'),
+      assistantEntry('claude-sonnet-4-6', 500, 100),
+      subagentEntry(undefined, 1000, 400), // resolvedModel absent → model_resolved:false
+      assistantEntry('claude-sonnet-4-6', 10, 5),
+    ];
+    const transcriptPath = path.join(dir, 'transcript.jsonl');
+    fs.writeFileSync(transcriptPath, transcriptLines.join('\n') + '\n');
+
+    const stdin = JSON.stringify({ session_id: 'test-session', transcript_path: transcriptPath });
+    await runScript('cost-tracker.ts', { stdin, cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+  });
+
+  afterAll(() => {
+    if (dir) fs.rmSync(dir, { recursive: true });
+  });
+
+  test('cost-tracker: missing resolvedModel is logged with model_resolved:false at sonnet default', () => {
+    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    const subEntry = JSON.parse(lines[1]);
+    expect(subEntry.subagent).toBe(true);
+    expect(subEntry.model_resolved).toBe(false);
+    expect(subEntry.model).toBe('sonnet');
+    expect(subEntry.input_tokens).toBe(1000);
   });
 });

--- a/plugins/claude-code-hermit/tests/cost-tracker.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-tracker.test.ts
@@ -1,0 +1,229 @@
+// Tests for scripts/cost-tracker.ts: collectSubagentUsage unit tests and
+// subprocess test confirming per-subagent cost-log lines are emitted.
+//
+// Unit tests use a thin subprocess helper (collect-subagent-usage.ts) rather
+// than an in-process import to avoid polluting the module cache — cost-tracker.ts
+// initialises HERMIT_DIR at load time, and hooks.contract.test.ts imports the
+// same module in-process from a different cwd.  A shared cache would cause
+// getCumulativeCost to read the wrong .status.json path.
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript, PLUGIN_ROOT, SCRIPTS_DIR } from './helpers/run';
+
+const HELPER = path.join(import.meta.dir, 'helpers', 'collect-subagent-usage.ts');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function withTmpdir(fn: (dir: string) => Promise<void>) {
+  return async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-cost-tracker-'));
+    try {
+      await fn(dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  };
+}
+
+async function runCollect(lines: string[], billedIndex: number): Promise<any[]> {
+  const proc = Bun.spawn({
+    cmd: [process.execPath, HELPER],
+    env: { ...process.env },
+    stdin: Buffer.from(JSON.stringify({ lines, billedIndex })),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+  return JSON.parse(stdout.trim() || '[]');
+}
+
+// Build a toolUseResult transcript entry.
+// CC uses a hybrid representation: both toolUseResult (the subagent summary) and
+// message.content:[{type:'tool_result'}] (so isToolResult returns true and boundary
+// scanning doesn't stop here).
+function subagentEntry(resolvedModel: string, inputTokens: number, outputTokens: number): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { content: [{ type: 'tool_result', tool_use_id: 'agent-1', content: 'done' }] },
+    toolUseResult: {
+      agentType: 'general-purpose',
+      resolvedModel,
+      usage: { input_tokens: inputTokens, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: outputTokens },
+    },
+  });
+}
+
+function assistantEntry(model: string, inputTokens: number, outputTokens: number): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      model,
+      usage: { input_tokens: inputTokens, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: outputTokens },
+      content: [{ type: 'text', text: 'ok' }],
+    },
+  });
+}
+
+function triggerPrompt(text: string): string {
+  return JSON.stringify({ type: 'user', message: { content: text } });
+}
+
+// ---------------------------------------------------------------------------
+// Unit: collectSubagentUsage (via subprocess helper to avoid module-cache pollution)
+// ---------------------------------------------------------------------------
+
+describe('collectSubagentUsage', () => {
+  test('collects a single subagent toolUseResult within the turn window', async () => {
+    const lines = [
+      triggerPrompt('[hermit-routine:demo] start'),          // 0 — turn boundary
+      assistantEntry('claude-sonnet-4-6', 100, 50),         // 1
+      subagentEntry('claude-haiku-4-5-20251001', 200, 80),  // 2
+      assistantEntry('claude-sonnet-4-6', 10, 5),           // 3 — billedIndex
+    ];
+    const results = await runCollect(lines, 3);
+    expect(results).toHaveLength(1);
+    expect(results[0].model).toBe('claude-haiku-4-5-20251001');
+    expect(results[0].inputTokens).toBe(200);
+    expect(results[0].outputTokens).toBe(80);
+    expect(results[0].agentType).toBe('general-purpose');
+  });
+
+  test('collects multiple subagent dispatches within the same turn', async () => {
+    const lines = [
+      triggerPrompt('HEARTBEAT_EVALUATE'),                   // 0 — turn boundary
+      assistantEntry('claude-opus-4-8', 500, 200),          // 1
+      subagentEntry('claude-haiku-4-5-20251001', 100, 40),  // 2
+      subagentEntry('claude-haiku-4-5-20251001', 120, 50),  // 3
+      assistantEntry('claude-opus-4-8', 10, 5),             // 4 — billedIndex
+    ];
+    const results = await runCollect(lines, 4);
+    expect(results).toHaveLength(2);
+    expect(results.every((r: any) => r.model === 'claude-haiku-4-5-20251001')).toBe(true);
+  });
+
+  test('does not cross the turn boundary into the prior turn', async () => {
+    const lines = [
+      triggerPrompt('prior turn'),                          // 0 — prior turn boundary
+      subagentEntry('claude-haiku-4-5-20251001', 999, 999), // 1 — prior turn dispatch (must be excluded)
+      assistantEntry('claude-sonnet-4-6', 10, 5),           // 2 — prior turn last entry
+      triggerPrompt('[hermit-routine:demo] start'),          // 3 — current turn boundary
+      assistantEntry('claude-sonnet-4-6', 50, 20),          // 4 — billedIndex
+    ];
+    const results = await runCollect(lines, 4);
+    expect(results).toHaveLength(0);
+  });
+
+  test('returns empty array when no subagent dispatches in turn', async () => {
+    const lines = [
+      triggerPrompt('[hermit-routine:demo] start'),
+      assistantEntry('claude-sonnet-4-6', 100, 50),
+    ];
+    const results = await runCollect(lines, 1);
+    expect(results).toHaveLength(0);
+  });
+
+  test('ignores subagent entries with no usage', async () => {
+    const lines = [
+      triggerPrompt('hello'),
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'x', content: '' }] }, toolUseResult: { agentType: 'general-purpose', resolvedModel: 'claude-haiku-4-5-20251001' } }),
+      assistantEntry('claude-sonnet-4-6', 10, 5),
+    ];
+    const results = await runCollect(lines, 2);
+    expect(results).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subprocess: cost-tracker emits per-subagent log lines
+// ---------------------------------------------------------------------------
+
+describe('cost-tracker subagent log lines', () => {
+  // Minimal hermit dir structure cost-tracker needs:
+  //   <dir>/.claude/cost-log.jsonl     (written by cost-tracker)
+  //   <dir>/.claude-code-hermit/state/runtime.json
+  //   <dir>/.claude-code-hermit/sessions/SHELL.md  (optional; non-fatal if absent)
+  let dir: string;
+  let transcriptPath: string;
+  let logPath: string;
+  let out = '';
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-cost-tracker-sub-'));
+
+    // Claude dir for the cost-log
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+    logPath = path.join(dir, '.claude', 'cost-log.jsonl');
+
+    // Hermit state dir
+    const stateDir = path.join(dir, '.claude-code-hermit', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'runtime.json'), JSON.stringify({ session_id: 'test-session', session_state: 'active' }));
+
+    // Transcript: routine trigger → assistant call → subagent dispatch → final assistant
+    const transcriptLines = [
+      triggerPrompt('[hermit-routine:demo] start\nlog-routine-event.sh demo started'),
+      assistantEntry('claude-sonnet-4-6', 500, 100),
+      subagentEntry('claude-haiku-4-5-20251001', 1000, 400),
+      assistantEntry('claude-sonnet-4-6', 10, 5),
+    ];
+    transcriptPath = path.join(dir, 'transcript.jsonl');
+    fs.writeFileSync(transcriptPath, transcriptLines.join('\n') + '\n');
+
+    const stdin = JSON.stringify({ session_id: 'test-session', transcript_path: transcriptPath });
+    const r = await runScript('cost-tracker.ts', { stdin, cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+    out = r.stdout + r.stderr;
+  });
+
+  afterAll(() => {
+    if (dir) fs.rmSync(dir, { recursive: true });
+  });
+
+  test('cost-tracker: cost-log.jsonl is written', () => {
+    expect(fs.existsSync(logPath)).toBe(true);
+  });
+
+  test('cost-tracker: cost-log.jsonl has exactly 2 lines (main + subagent)', () => {
+    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(2);
+  });
+
+  test('cost-tracker: first line is the main turn entry (no subagent field)', () => {
+    const [firstLine] = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    const entry = JSON.parse(firstLine);
+    expect(entry.subagent).toBeFalsy();
+    expect(entry.source).toBe('routine:demo');
+    expect(entry.model).toBe('sonnet');
+  });
+
+  test('cost-tracker: second line is the subagent entry at haiku', () => {
+    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    const entry = JSON.parse(lines[1]);
+    expect(entry.subagent).toBe(true);
+    expect(entry.model).toBe('haiku');
+    expect(entry.agent_type).toBe('general-purpose');
+    expect(entry.api_calls).toBe(0);
+  });
+
+  test('cost-tracker: subagent entry inherits the dispatching source', () => {
+    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    const subEntry = JSON.parse(lines[1]);
+    expect(subEntry.source).toBe('routine:demo');
+  });
+
+  test('cost-tracker: subagent entry has correct token counts', () => {
+    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    const subEntry = JSON.parse(lines[1]);
+    expect(subEntry.total_tokens).toBeGreaterThan(0);
+    expect(subEntry.input_tokens).toBe(1000);
+    expect(subEntry.output_tokens).toBe(400);
+  });
+
+  test('cost-tracker: stderr summary produced (exit 0)', () => {
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/plugins/claude-code-hermit/tests/helpers/collect-subagent-usage.ts
+++ b/plugins/claude-code-hermit/tests/helpers/collect-subagent-usage.ts
@@ -1,0 +1,9 @@
+// Helper: run collectSubagentUsage on a transcript passed as JSON via stdin.
+// Usage: echo '{"lines":["...","..."],"billedIndex":3}' | bun collect-subagent-usage.ts
+// Output: JSON array of subagent records on stdout.
+import { collectSubagentUsage } from '../../scripts/cost-tracker';
+
+const raw = await new Response(Bun.stdin.stream()).text();
+const { lines, billedIndex } = JSON.parse(raw.trim());
+const results = collectSubagentUsage(lines, billedIndex);
+process.stdout.write(JSON.stringify(results) + '\n');

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -1807,9 +1807,14 @@ describe('cost-reflect source attribution', () => {
     beforeAll(async () => {
       wd = setupWorkdir();
       const d = utcDate(daysAgo(1));
+      // Fixture: 4 main-turn entries + 1 subagent:true entry for routine:reflect (haiku).
+      // haiku cost: input=10000→$0.008, output=2000→$0.008 = $0.016.
+      // routine:reflect total: $0.06 (main) + $0.016 (subagent) = $0.076 → displayed as $0.08.
+      // turns count must remain 4 (subagent line excluded from turn counter).
       write(path.join(wd.dir, '.claude', 'cost-log.jsonl'), [
         `{"timestamp":"${d}T10:00:00.000Z","session_id":"s1","source":"heartbeat","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":100000,"output_tokens":0,"total_tokens":100000,"estimated_cost_usd":0.03}`,
         `{"timestamp":"${d}T10:01:00.000Z","session_id":"s2","source":"routine:reflect","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":100000,"output_tokens":2000,"total_tokens":102000,"estimated_cost_usd":0.06}`,
+        `{"timestamp":"${d}T10:01:30.000Z","session_id":"s2","source":"routine:reflect","model":"haiku","input_tokens":10000,"cache_write_tokens":0,"cache_read_tokens":0,"output_tokens":2000,"total_tokens":12000,"estimated_cost_usd":0.016,"subagent":true,"agent_type":"general-purpose","api_calls":0}`,
         `{"timestamp":"${d}T10:02:00.000Z","session_id":"s3","source":"other","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":50000,"output_tokens":5000,"total_tokens":55000,"estimated_cost_usd":0.09}`,
         `{"timestamp":"${d}T10:03:00.000Z","session_id":"s4","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":50000,"output_tokens":1000,"total_tokens":51000,"estimated_cost_usd":0.021}`,
         '',
@@ -1838,6 +1843,17 @@ describe('cost-reflect source attribution', () => {
     });
     test('cost-reflect (source fixture): output ≤1500 chars', () => {
       expect(out.length).toBeLessThanOrEqual(1500);
+    });
+    test('cost-reflect: subagent entry folds into routine:reflect row (cost rises)', () => {
+      // routine:reflect = $0.06 (main sonnet) + $0.016 (haiku subagent) = $0.076 → $0.08
+      // Without subagent attribution it would show $0.06; with it, $0.08.
+      const routineLine = out.split('\n').find(l => l.includes('routine:reflect'));
+      expect(routineLine).toBeDefined();
+      expect(routineLine).toMatch(/\$0\.0[78]/); // $0.07 or $0.08 depending on rounding
+    });
+    test('cost-reflect: subagent line is excluded from turns count', () => {
+      // 4 main-turn entries in fixture (not 5); subagent line must not inflate turns.
+      expect(out).toContain('4 turns');
     });
   });
 


### PR DESCRIPTION
## Summary

Agent tool_result token usage (model-override routines, heartbeat, ad-hoc Task dispatches) was silently dropped from the cost-log. `extractUsage` only processes `type:'assistant'` entries, but subagent assistant turns live in separate transcript files — they never appear in the main transcript. The Agent tool_result (`type:'user'` with `toolUseResult.usage`) does, but was not collected.

Proven empirically: a single heartbeat turn dispatched 3 haiku subagents totalling 133K tokens that appeared in **no** cost-log entry. This blocks #364's decision gate (you can't measure whether model-override dispatch saves money if the subagent cost is invisible).

## Changes

- **`scripts/cost-tracker.ts`**: adds `collectSubagentUsage()` scanning the same turn window as `sumTurnUsage`, collecting `type:'user'` entries with `toolUseResult.{agentType, usage}`. Emits one extra cost-log line per dispatched subagent at its `resolvedModel` with `subagent:true` and the dispatching turn's `source`. Folds subagent spend into `getCumulativeCost` so `.status.json` stays consistent.
- **`scripts/cost-reflect.ts`**: excludes `subagent:true` entries from turn counts and the cold-start heuristic; subagent cost still flows into `sourceMap`/`totals` so the `routine:<id>` row picks it up automatically. Updates the now-stale footnote.
- **`tests/cost-tracker.test.ts`** (new): unit tests for `collectSubagentUsage` boundary behaviour (multiple dispatches, no cross-turn bleed); subprocess test asserting 2 log lines with correct model/source/tokens.
- **`tests/helpers/collect-subagent-usage.ts`** (new): thin subprocess shim for the unit tests — avoids in-process import of `cost-tracker.ts` which would pollute the Bun module cache and break `hooks.contract.test.ts`'s `getCumulativeCost` tests.
- **`tests/scripts.test.ts`**: adds `subagent:true` entry to the cost-reflect source attribution fixture; asserts the `routine:reflect` row cost rises and `turns` count stays correct.

## Implementation note

CC's Agent tool_result uses a hybrid representation: `toolUseResult` at the top level *and* `message.content:[{type:'tool_result'}]`. `isToolResult` returns `true` for these entries, so the existing boundary logic correctly scans past multiple dispatches within one turn without stopping early.

The fix is general — covers all dispatch sources, not just model-override routines. Nested grandchildren (subagent's own subagents, living in the subagent's transcript file) remain uncounted.

## Test plan

```
cd plugins/claude-code-hermit && bun test
```

1011/1011 pass. Targeted:
- `bun test tests/cost-tracker.test.ts` — 12 tests (unit boundary + subprocess 2-line assertion)
- `bun test tests/scripts.test.ts --test-name-pattern "cost-reflect source attribution"` — 14 tests including new subagent-fold and turns-count assertions

Closes #390