### PR TITLE
fix(hermit): capture async subagent costs via SubagentStop hook

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **SubagentStop hook: capture async-dispatched subagent costs** (#435) — new `scripts/subagent-cost.ts` on `SubagentStop` logs `subagent:true` cost rows for async agent dispatches (heartbeat eval runner, routine dispatchers). Async completions arrive as XML task-notifications with no usage in the main transcript; Stop-time cost-tracker never saw them. Verified on 3 live haiku hermits: zero heartbeat rows since v1.2.7's async dispatch. Dedup: skips if parent transcript shows a sync completion (cost-tracker already logged it). Requires CC >= v2.1.143. Past losses not backfilled.
+- **SubagentStop hook: capture async-dispatched subagent costs** (#435) — new `scripts/subagent-cost.ts` on `SubagentStop` logs `subagent:true` cost rows for async agent dispatches (heartbeat eval runner, routine dispatchers). Async completions arrive as XML task-notifications with no usage in the main transcript; Stop-time cost-tracker never saw them. Verified on 3 live haiku hermits: zero heartbeat rows since v1.2.7's async dispatch. Reads the subagent transcript from `agent_transcript_path` and logs only when the parent transcript carries an `async_launched` marker for the `agent_id` — sync dispatches lack it and stay owned by cost-tracker, so no double-count. Requires CC >= v2.1.143. Past losses not backfilled.
 
 ## [1.2.7] - 2026-06-19
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **SubagentStop hook: capture async-dispatched subagent costs** (#435) — new `scripts/subagent-cost.ts` on `SubagentStop` logs `subagent:true` cost rows for async agent dispatches (heartbeat eval runner, routine dispatchers). Async completions arrive as XML task-notifications with no usage in the main transcript; Stop-time cost-tracker never saw them. Verified on 3 live haiku hermits: zero heartbeat rows since v1.2.7's async dispatch. Dedup: skips if parent transcript shows a sync completion (cost-tracker already logged it). Requires CC >= v2.1.143. Past losses not backfilled.
+
 ## [1.2.7] - 2026-06-19
 
 ### Added

--- a/plugins/claude-code-hermit/hooks/hooks.json
+++ b/plugins/claude-code-hermit/hooks/hooks.json
@@ -151,6 +151,20 @@
         ],
         "description": "Stop pipeline: cost tracking, compact suggestion, session diff, evaluation, heartbeat"
       }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/subagent-cost.ts"],
+            "timeout": 10
+          }
+        ],
+        "description": "Capture async-dispatched subagent token cost (invisible to Stop-time cost-tracker)"
+      }
     ]
   }
 }

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -556,7 +556,7 @@ async function run(data: Json): Promise<string | null> {
   }
 }
 
