### PR TITLE
feat(hermit): add update-alert-state.ts for deterministic heartbeat state writes

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **heartbeat: dedicated update-alert-state.ts** — deterministic alert-state merge replacing the model-performed write; mirrors reflect's update-reflection-state pattern.
+
 ## [1.2.8] - 2026-06-20
 
 ### Fixed

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **heartbeat: dedicated update-alert-state.ts** — deterministic alert-state merge replacing the model-performed write; mirrors reflect's update-reflection-state pattern.
+- **heartbeat: dedicated update-alert-state.ts** — deterministic alert-state merge replacing the model-performed write; mirrors reflect's update-reflection-state pattern. Payload is delivered on stdin via a quoted heredoc so free-text alert content (apostrophes, quotes) can't break the command.
 
 ## [1.2.8] - 2026-06-20
 

--- a/plugins/claude-code-hermit/scripts/update-alert-state.ts
+++ b/plugins/claude-code-hermit/scripts/update-alert-state.ts
@@ -1,0 +1,69 @@
+// Updates alert-state.json after a heartbeat evaluation tick — merges new/updated alert entries,
+// deletes resolved keys, sets last_clean_eval_at, and overlays self_eval updates.
+// Zero npm dependencies, Node stdlib only. Always exits 0 on I/O failure (fail-open).
+// Usage: bun update-alert-state.ts <state-file-path> '<eval-json>'
+
+import fs from 'node:fs';
+
+type Json = any;
+
+const stateFile = process.argv[2];
+const payloadJson = process.argv[3];
+
+if (!stateFile || !payloadJson) {
+  console.error('Usage: bun update-alert-state.ts <state-file-path> \'<eval-json>\'');
+  process.exit(1);
+}
+
+let payload: Json;
+try {
+  payload = JSON.parse(payloadJson);
+} catch (err: any) {
+  console.error(`update-alert-state: invalid payload JSON: ${err.message}`);
+  process.exit(1);
+}
+
+let state: Json = {};
+try {
+  state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+} catch {
+  // first run or unreadable — seed with the precheck's default shape
+  state = { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
+}
+
+const alerts: Json = {
+  ...(state.alerts && typeof state.alerts === 'object' ? state.alerts : {}),
+  ...(payload.new_entries && typeof payload.new_entries === 'object' ? payload.new_entries : {}),
+  ...(payload.updated_entries && typeof payload.updated_entries === 'object' ? payload.updated_entries : {}),
+};
+if (Array.isArray(payload.resolved_keys)) {
+  for (const key of payload.resolved_keys) {
+    delete alerts[key];
+  }
+}
+
+const self_eval: Json = {
+  ...(state.self_eval && typeof state.self_eval === 'object' ? state.self_eval : {}),
+  ...(payload.self_eval_updates && typeof payload.self_eval_updates === 'object' ? payload.self_eval_updates : {}),
+};
+
+// last_clean_eval_at: take payload value if the key is present (null is valid), else preserve.
+const last_clean_eval_at = 'last_clean_eval_at' in payload
+  ? payload.last_clean_eval_at
+  : (state.last_clean_eval_at ?? null);
+
+// Spread state first so precheck-owned fields (total_ticks, last_stale_wake_at) are preserved.
+const updated = {
+  ...state,
+  alerts,
+  self_eval,
+  last_clean_eval_at,
+};
+
+try {
+  fs.writeFileSync(stateFile, JSON.stringify(updated, null, 2) + '\n', 'utf-8');
+} catch (err: any) {
+  console.error(`update-alert-state: write failed: ${err.message}`);
+}
+
+process.exit(0);

--- a/plugins/claude-code-hermit/scripts/update-alert-state.ts
+++ b/plugins/claude-code-hermit/scripts/update-alert-state.ts
@@ -1,69 +1,77 @@
 // Updates alert-state.json after a heartbeat evaluation tick — merges new/updated alert entries,
 // deletes resolved keys, sets last_clean_eval_at, and overlays self_eval updates.
 // Zero npm dependencies, Node stdlib only. Always exits 0 on I/O failure (fail-open).
-// Usage: bun update-alert-state.ts <state-file-path> '<eval-json>'
+// The eval JSON is read from stdin (not argv) so free-text alert content can't break shell quoting.
+// Usage: bun update-alert-state.ts <state-file-path>   # eval-json on stdin
 
 import fs from 'node:fs';
 
 type Json = any;
 
 const stateFile = process.argv[2];
-const payloadJson = process.argv[3];
 
-if (!stateFile || !payloadJson) {
-  console.error('Usage: bun update-alert-state.ts <state-file-path> \'<eval-json>\'');
+if (!stateFile) {
+  console.error('Usage: bun update-alert-state.ts <state-file-path>   # eval-json on stdin');
   process.exit(1);
 }
 
-let payload: Json;
-try {
-  payload = JSON.parse(payloadJson);
-} catch (err: any) {
-  console.error(`update-alert-state: invalid payload JSON: ${err.message}`);
-  process.exit(1);
-}
-
-let state: Json = {};
-try {
-  state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
-} catch {
-  // first run or unreadable — seed with the precheck's default shape
-  state = { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
-}
-
-const alerts: Json = {
-  ...(state.alerts && typeof state.alerts === 'object' ? state.alerts : {}),
-  ...(payload.new_entries && typeof payload.new_entries === 'object' ? payload.new_entries : {}),
-  ...(payload.updated_entries && typeof payload.updated_entries === 'object' ? payload.updated_entries : {}),
-};
-if (Array.isArray(payload.resolved_keys)) {
-  for (const key of payload.resolved_keys) {
-    delete alerts[key];
+function apply(payloadJson: string): void {
+  let payload: Json;
+  try {
+    payload = JSON.parse(payloadJson);
+  } catch (err: any) {
+    console.error(`update-alert-state: invalid payload JSON: ${err.message}`);
+    process.exit(1);
   }
+
+  let state: Json = {};
+  try {
+    state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+  } catch {
+    // first run or unreadable — seed with the precheck's default shape
+    state = { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
+  }
+
+  const alerts: Json = {
+    ...(state.alerts && typeof state.alerts === 'object' ? state.alerts : {}),
+    ...(payload.new_entries && typeof payload.new_entries === 'object' ? payload.new_entries : {}),
+    ...(payload.updated_entries && typeof payload.updated_entries === 'object' ? payload.updated_entries : {}),
+  };
+  if (Array.isArray(payload.resolved_keys)) {
+    for (const key of payload.resolved_keys) {
+      delete alerts[key];
+    }
+  }
+
+  const self_eval: Json = {
+    ...(state.self_eval && typeof state.self_eval === 'object' ? state.self_eval : {}),
+    ...(payload.self_eval_updates && typeof payload.self_eval_updates === 'object' ? payload.self_eval_updates : {}),
+  };
+
+  // last_clean_eval_at: take payload value if the key is present (null is valid), else preserve.
+  const last_clean_eval_at = 'last_clean_eval_at' in payload
+    ? payload.last_clean_eval_at
+    : (state.last_clean_eval_at ?? null);
+
+  // Spread state first so precheck-owned fields (total_ticks, last_stale_wake_at) are preserved.
+  const updated = {
+    ...state,
+    alerts,
+    self_eval,
+    last_clean_eval_at,
+  };
+
+  try {
+    fs.writeFileSync(stateFile, JSON.stringify(updated, null, 2) + '\n', 'utf-8');
+  } catch (err: any) {
+    console.error(`update-alert-state: write failed: ${err.message}`);
+  }
+
+  process.exit(0);
 }
 
-const self_eval: Json = {
-  ...(state.self_eval && typeof state.self_eval === 'object' ? state.self_eval : {}),
-  ...(payload.self_eval_updates && typeof payload.self_eval_updates === 'object' ? payload.self_eval_updates : {}),
-};
-
-// last_clean_eval_at: take payload value if the key is present (null is valid), else preserve.
-const last_clean_eval_at = 'last_clean_eval_at' in payload
-  ? payload.last_clean_eval_at
-  : (state.last_clean_eval_at ?? null);
-
-// Spread state first so precheck-owned fields (total_ticks, last_stale_wake_at) are preserved.
-const updated = {
-  ...state,
-  alerts,
-  self_eval,
-  last_clean_eval_at,
-};
-
-try {
-  fs.writeFileSync(stateFile, JSON.stringify(updated, null, 2) + '\n', 'utf-8');
-} catch (err: any) {
-  console.error(`update-alert-state: write failed: ${err.message}`);
-}
-
-process.exit(0);
+let buf = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { buf += chunk; });
+process.stdin.on('error', () => {});
+process.stdin.on('end', () => { apply(buf.trim()); });

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -41,7 +41,11 @@ This subcommand is the handler for `HEARTBEAT_EVALUATE` notifications emitted by
 
    Receive the structured JSON back from the subagent.
 5. **Apply writes** in the main session (to preserve cost attribution and channel/file access). First, validate the subagent return: if it cannot be parsed as JSON, or is missing any required **key** (`resolved_keys`, `new_entries`, `updated_entries`, `last_clean_eval_at`, `self_eval_updates`, `shell_monitoring_lines`, `operator_message`, `heartbeat_result`), **skip all writes and emit `HEARTBEAT_OK`** — fail-open, never corrupt persistent state. A present key with a `null` value is valid, not missing (`last_clean_eval_at` and `operator_message` are legitimately `null`). Tradeoff: a malformed return during a genuine alert condition is swallowed for this tick; the next tick re-evaluates. Never corrupting `alert-state.json` is the deliberate priority. Otherwise:
-   - Write `state/alert-state.json`: merge `new_entries` and `updated_entries` into `alerts{}`, apply `resolved_keys` deletions, set `last_clean_eval_at` from the subagent result, merge `self_eval_updates` into `self_eval{}`. **Do NOT write `total_ticks`** — already incremented by the precheck.
+   - Write `state/alert-state.json` via the dedicated script (do NOT write `total_ticks` — owned by the precheck):
+     ```
+     bun ${CLAUDE_PLUGIN_ROOT}/scripts/update-alert-state.ts .claude-code-hermit/state/alert-state.json '<subagent-return-json>'
+     ```
+     The script merges `new_entries` and `updated_entries` into `alerts{}`, applies `resolved_keys` deletions, sets `last_clean_eval_at`, and overlays `self_eval_updates` into `self_eval{}`.
    - If `shell_monitoring_lines` is non-empty: append each line to SHELL.md `## Monitoring`.
    - If `operator_message` is non-null: notify the operator (per CLAUDE-APPEND.md § Operator Notification).
    - For each entry in `self_eval_updates` with a `proposal_args` field: invoke `/claude-code-hermit:proposal-create` with those args.

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -41,9 +41,11 @@ This subcommand is the handler for `HEARTBEAT_EVALUATE` notifications emitted by
 
    Receive the structured JSON back from the subagent.
 5. **Apply writes** in the main session (to preserve cost attribution and channel/file access). First, validate the subagent return: if it cannot be parsed as JSON, or is missing any required **key** (`resolved_keys`, `new_entries`, `updated_entries`, `last_clean_eval_at`, `self_eval_updates`, `shell_monitoring_lines`, `operator_message`, `heartbeat_result`), **skip all writes and emit `HEARTBEAT_OK`** — fail-open, never corrupt persistent state. A present key with a `null` value is valid, not missing (`last_clean_eval_at` and `operator_message` are legitimately `null`). Tradeoff: a malformed return during a genuine alert condition is swallowed for this tick; the next tick re-evaluates. Never corrupting `alert-state.json` is the deliberate priority. Otherwise:
-   - Write `state/alert-state.json` via the dedicated script (do NOT write `total_ticks` — owned by the precheck):
+   - Write `state/alert-state.json` via the dedicated script (do NOT write `total_ticks` — owned by the precheck). Pass the subagent return on **stdin** via a quoted heredoc so free-text alert / `self_eval` values (which may contain apostrophes) can't break the command:
      ```
-     bun ${CLAUDE_PLUGIN_ROOT}/scripts/update-alert-state.ts .claude-code-hermit/state/alert-state.json '<subagent-return-json>'
+     bun ${CLAUDE_PLUGIN_ROOT}/scripts/update-alert-state.ts .claude-code-hermit/state/alert-state.json <<'HERMIT_ALERT_JSON'
+     <subagent-return-json>
+     HERMIT_ALERT_JSON
      ```
      The script merges `new_entries` and `updated_entries` into `alerts{}`, applies `resolved_keys` deletions, sets `last_clean_eval_at`, and overlays `self_eval_updates` into `self_eval{}`.
    - If `shell_monitoring_lines` is non-empty: append each line to SHELL.md `## Monitoring`.

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -558,6 +558,98 @@ describe('archive-raw', () => {
 });
 
 // -------------------------------------------------------
+// update-alert-state.ts (subprocess — argv + file-write CLI contract)
+// -------------------------------------------------------
+
+describe('update-alert-state', () => {
+  async function updateAlertState(dir: string, payload: string) {
+    const stateFile = hermit(dir, 'state', 'alert-state.json');
+    const r = await runScript('update-alert-state.ts', { args: [stateFile, payload] });
+    expect(r.exitCode).toBe(0);
+    return readJson(stateFile);
+  }
+
+  test('update-alert-state (new_entries merged into alerts)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{},"self_eval":{},"total_ticks":5}');
+    const d = await updateAlertState(dir,
+      '{"new_entries":{"stale-session":{"severity":"low"}},"updated_entries":{},"resolved_keys":[],"last_clean_eval_at":null,"self_eval_updates":{}}');
+    expect(d.alerts['stale-session']).toEqual({ severity: 'low' });
+    expect(d.total_ticks).toBe(5); // precheck-owned — must survive untouched
+  }));
+
+  test('update-alert-state (updated_entries overlays existing alerts)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{"stale-session":{"severity":"low","count":1}},"self_eval":{},"total_ticks":10}');
+    const d = await updateAlertState(dir,
+      '{"new_entries":{},"updated_entries":{"stale-session":{"severity":"low","count":2}},"resolved_keys":[],"last_clean_eval_at":null,"self_eval_updates":{}}');
+    expect(d.alerts['stale-session'].count).toBe(2);
+    expect(d.total_ticks).toBe(10);
+  }));
+
+  test('update-alert-state (resolved_keys deleted from alerts)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{"stale-session":{"severity":"low"},"other-alert":{"severity":"high"}},"self_eval":{},"total_ticks":3}');
+    const d = await updateAlertState(dir,
+      '{"new_entries":{},"updated_entries":{},"resolved_keys":["stale-session"],"last_clean_eval_at":null,"self_eval_updates":{}}');
+    expect(d.alerts).not.toHaveProperty('stale-session');
+    expect(d.alerts['other-alert']).toBeDefined();
+  }));
+
+  test('update-alert-state (self_eval_updates overlays self_eval)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{},"self_eval":{"existing-key":"old-value"},"total_ticks":1}');
+    const d = await updateAlertState(dir,
+      '{"new_entries":{},"updated_entries":{},"resolved_keys":[],"last_clean_eval_at":null,"self_eval_updates":{"new-key":"new-value"}}');
+    expect(d.self_eval['existing-key']).toBe('old-value');
+    expect(d.self_eval['new-key']).toBe('new-value');
+  }));
+
+  test('update-alert-state (last_clean_eval_at set from payload)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{},"self_eval":{},"last_clean_eval_at":null,"total_ticks":2}');
+    const d = await updateAlertState(dir,
+      '{"new_entries":{},"updated_entries":{},"resolved_keys":[],"last_clean_eval_at":"2026-06-21T22:00:00.000Z","self_eval_updates":{}}');
+    expect(d.last_clean_eval_at).toBe('2026-06-21T22:00:00.000Z');
+  }));
+
+  test('update-alert-state (null last_clean_eval_at payload value honored)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{},"self_eval":{},"last_clean_eval_at":"2026-06-20T10:00:00.000Z","total_ticks":1}');
+    const d = await updateAlertState(dir,
+      '{"new_entries":{},"updated_entries":{},"resolved_keys":[],"last_clean_eval_at":null,"self_eval_updates":{}}');
+    expect(d.last_clean_eval_at).toBeNull();
+  }));
+
+  test('update-alert-state (total_ticks, last_stale_wake_at, last_digest_date preserved)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{},"self_eval":{},"total_ticks":42,"last_stale_wake_at":"2026-06-21T20:00:00.000Z","last_digest_date":"2026-06-21","last_clean_eval_at":null}');
+    const d = await updateAlertState(dir,
+      '{"new_entries":{},"updated_entries":{},"resolved_keys":[],"last_clean_eval_at":null,"self_eval_updates":{}}');
+    expect(d.total_ticks).toBe(42);
+    expect(d.last_stale_wake_at).toBe('2026-06-21T20:00:00.000Z');
+    expect(d.last_digest_date).toBe('2026-06-21');
+  }));
+
+  test('update-alert-state (missing state file — fail-open, exits 0)', withDir(async (dir) => {
+    const stateFile = hermit(dir, 'state', 'alert-state.json');
+    const r = await runScript('update-alert-state.ts', {
+      args: [stateFile, '{"new_entries":{"k":{"severity":"low"}},"updated_entries":{},"resolved_keys":[],"last_clean_eval_at":null,"self_eval_updates":{}}'],
+    });
+    expect(r.exitCode).toBe(0);
+    const d = readJson(stateFile);
+    expect(d.alerts['k']).toBeDefined();
+  }));
+
+  test('update-alert-state (bad JSON payload — exits 1, no write)', withDir(async (dir) => {
+    const stateFile = hermit(dir, 'state', 'alert-state.json');
+    const r = await runScript('update-alert-state.ts', { args: [stateFile, 'not-json'] });
+    expect(r.exitCode).toBe(1);
+    expect(fs.existsSync(stateFile)).toBe(false);
+  }));
+});
+
+// -------------------------------------------------------
 // update-reflection-state.ts (subprocess — argv + file-write CLI contract)
 // -------------------------------------------------------
 

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -558,13 +558,13 @@ describe('archive-raw', () => {
 });
 
 // -------------------------------------------------------
