### PR TITLE
fix: clarify background-session worktree handling in dev-hermit CLAUDE-APPEND

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **CLAUDE-APPEND: background-session worktree clarifier** — §Git Safety in both templates now tells background (`--bg`/agent-view) dev agents to let the harness auto-isolate on first edit instead of proactively calling `EnterWorktree` (which fails in daemon-spawned pinned-cwd sessions and stalled #435).
+
 ## [0.4.2] - 2026-06-16
 
 ### Changed

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND-SAFETY.md
@@ -9,7 +9,7 @@ These rules apply to every agent doing dev work in this project — the native `
 - **Never use `--no-verify`** on any git command (commit, push, merge, rebase). Pre-commit hooks exist for a reason.
 - **Never commit to a branch in `claude-code-dev-hermit.protected_branches`** (defaults to `main`/`master` if unset). Always work on a feature branch.
 - **Never force-push from agent context.** No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.
-- **Stay in your worktree.** When the session runs in a git worktree, never edit files in the original checkout or a sibling worktree — that's another session's territory. The `worktree-boundary-guard` hook hard-blocks edits that escape the worktree.
+- **Stay in your worktree.** When the session runs in a git worktree, never edit files in the original checkout or a sibling worktree — that's another session's territory. The `worktree-boundary-guard` hook hard-blocks edits that escape the worktree. In a **background** session the harness moves you into a worktree automatically on your first edit, so don't proactively call `EnterWorktree`, and don't treat an "isolate first" message as a rule violation or a reason to stop and ask: just re-attempt the edit.
 
 If a task would require violating these rules, stop and ask the operator. Do not attempt workarounds (alternate commands, env vars, manual git plumbing).
 

--- a/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-dev-hermit/state-templates/CLAUDE-APPEND.md
@@ -10,7 +10,7 @@ These rules apply to every agent doing dev work in this project — the native `
 - **Never use `--no-verify`** on any git command (commit, push, merge, rebase). Pre-commit hooks exist for a reason.
 - **Never commit to a branch in `claude-code-dev-hermit.protected_branches`** (defaults to `main`/`master` if unset). Always work on a feature branch.
 - **Never force-push from agent context.** No bare `--force` or `-f`. `--force-with-lease` is allowed only to a non-protected branch with an explicit refspec (the safe rebase-recovery case); ambiguous-target leases and leases to protected branches are blocked. When in doubt, surface the divergence and let the operator resolve.
-- **Stay in your worktree.** When the session runs in a git worktree, never edit files in the original checkout or a sibling worktree — that's another session's territory. The `worktree-boundary-guard` hook hard-blocks edits that escape the worktree.
+- **Stay in your worktree.** When the session runs in a git worktree, never edit files in the original checkout or a sibling worktree — that's another session's territory. The `worktree-boundary-guard` hook hard-blocks edits that escape the worktree. In a **background** session the harness moves you into a worktree automatically on your first edit, so don't proactively call `EnterWorktree`, and don't treat an "isolate first" message as a rule violation or a reason to stop and ask: just re-attempt the edit.
 
 If a task would require violating these rules, stop and ask the operator. Do not attempt workarounds (alternate commands, env vars, manual git plumbing).
 


### PR DESCRIPTION
## Summary
Background dev agents were proactively calling `EnterWorktree`, driven by §Git Safety's isolate-first posture ("Stay in your worktree" + "stop and ask, don't attempt workarounds"). That call fails in daemon-spawned `--bg`/agent-view sessions (cwd pinned with an override) and stalled the #435 dev session. The fix appends one clarifier to the "Stay in your worktree" bullet in both dev-hermit CLAUDE-APPEND templates: in a background session, let the harness auto-isolate on first edit, don't proactively call `EnterWorktree`, and don't treat an "isolate first" message as a stop-and-ask.

This is the workflow fix that unblocks #435; it does not implement #435 itself (async subagent cost capture), so it doesn't close it.

## Changes
- **§Git Safety clarifier** appended in both `CLAUDE-APPEND.md` and `CLAUDE-APPEND-SAFETY.md` (templates kept in sync).
- **CHANGELOG** `[Unreleased] → Fixed` entry (first use of `[Unreleased]` in this file).

No version bump (ships on the next operator-initiated `/release` via the `/hatch` version-gate); no hook or settings change.

## Test plan
- dev-hermit suite green: **49/49** (37 skill-structure + 12 worktree-guard), `bash tests/run-all.sh`.
- Empirically grounded (Claude Code v2.1.183): a `--bg` session that just edits auto-isolates cleanly into `.claude/worktrees/` (no deadlock); the deadlock reproduces only when the agent *proactively* calls `EnterWorktree` in the daemon-spawned `--bg` mode (this session + the #435 log). Downstream hermit operators run plain `claude` in tmux and never hit this mode.