### PR TITLE
fix(hermit): deterministic _hermit_versions bump in hermit-evolve (#426)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **hermit-evolve: confirm the `_hermit_versions` bump on disk (#426)** — step 9 now performs the version bump via a deterministic `scripts/evolve-finalize.ts` instead of an LLM hand-edit. The runner reports the re-read on-disk version (`core.confirmed`) instead of `plan.to`. A dropped bump now surfaces as `Upgrade: blocked` instead of falsely reporting success and re-nagging the upgrade banner every session.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `scripts/evolve-finalize.ts` | New: deterministic `_hermit_versions` writer — atomic read-modify-write, on-disk confirm, fail-loud exit |
+| `skills/hermit-evolve/SKILL.md` | Step 8: add `evolve-finalize.ts` to required permissions; step 9: run finalizer after key merge, report `core.confirmed` |
+| `agents/evolve-runner.md` | Step-9 delegated note + version-bump rule; report `vNEW` from `core.confirmed`; blocked on mismatch |
+| `skills/hatch/SKILL.md` | Add `Bash(bun */scripts/evolve-finalize.ts*)` to permissions seed list |
+| `tests/evolve-finalize.test.ts` | New: 16 cases covering #426 regression, key preservation, sibling gating, mismatch, idempotency, exit codes |
+
 ## [1.2.6] - 2026-06-17
 
 ### Added

--- a/plugins/claude-code-hermit/agents/evolve-runner.md
+++ b/plugins/claude-code-hermit/agents/evolve-runner.md
@@ -46,9 +46,14 @@ never block:
 - **`### Upgrade Instructions` migrations (steps 2b, 7):** execute every non-interactive instruction. If a
   step poses a genuine either/or with **no safe non-destructive default**, do **not** guess — record it
   as a deferred-migration block (below) and **skip that step only**. This is the sole escalation path.
+- **Version bump (step 9):** run `evolve-finalize.ts` and parse its stdout JSON. Use `core.confirmed` as
+  `vNEW` in the report — NOT `plan.to`. If the script exits non-zero, `core.matched` is false, or `errors`
+  is non-empty, return `Upgrade: blocked: config version bump failed — <joined error messages>` and omit
+  the rest of the report.
 
 Everything else (version gates 0/0b, the plan pre-pass, classification, copies, manifest write, config
-write incl. the `_hermit_versions` bump in step 9) runs exactly as the SKILL.md specifies.
+write in step 9 — the `new_config_keys` merge by hand then the `_hermit_versions` bump via
+`evolve-finalize.ts`) runs exactly as the SKILL.md specifies.
 
 ## Return value — the report (your final message, nothing else)
 