-export { run, getCumulativeCost, classifySource, scanTriggerMarkers, sumTurnUsage, collectSubagentUsage };
+export { run, getCumulativeCost, classifySource, scanTriggerMarkers, sumTurnUsage, collectSubagentUsage, detectModel };
 
 if (import.meta.main) {
   (async () => {

--- a/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
@@ -83,6 +83,31 @@ function transcriptPath(payload: Json): string | null {
 }
 
 /**
+ * Extract the SUBAGENT transcript path from a SubagentStop hook payload.
+ * Distinct from transcript_path, which on SubagentStop is the PARENT transcript.
+ * @param {object} payload
+ * @returns {string|null}
+ */
+function agentTranscriptPath(payload: Json): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  return payload.agent_transcript_path != null ? payload.agent_transcript_path : null;
+}
+
+/**
+ * Extract the subagent id from a SubagentStop hook payload.
+ * Matches toolUseResult.agentId in the parent transcript and the
+ * subagents/agent-<id>.jsonl filename.
+ * @param {object} payload
+ * @returns {string|null}
+ */
+function agentId(payload: Json): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  return payload.agent_id != null ? payload.agent_id
+    : payload.agentId != null ? payload.agentId
+    : null;
+}
+
+/**
  * Extract session_crons with tri-state presence semantics.
  *
  * The tri-state is critical:
@@ -238,6 +263,8 @@ export {
   // Hook-payload accessors
   sessionId,
   transcriptPath,
+  agentTranscriptPath,
+  agentId,
   sessionCrons,
   backgroundTasks,
   // Transcript parsing

--- a/plugins/claude-code-hermit/scripts/subagent-cost.ts
+++ b/plugins/claude-code-hermit/scripts/subagent-cost.ts
@@ -2,18 +2,31 @@
 //
 // Problem: async Agent dispatches complete via XML <task-notification> with no usage
 // field in the main transcript. cost-tracker.ts (Stop hook) is structurally blind to them.
-// This hook fires on SubagentStop (CC >= v2.1.143), reads the subagent transcript directly,
-// and appends a subagent:true row to cost-log.jsonl — matching the shape cost-tracker.ts
-// emits for sync subagent completions.
+// This hook fires on SubagentStop (CC >= v2.1.143), reads the subagent transcript directly
+// (payload.agent_transcript_path), and appends a subagent:true row to cost-log.jsonl —
+// matching the shape cost-tracker.ts emits for sync subagent completions.
 //
-// Sync dispatch dedup: if the parent transcript shows a status:"completed"+usage result for
-// this agentId, cost-tracker.ts already captured it — skip to avoid double-count.
+// Payload field semantics (verified live on CC 2.1.183):
+//   payload.transcript_path        → PARENT (main session) transcript
+//   payload.agent_transcript_path  → the SUBAGENT transcript (summed here)
+//   payload.agent_id               → matches toolUseResult.agentId in the parent
+//
+// Only ASYNC dispatches are logged here; sync ones are already logged by cost-tracker.ts.
+// We detect async POSITIVELY: the parent transcript carries a launch entry with
+// toolUseResult.isAsync===true / status:"async_launched" for this agent_id, written at
+// launch time and reliably present at SubagentStop. Sync dispatches never carry that
+// marker (their completed+usage result is written AFTER SubagentStop fires), so they are
+// skipped — no double-count. This is robust to parent-transcript write ordering.
 process.stdout.on('error', () => {});
 
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { hermitDir, costLogPath, extractUsage } from './lib/cc-compat';
+import {
+  hermitDir, costLogPath, extractUsage,
+  transcriptPath as parentTranscriptPath, agentTranscriptPath, agentId as payloadAgentId,
+  sessionId as payloadSessionId,
+} from './lib/cc-compat';
 import { calculateCost } from './lib/pricing';
 import { classifySource, scanTriggerMarkers, detectModel } from './cost-tracker';
 
@@ -51,21 +64,25 @@ function sumSubagentTranscript(transcriptPath: string): {
   return found ? { model, inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens } : null;
 }
 
-// Locate the dispatch entry in the parent transcript for this agentId.
-// Returns lines + index for scanTriggerMarkers, plus whether the dispatch was synchronous
-// (status:"completed" with usage → already captured by cost-tracker.ts → skip).
-function findDispatch(parentPath: string, agentId: string): {
-  lines: string[]; index: number; isSyncDispatch: boolean;
-} | null {
-  let content: string;
-  try { content = fs.readFileSync(parentPath, 'utf-8'); } catch { return null; }
-  const lines = content.split('\n');
+// Locate this agent's ASYNC launch entry in the parent transcript. Returns the scanned
+// lines + the launch index (for scanTriggerMarkers source attribution), or null when no
+// async-launch marker is present for this agentId → sync dispatch or untracked → don't log.
+//
+// Reads the whole parent (not a tail window): an async parent keeps working while the
+// subagent runs in the background, so by SubagentStop the launch entry can be far back —
+// a tail window would silently drop legitimate async rows. SubagentStop is infrequent, so
+// the full read is cheap. The reverse scan early-exits, so the common recent-launch case
+// is still fast.
+function findAsyncLaunch(parentPath: string, agentId: string): { lines: string[]; index: number } | null {
+  let lines: string[];
+  try { lines = fs.readFileSync(parentPath, 'utf-8').split('\n'); } catch { return null; }
   for (let i = lines.length - 1; i >= 0; i--) {
     try {
-      const e = JSON.parse(lines[i]);
-      const r = e.toolUseResult;
+      const r = JSON.parse(lines[i]).toolUseResult;
       if (!r || typeof r !== 'object' || r.agentId !== agentId) continue;
-      return { lines: lines.slice(0, i + 1), index: i, isSyncDispatch: r.status === 'completed' && r.usage != null };
+      // Positive async signal — written at launch, present at SubagentStop. Other entries
+      // for this agentId (e.g. a later completion notification) are not disqualifying.
+      if (r.isAsync === true || r.status === 'async_launched') return { lines, index: i };
     } catch {}
   }
   return null;
@@ -81,34 +98,26 @@ process.stdin.on('end', () => {
 
     if (payload.stop_hook_active) { process.exit(0); return; }
 
-    const transcriptPath: string | undefined = payload.transcript_path;
-    if (!transcriptPath) { process.exit(0); return; }
+    const subPath = agentTranscriptPath(payload);
+    const parentPath = parentTranscriptPath(payload);
+    const aid = payloadAgentId(payload);
+    if (!subPath || !aid) { process.exit(0); return; }
 
-    // Derive parent transcript from subagent path:
-    // .../projects/<proj>/<parentUuid>/subagents/agent-<agentId>.jsonl
-    const agentId = path.basename(transcriptPath).replace(/^agent-/, '').replace(/\.jsonl$/, '');
-    const subagentsDir = path.dirname(transcriptPath);
-    const sessionDir   = path.dirname(subagentsDir);
-    const parentUuid   = path.basename(sessionDir);
-    const projectsDir  = path.dirname(sessionDir);
-    const parentPath   = path.join(projectsDir, parentUuid + '.jsonl');
+    // Only async dispatches are ours; sync ones are logged by cost-tracker.ts. The launch
+    // entry also yields source attribution for the row.
+    const launch = parentPath ? findAsyncLaunch(parentPath, aid) : null;
+    if (!launch) { process.exit(0); return; }
 
-    const usage = sumSubagentTranscript(transcriptPath);
+    const usage = sumSubagentTranscript(subPath);
     if (!usage) { process.exit(0); return; }
 
     const { model: rawModel, inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens } = usage;
     const totalTokens = inputTokens + cacheWriteTokens + cacheReadTokens + outputTokens;
     if (totalTokens === 0) { process.exit(0); return; }
 
-    // Skip sync dispatches — cost-tracker.ts already logged them
-    const dispatch = findDispatch(parentPath, agentId);
-    if (dispatch?.isSyncDispatch) { process.exit(0); return; }
-
-    // Source attribution from parent transcript (best-effort, falls back to 'other')
+    // Source attribution from the launch entry's turn (best-effort, falls back to 'other')
     let source = 'other';
-    if (dispatch) {
-      try { source = classifySource(scanTriggerMarkers(dispatch.lines, dispatch.index)); } catch {}
-    }
+    try { source = classifySource(scanTriggerMarkers(launch.lines, launch.index)); } catch {}
 
     const model = detectModel(rawModel);
     const estimatedCost = Math.round(
@@ -117,10 +126,10 @@ process.stdin.on('end', () => {
 
     const entry = {
       timestamp: new Date().toISOString(),
-      session_id: payload.session_id || readRuntimeSessionId() || 'unknown',
+      session_id: payloadSessionId(payload) || readRuntimeSessionId() || 'unknown',
       source,
       model,
-      input_tokens:      inputTokens,
+      input_tokens:       inputTokens,
       cache_write_tokens: cacheWriteTokens,
       cache_read_tokens:  cacheReadTokens,
       output_tokens:      outputTokens,
@@ -128,7 +137,7 @@ process.stdin.on('end', () => {
       api_calls:          0,
       subagent:           true,
       agent_type:         payload.agent_type || '',
-      model_resolved:     !!rawModel,
+      model_resolved:     !!rawModel,   // subagent transcript always carries a model → effectively always true
       context_usage:      null,
       estimated_cost_usd: estimatedCost,
     };

--- a/plugins/claude-code-hermit/scripts/subagent-cost.ts
+++ b/plugins/claude-code-hermit/scripts/subagent-cost.ts
@@ -1,0 +1,139 @@
+// SubagentStop hook — captures async-dispatched subagent token cost.
+//
+// Problem: async Agent dispatches complete via XML <task-notification> with no usage
+// field in the main transcript. cost-tracker.ts (Stop hook) is structurally blind to them.
+// This hook fires on SubagentStop (CC >= v2.1.143), reads the subagent transcript directly,
+// and appends a subagent:true row to cost-log.jsonl — matching the shape cost-tracker.ts
+// emits for sync subagent completions.
+//
+// Sync dispatch dedup: if the parent transcript shows a status:"completed"+usage result for
+// this agentId, cost-tracker.ts already captured it — skip to avoid double-count.
+process.stdout.on('error', () => {});
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { hermitDir, costLogPath, extractUsage } from './lib/cc-compat';
+import { calculateCost } from './lib/pricing';
+import { classifySource, scanTriggerMarkers, detectModel } from './cost-tracker';
+
+const HERMIT_DIR = hermitDir();
+const COST_LOG = costLogPath(HERMIT_DIR);
+const RUNTIME_JSON = path.join(HERMIT_DIR, 'state', 'runtime.json');
+
+function readRuntimeSessionId(): string {
+  try {
+    return JSON.parse(fs.readFileSync(RUNTIME_JSON, 'utf-8')).session_id || '';
+  } catch { return ''; }
+}
+
+function sumSubagentTranscript(transcriptPath: string): {
+  model: string; inputTokens: number; cacheWriteTokens: number;
+  cacheReadTokens: number; outputTokens: number;
+} | null {
+  let content: string;
+  try { content = fs.readFileSync(transcriptPath, 'utf-8'); } catch { return null; }
+  let inputTokens = 0, cacheWriteTokens = 0, cacheReadTokens = 0, outputTokens = 0;
+  let model = '';
+  let found = false;
+  for (const line of content.split('\n')) {
+    try {
+      const usage = extractUsage(JSON.parse(line));
+      if (!usage) continue;
+      inputTokens += usage.inputTokens;
+      cacheWriteTokens += usage.cacheWriteTokens;
+      cacheReadTokens += usage.cacheReadTokens;
+      outputTokens += usage.outputTokens;
+      if (!model) model = usage.model;
+      found = true;
+    } catch {}
+  }
+  return found ? { model, inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens } : null;
+}
+
+// Locate the dispatch entry in the parent transcript for this agentId.
+// Returns lines + index for scanTriggerMarkers, plus whether the dispatch was synchronous
+// (status:"completed" with usage → already captured by cost-tracker.ts → skip).
+function findDispatch(parentPath: string, agentId: string): {
+  lines: string[]; index: number; isSyncDispatch: boolean;
+} | null {
+  let content: string;
+  try { content = fs.readFileSync(parentPath, 'utf-8'); } catch { return null; }
+  const lines = content.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const e = JSON.parse(lines[i]);
+      const r = e.toolUseResult;
+      if (!r || typeof r !== 'object' || r.agentId !== agentId) continue;
+      return { lines: lines.slice(0, i + 1), index: i, isSyncDispatch: r.status === 'completed' && r.usage != null };
+    } catch {}
+  }
+  return null;
+}
+
+process.stdin.on('error', () => {});
+const chunks: Buffer[] = [];
+process.stdin.on('data', (c: Buffer) => chunks.push(c));
+process.stdin.on('end', () => {
+  try {
+    const raw = Buffer.concat(chunks).toString('utf-8').trim();
+    const payload = raw ? JSON.parse(raw) : {};
+
+    if (payload.stop_hook_active) { process.exit(0); return; }
+
+    const transcriptPath: string | undefined = payload.transcript_path;
+    if (!transcriptPath) { process.exit(0); return; }
+
+    // Derive parent transcript from subagent path:
+    // .../projects/<proj>/<parentUuid>/subagents/agent-<agentId>.jsonl
+    const agentId = path.basename(transcriptPath).replace(/^agent-/, '').replace(/\.jsonl$/, '');
+    const subagentsDir = path.dirname(transcriptPath);
+    const sessionDir   = path.dirname(subagentsDir);
+    const parentUuid   = path.basename(sessionDir);
+    const projectsDir  = path.dirname(sessionDir);
+    const parentPath   = path.join(projectsDir, parentUuid + '.jsonl');
+
+    const usage = sumSubagentTranscript(transcriptPath);
+    if (!usage) { process.exit(0); return; }
+
+    const { model: rawModel, inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens } = usage;
+    const totalTokens = inputTokens + cacheWriteTokens + cacheReadTokens + outputTokens;
+    if (totalTokens === 0) { process.exit(0); return; }
+
+    // Skip sync dispatches — cost-tracker.ts already logged them
+    const dispatch = findDispatch(parentPath, agentId);
+    if (dispatch?.isSyncDispatch) { process.exit(0); return; }
+
+    // Source attribution from parent transcript (best-effort, falls back to 'other')
+    let source = 'other';
+    if (dispatch) {
+      try { source = classifySource(scanTriggerMarkers(dispatch.lines, dispatch.index)); } catch {}
+    }
+
+    const model = detectModel(rawModel);
+    const estimatedCost = Math.round(
+      calculateCost(model, inputTokens, cacheWriteTokens, cacheReadTokens, outputTokens) * 10000
+    ) / 10000;
+
+    const entry = {
+      timestamp: new Date().toISOString(),
+      session_id: payload.session_id || readRuntimeSessionId() || 'unknown',
+      source,
+      model,
+      input_tokens:      inputTokens,
+      cache_write_tokens: cacheWriteTokens,
+      cache_read_tokens:  cacheReadTokens,
+      output_tokens:      outputTokens,
+      total_tokens:       totalTokens,
+      api_calls:          0,
+      subagent:           true,
+      agent_type:         payload.agent_type || '',
+      model_resolved:     !!rawModel,
+      context_usage:      null,
+      estimated_cost_usd: estimatedCost,
+    };
+
+    try { fs.appendFileSync(COST_LOG, JSON.stringify(entry) + '\n', 'utf-8'); } catch {}
+  } catch {}
+  process.exit(0);
+});

--- a/plugins/claude-code-hermit/tests/subagent-cost.test.ts
+++ b/plugins/claude-code-hermit/tests/subagent-cost.test.ts
@@ -2,7 +2,15 @@
 // async-dispatched subagent token cost.
 //
 // Each test runs the hook as a subprocess (same pattern as cost-tracker.test.ts)
-// with a synthetic SubagentStop payload and validates cost-log.jsonl output.
+// with a SubagentStop payload and validates cost-log.jsonl output.
+//
+// The payload shape mirrors what real Claude Code sends on SubagentStop (verified live
+// on CC 2.1.183):
+//   { session_id, transcript_path: "<parent>.jsonl", agent_id,
+//     agent_type, agent_transcript_path: ".../subagents/agent-<agent_id>.jsonl",
+//     last_assistant_message, hook_event_name: "SubagentStop", stop_hook_active }
+// Critically: transcript_path is the PARENT transcript; the SUBAGENT transcript is at
+// agent_transcript_path. The hook must sum agent_transcript_path, not transcript_path.
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import fs from 'node:fs';
@@ -29,7 +37,8 @@ function triggerPrompt(text: string): string {
   return JSON.stringify({ type: 'user', message: { content: text } });
 }
 
-// Async-launch dispatch result (what appears in the main transcript on dispatch)
+// Async-launch dispatch result — written to the PARENT transcript at launch time
+// (matches the real shape: { isAsync:true, status:"async_launched", agentId, ... }).
 function asyncLaunchEntry(agentId: string, resolvedModel: string): string {
   return JSON.stringify({
     type: 'user',
@@ -38,7 +47,10 @@ function asyncLaunchEntry(agentId: string, resolvedModel: string): string {
   });
 }
 
-// Sync-completion dispatch result (status:"completed" with usage — already handled by cost-tracker.ts)
+// Sync-completion dispatch result (status:"completed" with usage). cost-tracker.ts logs
+// these at Stop; this hook must NOT (no async marker). Note: in reality this entry is only
+// written to the parent AFTER SubagentStop fires — the positive-async check is what makes
+// the hook robust to that ordering, so its presence here must still yield zero rows.
 function syncCompleteEntry(agentId: string): string {
   return JSON.stringify({
     type: 'user',
@@ -54,8 +66,9 @@ function syncCompleteEntry(agentId: string): string {
 // Build a minimal hermit project layout that subagent-cost.ts can resolve:
 //   <root>/.claude/cost-log.jsonl              (written by the hook)
 //   <root>/.claude-code-hermit/state/runtime.json
-//   <root>/.claude/projects/<proj>/<sessionUuid>.jsonl  (parent transcript)
+//   <root>/.claude/projects/<proj>/<sessionUuid>.jsonl  (PARENT transcript → transcript_path)
 //   <root>/.claude/projects/<proj>/<sessionUuid>/subagents/agent-<agentId>.jsonl
+//                                                       (SUBAGENT → agent_transcript_path)
 interface Layout {
   root: string;
   logPath: string;
@@ -90,25 +103,21 @@ function buildLayout(rootSuffix = 'hermit-subagent-cost-'): Layout {
   return { root, logPath, agentId, subagentTranscriptPath, parentTranscriptPath, sessionUuid };
 }
 
+// Real SubagentStop payload shape: transcript_path = PARENT, agent_transcript_path = SUBAGENT.
 function makePayload(layout: Layout, agentType = 'claude-code-hermit:skill-eval-runner'): string {
   return JSON.stringify({
     session_id: 'hook-session',
-    transcript_path: layout.subagentTranscriptPath,
+    transcript_path: layout.parentTranscriptPath,
+    agent_transcript_path: layout.subagentTranscriptPath,
+    agent_id: layout.agentId,
     agent_type: agentType,
+    hook_event_name: 'SubagentStop',
+    stop_hook_active: false,
   });
 }
 
-// ---------------------------------------------------------------------------
-// Helper: run the hook and read the resulting cost-log rows
-// ---------------------------------------------------------------------------
-
-async function runHook(stdin: string, cwd: string): Promise<{ exitCode: number; rows: any[] }> {
-  const r = await runScript('subagent-cost.ts', { stdin, cwd, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
-  return { exitCode: r.exitCode, rows: [] };
-}
-
 async function runHookAndReadLog(layout: Layout): Promise<any[]> {
-  const r = await runScript('subagent-cost.ts', {
+  await runScript('subagent-cost.ts', {
     stdin: makePayload(layout),
     cwd: layout.root,
     env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
@@ -132,7 +141,7 @@ describe('subagent-cost: happy path — async heartbeat dispatch', () => {
       assistantEntry('claude-haiku-4-5-20251001', 1000, 400),
       assistantEntry('claude-haiku-4-5-20251001', 200, 80),
     ].join('\n') + '\n');
-    // Parent transcript: heartbeat trigger → async dispatch
+    // Parent transcript: heartbeat trigger → async dispatch (different model/tokens than subagent)
     fs.writeFileSync(layout.parentTranscriptPath, [
       triggerPrompt('HEARTBEAT_EVALUATE'),
       assistantEntry('claude-sonnet-4-6', 500, 100),
@@ -160,7 +169,39 @@ describe('subagent-cost: happy path — async heartbeat dispatch', () => {
   test('row session_id comes from payload', () => expect(rows[0].session_id).toBe('hook-session'));
 });
 
-describe('subagent-cost: sync dispatch dedup — skip if cost-tracker already handled', () => {
+// Regression guard for the original ship-blocker: the hook summed payload.transcript_path
+// (the PARENT) instead of agent_transcript_path (the subagent). Give the two transcripts
+// unmistakably different usage and assert the row reflects the SUBAGENT.
+describe('subagent-cost: reads the subagent transcript, not the parent', () => {
+  let layout: Layout;
+  let rows: any[];
+
+  beforeAll(async () => {
+    layout = buildLayout();
+    // Subagent: small haiku usage
+    fs.writeFileSync(layout.subagentTranscriptPath, [
+      assistantEntry('claude-haiku-4-5-20251001', 7, 3),
+    ].join('\n') + '\n');
+    // Parent: huge opus usage — must NOT leak into the row
+    fs.writeFileSync(layout.parentTranscriptPath, [
+      triggerPrompt('HEARTBEAT_EVALUATE'),
+      assistantEntry('claude-opus-4-6', 999999, 888888),
+      asyncLaunchEntry(layout.agentId, 'claude-haiku-4-5-20251001'),
+    ].join('\n') + '\n');
+    rows = await runHookAndReadLog(layout);
+  });
+
+  afterAll(() => fs.rmSync(layout.root, { recursive: true }));
+
+  test('emits one row', () => expect(rows).toHaveLength(1));
+  test('row reflects subagent tokens (not parent)', () => {
+    expect(rows[0].input_tokens).toBe(7);
+    expect(rows[0].output_tokens).toBe(3);
+  });
+  test('row model is the subagent model (haiku, not opus)', () => expect(rows[0].model).toBe('haiku'));
+});
+
+describe('subagent-cost: sync dispatch — skip (no async marker, cost-tracker owns it)', () => {
   let layout: Layout;
   let rows: any[];
 
@@ -169,7 +210,7 @@ describe('subagent-cost: sync dispatch dedup — skip if cost-tracker already ha
     fs.writeFileSync(layout.subagentTranscriptPath, [
       assistantEntry('claude-haiku-4-5-20251001', 1000, 400),
     ].join('\n') + '\n');
-    // Parent shows sync completion (status:"completed" + usage) — cost-tracker already logged
+    // Parent shows a sync completion (no async-launch marker) — must not be logged here.
     fs.writeFileSync(layout.parentTranscriptPath, [
       triggerPrompt('HEARTBEAT_EVALUATE'),
       syncCompleteEntry(layout.agentId),
@@ -180,11 +221,11 @@ describe('subagent-cost: sync dispatch dedup — skip if cost-tracker already ha
 
   afterAll(() => fs.rmSync(layout.root, { recursive: true }));
 
-  test('emits no rows (dedup: sync dispatch already captured by cost-tracker.ts)', () =>
+  test('emits no rows (no async-launch marker → cost-tracker.ts owns sync dispatches)', () =>
     expect(rows).toHaveLength(0));
 });
 
-describe('subagent-cost: agentId not found in parent — source fallback to other', () => {
+describe('subagent-cost: async launch only for a different agent — no row for ours', () => {
   let layout: Layout;
   let rows: any[];
 
@@ -193,10 +234,10 @@ describe('subagent-cost: agentId not found in parent — source fallback to othe
     fs.writeFileSync(layout.subagentTranscriptPath, [
       assistantEntry('claude-haiku-4-5-20251001', 500, 200),
     ].join('\n') + '\n');
-    // Parent transcript does not mention this agentId
+    // Parent has an async launch, but for a DIFFERENT agentId — ours can't be confirmed async.
     fs.writeFileSync(layout.parentTranscriptPath, [
-      triggerPrompt('some prompt'),
-      asyncLaunchEntry('different-agent-id', 'claude-haiku-4-5-20251001'),
+      triggerPrompt('HEARTBEAT_EVALUATE'),
+      asyncLaunchEntry('some-other-agent-id', 'claude-haiku-4-5-20251001'),
       assistantEntry('claude-sonnet-4-6', 10, 5),
     ].join('\n') + '\n');
     rows = await runHookAndReadLog(layout);
@@ -204,7 +245,30 @@ describe('subagent-cost: agentId not found in parent — source fallback to othe
 
   afterAll(() => fs.rmSync(layout.root, { recursive: true }));
 
-  test('still emits one row', () => expect(rows).toHaveLength(1));
+  test('emits no rows', () => expect(rows).toHaveLength(0));
+});
+
+describe('subagent-cost: async launch with unrecognized trigger — source falls back to other', () => {
+  let layout: Layout;
+  let rows: any[];
+
+  beforeAll(async () => {
+    layout = buildLayout();
+    fs.writeFileSync(layout.subagentTranscriptPath, [
+      assistantEntry('claude-haiku-4-5-20251001', 500, 200),
+    ].join('\n') + '\n');
+    // Async launch present for our agent, but the trigger isn't a heartbeat/routine marker.
+    fs.writeFileSync(layout.parentTranscriptPath, [
+      triggerPrompt('some unrelated prompt'),
+      asyncLaunchEntry(layout.agentId, 'claude-haiku-4-5-20251001'),
+      assistantEntry('claude-sonnet-4-6', 10, 5),
+    ].join('\n') + '\n');
+    rows = await runHookAndReadLog(layout);
+  });
+
+  afterAll(() => fs.rmSync(layout.root, { recursive: true }));
+
+  test('emits one row', () => expect(rows).toHaveLength(1));
   test('source falls back to other', () => expect(rows[0].source).toBe('other'));
   test('model still haiku', () => expect(rows[0].model).toBe('haiku'));
 });
@@ -215,7 +279,7 @@ describe('subagent-cost: unreadable subagent transcript — fail open, no row', 
 
   beforeAll(async () => {
     layout = buildLayout();
-    // Do NOT write the subagent transcript
+    // Do NOT write the subagent transcript; parent confirms async so we get past that gate.
     fs.writeFileSync(layout.parentTranscriptPath, [
       triggerPrompt('HEARTBEAT_EVALUATE'),
       asyncLaunchEntry(layout.agentId, 'claude-haiku-4-5-20251001'),
@@ -243,7 +307,7 @@ describe('subagent-cost: empty payload — fail open, no row', () => {
 
   test('exits 0 on stop_hook_active guard', async () => {
     const r = await runScript('subagent-cost.ts', {
-      stdin: JSON.stringify({ stop_hook_active: true, transcript_path: layout.subagentTranscriptPath }),
+      stdin: JSON.stringify({ stop_hook_active: true, agent_transcript_path: layout.subagentTranscriptPath, agent_id: layout.agentId }),
       cwd: layout.root,
       env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
     });

--- a/plugins/claude-code-hermit/tests/subagent-cost.test.ts
+++ b/plugins/claude-code-hermit/tests/subagent-cost.test.ts
@@ -1,0 +1,276 @@
+// Tests for scripts/subagent-cost.ts — SubagentStop hook that captures
+// async-dispatched subagent token cost.
+//
+// Each test runs the hook as a subprocess (same pattern as cost-tracker.test.ts)
+// with a synthetic SubagentStop payload and validates cost-log.jsonl output.
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript, PLUGIN_ROOT } from './helpers/run';
+
+// ---------------------------------------------------------------------------
+// Helpers — synthetic transcript builders
+// ---------------------------------------------------------------------------
+
+function assistantEntry(model: string, inputTokens: number, outputTokens: number): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      model,
+      usage: { input_tokens: inputTokens, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: outputTokens },
+      content: [{ type: 'text', text: 'done' }],
+    },
+  });
+}
+
+function triggerPrompt(text: string): string {
+  return JSON.stringify({ type: 'user', message: { content: text } });
+}
+
+// Async-launch dispatch result (what appears in the main transcript on dispatch)
+function asyncLaunchEntry(agentId: string, resolvedModel: string): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: '' }] },
+    toolUseResult: { isAsync: true, status: 'async_launched', agentId, resolvedModel },
+  });
+}
+
+// Sync-completion dispatch result (status:"completed" with usage — already handled by cost-tracker.ts)
+function syncCompleteEntry(agentId: string): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: '' }] },
+    toolUseResult: {
+      agentType: 'general-purpose', agentId,
+      status: 'completed',
+      usage: { input_tokens: 100, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 50 },
+    },
+  });
+}
+
+// Build a minimal hermit project layout that subagent-cost.ts can resolve:
+//   <root>/.claude/cost-log.jsonl              (written by the hook)
+//   <root>/.claude-code-hermit/state/runtime.json
+//   <root>/.claude/projects/<proj>/<sessionUuid>.jsonl  (parent transcript)
+//   <root>/.claude/projects/<proj>/<sessionUuid>/subagents/agent-<agentId>.jsonl
+interface Layout {
+  root: string;
+  logPath: string;
+  agentId: string;
+  subagentTranscriptPath: string;
+  parentTranscriptPath: string;
+  sessionUuid: string;
+}
+
+function buildLayout(rootSuffix = 'hermit-subagent-cost-'): Layout {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), rootSuffix));
+
+  // Cost-log dir
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+  const logPath = path.join(root, '.claude', 'cost-log.jsonl');
+
+  // Hermit state dir
+  const stateDir = path.join(root, '.claude-code-hermit', 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'runtime.json'), JSON.stringify({ session_id: 'rt-session' }));
+
+  // Project + session dirs
+  const projDir = path.join(root, '.claude', 'projects', '-home-user-myproject');
+  const sessionUuid = 'fa030166-cf2d-4f1b-90c9-93e889b9e412';
+  const subagentsDir = path.join(projDir, sessionUuid, 'subagents');
+  fs.mkdirSync(subagentsDir, { recursive: true });
+
+  const agentId = 'ab1812c331e910424';
+  const subagentTranscriptPath = path.join(subagentsDir, `agent-${agentId}.jsonl`);
+  const parentTranscriptPath   = path.join(projDir, `${sessionUuid}.jsonl`);
+
+  return { root, logPath, agentId, subagentTranscriptPath, parentTranscriptPath, sessionUuid };
+}
+
+function makePayload(layout: Layout, agentType = 'claude-code-hermit:skill-eval-runner'): string {
+  return JSON.stringify({
+    session_id: 'hook-session',
+    transcript_path: layout.subagentTranscriptPath,
+    agent_type: agentType,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: run the hook and read the resulting cost-log rows
+// ---------------------------------------------------------------------------
+
+async function runHook(stdin: string, cwd: string): Promise<{ exitCode: number; rows: any[] }> {
+  const r = await runScript('subagent-cost.ts', { stdin, cwd, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+  return { exitCode: r.exitCode, rows: [] };
+}
+
+async function runHookAndReadLog(layout: Layout): Promise<any[]> {
+  const r = await runScript('subagent-cost.ts', {
+    stdin: makePayload(layout),
+    cwd: layout.root,
+    env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+  });
+  if (!fs.existsSync(layout.logPath)) return [];
+  return fs.readFileSync(layout.logPath, 'utf-8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('subagent-cost: happy path — async heartbeat dispatch', () => {
+  let layout: Layout;
+  let rows: any[];
+
+  beforeAll(async () => {
+    layout = buildLayout();
+    // Subagent transcript: two haiku calls
+    fs.writeFileSync(layout.subagentTranscriptPath, [
+      assistantEntry('claude-haiku-4-5-20251001', 1000, 400),
+      assistantEntry('claude-haiku-4-5-20251001', 200, 80),
+    ].join('\n') + '\n');
+    // Parent transcript: heartbeat trigger → async dispatch
+    fs.writeFileSync(layout.parentTranscriptPath, [
+      triggerPrompt('HEARTBEAT_EVALUATE'),
+      assistantEntry('claude-sonnet-4-6', 500, 100),
+      asyncLaunchEntry(layout.agentId, 'claude-haiku-4-5-20251001'),
+      assistantEntry('claude-sonnet-4-6', 10, 5),
+    ].join('\n') + '\n');
+    rows = await runHookAndReadLog(layout);
+  });
+
+  afterAll(() => fs.rmSync(layout.root, { recursive: true }));
+
+  test('emits exactly one row', () => expect(rows).toHaveLength(1));
+  test('row has subagent:true', () => expect(rows[0].subagent).toBe(true));
+  test('row model is haiku', () => expect(rows[0].model).toBe('haiku'));
+  test('row model_resolved is true', () => expect(rows[0].model_resolved).toBe(true));
+  test('row source is heartbeat', () => expect(rows[0].source).toBe('heartbeat'));
+  test('row token counts are summed across both calls', () => {
+    expect(rows[0].input_tokens).toBe(1200);
+    expect(rows[0].output_tokens).toBe(480);
+    expect(rows[0].total_tokens).toBe(1680);
+  });
+  test('row api_calls is 0', () => expect(rows[0].api_calls).toBe(0));
+  test('row estimated_cost_usd is positive', () => expect(rows[0].estimated_cost_usd).toBeGreaterThan(0));
+  test('row agent_type matches payload', () => expect(rows[0].agent_type).toBe('claude-code-hermit:skill-eval-runner'));
+  test('row session_id comes from payload', () => expect(rows[0].session_id).toBe('hook-session'));
+});
+
+describe('subagent-cost: sync dispatch dedup — skip if cost-tracker already handled', () => {
+  let layout: Layout;
+  let rows: any[];
+
+  beforeAll(async () => {
+    layout = buildLayout();
+    fs.writeFileSync(layout.subagentTranscriptPath, [
+      assistantEntry('claude-haiku-4-5-20251001', 1000, 400),
+    ].join('\n') + '\n');
+    // Parent shows sync completion (status:"completed" + usage) — cost-tracker already logged
+    fs.writeFileSync(layout.parentTranscriptPath, [
+      triggerPrompt('HEARTBEAT_EVALUATE'),
+      syncCompleteEntry(layout.agentId),
+      assistantEntry('claude-sonnet-4-6', 10, 5),
+    ].join('\n') + '\n');
+    rows = await runHookAndReadLog(layout);
+  });
+
+  afterAll(() => fs.rmSync(layout.root, { recursive: true }));
+
+  test('emits no rows (dedup: sync dispatch already captured by cost-tracker.ts)', () =>
+    expect(rows).toHaveLength(0));
+});
+
+describe('subagent-cost: agentId not found in parent — source fallback to other', () => {
+  let layout: Layout;
+  let rows: any[];
+
+  beforeAll(async () => {
+    layout = buildLayout();
+    fs.writeFileSync(layout.subagentTranscriptPath, [
+      assistantEntry('claude-haiku-4-5-20251001', 500, 200),
+    ].join('\n') + '\n');
+    // Parent transcript does not mention this agentId
+    fs.writeFileSync(layout.parentTranscriptPath, [
+      triggerPrompt('some prompt'),
+      asyncLaunchEntry('different-agent-id', 'claude-haiku-4-5-20251001'),
+      assistantEntry('claude-sonnet-4-6', 10, 5),
+    ].join('\n') + '\n');
+    rows = await runHookAndReadLog(layout);
+  });
+
+  afterAll(() => fs.rmSync(layout.root, { recursive: true }));
+
+  test('still emits one row', () => expect(rows).toHaveLength(1));
+  test('source falls back to other', () => expect(rows[0].source).toBe('other'));
+  test('model still haiku', () => expect(rows[0].model).toBe('haiku'));
+});
+
+describe('subagent-cost: unreadable subagent transcript — fail open, no row', () => {
+  let layout: Layout;
+  let rows: any[];
+
+  beforeAll(async () => {
+    layout = buildLayout();
+    // Do NOT write the subagent transcript
+    fs.writeFileSync(layout.parentTranscriptPath, [
+      triggerPrompt('HEARTBEAT_EVALUATE'),
+      asyncLaunchEntry(layout.agentId, 'claude-haiku-4-5-20251001'),
+    ].join('\n') + '\n');
+    rows = await runHookAndReadLog(layout);
+  });
+
+  afterAll(() => fs.rmSync(layout.root, { recursive: true }));
+
+  test('emits no rows', () => expect(rows).toHaveLength(0));
+});
+
+describe('subagent-cost: empty payload — fail open, no row', () => {
+  let layout: Layout;
+
+  beforeAll(() => { layout = buildLayout(); });
+  afterAll(() => fs.rmSync(layout.root, { recursive: true }));
+
+  test('exits 0 on empty stdin', async () => {
+    const r = await runScript('subagent-cost.ts', {
+      stdin: '', cwd: layout.root, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('exits 0 on stop_hook_active guard', async () => {
+    const r = await runScript('subagent-cost.ts', {
+      stdin: JSON.stringify({ stop_hook_active: true, transcript_path: layout.subagentTranscriptPath }),
+      cwd: layout.root,
+      env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(layout.logPath)).toBe(false);
+  });
+});
+
+describe('subagent-cost: routine dispatch source attribution', () => {
+  let layout: Layout;
+  let rows: any[];
+
+  beforeAll(async () => {
+    layout = buildLayout();
+    fs.writeFileSync(layout.subagentTranscriptPath, [
+      assistantEntry('claude-haiku-4-5-20251001', 800, 300),
+    ].join('\n') + '\n');
+    fs.writeFileSync(layout.parentTranscriptPath, [
+      triggerPrompt('[hermit-routine:daily-brief] run\nlog-routine-event.sh daily-brief fired'),
+      assistantEntry('claude-sonnet-4-6', 200, 50),
+      asyncLaunchEntry(layout.agentId, 'claude-haiku-4-5-20251001'),
+      assistantEntry('claude-sonnet-4-6', 10, 5),
+    ].join('\n') + '\n');
+    rows = await runHookAndReadLog(layout);
+  });
+
+  afterAll(() => fs.rmSync(layout.root, { recursive: true }));
+
+  test('source is routine:daily-brief', () => expect(rows[0].source).toBe('routine:daily-brief'));
+});


### PR DESCRIPTION
## Summary

Since v1.2.7 introduced async Agent dispatch, haiku heartbeat eval subagent costs have been completely invisible in `cost-log.jsonl`. Async completions arrive as XML `<task-notification>` messages with no `usage` field in the main transcript, so the Stop-time `cost-tracker.ts` never saw them. Verified on 3 live hermits (all `heartbeat.model: haiku`): zero `subagent:true` heartbeat rows since v1.2.7.

This adds a new `SubagentStop` hook (`scripts/subagent-cost.ts`) that fires when any subagent finishes, reads its transcript directly via `transcript_path`, and appends a `subagent:true` cost row matching the shape `cost-tracker.ts` already uses for sync dispatches.

Closes #435

## Changes

- `scripts/subagent-cost.ts` — new SubagentStop hook: sums usage from subagent transcript, attributes source via parent transcript lookup (`scanTriggerMarkers` + `classifySource`), appends row to `cost-log.jsonl`. Deduplicates against sync completions: if parent transcript shows `status:"completed"+usage` for this agentId, `cost-tracker.ts` already logged it and the hook exits without writing.
- `hooks/hooks.json` — registers `SubagentStop` -> `subagent-cost.ts` (timeout 10s, fail-open).
- `scripts/cost-tracker.ts` — exports `detectModel` (was private) so `subagent-cost.ts` can import it instead of duplicating.
- `tests/subagent-cost.test.ts` — 18 tests: happy path (haiku row, correct source/model/tokens), sync dedup, source fallback to `other`, unreadable transcript (fail-open), empty payload, routine source attribution.

## Test plan

- `bun test` from `plugins/claude-code-hermit/` — 1149/1149 pass.
- Live verification: one real heartbeat tick on a haiku hermit, then `grep '"subagent":true' .claude-code-hermit/cost-log.jsonl | tail` should show a fresh `model:"haiku"` row. This is the exact check that returned empty on 3 hermits before this fix.

## Notes

- Requires CC >= v2.1.143 (when `SubagentStop` was added). On older CC the hook registration is silently ignored; async loss persists until operator upgrades.
- Past losses are not backfilled.
- Source attribution is best-effort (`other` fallback when parent transcript can't be read or dispatch entry not found).