### PR TITLE
fix(dev-hermit): bless /dev-pr's own push in §Git Safety (#404)

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **CLAUDE-APPEND/dev-pr: bless `/dev-pr`'s own push in §Git Safety** — the absolute "Never `git push`" rule made auto-mode agents refuse `/dev-pr`'s Gate 1 push; carve-out scopes the prohibition to ad-hoc pushes (#404).
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `state-templates/CLAUDE-APPEND-SAFETY.md` | Appended carve-out clause to §Git Safety "Never git push" bullet |
+| `state-templates/CLAUDE-APPEND.md` | Same |
+| `docs/GIT-SAFETY.md` | Same (plain-text variant) |
+| `docs/WORKFLOW.md` | Same (short-form style, human-facing doc) |
+| `skills/dev-pr/SKILL.md` | One-line Gate 1 note: push is the sanctioned action, do not pause |
+| `tests/hatch-mode.test.ts` | Added regression assertions: carve-out present + no short-form `/dev-pr` in injected templates |
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
+
+1. **Update the plugin** — run `claude plugin update claude-code-dev-hermit` to get the refreshed templates.
+2. **Re-inject CLAUDE-APPEND** — run `/claude-code-dev-hermit:hatch` in any dev hermit project to re-inject the updated template with the carve-out.
+
+No `config.json` changes required.
+
 ## [0.4.1] - 2026-06-13
 
 ### Fixed

--- a/plugins/claude-code-dev-hermit/docs/GIT-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/docs/GIT-SAFETY.md
@@ -8,7 +8,7 @@ Two layers of protection: prose rules in `state-templates/CLAUDE-APPEND.md` (alw
 
 Injected into the project's `CLAUDE.md` by `/hatch`. The §Git Safety section reads:
 
-- Never `git push` from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
+- Never `git push` from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR. This forbids *improvised* pushes, not the push performed by that skill itself: while executing it, its Gate 1 push is the sanctioned action — run it, don't stop to ask.
 - Never use `--no-verify` on any git command (commit, push, merge, rebase).
 - Never commit to a branch in `claude-code-dev-hermit.protected_branches`. Always work on a feature branch.
 - Never force-push from agent context. No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.

--- a/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
+++ b/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
@@ -35,7 +35,7 @@ Per `§Branch Discipline`:
 
 Agent writes code on the feature branch. The `§Git Safety` rules apply throughout:
 
-- No `git push` from agent context. Stop and ask the operator. The sanctioned answer is `/dev-pr`.
+- No `git push` from agent context. Stop and ask the operator. The sanctioned answer is `/dev-pr` — and executing that skill's own Gate 1 push is the sanctioned action, not a violation.
 - No `--no-verify` on any git command.
 - No commits to a branch in `protected_branches`.
 - No force-push (any flavor).

--- a/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
+++ b/plugins/claude-code-dev-hermit/docs/WORKFLOW.md
@@ -35,7 +35,7 @@ Per `§Branch Discipline`:
 
 Agent writes code on the feature branch. The `§Git Safety` rules apply throughout:
 
-- No `git push` from agent context. Stop and ask the operator. The sanctioned answer is `/dev-pr` — and executing that skill's own Gate 1 push is the sanctioned action, not a violation.
+- No `git push` from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr` — and executing that skill's own Gate 1 push is the sanctioned action, not a violation.
 - No `--no-verify` on any git command.
 - No commits to a branch in `protected_branches`.
 - No force-push (any flavor).

--- a/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/dev-pr/SKILL.md
@@ -106,6 +106,8 @@ If 0: FAIL with `"nothing to PR — no commits ahead of $BASE"`.
 
 ### Gate 1 — push
 
+Note: this push is the §Git Safety-sanctioned action — execute the commands below; do not pause to ask the operator (that rule governs *ad-hoc* pushes, not this skill's Gate 1 push).
+
 ```bash
 git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" 2>/dev/null
 ```

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -5,7 +5,7 @@
 
 These rules apply to every agent doing dev work in this project — the native `Agent` tool, custom subagents, the main session. The `git-push-guard` hook backs them at strict profile.
 
-- **Never `git push`** from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
+- **Never `git push`** from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR. This forbids *improvised* pushes, not the push performed by that skill itself: while executing it, its Gate 1 push **is** the sanctioned action — run it, don't stop to ask.
 - **Never use `--no-verify`** on any git command (commit, push, merge, rebase). Pre-commit hooks exist for a reason.
 - **Never commit to a branch in `claude-code-dev-hermit.protected_branches`** (defaults to `main`/`master` if unset). Always work on a feature branch.
 - **Never force-push from agent context.** No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -6,7 +6,7 @@
 
 These rules apply to every agent doing dev work in this project — the native `Agent` tool, custom subagents, the main session. The `git-push-guard` hook backs them at strict profile.
 
-- **Never `git push`** from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR.
+- **Never `git push`** from agent context. Stop and ask the operator. The sanctioned answer is `/claude-code-dev-hermit:dev-pr`, which runs Gate 0 checks then pushes + opens a PR. This forbids *improvised* pushes, not the push performed by that skill itself: while executing it, its Gate 1 push **is** the sanctioned action — run it, don't stop to ask.
 - **Never use `--no-verify`** on any git command (commit, push, merge, rebase). Pre-commit hooks exist for a reason.
 - **Never commit to a branch in `claude-code-dev-hermit.protected_branches`** (defaults to `main`/`master` if unset). Always work on a feature branch.
 - **Never force-push from agent context.** No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.

--- a/plugins/claude-code-dev-hermit/tests/hatch-mode.test.ts
+++ b/plugins/claude-code-dev-hermit/tests/hatch-mode.test.ts
@@ -34,6 +34,10 @@ if (fs.existsSync(SAFETY)) {
   ok('no /dev-test reference', !text.includes('/dev-test'));
   ok('safety: §Git Safety push rule names /dev-pr',
     /Never `git push`[\s\S]{0,200}\/claude-code-dev-hermit:dev-pr/.test(text));
+  ok("safety: §Git Safety blesses /dev-pr's own push (carve-out present)",
+    text.includes("run it, don't stop to ask"));
+  ok('safety: no short-form /dev-pr in injected rules',
+    !/(?<!claude-code-dev-hermit:)\/dev-pr\b/.test(text));
   ok('no commands.test reference', !text.includes('commands.test'));
   ok('no §Implementation Flow section', !text.includes('## Implementation Flow'));
   ok('no §Tests Before PR section', !text.includes('## Tests Before PR'));
@@ -61,6 +65,10 @@ if (fs.existsSync(STANDARD)) {
   ok('§Dev Proposal Categories present', text.includes('## Dev Proposal Categories'));
   ok('standard: §Git Safety push rule names /dev-pr',
     /Never `git push`[\s\S]{0,200}\/claude-code-dev-hermit:dev-pr/.test(text));
+  ok("standard: §Git Safety blesses /dev-pr's own push (carve-out present)",
+    text.includes("run it, don't stop to ask"));
+  ok('standard: no short-form /dev-pr in injected rules',
+    !/(?<!claude-code-dev-hermit:)\/dev-pr\b/.test(text));
 
   // Each preamble ends with "fallback for projects without one" or "fallback."
   const branchSection = text.match(/## Branch Discipline[\s\S]*?## Implementation Flow/);

--- a/plugins/claude-code-dev-hermit/tests/hatch-mode.test.ts
+++ b/plugins/claude-code-dev-hermit/tests/hatch-mode.test.ts
@@ -37,7 +37,7 @@ if (fs.existsSync(SAFETY)) {
   ok("safety: §Git Safety blesses /dev-pr's own push (carve-out present)",
     text.includes("run it, don't stop to ask"));
   ok('safety: no short-form /dev-pr in injected rules',
-    !/(?<!claude-code-dev-hermit:)\/dev-pr\b/.test(text));
+    !/\/dev-pr\b/.test(text));
   ok('no commands.test reference', !text.includes('commands.test'));
   ok('no §Implementation Flow section', !text.includes('## Implementation Flow'));
   ok('no §Tests Before PR section', !text.includes('## Tests Before PR'));
@@ -68,7 +68,7 @@ if (fs.existsSync(STANDARD)) {
   ok("standard: §Git Safety blesses /dev-pr's own push (carve-out present)",
     text.includes("run it, don't stop to ask"));
   ok('standard: no short-form /dev-pr in injected rules',
-    !/(?<!claude-code-dev-hermit:)\/dev-pr\b/.test(text));
+    !/\/dev-pr\b/.test(text));
 
   // Each preamble ends with "fallback for projects without one" or "fallback."
   const branchSection = text.match(/## Branch Discipline[\s\S]*?## Implementation Flow/);


### PR DESCRIPTION
## Summary

The §Git Safety "Never \`git push\`" rule is absolute — no carve-out for the push \`/dev-pr\` performs in its own Gate 1. Auto-mode agents re-applying the rule mid-skill read their own push as a violation and stop to ask the operator, defeating the skill's purpose.

Root cause is prose, not code. Both strict-profile hooks (\`git-push-guard\`, \`enforce-deny-patterns\`) pass feature-branch pushes cleanly (probed live). The blocker is the rule text itself.

## Changes

- \`state-templates/CLAUDE-APPEND-SAFETY.md\`, \`CLAUDE-APPEND.md\` — appended narrow carve-out clause: "This forbids *improvised* pushes, not the push performed by that skill itself…"
- \`docs/GIT-SAFETY.md\` — same carve-out, plain-text variant
- \`docs/WORKFLOW.md\` — same carve-out, short-form doc style
- \`skills/dev-pr/SKILL.md\` — one-line Gate 1 note reassuring the agent the push is sanctioned
- \`tests/hatch-mode.test.ts\` — regression assertions: carve-out present in both templates + no short-form \`/dev-pr\` leak (0.4.1 namespacing discipline preserved)

## Test plan

- \`cd plugins/claude-code-dev-hermit && bash tests/run-all.sh\` — all 162 tests pass including the two new regression assertions

Closes #404