--- a/plugins/claude-code-hermit/scripts/evolve-finalize.ts
+++ b/plugins/claude-code-hermit/scripts/evolve-finalize.ts
@@ -1,0 +1,204 @@
+// Deterministic writer for _hermit_versions in .claude-code-hermit/config.json.
+// Moves the step-9 version bump out of LLM prose into code, so a dropped bump
+// surfaces as a blocked report instead of a silent mismatch (issue #426).
+//
+// NOTE: this is a runner-invoked script, NOT a fail-open hook. It exits non-zero
+// on any write/verify failure so the evolve-runner can report `blocked` rather
+// than claiming success. Do not apply the hook fail-open (exit 0) pattern here.
+//
+// Usage:
+//   bun evolve-finalize.ts [hermit-dir] --core=<version> --plugin-root=<abs>
+//                          [--sibling=<name>=<version> ...]
+//
+// hermit-dir defaults to .claude-code-hermit (like evolve-plan.ts).
+// --plugin-root cross-checks --core against plugin.json.version to defend the
+// exact-string compare in check-upgrade.sh:24. Omit only in tests.
+//
+// Stdout: one JSON object matching FinalizeResult.
+// Exit 0: ok:true and core confirmed on-disk.
+// Exit 1: any error (no_core_target, no_config, config_json_invalid,
+//          config_unreadable, plugin_json_unreadable, core_version_mismatch,
+//          bad_sibling_arg, write_failed, verify_failed, fatal).
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+type Json = any;
+
+export interface FinalizeResult {
+  ok: boolean;
+  core: { requested: string; confirmed: string | null; matched: boolean };
+  siblings_confirmed: Record<string, string>;
+  siblings_skipped: string[];
+  errors: { code: string; message: string }[];
+}
+
+function parseArgs(argv: string[]): {
+  hermitDir: string;
+  core: string | null;
+  pluginRoot: string | null;
+  siblings: { name: string; version: string }[];
+} {
+  let hermitDir = '.claude-code-hermit';
+  let core: string | null = null;
+  let pluginRoot: string | null = null;
+  const siblings: { name: string; version: string }[] = [];
+
+  for (const a of argv) {
+    if (a.startsWith('--core=')) {
+      core = a.slice('--core='.length);
+    } else if (a.startsWith('--plugin-root=')) {
+      pluginRoot = a.slice('--plugin-root='.length);
+    } else if (a.startsWith('--sibling=')) {
+      const rest = a.slice('--sibling='.length);
+      const eq = rest.indexOf('=');
+      siblings.push(
+        eq === -1
+          ? { name: rest, version: '' }                           // malformed — caught in finalize
+          : { name: rest.slice(0, eq), version: rest.slice(eq + 1) },
+      );
+    } else if (!a.startsWith('--') && a !== '') {
+      hermitDir = a;
+    }
+  }
+  return { hermitDir, core, pluginRoot, siblings };
+}
+
+function isPlainObject(v: any): boolean {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+export function finalize(opts: {
+  hermitDir: string;
+  core: string | null;
+  pluginRoot: string | null;
+  siblings: { name: string; version: string }[];
+}): FinalizeResult {
+  const errors: { code: string; message: string }[] = [];
+  const siblingsSkipped: string[] = [];
+
+  if (!opts.core || opts.core.trim() === '') {
+    errors.push({ code: 'no_core_target', message: '--core=<version> is required' });
+    return { ok: false, core: { requested: opts.core ?? '', confirmed: null, matched: false }, siblings_confirmed: {}, siblings_skipped: [], errors };
+  }
+
+  // Validate sibling args. Malformed entries go to siblings_skipped (not errors) —
+  // the runner always constructs valid args so a bad arg is a programming fault, not
+  // a bump failure. It does not affect ok or block reporting.
+  const validSiblings: { name: string; version: string }[] = [];
+  for (const s of opts.siblings) {
+    if (!s.name || s.version === '') {
+      siblingsSkipped.push(`[bad-arg:${s.name || ''}]`);
+    } else {
+      validSiblings.push(s);
+    }
+  }
+
+  // Cross-check --core against plugin.json.version (defends check-upgrade.sh exact string compare)
+  if (opts.pluginRoot) {
+    let pluginVer: string | null = null;
+    try {
+      const pj = JSON.parse(fs.readFileSync(path.join(opts.pluginRoot, '.claude-plugin', 'plugin.json'), 'utf8'));
+      pluginVer = typeof pj.version === 'string' ? pj.version : null;
+    } catch (e: any) {
+      errors.push({ code: 'plugin_json_unreadable', message: e.message });
+      return { ok: false, core: { requested: opts.core, confirmed: null, matched: false }, siblings_confirmed: {}, siblings_skipped: siblingsSkipped, errors };
+    }
+    if (pluginVer === null) {
+      errors.push({ code: 'plugin_json_unreadable', message: 'plugin.json missing .version field' });
+      return { ok: false, core: { requested: opts.core, confirmed: null, matched: false }, siblings_confirmed: {}, siblings_skipped: siblingsSkipped, errors };
+    }
+    if (pluginVer !== opts.core) {
+      errors.push({ code: 'core_version_mismatch', message: `--core="${opts.core}" does not match plugin.json version="${pluginVer}"` });
+      return { ok: false, core: { requested: opts.core, confirmed: null, matched: false }, siblings_confirmed: {}, siblings_skipped: siblingsSkipped, errors };
+    }
+  }
+
+  // Read live config from disk (after step 9's new_config_keys merge is already written)
+  const configPath = path.join(opts.hermitDir, 'config.json');
+  let config: Json;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch (e: any) {
+    const code = e && e.code === 'ENOENT' ? 'no_config'
+      : e && e.name === 'SyntaxError' ? 'config_json_invalid'
+      : 'config_unreadable';
+    errors.push({ code, message: e.message });
+    return { ok: false, core: { requested: opts.core, confirmed: null, matched: false }, siblings_confirmed: {}, siblings_skipped: siblingsSkipped, errors };
+  }
+
+  // Core is the install marker so it's safe to create the object if absent.
+  // Unconditional bump covers the step-10 deferred-migration caveat.
+  if (!isPlainObject(config._hermit_versions)) {
+    config._hermit_versions = {};
+  }
+  config._hermit_versions['claude-code-hermit'] = opts.core;
+
+  // Never add a new sibling key — only update keys already present.
+  const appliedSiblingNames: string[] = [];
+  for (const s of validSiblings) {
+    if (Object.prototype.hasOwnProperty.call(config._hermit_versions, s.name)) {
+      config._hermit_versions[s.name] = s.version;
+      appliedSiblingNames.push(s.name);
+    } else {
+      siblingsSkipped.push(s.name);
+    }
+  }
+
+  // Atomic write: serialize → .tmp → rename (mirrors lib/cost-log.ts:60-62)
+  const tmp = configPath + '.tmp';
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n', 'utf8');
+    fs.renameSync(tmp, configPath);
+  } catch (e: any) {
+    try { fs.unlinkSync(tmp); } catch {}
+    errors.push({ code: 'write_failed', message: e.message });
+    return { ok: false, core: { requested: opts.core, confirmed: null, matched: false }, siblings_confirmed: {}, siblings_skipped: siblingsSkipped, errors };
+  }
+
+  // Re-read from disk to confirm (the fix's whole point — catches a write that didn't land)
+  let onDisk: Json;
+  try {
+    onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch (e: any) {
+    errors.push({ code: 'verify_failed', message: `re-read after write failed: ${e.message}` });
+    return { ok: false, core: { requested: opts.core, confirmed: null, matched: false }, siblings_confirmed: {}, siblings_skipped: siblingsSkipped, errors };
+  }
+
+  const coreOnDisk: string = (isPlainObject(onDisk._hermit_versions) ? onDisk._hermit_versions['claude-code-hermit'] : null) ?? '';
+  const coreMatched = coreOnDisk === opts.core;
+  if (!coreMatched) {
+    errors.push({ code: 'verify_failed', message: `on-disk _hermit_versions["claude-code-hermit"]="${coreOnDisk}" but expected "${opts.core}"` });
+  }
+
+  const siblingsConfirmed: Record<string, string> = {};
+  for (const name of appliedSiblingNames) {
+    siblingsConfirmed[name] = onDisk._hermit_versions[name] ?? '';
+  }
+
+  return {
+    ok: errors.length === 0 && coreMatched,
+    core: { requested: opts.core, confirmed: coreOnDisk, matched: coreMatched },
+    siblings_confirmed: siblingsConfirmed,
+    siblings_skipped: siblingsSkipped,
+    errors,
+  };
+}
+
+if (import.meta.main) {
+  const { hermitDir, core, pluginRoot, siblings } = parseArgs(process.argv.slice(2));
+  let result: FinalizeResult;
+  try {
+    result = finalize({ hermitDir: path.resolve(hermitDir), core, pluginRoot, siblings });
+  } catch (e: any) {
+    result = {
+      ok: false,
+      core: { requested: core ?? '', confirmed: null, matched: false },
+      siblings_confirmed: {},
+      siblings_skipped: [],
+      errors: [{ code: 'fatal', message: e.message }],
+    };
+  }
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  process.exit(result.ok ? 0 : 1);
+}

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -620,6 +620,7 @@ Merge these into the target file:
       "Bash(bun */scripts/update-reflection-state.ts*)",
       "Bash(bun */scripts/cron-tz-shift.ts*)",
       "Bash(bun */scripts/evolve-plan.ts*)",
+      "Bash(bun */scripts/evolve-finalize.ts*)",
       "Bash(bash -c 'AGENT_DIR=\".claude-code-hermit\"*)",
       "Edit(.claude-code-hermit/**)",
       "Write(.claude-code-hermit/**)"

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -248,7 +248,7 @@ Same logic as init step 8, but target the file determined by `hatch_target` (res
 - `hatch_target == "local"` → `.claude/settings.local.json`
 - `hatch_target == "committed"` → `.claude/settings.json`
 
-Check the target settings file for the plugin's required permissions (`git diff/status/log`, per-script `bun` entries, the SessionStart `bash -c` hook, and `Edit`/`Write` on `.claude-code-hermit/**`). The required entries are: `cost-tracker.ts`, `suggest-compact.ts`, `run-with-profile.ts`, `evaluate-session.ts`, `append-metrics.ts`, `generate-summary.ts`, `cron-tz-shift.ts`, `archive-shell.ts`, `evolve-plan.ts`. **Delegated mode: add any missing entries without asking** (a missing `bun` permission breaks hooks, so this is non-optional), and collect them for the step-10 report. Only add missing entries — never remove existing ones. If all are already present, skip silently. Also remove stale permissions from previous versions if found in the target file:
+Check the target settings file for the plugin's required permissions (`git diff/status/log`, per-script `bun` entries, the SessionStart `bash -c` hook, and `Edit`/`Write` on `.claude-code-hermit/**`). The required entries are: `cost-tracker.ts`, `suggest-compact.ts`, `run-with-profile.ts`, `evaluate-session.ts`, `append-metrics.ts`, `generate-summary.ts`, `cron-tz-shift.ts`, `archive-shell.ts`, `evolve-plan.ts`, `evolve-finalize.ts`. **Delegated mode: add any missing entries without asking** (a missing `bun` permission breaks hooks, so this is non-optional), and collect them for the step-10 report. Only add missing entries — never remove existing ones. If all are already present, skip silently. Also remove stale permissions from previous versions if found in the target file:
 
 - `Bash(python3:*)`, `Bash(node:*)` — replaced by scoped bun entries
 - `Edit(.claude/.claude-code-hermit/**)`, `Write(.claude/.claude-code-hermit/**)` — replaced by `.claude-code-hermit/**` (v0.0.6 path change)
@@ -256,10 +256,16 @@ Check the target settings file for the plugin's required permissions (`git diff/
 ### 9. Write updated config
 
 - **Re-read `.claude-code-hermit/config.json` now** — Step 2b migrations may have written keys since the pre-pass ran.
-- For each entry in `new_config_keys` (with the defaults applied in Step 4), set `path` to its value **only if that path is still missing** in the freshly-read config. Never overwrite an existing operator or migration-set value.
-- Update `_hermit_versions["claude-code-hermit"]` to the current plugin version (the plan's `to`)
-- For hermits: only update versions for hermits already present as keys in `_hermit_versions` — never add new keys here
-- Write to `.claude-code-hermit/config.json`
+- For each entry in `new_config_keys` (with the defaults applied in Step 4), set `path` to its value **only if that path is still missing** in the freshly-read config. Never overwrite an existing operator or migration-set value. Write these merged keys to `.claude-code-hermit/config.json` before running the finalizer below.
+- **Bump `_hermit_versions` deterministically — do NOT hand-edit this key.** After the `new_config_keys` merge above is written to disk, run the finalizer. It re-reads config from disk, writes the version bumps atomically, and prints the confirmed on-disk values:
+
+  ```
+  bun ${CLAUDE_PLUGIN_ROOT}/scripts/evolve-finalize.ts .claude-code-hermit --core=<to> --plugin-root=${CLAUDE_PLUGIN_ROOT} [--sibling=<name>=<vNEW> ...]
+  ```
+
+  - `<to>` is the plan's `to`. Add one `--sibling=<name>=<vNEW>` for each sibling hermit upgraded in Step 7 (where `name` is the sibling's plugin name and `vNEW` is its new version). Omit `--sibling` entirely if no siblings were upgraded.
+  - Parse stdout as JSON. The finalizer's `core.confirmed` is the **authoritative on-disk version** — use it as `vNEW` in the Step 10 report, NOT `plan.to`.
+  - If `core.matched` is `false` or `errors` is non-empty, the bump did not land: set the `Upgrade:` line in the Step 10 report to `blocked: config version bump failed (<joined errors>)` and stop.
 
 ### 10. Report
 

--- a/plugins/claude-code-hermit/tests/evolve-finalize.test.ts
+++ b/plugins/claude-code-hermit/tests/evolve-finalize.test.ts
@@ -1,0 +1,302 @@
+// bun test suite for scripts/evolve-finalize.ts — the deterministic
+// _hermit_versions writer that replaces the LLM hand-edit in evolve step 9.
+// These are the regression tests for issue #426 (silent dropped version bump).
+//
+// Usage: bun test tests/evolve-finalize.test.ts   (from the plugin root)
+
+import { test, expect, beforeAll, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { finalize } from '../scripts/evolve-finalize';
+import { runScript } from './helpers/run';
+
+// Fake plugin root with plugin.json version "1.2.6" (shared, read-only across tests).
+let PR: string;
+
+beforeAll(() => {
+  PR = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-finalize-pr-'));
+  fs.mkdirSync(path.join(PR, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(PR, '.claude-plugin', 'plugin.json'), '{"version":"1.2.6"}\n');
+});
+
+afterAll(() => {
+  try { fs.rmSync(PR, { recursive: true, force: true }); } catch {}
+});
+
+/** Run a test body against a throwaway hermit dir, always cleaning up. */
+function withProj(fn: (hermitDir: string) => Promise<void> | void) {
+  return async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-finalize-'));
+    try { await fn(dir); } finally {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+  };
+}
+
+const writeConfig = (dir: string, content: string) =>
+  fs.writeFileSync(path.join(dir, 'config.json'), content);
+
+const readConfig = (dir: string) =>
+  JSON.parse(fs.readFileSync(path.join(dir, 'config.json'), 'utf8'));
+
+// -------------------------------------------------------
+// 1. #426 regression — core bump actually lands on disk
+// -------------------------------------------------------
+
+test('#426 regression: core bump lands and confirmed', withProj(async (dir) => {
+  writeConfig(dir, '{"_hermit_versions":{"claude-code-hermit":"1.2.5"}}');
+  const result = finalize({ hermitDir: dir, core: '1.2.6', pluginRoot: PR, siblings: [] });
+
+  expect(result.ok).toBe(true);
+  expect(result.core.requested).toBe('1.2.6');
+  expect(result.core.confirmed).toBe('1.2.6');
+  expect(result.core.matched).toBe(true);
+  expect(result.errors).toEqual([]);
+
+  // Independently verify the on-disk file actually changed
+  const onDisk = readConfig(dir);
+  expect(onDisk._hermit_versions['claude-code-hermit']).toBe('1.2.6');
+}));
+
+// -------------------------------------------------------
+// 2. Step-9 keys preserved — only _hermit_versions.claude-code-hermit changes
+// -------------------------------------------------------
+
+test('step-9 keys preserved: other keys untouched after bump', withProj(async (dir) => {
+  writeConfig(dir, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.2.5' },
+    model: 'sonnet',
+    reflection: { graduation_min_sessions: 1 },
+    routines: [{ id: 'pulse' }],
+  }, null, 2));
+
+  finalize({ hermitDir: dir, core: '1.2.6', pluginRoot: PR, siblings: [] });
+
+  const onDisk = readConfig(dir);
+  expect(onDisk._hermit_versions['claude-code-hermit']).toBe('1.2.6');
+  expect(onDisk.model).toBe('sonnet');
+  expect(onDisk.reflection).toEqual({ graduation_min_sessions: 1 });
+  expect(onDisk.routines).toEqual([{ id: 'pulse' }]);
+}));
+
+// -------------------------------------------------------
+// 3. Sibling present → applied; sibling NOT a key → skipped, not added
+// -------------------------------------------------------
+
+test('sibling present: bumped and confirmed', withProj(async (dir) => {
+  writeConfig(dir, JSON.stringify({
+    _hermit_versions: {
+      'claude-code-hermit': '1.2.5',
+      'claude-code-dev-hermit': '0.3.0',
+    },
+  }));
+  const result = finalize({
+    hermitDir: dir,
+    core: '1.2.6',
+    pluginRoot: PR,
+    siblings: [{ name: 'claude-code-dev-hermit', version: '0.4.0' }],
+  });
+
+  expect(result.ok).toBe(true);
+  expect(result.siblings_confirmed['claude-code-dev-hermit']).toBe('0.4.0');
+  expect(result.siblings_skipped).toEqual([]);
+
+  const onDisk = readConfig(dir);
+  expect(onDisk._hermit_versions['claude-code-dev-hermit']).toBe('0.4.0');
+}));
+
+test('sibling NOT a key: skipped, not added to config', withProj(async (dir) => {
+  writeConfig(dir, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.2.5' },
+  }));
+  const result = finalize({
+    hermitDir: dir,
+    core: '1.2.6',
+    pluginRoot: PR,
+    siblings: [{ name: 'foo-hermit', version: '1.0.0' }],
+  });
+
+  expect(result.ok).toBe(true);
+  expect(result.siblings_skipped).toContain('foo-hermit');
+  expect('foo-hermit' in result.siblings_confirmed).toBe(false);
+
+  const onDisk = readConfig(dir);
+  expect('foo-hermit' in onDisk._hermit_versions).toBe(false); // key must NOT be added
+}));
+
+// -------------------------------------------------------
+// 4. --core ≠ plugin.json.version → refuse, file unchanged
+// -------------------------------------------------------
+
+test('core_version_mismatch: --core differs from plugin.json → error, file unchanged', withProj(async (dir) => {
+  const original = '{"_hermit_versions":{"claude-code-hermit":"1.2.5"}}';
+  writeConfig(dir, original);
+
+  const result = finalize({ hermitDir: dir, core: '1.2.9', pluginRoot: PR, siblings: [] });
+
+  expect(result.ok).toBe(false);
+  expect(result.errors.map(e => e.code)).toContain('core_version_mismatch');
+  expect(result.core.confirmed).toBeNull(); // no write attempted
+
+  // File must be unchanged
+  expect(fs.readFileSync(path.join(dir, 'config.json'), 'utf8')).toBe(original);
+}));
+
+// -------------------------------------------------------
+// 5. Missing config → no_config; malformed config → config_json_invalid
+// -------------------------------------------------------
+
+test('no_config: missing config.json → error, exit behavior', withProj(async (dir) => {
+  const result = finalize({ hermitDir: dir, core: '1.2.6', pluginRoot: PR, siblings: [] });
+
+  expect(result.ok).toBe(false);
+  expect(result.errors.map(e => e.code)).toContain('no_config');
+}));
+
+test('config_json_invalid: malformed JSON → error, bytes unchanged', withProj(async (dir) => {
+  const bad = '{"_hermit_versions":';
+  writeConfig(dir, bad);
+
+  const result = finalize({ hermitDir: dir, core: '1.2.6', pluginRoot: PR, siblings: [] });
+
+  expect(result.ok).toBe(false);
+  expect(result.errors.map(e => e.code)).toContain('config_json_invalid');
+
+  // Original bytes must be unchanged
+  expect(fs.readFileSync(path.join(dir, 'config.json'), 'utf8')).toBe(bad);
+}));
+
+// -------------------------------------------------------
+// 6. Missing --core → no_core_target, no write
+// -------------------------------------------------------
+
+test('no_core_target: --core absent → error, no file touched', withProj(async (dir) => {
+  const original = '{"_hermit_versions":{"claude-code-hermit":"1.2.5"}}';
+  writeConfig(dir, original);
+
+  const result = finalize({ hermitDir: dir, core: null, pluginRoot: PR, siblings: [] });
+
+  expect(result.ok).toBe(false);
+  expect(result.errors.map(e => e.code)).toContain('no_core_target');
+  expect(fs.readFileSync(path.join(dir, 'config.json'), 'utf8')).toBe(original);
+}));
+
+test('no_core_target: empty --core string → error', withProj(async (dir) => {
+  writeConfig(dir, '{"_hermit_versions":{"claude-code-hermit":"1.2.5"}}');
+  const result = finalize({ hermitDir: dir, core: '', pluginRoot: null, siblings: [] });
+  expect(result.errors.map(e => e.code)).toContain('no_core_target');
+}));
+
+// -------------------------------------------------------
+// 7. _hermit_versions absent entirely → created, core key set
+// -------------------------------------------------------
+
+test('_hermit_versions absent: created and core key set', withProj(async (dir) => {
+  writeConfig(dir, '{"model":"sonnet"}');
+
+  const result = finalize({ hermitDir: dir, core: '1.2.6', pluginRoot: PR, siblings: [] });
+
+  expect(result.ok).toBe(true);
+  expect(result.core.confirmed).toBe('1.2.6');
+
+  const onDisk = readConfig(dir);
+  expect(onDisk._hermit_versions['claude-code-hermit']).toBe('1.2.6');
+  expect(onDisk.model).toBe('sonnet'); // other keys preserved
+}));
+
+// -------------------------------------------------------
+// 8. Idempotency — running twice produces identical file
+// -------------------------------------------------------
+
+test('idempotency: second run is a no-op, both ok:true', withProj(async (dir) => {
+  writeConfig(dir, '{"_hermit_versions":{"claude-code-hermit":"1.2.5"}}');
+
+  const r1 = finalize({ hermitDir: dir, core: '1.2.6', pluginRoot: PR, siblings: [] });
+  expect(r1.ok).toBe(true);
+  const afterFirst = fs.readFileSync(path.join(dir, 'config.json'), 'utf8');
+
+  const r2 = finalize({ hermitDir: dir, core: '1.2.6', pluginRoot: PR, siblings: [] });
+  expect(r2.ok).toBe(true);
+  const afterSecond = fs.readFileSync(path.join(dir, 'config.json'), 'utf8');
+
+  expect(afterSecond).toBe(afterFirst);
+}));
+
+// -------------------------------------------------------
+// 9. Sibling version contains dots + = in rest of version string
+// -------------------------------------------------------
+
+test('sibling first-= split: name and version parsed correctly', withProj(async (dir) => {
+  writeConfig(dir, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.2.5', 'x-hermit': '0.1.0' },
+  }));
+  const result = finalize({
+    hermitDir: dir,
+    core: '1.2.6',
+    pluginRoot: PR,
+    siblings: [{ name: 'x-hermit', version: '1.2.3.4' }],
+  });
+
+  expect(result.ok).toBe(true);
+  expect(result.siblings_confirmed['x-hermit']).toBe('1.2.3.4');
+  const onDisk = readConfig(dir);
+  expect(onDisk._hermit_versions['x-hermit']).toBe('1.2.3.4');
+}));
+
+// -------------------------------------------------------
+// 10. Exit code via subprocess (the actual binary contract)
+// -------------------------------------------------------
+
+test('process exit 0 on success', withProj(async (dir) => {
+  writeConfig(dir, '{"_hermit_versions":{"claude-code-hermit":"1.2.5"}}');
+  const r = await runScript('evolve-finalize.ts', {
+    args: [dir, `--core=1.2.6`, `--plugin-root=${PR}`],
+  });
+  expect(r.exitCode).toBe(0);
+  const out = JSON.parse(r.stdout);
+  expect(out.ok).toBe(true);
+  expect(out.core.confirmed).toBe('1.2.6');
+}));
+
+test('process exit 1 on error (no_config)', withProj(async (dir) => {
+  // No config.json
+  const r = await runScript('evolve-finalize.ts', {
+    args: [dir, `--core=1.2.6`, `--plugin-root=${PR}`],
+  });
+  expect(r.exitCode).toBe(1);
+  const out = JSON.parse(r.stdout);
+  expect(out.ok).toBe(false);
+  expect(out.errors.map((e: any) => e.code)).toContain('no_config');
+}));
+
+test('process exit 1 on mismatch (core_version_mismatch)', withProj(async (dir) => {
+  writeConfig(dir, '{"_hermit_versions":{"claude-code-hermit":"1.2.5"}}');
+  const r = await runScript('evolve-finalize.ts', {
+    args: [dir, `--core=9.9.9`, `--plugin-root=${PR}`],
+  });
+  expect(r.exitCode).toBe(1);
+  const out = JSON.parse(r.stdout);
+  expect(out.ok).toBe(false);
+  expect(out.errors.map((e: any) => e.code)).toContain('core_version_mismatch');
+}));
+
+// -------------------------------------------------------
+// 11. malformed --sibling: goes to siblings_skipped, does not affect ok
+// -------------------------------------------------------
+
+test('malformed sibling: goes to siblings_skipped, core still bumps, ok:true', withProj(async (dir) => {
+  writeConfig(dir, '{"_hermit_versions":{"claude-code-hermit":"1.2.5"}}');
+  const result = finalize({
+    hermitDir: dir,
+    core: '1.2.6',
+    pluginRoot: PR,
+    siblings: [{ name: 'bad-hermit', version: '' }], // malformed (no version)
+  });
+
+  expect(result.siblings_skipped.some(s => s.includes('bad-hermit'))).toBe(true);
+  expect(result.errors).toEqual([]);
+  expect(result.core.confirmed).toBe('1.2.6');
+  expect(result.ok).toBe(true);
+}));