-// update-alert-state.ts (subprocess — argv + file-write CLI contract)
+// update-alert-state.ts (subprocess — stdin payload + file-write CLI contract)
 // -------------------------------------------------------
 
 describe('update-alert-state', () => {
   async function updateAlertState(dir: string, payload: string) {
     const stateFile = hermit(dir, 'state', 'alert-state.json');
-    const r = await runScript('update-alert-state.ts', { args: [stateFile, payload] });
+    const r = await runScript('update-alert-state.ts', { args: [stateFile], stdin: payload });
     expect(r.exitCode).toBe(0);
     return readJson(stateFile);
   }
@@ -634,7 +634,8 @@ describe('update-alert-state', () => {
   test('update-alert-state (missing state file — fail-open, exits 0)', withDir(async (dir) => {
     const stateFile = hermit(dir, 'state', 'alert-state.json');
     const r = await runScript('update-alert-state.ts', {
-      args: [stateFile, '{"new_entries":{"k":{"severity":"low"}},"updated_entries":{},"resolved_keys":[],"last_clean_eval_at":null,"self_eval_updates":{}}'],
+      args: [stateFile],
+      stdin: '{"new_entries":{"k":{"severity":"low"}},"updated_entries":{},"resolved_keys":[],"last_clean_eval_at":null,"self_eval_updates":{}}',
     });
     expect(r.exitCode).toBe(0);
     const d = readJson(stateFile);
@@ -643,9 +644,39 @@ describe('update-alert-state', () => {
 
   test('update-alert-state (bad JSON payload — exits 1, no write)', withDir(async (dir) => {
     const stateFile = hermit(dir, 'state', 'alert-state.json');
-    const r = await runScript('update-alert-state.ts', { args: [stateFile, 'not-json'] });
+    const r = await runScript('update-alert-state.ts', { args: [stateFile], stdin: 'not-json' });
     expect(r.exitCode).toBe(1);
     expect(fs.existsSync(stateFile)).toBe(false);
+  }));
+
+  test('update-alert-state (apostrophe in free-text value round-trips intact)', withDir(async (dir) => {
+    // Regression: apostrophes broke single-quoted argv passing.
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{},"self_eval":{},"total_ticks":7}');
+    const d = await updateAlertState(dir, JSON.stringify({
+      new_entries: { 'stale-session': { severity: 'low', note: "the session's been idle" } },
+      updated_entries: {},
+      resolved_keys: [],
+      last_clean_eval_at: null,
+      self_eval_updates: { 'last-note': "prod's disk > 80%" },
+    }));
+    expect(d.alerts['stale-session'].note).toBe("the session's been idle");
+    expect(d.self_eval['last-note']).toBe("prod's disk > 80%");
+    expect(d.total_ticks).toBe(7);
+  }));
+
+  test('update-alert-state (embedded double-quote and newline round-trip intact)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'),
+      '{"alerts":{},"self_eval":{},"total_ticks":1}');
+    const note = 'said "hi"\nthen left';
+    const d = await updateAlertState(dir, JSON.stringify({
+      new_entries: { 'k': { note } },
+      updated_entries: {},
+      resolved_keys: [],
+      last_clean_eval_at: null,
+      self_eval_updates: {},
+    }));
+    expect(d.alerts['k'].note).toBe(note);
   }));
 });
 


### PR DESCRIPTION
## Summary

Heartbeat Step 5 previously relied on the model to read, merge, and write `alert-state.json` in-context (natural-language prose instruction). This is the one genuinely corruption-prone step in the heartbeat path — a mis-merge of `alerts{}`/`self_eval{}` isn't caught by the existing 8-key validation guard. This PR replaces that model-performed write with a dedicated deterministic script, mirroring the pattern already used by reflect's `update-reflection-state.ts`.

## Changes

- **`scripts/update-alert-state.ts`** (new): merges `new_entries`/`updated_entries` into `alerts{}`, applies `resolved_keys` deletions, sets `last_clean_eval_at`, overlays `self_eval_updates` into `self_eval{}`. Preserves precheck-owned fields (`total_ticks`, `last_stale_wake_at`) via `...state` spread. Fail-open on read/write; exits 1 on bad payload.
- **`skills/heartbeat/SKILL.md`**: Step 5 alert-state write bullet replaced with the `bun` invocation; the fail-open 8-key validation guard stays in SKILL.md (tied to the `HEARTBEAT_OK` emit logic).
- **`tests/scripts.test.ts`**: 9 new tests covering merge, deletion, field preservation, `null` payload handling, missing-file fail-open, and bad-JSON exit 1.
- **`CHANGELOG.md`**: `[Unreleased] ### Added` entry.

## Test plan

- `cd plugins/claude-code-hermit && bun test tests/scripts.test.ts` — 218 tests pass (9 new).
- Manual: seed an `alert-state.json` with `total_ticks`/`last_stale_wake_at`, run the script with a representative eval JSON, confirm precheck-owned fields survive untouched and the merge is correct.

Closes #439