### PR TITLE
feat(channel-responder): add Context-hygiene delegation nudge at §2

### DIFF
--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -85,6 +85,8 @@ This is how the agent learns the DM channel ID for proactive outbound notificati
 
 ## 2. Classify the Message
 
+Before running any heavy sub-step — an archive traversal, a multi-file search, or a delegated execution step — apply the **Context-hygiene & delegation** rule: delegate when its criteria hold and keep only the verdict.
+
 - **Slash command** (message starts with `/`, e.g. `/claude-code-hermit:simplify`, `/plugin:command`)
   - Invoke the matching skill, slash command, or subagent via the appropriate tool. Pass any remaining text as arguments/prompt.
   - If nothing matches, say so briefly.


### PR DESCRIPTION
## Summary
The Context-hygiene & delegation rule exists globally in `CLAUDE-APPEND.md` but had no prompt at the classification decision point inside `channel-responder`. Without a reminder at that location, the model must recall the rule when handling an inbound research or execution message — the failure mode the rule was written to prevent. This adds a one-sentence pointer before the §2 handler list so it fires at the decision point.

## Changes
- `channel-responder/SKILL.md` §2: single sentence added before the handler list, naming the **Context-hygiene & delegation** rule by its canonical name and stating it covers both research (archive traversals, multi-file searches) and execution sub-steps.

## Test plan
- Re-read the edited §2 header to confirm tone-match against the CLAUDE-APPEND § Rules wording.
- No code or automated tests affected — skill text only. `tests/channel-responder-reply-rule.test.ts` tests §0 (reply-tool rule) and is unaffected.

Closes #410