### PR DESCRIPTION
## Summary

Step 9 of `hermit-evolve` bumped `_hermit_versions["claude-code-hermit"]` in config.json via an LLM prose instruction — one bullet competing with the `new_config_keys` merge and CHANGELOG migration for the model's attention. A dropped bump caused `check-upgrade.sh` to re-nag every session start (the banner fires on version mismatch, not silence), and in always-on mode would force a full re-evolve on every session until the bump finally stuck.

This adds `scripts/evolve-finalize.ts`: a deterministic finalizer that reads the live config after the LLM's `new_config_keys` merge, mutates only `_hermit_versions` (core unconditionally, siblings only if the key already exists), atomic-writes via `.tmp` → `rename`, then re-reads from disk to confirm. Exits non-zero on any mismatch so the evolve-runner reports `Upgrade: blocked` instead of false success. Runner now sources `vNEW` from `core.confirmed` (the on-disk confirmed value) rather than `plan.to` (the pre-write analyzer value).

Closes #426

## Changes

- **`scripts/evolve-finalize.ts`** (new) — deterministic `_hermit_versions` writer; fail-loud (not fail-open like hooks); cross-checks `--core` against `plugin.json.version` to defend `check-upgrade.sh`'s exact string compare
- **`skills/hermit-evolve/SKILL.md`** step 9 — LLM still writes `new_config_keys` first; finalizer runs after and owns the `_hermit_versions` bump
- **`skills/hermit-evolve/SKILL.md`** step 8 — added `evolve-finalize.ts` to the required permission list (self-seeded by the same run that first needs it)
- **`agents/evolve-runner.md`** — delegated-mode rule: use `core.confirmed` as `vNEW`, report `blocked` if finalizer exits non-zero or `errors` non-empty
- **`skills/hatch/SKILL.md`** — seeds `Bash(bun */scripts/evolve-finalize.ts*)` permission for new hermits
- **`tests/evolve-finalize.test.ts`** (new, 16 tests) — covers the #426 regression, key preservation, sibling gating, `core_version_mismatch`, `no_config`, `config_json_invalid`, `no_core_target`, absent `_hermit_versions`, idempotency, first-`=` split, process exit codes, malformed sibling → `siblings_skipped`

## Test plan

```
cd plugins/claude-code-hermit && bun test tests/evolve-finalize.test.ts tests/evolve-plan.test.ts tests/contracts.test.ts
# 160 pass, 0 fail
```