### PR TITLE
feat(proposal-act): dispatch step (e) implementation to general-purpose subagent (#402)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **proposal-act: dispatch step (e) implementation to a general-purpose subagent (#402)** — keeps multi-file implementation noise out of the always-on main session; only a compact structured report (status, touched files, tests run, escalation) returns. e.5 quality gate, e.6 verification, and resolve stay in main. Skill-authoring (`## Skill Improvement`, `## Skill Draft`) and routine proposals are unaffected.
+
 ## [1.2.4] - 2026-06-14
 
 ### Fixed

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **proposal-act: dispatch step (e) implementation to a general-purpose subagent (#402)** — keeps multi-file implementation noise out of the always-on main session; only a compact structured report (status, touched files, tests run, escalation) returns. e.5 quality gate, e.6 verification, and resolve stay in main. Skill-authoring (`## Skill Improvement`, `## Skill Draft`) and routine proposals are unaffected.
+- **proposal-act: dispatch the whole accept-flow tail to a general-purpose subagent (#402)** — implement, quality gate (`/simplify`), and verification all run in one isolated subagent context; only a compact structured report returns. Main keeps just the `resolve` lifecycle mutation and operator/channel notification. Skill-authoring (`## Skill Improvement` with skill-creator, `## Skill Draft`) and routine proposals stay in main and are unaffected; a `## Skill Improvement` proposal with skill-creator absent now runs the falsification gate and dispatches as a normal code edit.
 
 ## [1.2.4] - 2026-06-14
 

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -104,7 +104,7 @@ When the operator accepts a proposal:
         - Yes: append `[HH:MM] switched to PROP-NNN: <title> (prior task: <prior task>)` to SHELL.md `## Progress Log`; overwrite SHELL.md `Task:` field with "Implement PROP-NNN: <title>"; `runtime.json session_state` stays `in_progress`. Proceed to (e).
         - No: fall back to "Create a session task" below.
      d. **Waiting:** fall back to "Create a session task" without asking, then notify: "PROP-NNN queued. Session is currently waiting."
-     e. Implement the proposal. If the body contains `## Skill Improvement`, use `/skill-creator:skill-creator` for the implementation (run in main — subagents cannot invoke skills). If the body contains `## Skill Draft`, follow the procedure-capture install flow below. Otherwise, dispatch implementation to the native `general-purpose` agent:
+     e. Implement the proposal. If the body contains `## Skill Improvement` and `skill-creator:skill-creator` is in the available-skills list, use `/skill-creator:skill-creator` for the implementation. If the body contains `## Skill Draft`, follow the procedure-capture install flow below. Otherwise, dispatch implementation to the native `general-purpose` agent (this includes `## Skill Improvement` proposals when skill-creator is absent):
 
         **Dispatch (PROCEED + no skill marker):**
         Invoke `general-purpose` via the Agent tool with this prompt (fill in the bracketed value):

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -104,7 +104,32 @@ When the operator accepts a proposal:
         - Yes: append `[HH:MM] switched to PROP-NNN: <title> (prior task: <prior task>)` to SHELL.md `## Progress Log`; overwrite SHELL.md `Task:` field with "Implement PROP-NNN: <title>"; `runtime.json session_state` stays `in_progress`. Proceed to (e).
         - No: fall back to "Create a session task" below.
      d. **Waiting:** fall back to "Create a session task" without asking, then notify: "PROP-NNN queued. Session is currently waiting."
-     e. Read the proposal body and execute the Proposed Solution as the active task. If the body contains `## Skill Improvement`, use `/skill-creator:skill-creator` for the implementation. If the body contains `## Skill Draft`, follow the procedure-capture install flow below. If the body is vague, ask the operator for clarification before proceeding — unless the falsification gate already returned `PROCEED` with a file list, in which case actionability is confirmed and this check is skipped.
+     e. Implement the proposal. If the body contains `## Skill Improvement`, use `/skill-creator:skill-creator` for the implementation (run in main — subagents cannot invoke skills). If the body contains `## Skill Draft`, follow the procedure-capture install flow below. Otherwise, dispatch implementation to the native `general-purpose` agent:
+
+        **Dispatch (PROCEED + no skill marker):**
+        Invoke `general-purpose` via the Agent tool with this prompt (fill in the bracketed value):
+
+        > Implement the accepted proposal at `<absolute path to PROP-NNN-*.md>`.
+        >
+        > Read the proposal file. The `## Operator Decision` section contains a `PROCEED` line from the falsification gate with the authoritative file list — use that list as your scope (over any files mentioned in the proposal body).
+        >
+        > Do the edits and any test/fix loops yourself. You may spawn a nested Explore subagent if the proposal warrants a search. You cannot prompt the operator — if you encounter an ambiguous spec or an undecidable/destructive choice, **stop and return an escalation block** in your final message rather than guessing.
+        >
+        > Return exactly this structure as your final message (nothing else):
+        > ```
+        > Status: implemented | escalated | blocked: <reason>
+        > Touched files: <relative paths, space-separated | none>
+        > Tests run: <commands + pass/fail summary | none>
+        > Deferred for operator: <none | what was ambiguous and what safe no-op was taken>
+        > ```
+
+        After the subagent returns:
+        - `Status: implemented` → continue to e.5, passing the returned **Touched files** as the `/simplify` focus scope.
+        - `Status: escalated` or `Status: blocked:` → do **not** resolve. Interactive mode: surface the Deferred-for-operator block to the operator. Autonomous mode: notify via channel. Proposal status stays `accepted`.
+
+        **e.6 re-dispatch:** if a defined `## Verification` step fails after a dispatched implementation, re-dispatch to `general-purpose` once with the failure output appended to the original prompt; if it fails again, surface to the operator (interactive) or channel (autonomous) and do not resolve.
+
+        If the body is vague and the falsification gate did not return `PROCEED`, ask the operator for clarification before proceeding.
 
      **Procedure-capture install flow (when body contains `## Skill Draft`):**
      1. Parse `name`, `source_artifact`, `install_target`, and `triggers` from the `## Skill Draft` block.
@@ -124,7 +149,7 @@ When the operator accepts a proposal:
          | `tier` is `"budget"` / `"balanced"` / `"quality"` | use as-is |
          | `tier` missing, `quality_gate` missing, or value not in enum | `budget` (log one-line warning to SHELL.md Findings) |
 
-         Build a touched-files list from the writes you made during step (e) if you can reliably enumerate them. This is the precise scope for `/claude-code-hermit:simplify` and for the judge. If you can't recall the list (multi-turn work, sub-agent delegation), omit it; downstream falls back to `git diff --name-only HEAD`.
+         Build a touched-files list for step (e): when step (e) was dispatched to `general-purpose`, use the **Touched files** from the subagent's return. For in-main implementations, enumerate the writes made during step (e). This is the precise scope for `/claude-code-hermit:simplify` and for the judge. If the list is unavailable (multi-turn work, subagent returned `none`), omit it; downstream falls back to `git diff --name-only HEAD`.
 
          Branch on the resolved tier:
 

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -83,7 +83,7 @@ When the operator accepts a proposal:
 4. Ask: **"How should this be implemented?"**
 
    - **"Start implementing now"** (default, typical answer): run the falsification gate, then handle session lifecycle, then execute in this turn.
-     **Falsification gate (runs first, before any session transition).** Verify the proposal is actionable as written with a read-only pass. Skip if the body contains `## Skill Improvement` (step (e) routes that to `/skill-creator:skill-creator`). Also skip if the body contains `## Skill Draft` — authoring is delegated to `/skill-creator:skill-creator` on accept, not a code-edit plan — but first check that the `source_artifact` path listed in `## Skill Draft` exists and is readable (if the file is missing or unreadable, REJECT with code `stale-paths` — the procedure brief was removed or archived; the operator should re-run reflect to generate a fresh brief).
+     **Falsification gate (runs first, before any session transition).** Verify the proposal is actionable as written with a read-only pass. Skip only when the body contains `## Skill Improvement` **and** `/skill-creator:skill-creator` is in the available-skills list (step (e) routes that to `/skill-creator:skill-creator`) — if `## Skill Improvement` is present but skill-creator is absent, the proposal becomes a code-edit implementation, so the gate runs to produce a `PROCEED` file list for the dispatch. Also skip if the body contains `## Skill Draft` — authoring is delegated to `/skill-creator:skill-creator` on accept, not a code-edit plan — but first check that the `source_artifact` path listed in `## Skill Draft` exists and is readable (if the file is missing or unreadable, REJECT with code `stale-paths` — the procedure brief was removed or archived; the operator should re-run reflect to generate a fresh brief).
 
        Agent selection — check the harness's available-skills list (never `claude plugin list` or disk checks):
        - `feature-dev:feature-dev` in available-skills → use `feature-dev:code-explorer` as the subagent.
@@ -104,30 +104,33 @@ When the operator accepts a proposal:
         - Yes: append `[HH:MM] switched to PROP-NNN: <title> (prior task: <prior task>)` to SHELL.md `## Progress Log`; overwrite SHELL.md `Task:` field with "Implement PROP-NNN: <title>"; `runtime.json session_state` stays `in_progress`. Proceed to (e).
         - No: fall back to "Create a session task" below.
      d. **Waiting:** fall back to "Create a session task" without asking, then notify: "PROP-NNN queued. Session is currently waiting."
-     e. Implement the proposal. If the body contains `## Skill Improvement` and `skill-creator:skill-creator` is in the available-skills list, use `/skill-creator:skill-creator` for the implementation. If the body contains `## Skill Draft`, follow the procedure-capture install flow below. Otherwise, dispatch implementation to the native `general-purpose` agent (this includes `## Skill Improvement` proposals when skill-creator is absent):
+     e. Implement the proposal. If the body contains `## Skill Improvement` and `skill-creator:skill-creator` is in the available-skills list, use `/skill-creator:skill-creator` for the implementation (in-main; continues to e.5). If the body contains `## Skill Draft`, follow the procedure-capture install flow below (in-main; continues to e.5). Otherwise, dispatch the full implementation tail to the native `general-purpose` agent (this includes `## Skill Improvement` proposals when skill-creator is absent):
 
-        **Dispatch (PROCEED + no skill marker):**
-        Invoke `general-purpose` via the Agent tool with this prompt (fill in the bracketed value):
+        **Dispatch (falsification gate returned PROCEED, no in-main skill handler):**
+        Invoke `general-purpose` via the Agent tool with this prompt (fill in the bracketed value). The subagent inherits `CLAUDE.md`/`CLAUDE.local.md`, can invoke skills, and can spawn nested subagents — so it runs the whole tail (implement → quality gate → verification) in its own isolated context and returns one report.
 
-        > Implement the accepted proposal at `<absolute path to PROP-NNN-*.md>`.
+        > Implement the accepted proposal at `<absolute path to PROP-NNN-*.md>`, then run its quality gate and verification. Work entirely in this context; your final message is the only thing returned to the caller.
         >
-        > Read the proposal file. The `## Operator Decision` section contains a `PROCEED` line from the falsification gate with the authoritative file list — use that list as your scope (over any files mentioned in the proposal body).
-        >
-        > Do the edits and any test/fix loops yourself. You may spawn a nested Explore subagent if the proposal warrants a search. You cannot prompt the operator — if you encounter an ambiguous spec or an undecidable/destructive choice, **stop and return an escalation block** in your final message rather than guessing.
+        > 1. Read the proposal file. The `## Operator Decision` section contains a `PROCEED` line from the falsification gate with the authoritative file list — use that list as your scope (over any files mentioned in the proposal body).
+        > 2. Do the edits and any test/fix loops yourself. You may spawn a nested Explore subagent if the proposal warrants a search.
+        > 3. **Quality gate.** Read `.claude-code-hermit/config.json` → `quality_gate.tier` (treat missing/invalid as `budget`). `budget` → skip cleanup. `quality` → invoke `/claude-code-hermit:simplify` focused on the files you touched. `balanced` → delegate to the `claude-code-hermit:quality-gate-judge` subagent (pass the proposal path + touched files); on `RUN:` invoke `/claude-code-hermit:simplify` as for `quality`, on `SKIP:` skip. Capture `/simplify`'s totals line (`applied N · deduped M · principle-rejected K · …`). Best-effort: if the judge or `/simplify` errors, note it and continue — never block on this step.
+        > 4. **Verification.** Read the proposal's `## Verification` section. If it has real steps (more than the HTML-comment placeholder), perform them. If a step fails, attempt **one** fix and re-verify; if it still fails, set `Verification: failed` with the output and stop (do not loop further). If the section is empty or placeholder-only, set `Verification: none defined`.
+        > 5. You cannot prompt the operator — if you hit an ambiguous spec or an undecidable/destructive choice at any step, **stop and return an escalation block** rather than guessing.
         >
         > Return exactly this structure as your final message (nothing else):
         > ```
         > Status: implemented | escalated | blocked: <reason>
         > Touched files: <relative paths, space-separated | none>
         > Tests run: <commands + pass/fail summary | none>
-        > Deferred for operator: <none | what was ambiguous and what safe no-op was taken>
+        > Quality gate: <tier> — simplify <totals line> | skipped: <reason> | n/a
+        > Verification: passed | failed: <output> | none defined
+        > Deferred for operator: <none | what was ambiguous and the safe no-op you took>
         > ```
 
-        After the subagent returns:
-        - `Status: implemented` → continue to e.5, passing the returned **Touched files** as the `/simplify` focus scope.
-        - `Status: escalated` or `Status: blocked:` → do **not** resolve. Interactive mode: surface the Deferred-for-operator block to the operator. Autonomous mode: notify via channel. Proposal status stays `accepted`.
-
-        **e.6 re-dispatch:** if a defined `## Verification` step fails after a dispatched implementation, re-dispatch to `general-purpose` once with the failure output appended to the original prompt; if it fails again, surface to the operator (interactive) or channel (autonomous) and do not resolve.
+        **After the subagent returns** (the dispatched path ran its own quality gate + verification, so it skips main's e.5/e.6 and is handled here):
+        - `Status: implemented` **and** `Verification:` is `passed` or `none defined` → run `/proposal-act resolve PROP-NNN`, then notify the operator (interactive) or channel (autonomous), building the message from the `Quality gate` field: if it carries a simplify totals line → "PROP-NNN implemented and resolved. /simplify applied N edits (M deduped, K rejected on principle)." (use "… /simplify made no changes." when N == 0, and "… /simplify completed (totals unavailable)." if the line is unparseable); if it is `skipped:` or `n/a` → "PROP-NNN implemented and resolved."
+        - `Verification: failed: <output>` → do **not** resolve. Surface the failure output to the operator (interactive) or channel (autonomous). Proposal status stays `accepted`.
+        - `Status: escalated` or `Status: blocked: <reason>` → do **not** resolve. Surface the `Deferred for operator` block to the operator (interactive) or channel (autonomous). Proposal status stays `accepted`.
 
         If the body is vague and the falsification gate did not return `PROCEED`, ask the operator for clarification before proceeding.
 
@@ -142,14 +145,14 @@ When the operator accepts a proposal:
      6. **Do not auto-stage or commit** the new skill file. Notify the operator: "Skill `<name>` installed at `<install_target>`. Commit it if you want it tracked in version control."
 
      **Verification for procedure-capture proposals (e.6 note):** the `## Verification` section of a procedure-capture PROP should instruct reading the installed file's frontmatter (`name`/`description` parse) rather than checking the live available-skills list — the harness only picks up new skills on the next session reload, so the live list is unreliable here. A missing or malformed installed file blocks resolution per the normal e.6 contract.
-     e.5. **Quality gate (tier-branched).** Read `.claude-code-hermit/config.json` → `quality_gate.tier`. Resolve per this table:
+     e.5. **Quality gate (tier-branched).** Applies to **in-main** implementations only (the `## Skill Improvement` → skill-creator and `## Skill Draft` → procedure-capture branches). Dispatched implementations run their own quality gate inside the subagent (see the step (e) dispatch) and are resolved there. Read `.claude-code-hermit/config.json` → `quality_gate.tier`. Resolve per this table:
 
          | Config state | Resolved tier |
          |---|---|
          | `tier` is `"budget"` / `"balanced"` / `"quality"` | use as-is |
          | `tier` missing, `quality_gate` missing, or value not in enum | `budget` (log one-line warning to SHELL.md Findings) |
 
-         Build a touched-files list for step (e): when step (e) was dispatched to `general-purpose`, use the **Touched files** from the subagent's return. For in-main implementations, enumerate the writes made during step (e). This is the precise scope for `/claude-code-hermit:simplify` and for the judge. If the list is unavailable (multi-turn work, subagent returned `none`), omit it; downstream falls back to `git diff --name-only HEAD`.
+         Build a touched-files list from the writes made during the in-main implementation (skill-creator / skill-draft). This is the precise scope for `/claude-code-hermit:simplify` and for the judge. If you can't reliably enumerate it (multi-turn work), omit it; downstream falls back to `git diff --name-only HEAD`.
 
          Branch on the resolved tier:
 
@@ -173,12 +176,12 @@ When the operator accepts a proposal:
          **The quality gate is cleanup, not correctness** — `/simplify` does not check that the proposal works. Correctness is verified by the `## Verification` gate in step (e.6); proposals with no defined verification still resolve, but the skip is recorded.
 
          Best-effort throughout: if any step errors out (judge fails, `/simplify` failed or totals unavailable, file read fails), log a one-line warning to SHELL.md Findings and fall back to skip. The gate never blocks resolution.
-     e.6. **Verification gate.** Read the proposal's `## Verification` section.
+     e.6. **Verification gate** (in-main implementations only — dispatched implementations verify inside the subagent). Read the proposal's `## Verification` section.
          - If it contains real steps (more than the HTML-comment placeholder), perform them now — after the quality gate has applied any `/simplify` edits — before resolving. If a defined step fails, **do not resolve**: report the failure to the operator (or channel in autonomous mode) and stop.
          - If the section is empty, missing, or contains only its placeholder comment, append `Verification: none defined for PROP-NNN — skipped.` to SHELL.md `## Findings` and proceed. The omission is recorded, not blocked.
 
          Unlike the e.5 quality gate (best-effort, never blocks), e.6 **blocks resolution when a defined verification step fails** — that is the correctness check the quality gate does not provide.
-     f. When verifiably done: run `/proposal-act resolve PROP-NNN`, then notify the operator (or channel in autonomous mode) with the tier-appropriate message from (e.5).
+     f. **(in-main path)** When verifiably done: run `/proposal-act resolve PROP-NNN`, then notify the operator (or channel in autonomous mode) with the tier-appropriate message from (e.5). (Dispatched implementations resolve + notify in the step (e) post-return handling.)
 
    - **"Create a session task"** → Write `.claude-code-hermit/sessions/NEXT-TASK.md`:
      ```markdown

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -1419,3 +1419,52 @@ describe('reference.md plugin-root contract', () => {
     });
   }
 });
+
+// ============================================================
+// proposal-act dispatch contract (TestProposalActDispatchContract)
+//
+// Step (e) dispatches implementation to general-purpose when the falsification
+// gate returned PROCEED and the body has no skill marker. The dispatch prompt is
+// the contract — guard its key invariants so they can't silently drift.
+// ============================================================
+
+describe('proposal-act dispatch contract', () => {
+  const skill = read(path.join(SKILLS, 'proposal-act', 'SKILL.md'));
+
+  test('step (e) gates dispatch on PROCEED and absence of skill markers', () => {
+    // missing → skill-authoring or routine proposals would be incorrectly dispatched
+    expect(skill).toContain('PROCEED + no skill marker');
+    expect(skill).toContain('## Skill Draft');
+    expect(skill).toContain('## Skill Improvement');
+  });
+
+  test('dispatch prompt instructs escalate-don\'t-guess (cannot prompt the operator)', () => {
+    // missing → subagent guesses on ambiguous/destructive choices instead of escalating
+    expect(skill).toContain('You cannot prompt the operator');
+    expect(skill).toContain('stop and return an escalation block');
+  });
+
+  test('dispatch prompt defines the four-field structured return shape', () => {
+    // missing → e.5 touched-files source and escalation relay are undefined
+    expect(skill).toContain('Status: implemented | escalated | blocked:');
+    expect(skill).toContain('Touched files:');
+    expect(skill).toContain('Tests run:');
+    expect(skill).toContain('Deferred for operator:');
+  });
+
+  test('e.5 sources touched-files from the subagent return when dispatched', () => {
+    // missing → simplify focus loses precision after dispatch; falls back to git diff silently
+    expect(skill).toContain('from the subagent\'s return');
+  });
+
+  test('e.6 re-dispatch path is documented for verification failures', () => {
+    // missing → a verification failure after dispatch has no defined recovery path
+    expect(skill).toContain('e.6 re-dispatch');
+  });
+
+  test('escalation handling branches on interactive vs autonomous mode', () => {
+    // missing → escalated results silently discarded in autonomous mode
+    expect(skill).toContain('Interactive mode');
+    expect(skill).toContain('Autonomous mode');
+  });
+});

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -1423,19 +1423,22 @@ describe('reference.md plugin-root contract', () => {
 // ============================================================
 // proposal-act dispatch contract (TestProposalActDispatchContract)
 //
-// Step (e) dispatches implementation to general-purpose when the falsification
-// gate returned PROCEED and the body has no skill marker. The dispatch prompt is
-// the contract — guard its key invariants so they can't silently drift.
+// Step (e) dispatches the WHOLE implementation tail (implement → quality gate →
+// verification) to general-purpose when the falsification gate returned PROCEED and
+// there is no in-main skill handler. Main only resolves + notifies on a verified
+// return. The dispatch prompt is the contract — guard its key invariants so they
+// can't silently drift.
 // ============================================================
 
 describe('proposal-act dispatch contract', () => {
   const skill = read(path.join(SKILLS, 'proposal-act', 'SKILL.md'));
 
-  test('step (e) gates dispatch on PROCEED and absence of skill markers', () => {
-    // missing → skill-authoring or routine proposals would be incorrectly dispatched
-    expect(skill).toContain('PROCEED + no skill marker');
-    expect(skill).toContain('## Skill Draft');
-    expect(skill).toContain('## Skill Improvement');
+  test('falsification gate runs for every code-edit implementation', () => {
+    // missing → skill-improvement-without-skill-creator dispatches with no PROCEED file list
+    expect(skill).toContain('Skip only when the body contains `## Skill Improvement` **and** `/skill-creator:skill-creator` is in the available-skills list');
+    expect(skill).toContain('the gate runs to produce a `PROCEED` file list for the dispatch');
+    // dispatch block is labelled by what gates it, not the stale "no skill marker"
+    expect(skill).toContain('Dispatch (falsification gate returned PROCEED, no in-main skill handler)');
   });
 
   test('dispatch prompt instructs escalate-don\'t-guess (cannot prompt the operator)', () => {
@@ -1444,27 +1447,35 @@ describe('proposal-act dispatch contract', () => {
     expect(skill).toContain('stop and return an escalation block');
   });
 
-  test('dispatch prompt defines the four-field structured return shape', () => {
-    // missing → e.5 touched-files source and escalation relay are undefined
+  test('dispatch prompt defines the six-field structured return shape', () => {
+    // missing → resolve/notify branch and escalation relay have no defined source fields
     expect(skill).toContain('Status: implemented | escalated | blocked:');
     expect(skill).toContain('Touched files:');
     expect(skill).toContain('Tests run:');
+    expect(skill).toContain('Quality gate:');
+    expect(skill).toContain('Verification: passed | failed:');
     expect(skill).toContain('Deferred for operator:');
   });
 
-  test('e.5 sources touched-files from the subagent return when dispatched', () => {
-    // missing → simplify focus loses precision after dispatch; falls back to git diff silently
-    expect(skill).toContain('from the subagent\'s return');
+  test('subagent owns the quality gate and verification (design b)', () => {
+    // missing → e.5/e.6 bounce back to main, splitting execution across two contexts
+    expect(skill).toContain('then run its quality gate and verification');
+    expect(skill).toContain('quality_gate.tier');
+    expect(skill).toContain('/claude-code-hermit:simplify');
+    expect(skill).toContain('claude-code-hermit:quality-gate-judge');
   });
 
-  test('e.6 re-dispatch path is documented for verification failures', () => {
+  test('verification failure is handled inside the subagent with a bounded retry', () => {
     // missing → a verification failure after dispatch has no defined recovery path
-    expect(skill).toContain('e.6 re-dispatch');
+    expect(skill).toContain('attempt **one** fix and re-verify');
+    expect(skill).toContain('it still fails, set `Verification: failed`');
   });
 
-  test('escalation handling branches on interactive vs autonomous mode', () => {
-    // missing → escalated results silently discarded in autonomous mode
-    expect(skill).toContain('Interactive mode');
-    expect(skill).toContain('Autonomous mode');
+  test('main resolves only on a verified return; escalation branches interactive vs autonomous', () => {
+    // missing → main resolves on failed/escalated, or silently discards escalations
+    expect(skill).toContain('`Status: implemented` **and** `Verification:` is `passed` or `none defined`');
+    expect(skill).toContain('do **not** resolve');
+    expect(skill).toContain('(interactive)');
+    expect(skill).toContain('(autonomous)');
   });
 });


### PR DESCRIPTION
## Summary

The always-on hermit is an orchestrator that delegates its heaviest sub-steps to isolated-context subagents. v1.2.4 pushed this pattern broadly across `reflect`, `brief`, `weekly-review`, `heartbeat`, and analytics skills — but the implementation write-phase in `proposal-act` step (e) still ran inline. This PR closes that gap.

## Changes

- **`proposal-act/SKILL.md`** — step (e) now dispatches to the native `general-purpose` agent when the falsification gate returned `PROCEED` and the proposal body has no skill markers. The subagent reads the PROP file directly (rather than receiving pasted excerpts), uses the `PROCEED` file list in `## Operator Decision` as its scope, and returns a structured prose report (`Status` / `Touched files` / `Tests run` / `Deferred for operator`). Skill-authoring (`## Skill Improvement`, `## Skill Draft`) and routine proposals are unaffected. e.5 simplify, e.6 verification, and resolve stay in main (subagents cannot invoke skills).
- **`tests/contracts.test.ts`** — six guard tests for the dispatch-prompt contract: gate condition, escalate-don't-guess instruction, four-field return shape, e.5 touched-files sourcing, e.6 re-dispatch path, and interactive/autonomous escalation branching.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

## Design notes

- `general-purpose` inherits `CLAUDE.md` and `CLAUDE.local.md` (verified empirically with a live probe), so project conventions and the hermit's CLAUDE-APPEND block are already present — no re-passing needed.
- OPERATOR.md and config operator-context are not inherited (delivered by `SessionStart` hook to main only) but are intentionally not passed: an implementer doesn't need operator priorities or channel config, and anything proposal-specific is already in the PROP file.
- The subagent may spawn a nested `Explore` at its own discretion; nested dispatch is supported on the required CC floor (min bumped to 2.1.172 in #389).
- Return shape is structured prose (evolve-runner style) rather than JSON: a write-flow agent producing edits + test output emits a compact text report reliably; JSON parsability buys nothing here.

## Test plan

- `cd plugins/claude-code-hermit && bun test` — 1058 pass, 0 fail (verified).
- Read-through of edited step (e): gate is `PROCEED + no skill marker`; skill-authoring and routine paths untouched; e.5/e.6/resolve still in main.

Closes #402