### PR TITLE
fix(hermit): deliver append-metrics free-text payloads via stdin heredoc (#442)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **heartbeat: dedicated update-alert-state.ts** — deterministic alert-state merge replacing the model-performed write; mirrors reflect's update-reflection-state pattern. Payload is delivered on stdin via a quoted heredoc so free-text alert content (apostrophes, quotes) can't break the command.
 
+### Fixed
+
+- **reflect/append-metrics: free-text JSON events delivered via stdin heredoc** — apostrophes in pattern labels and question strings no longer corrupt the metrics ledger (same shell-quoting class as #441). `append-metrics.ts` is now dual-mode: argv for enum/id/count/slug payloads, stdin for free-text. Call sites in reflect, reflect-scheduled-checks, channel-responder, and brief updated accordingly.
+
 ## [1.2.8] - 2026-06-20
 
 ### Fixed

--- a/plugins/claude-code-hermit/scripts/append-metrics.ts
+++ b/plugins/claude-code-hermit/scripts/append-metrics.ts
@@ -1,23 +1,49 @@
 // Append-only JSONL helper — appends one line and exits.
 // Zero npm dependencies, Node stdlib only.
-// Usage: bun append-metrics.ts <jsonl-file-path> '<json-event-object>'
+//
+// Usage (argv):  bun append-metrics.ts <jsonl-file-path> '<json-event>'
+//   — argv[3] is reserved for enum/id/count/slug/numeric values only.
+//     Apostrophes cannot appear in those payloads, so single-quoting is safe.
+//
+// Usage (stdin): bun append-metrics.ts <jsonl-file-path> <<'HERMIT_METRICS_JSON'
+//                <json-event>
+//                HERMIT_METRICS_JSON
+//   — required for free-text payloads (question, pattern labels, prose values)
+//     where apostrophes in single-quoted argv would corrupt the shell command.
 
 import fs from 'node:fs';
 
 const filePath = process.argv[2];
-const eventJson = process.argv[3];
 
-if (!filePath || !eventJson) {
-  console.error('Usage: bun append-metrics.ts <jsonl-file-path> \'<json-event-object>\'');
+if (!filePath) {
+  console.error("Usage: bun append-metrics.ts <jsonl-file-path> '<json-event>'");
   process.exit(1);
 }
 
-// Validate JSON before appending
-try {
-  JSON.parse(eventJson);
-} catch (err: any) {
-  console.error(`Invalid JSON: ${err.message}`);
-  process.exit(1);
+function append(eventJson: string): void {
+  if (!eventJson) {
+    console.error('Error: event payload is empty');
+    process.exit(1);
+  }
+  // Validate JSON before appending
+  try {
+    JSON.parse(eventJson);
+  } catch (err: any) {
+    console.error(`Invalid JSON: ${err.message}`);
+    process.exit(1);
+  }
+  fs.appendFileSync(filePath!, eventJson + '\n', 'utf-8');
 }
 
-fs.appendFileSync(filePath, eventJson + '\n', 'utf-8');
+if (process.argv[3] !== undefined) {
+  // Argv mode — synchronous, for enum/id/count/slug/numeric payloads.
+  append(process.argv[3]);
+} else {
+  // Stdin mode — for free-text payloads that may contain apostrophes.
+  // Deliver via quoted heredoc: <<'HERMIT_METRICS_JSON' ... HERMIT_METRICS_JSON
+  let buf = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => { buf += chunk; });
+  process.stdin.on('error', () => {});
+  process.stdin.on('end', () => { append(buf.trim()); });
+}

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -70,7 +70,7 @@ Emphasize forward-looking content. Compose from runner JSON (see Dispatch above)
 After composing the morning brief, check `state/micro-proposals.json → pending` for entries with `status: "pending"` **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**:
 - If **one or more** pending entries with `follow_up_count` of 0: append each as a final line: `MP-YYYYMMDD-N (tier N): [question]` — Reply `"MP-YYYYMMDD-N yes"` or `"MP-YYYYMMDD-N no"`. (Bare `yes`/`no` accepted when only one pending.)
 - For any entry with `follow_up_count` of 1: append with softer framing: "Still waiting on MP-YYYYMMDD-N: [question] — ignore again to drop it". Increment `follow_up_count` to 2.
-- For any entry with `follow_up_count` >= 2: read `question` first, then set `status: "expired"`, remove from `pending`. Append `micro-resolved` event via `append-metrics.ts` with `"action":"expired","question":"<question>"`. Do not resurrect unless fresh evidence accumulates from scratch.
+- For any entry with `follow_up_count` >= 2: read `question` first, then set `status: "expired"`, remove from `pending`. Append `micro-resolved` event via stdin heredoc (question may contain apostrophes): `{"ts":"<now ISO>","type":"micro-resolved","micro_id":"<id>","action":"expired","question":"<question>"}`. Do not resurrect unless fresh evidence accumulates from scratch.
 - If no pending entries: brief ends without a decision prompt.
 
 ### --evening (routine mode)

--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -109,9 +109,15 @@ Before running any heavy sub-step — an archive traversal, a multi-file search,
     - If bare `yes`/`no` and multiple pending entries: reply listing the pending IDs and ask the operator to specify (e.g. `"MP-20260422-0 yes"`). Do not resolve yet.
   - **On resolved entry:**
     - Read `question` from the entry before modifying.
-    - **"yes"** on tier 1 → execute the change at next idle, log outcome in SHELL.md, set `status: "approved"`. Append `micro-resolved` event via `append-metrics.ts`: `{"ts":"<now ISO>","type":"micro-resolved","micro_id":"<id>","action":"approved","question":"<question>"}`
-    - **"yes"** on tier 2 → create PROP-NNN via `/claude-code-hermit:proposal-create`, queue for next idle, set `status: "approved"`. Append `micro-resolved` event with `"action":"approved"`.
-    - **"no"** → set `status: "rejected"`. Append `micro-resolved` event with `"action":"rejected","question":"<question>"`.
+    - **"yes"** on tier 1 → execute the change at next idle, log outcome in SHELL.md, set `status: "approved"`. Append `micro-resolved` event via stdin heredoc (question is operator text and may contain apostrophes):
+      ```bash
+      bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/proposal-metrics.jsonl <<'HERMIT_METRICS_JSON'
+      {"ts":"<now ISO>","type":"micro-resolved","micro_id":"<id>","action":"approved","question":"<question>"}
+      HERMIT_METRICS_JSON
+      ```
+    - **"yes"** on tier 2 → create PROP-NNN via `/claude-code-hermit:proposal-create`, queue for next idle, set `status: "approved"`. Append `micro-resolved` event (same stdin heredoc form, `"action":"approved"`).
+    - **"no"** → set `status: "rejected"`. Append `micro-resolved` event (stdin heredoc, `"action":"rejected","question":"<question>"`).
+
     - Remove the resolved entry from `pending`. Write the file.
     - **Ambiguous response** → ask for clarification once, do not resolve yet.
   - If no pending micro-proposals: classify as normal message (fall through to categories below).

--- a/plugins/claude-code-hermit/skills/reflect-scheduled-checks/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect-scheduled-checks/SKILL.md
@@ -108,9 +108,9 @@ Queuing procedure:
 1. Generate ID: `MP-YYYYMMDD-N` where N increments within the same day (0, 1, 2). Check existing `micro-queued` events in `proposal-metrics.jsonl` for today to determine N.
 2. Append `micro-queued` event to `proposal-metrics.jsonl` first (so a partial failure leaves a recoverable orphaned event, not a silent ghost entry):
    ```bash
-   bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
-     .claude-code-hermit/state/proposal-metrics.jsonl \
-     '{"ts":"<now ISO>","type":"micro-queued","micro_id":"MP-YYYYMMDD-N","tier":1,"question":"<full question text>"}'
+   bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/proposal-metrics.jsonl <<'HERMIT_METRICS_JSON'
+   {"ts":"<now ISO>","type":"micro-queued","micro_id":"MP-YYYYMMDD-N","tier":1,"question":"<full question text>"}
+   HERMIT_METRICS_JSON
    ```
 3. Read `state/micro-proposals.json`. Append a new entry to `pending` with `id: "MP-YYYYMMDD-N"`, `tier: <1|2>`, `status: "pending"`, `follow_up_count: 0`, `ts: "<now ISO>"`, `question: "<full question text>"`. Write the file.
 4. Notify the operator with the question.

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -15,7 +15,13 @@ If `$ARGUMENTS` contains `--quick` (invoked as `/claude-code-hermit:reflect --qu
 - **Skip the precheck** entirely — the cadence gate does not apply.
 - **Bind `$PHASE = adult`** — skip the compute phase eval.
 - **Skip the cost_spike read, proposal scan, Resolution Check, and Component Health section.** Only the live SHELL.md scan + judge + outcomes path runs.
-- Read SHELL.md `## Findings` and `## Blockers` for actionable patterns. **Only Tier-1 + `Evidence Source: current-session` candidates are eligible** — see § Three-Condition Rule, condition 1. Candidates that would need archived-session evidence or belong to Tier 2/3 are deferred to the next scheduled reflect — append one ledger entry per deferred candidate (`bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/observations.jsonl '{"ts":"<now ISO>","pattern":"<candidate-title-slug>","session_id":"<S-NNN>","source":"quick-deferral"}'`) so the signal survives session archival and can graduate by recurrence (§ Outcomes). **Exception:** a `current-session` candidate with `Evidence Origin: external-content` (see § Proposal Tier Classification) is **not** deferred — send it to the judge and let the Tier-3 escalation route it to `proposal-create`.
+- Read SHELL.md `## Findings` and `## Blockers` for actionable patterns. **Only Tier-1 + `Evidence Source: current-session` candidates are eligible** — see § Three-Condition Rule, condition 1. Candidates that would need archived-session evidence or belong to Tier 2/3 are deferred to the next scheduled reflect — append one ledger entry per deferred candidate via stdin heredoc:
+  ```bash
+  bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/observations.jsonl <<'HERMIT_METRICS_JSON'
+  {"ts":"<now ISO>","pattern":"<candidate-title-slug>","session_id":"<S-NNN>","source":"quick-deferral"}
+  HERMIT_METRICS_JSON
+  ```
+  so the signal survives session archival and can graduate by recurrence (§ Outcomes). **Exception:** a `current-session` candidate with `Evidence Origin: external-content` (see § Proposal Tier Classification) is **not** deferred — send it to the judge and let the Tier-3 escalation route it to `proposal-create`.
 - For each candidate that passes the evidence integrity rule, run `claude-code-hermit:proposal-triage`. Collect candidates where triage returned CREATE, then make a single `claude-code-hermit:reflection-judge` call for those candidates (see § Evidence Validation for input/output format). Route each ACCEPT/DOWNGRADE verdict through the standard Outcomes path (micro-approval queue for Tier 1/2, `/claude-code-hermit:proposal-create` for Tier 3).
 - Append one Progress Log line: `[HH:MM] reflect (quick, post-routine) — N candidates; verdicts: accept=A downgrade=D suppress=S; outcomes: <list or "none">`. When suppress>0, append the same `; suppressed: [<slug>: <code>, ...]` suffix the scheduled path uses (see § Progress Log Entry) so quick-run suppressions reach the weekly digest.
 - **Do not call `update-reflection-state.ts`** — quick runs are event-driven, not cadence ticks. Mutating `last_run_at` would suppress the next scheduled reflect. Consequence: judge verdicts from quick runs do not accumulate into the Component Health counters (`judge_accept` / `judge_suppress`); on daemons with frequent `reflect_after` use, those counters will under-represent total judge activity. This is intentional — cadence preservation wins.
@@ -86,7 +92,13 @@ If `$ARGUMENTS` contains `--quick` (invoked as `/claude-code-hermit:reflect --qu
 <!-- reflect-eval-schema:end -->
 
    **Apply `resolution_actions`** (housekeeping writes; exempt from the evidence integrity rule):
-   - `action == "auto-resolve"`: write `frontmatter_patch` fields to the proposal's YAML frontmatter; run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/proposal-metrics.jsonl '<metrics_event>'`; append `shell_findings_line` to SHELL.md `## Findings`.
+   - `action == "auto-resolve"`: write `frontmatter_patch` fields to the proposal's YAML frontmatter; run `append-metrics.ts` via stdin heredoc (metrics_event is model-authored JSON and may contain apostrophes):
+     ```bash
+     bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/proposal-metrics.jsonl <<'HERMIT_METRICS_JSON'
+     <metrics_event>
+     HERMIT_METRICS_JSON
+     ```
+     append `shell_findings_line` to SHELL.md `## Findings`.
    - `action == "nudge"`: append `shell_findings_line` to SHELL.md `## Findings`. (Nudge debounce is handled inside the runner — `action: "nudge"` already passed the 7-day guard.)
    - `action == "skip"`: no action.
 
@@ -285,7 +297,13 @@ After reflecting and validating with `claude-code-hermit:reflection-judge`, choo
 
    `routine_candidates` from the eval runner are Tier 1; any pre-rendered `shell_findings_line` (diagnostic entries) goes to SHELL.md `## Findings` directly — no judge/triage needed for diagnostics, only for disable/retime action candidates.
 
-Sub-threshold observations (interesting but failing the Three-Condition Rule — typically single-occurrence) do not surface to the operator in steady state. Append them to the observations ledger with a short stable pattern label: `bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/observations.jsonl '{"ts":"<now ISO>","pattern":"<short pattern label>","session_id":"<S-NNN>","source":"reflect-noticed","origin":"own-work"}'` — they graduate via the step 3b recurrence promotion. Include `"origin":"external-content"` instead of `"own-work"` when the observation derives from a SHELL.md finding carrying an `[origin: external]` marker (copy the marker deterministically, don't infer from content). Reuse the exact label when re-observing a known pattern; grouping is by string equality. Do not generate observations for their own sake; only append when a genuine pattern is noticed.
+Sub-threshold observations (interesting but failing the Three-Condition Rule — typically single-occurrence) do not surface to the operator in steady state. Append them to the observations ledger with a short stable pattern label via stdin heredoc (pattern labels are free text and may contain apostrophes):
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/observations.jsonl <<'HERMIT_METRICS_JSON'
+{"ts":"<now ISO>","pattern":"<short pattern label>","session_id":"<S-NNN>","source":"reflect-noticed","origin":"own-work"}
+HERMIT_METRICS_JSON
+```
+they graduate via the step 3b recurrence promotion. Include `"origin":"external-content"` instead of `"own-work"` when the observation derives from a SHELL.md finding carrying an `[origin: external]` marker (copy the marker deterministically, don't infer from content). Reuse the exact label when re-observing a known pattern; grouping is by string equality. Do not generate observations for their own sake; only append when a genuine pattern is noticed.
 
 Reflect-generated inferences (cost spikes, token-count shapes, timing patterns) **never** use bypass Evidence Sources (`scheduled-check/*` or `operator-request`). They either (a) carry a verifiable `Artifact:` citation to a machine-written state file and take the artifact-cited path now (see § Evidence integrity rule), or (b) land in the observations ledger and graduate by recurrence, at which point step 3b promotes them with `Evidence Source: archived-session` and the ledger `Artifact:` citation.
 
@@ -349,7 +367,12 @@ Dedup: do not re-append the same candidate if an entry with the same title/id al
 
 1. Generate ID: `MP-YYYYMMDD-N` where N increments within the same day (0, 1, 2). Check existing `micro-queued` events in `proposal-metrics.jsonl` for today to determine N.
 2. Read `state/micro-proposals.json`. Append a new entry to `pending` with `id: "MP-YYYYMMDD-N"`, `tier: <1|2>`, `status: "pending"`, `follow_up_count: 0`, `ts: "<now ISO>"`, `question: "<full question text>"`. Write the file.
-3. Append `micro-queued` event to `proposal-metrics.jsonl` via `append-metrics.ts`: `{"ts":"<now ISO>","type":"micro-queued","micro_id":"MP-YYYYMMDD-N","tier":1,"question":"<full question text>"}`
+3. Append `micro-queued` event to `proposal-metrics.jsonl` via stdin heredoc (question is free text and may contain apostrophes):
+   ```bash
+   bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/proposal-metrics.jsonl <<'HERMIT_METRICS_JSON'
+   {"ts":"<now ISO>","type":"micro-queued","micro_id":"MP-YYYYMMDD-N","tier":1,"question":"<full question text>"}
+   HERMIT_METRICS_JSON
+   ```
 4. Notify the operator with the question in the form: `MP-YYYYMMDD-N (tier <N>): <question>` — Reply `"MP-YYYYMMDD-N yes"` or `"MP-YYYYMMDD-N no"` (bare `yes`/`no` accepted when only one entry is pending).
 
 ## State Update

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -751,18 +751,54 @@ describe('append-metrics (dual-mode)', () => {
     expect(fs.existsSync(ledger)).toBe(false);
   }));
 
-  // Lint guard: no literal single-quoted argv append-metrics call may carry a
-  // free-text field (question/note/message/text). Those must use stdin heredoc.
+  // Lint guard: no single-quoted argv append-metrics call may carry a free-text
+  // field (question/note/message/text). Those must use stdin heredoc.
   // Enum/id/count/slug/numeric fields (type, proposal_id, source, pattern) remain
   // on argv and are intentionally excluded from this check.
+  //
+  // Multi-line aware: bash backslash-continuation (the only multi-line argv form
+  // used in skills) is merged into one logical line before matching, so a free-text
+  // field split across `append-metrics.ts \` + path + `'{...}'` lines is still caught.
+  // Heredoc calls never match — their single-quoted token is the `'HERMIT_METRICS_JSON'`
+  // delimiter, not a `'{...}'` payload.
+  const FREE_TEXT_KEYS = ['question', 'note', 'message', 'text'];
+
+  function scanArgvFreeText(content: string, label = 'inline'): string[] {
+    const physical = content.split('\n');
+    // Merge trailing-backslash continuations into logical lines, keeping each
+    // logical line's first physical line number so violations stay locatable.
+    const logical: { text: string; line: number }[] = [];
+    for (let i = 0; i < physical.length; i++) {
+      let text = physical[i];
+      const start = i;
+      while (text.endsWith('\\') && i + 1 < physical.length) {
+        text = text.slice(0, -1) + ' ' + physical[++i].trimStart();
+      }
+      logical.push({ text, line: start + 1 });
+    }
+
+    const violations: string[] = [];
+    for (const { text, line } of logical) {
+      if (!text.includes('append-metrics.ts')) continue;
+      // Match: append-metrics.ts <path> '<json-containing-free-text-key>'
+      const single = text.match(/append-metrics\.ts\s+\S+\s+'(\{[^']+\})'/);
+      if (!single) continue;
+      const payload = single[1];
+      for (const key of FREE_TEXT_KEYS) {
+        if (payload.includes(`"${key}"`)) {
+          violations.push(`${label}:${line} — "${key}" in single-quoted argv (use stdin heredoc)`);
+        }
+      }
+    }
+    return violations;
+  }
+
   test('append-metrics (lint: no single-quoted argv call with free-text field)', () => {
     const skillsRoot = path.join(PLUGIN_ROOT, 'skills');
     const devSkillsRoot = path.join(MONOREPO_ROOT, 'plugins', 'claude-code-dev-hermit', 'skills');
     const roots = [skillsRoot, ...(fs.existsSync(devSkillsRoot) ? [devSkillsRoot] : [])];
 
-    const freeTextKeys = ['question', 'note', 'message', 'text'];
     const violations: string[] = [];
-
     for (const root of roots) {
       if (!fs.existsSync(root)) continue;
       const skillFiles = fs.readdirSync(root)
@@ -770,25 +806,42 @@ describe('append-metrics (dual-mode)', () => {
         .filter(f => fs.existsSync(f));
 
       for (const file of skillFiles) {
-        const lines = fs.readFileSync(file, 'utf-8').split('\n');
-        lines.forEach((line, i) => {
-          if (!line.includes('append-metrics.ts')) return;
-          // Match: append-metrics.ts ... '<json-containing-free-text-key>'
-          const single = line.match(/append-metrics\.ts\s+\S+\s+'(\{[^']+\})'/);
-          if (!single) return;
-          const payload = single[1];
-          for (const key of freeTextKeys) {
-            if (payload.includes(`"${key}"`)) {
-              violations.push(`${file}:${i + 1} — "${key}" in single-quoted argv (use stdin heredoc)`);
-            }
-          }
-        });
+        violations.push(...scanArgvFreeText(fs.readFileSync(file, 'utf-8'), file));
       }
     }
 
     if (violations.length > 0) {
       throw new Error(`append-metrics free-text-in-argv violations:\n${violations.join('\n')}`);
     }
+  });
+
+  test('append-metrics (lint: scan catches multi-line argv, ignores heredoc)', () => {
+    // Payloads use apostrophe-free placeholders, mirroring real skill templates —
+    // a literal apostrophe inside single-quoted argv is itself broken bash (the very
+    // bug this guard prevents), so the guard keys off the field name, not the value.
+    // Positive: a 3-line backslash-continuation call carrying "question" is caught.
+    const multiLineArgv = [
+      "bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \\",
+      "  .claude-code-hermit/state/proposal-metrics.jsonl \\",
+      `  '{"ts":"<now ISO>","type":"micro-queued","question":"<full question text>"}'`,
+    ].join('\n');
+    expect(scanArgvFreeText(multiLineArgv)).toHaveLength(1);
+
+    // Negative: the same free-text payload delivered via heredoc is not a violation.
+    const heredoc = [
+      "bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts .claude-code-hermit/state/proposal-metrics.jsonl <<'HERMIT_METRICS_JSON'",
+      `{"ts":"<now ISO>","type":"micro-queued","question":"<full question text>"}`,
+      "HERMIT_METRICS_JSON",
+    ].join('\n');
+    expect(scanArgvFreeText(heredoc)).toHaveLength(0);
+
+    // Negative: a multi-line argv call with only enum/slug fields is fine.
+    const enumArgv = [
+      "bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \\",
+      "  .claude-code-hermit/state/proposal-metrics.jsonl \\",
+      `  '{"ts":"<now ISO>","type":"triage-verdict","verdict":"CREATE"}'`,
+    ].join('\n');
+    expect(scanArgvFreeText(enumArgv)).toHaveLength(0);
   });
 });
 

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -14,7 +14,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { runScript, PLUGIN_ROOT, SCRIPTS_DIR } from './helpers/run';
+import { runScript, PLUGIN_ROOT, SCRIPTS_DIR, MONOREPO_ROOT } from './helpers/run';
 import { setupWorkdir, fixturesDir, type Workdir } from './helpers/workdir';
 
 // In-process imports — pure libs with no import-time CWD dependence.
@@ -678,6 +678,118 @@ describe('update-alert-state', () => {
     }));
     expect(d.alerts['k'].note).toBe(note);
   }));
+});
+
+// -------------------------------------------------------
+// append-metrics.ts (subprocess — dual-mode stdin/argv contract)
+// Regression: #442 — free-text pattern/question values with apostrophes
+// must survive shell delivery. Dual-mode: argv for enum/slug/numeric,
+// stdin heredoc for any free-text payload.
+// -------------------------------------------------------
+
+describe('append-metrics (dual-mode)', () => {
+  async function appendMetricsArgv(ledger: string, event: string) {
+    return runScript('append-metrics.ts', { args: [ledger, event] });
+  }
+  async function appendMetricsStdin(ledger: string, event: string) {
+    return runScript('append-metrics.ts', { args: [ledger], stdin: event });
+  }
+
+  test('append-metrics (stdin: apostrophe in pattern survives)', withDir(async (dir) => {
+    // Regression: apostrophes broke single-quoted argv passing (issue #442).
+    // Stdin heredoc form must deliver the value verbatim.
+    const ledger = hermit(dir, 'state', 'observations.jsonl');
+    const event = JSON.stringify({ ts: '2026-06-22T00:00:00Z', pattern: "bob's pattern", session_id: 'S-1', source: 'reflect-noticed', origin: 'own-work' });
+    const r = await appendMetricsStdin(ledger, event);
+    expect(r.exitCode).toBe(0);
+    const line = JSON.parse(fs.readFileSync(ledger, 'utf-8').trim());
+    expect(line.pattern).toBe("bob's pattern");
+  }));
+
+  test('append-metrics (stdin: apostrophe in question survives)', withDir(async (dir) => {
+    const ledger = hermit(dir, 'state', 'proposal-metrics.jsonl');
+    const event = JSON.stringify({ ts: '2026-06-22T00:00:00Z', type: 'micro-queued', micro_id: 'MP-20260622-0', tier: 1, question: "what's the plan?" });
+    const r = await appendMetricsStdin(ledger, event);
+    expect(r.exitCode).toBe(0);
+    const line = JSON.parse(fs.readFileSync(ledger, 'utf-8').trim());
+    expect(line.question).toBe("what's the plan?");
+  }));
+
+  test('append-metrics (stdin: embedded double-quote and dollar sign survive)', withDir(async (dir) => {
+    // Dollar signs in pattern must not expand (no $X -> empty) under stdin delivery.
+    const ledger = hermit(dir, 'state', 'observations.jsonl');
+    const event = JSON.stringify({ ts: '2026-06-22T00:00:00Z', pattern: 'cost_spike: $5.00 vs 7d median $3.50', session_id: 'S-1', source: 'cost-spike' });
+    const r = await appendMetricsStdin(ledger, event);
+    expect(r.exitCode).toBe(0);
+    const line = JSON.parse(fs.readFileSync(ledger, 'utf-8').trim());
+    expect(line.pattern).toBe('cost_spike: $5.00 vs 7d median $3.50');
+  }));
+
+  test('append-metrics (argv and stdin produce identical ledger lines)', withDir(async (dir) => {
+    // Dual-mode parity: the two delivery paths must write the same bytes.
+    const ledgerA = hermit(dir, 'state', 'a.jsonl');
+    const ledgerB = hermit(dir, 'state', 'b.jsonl');
+    const event = JSON.stringify({ ts: '2026-06-22T00:00:00Z', type: 'resolved', proposal_id: 'PROP-001' });
+    await appendMetricsArgv(ledgerA, event);
+    await appendMetricsStdin(ledgerB, event);
+    expect(fs.readFileSync(ledgerA, 'utf-8')).toBe(fs.readFileSync(ledgerB, 'utf-8'));
+  }));
+
+  test('append-metrics (argv mode still works — back-compat)', withDir(async (dir) => {
+    const ledger = hermit(dir, 'state', 'proposal-metrics.jsonl');
+    const event = JSON.stringify({ ts: '2026-06-22T00:00:00Z', type: 'resolved', proposal_id: 'PROP-001' });
+    const r = await appendMetricsArgv(ledger, event);
+    expect(r.exitCode).toBe(0);
+    const line = JSON.parse(fs.readFileSync(ledger, 'utf-8').trim());
+    expect(line.proposal_id).toBe('PROP-001');
+  }));
+
+  test('append-metrics (stdin: bad JSON — exits 1, no write)', withDir(async (dir) => {
+    const ledger = hermit(dir, 'state', 'observations.jsonl');
+    const r = await appendMetricsStdin(ledger, 'not-json');
+    expect(r.exitCode).toBe(1);
+    expect(fs.existsSync(ledger)).toBe(false);
+  }));
+
+  // Lint guard: no literal single-quoted argv append-metrics call may carry a
+  // free-text field (question/note/message/text). Those must use stdin heredoc.
+  // Enum/id/count/slug/numeric fields (type, proposal_id, source, pattern) remain
+  // on argv and are intentionally excluded from this check.
+  test('append-metrics (lint: no single-quoted argv call with free-text field)', () => {
+    const skillsRoot = path.join(PLUGIN_ROOT, 'skills');
+    const devSkillsRoot = path.join(MONOREPO_ROOT, 'plugins', 'claude-code-dev-hermit', 'skills');
+    const roots = [skillsRoot, ...(fs.existsSync(devSkillsRoot) ? [devSkillsRoot] : [])];
+
+    const freeTextKeys = ['question', 'note', 'message', 'text'];
+    const violations: string[] = [];
+
+    for (const root of roots) {
+      if (!fs.existsSync(root)) continue;
+      const skillFiles = fs.readdirSync(root)
+        .map(s => path.join(root, s, 'SKILL.md'))
+        .filter(f => fs.existsSync(f));
+
+      for (const file of skillFiles) {
+        const lines = fs.readFileSync(file, 'utf-8').split('\n');
+        lines.forEach((line, i) => {
+          if (!line.includes('append-metrics.ts')) return;
+          // Match: append-metrics.ts ... '<json-containing-free-text-key>'
+          const single = line.match(/append-metrics\.ts\s+\S+\s+'(\{[^']+\})'/);
+          if (!single) return;
+          const payload = single[1];
+          for (const key of freeTextKeys) {
+            if (payload.includes(`"${key}"`)) {
+              violations.push(`${file}:${i + 1} — "${key}" in single-quoted argv (use stdin heredoc)`);
+            }
+          }
+        });
+      }
+    }
+
+    if (violations.length > 0) {
+      throw new Error(`append-metrics free-text-in-argv violations:\n${violations.join('\n')}`);
+    }
+  });
 });
 
 // -------------------------------------------------------


### PR DESCRIPTION
## Summary

`append-metrics.ts` was invoked with the JSON payload in single-quoted argv across ~13 call sites. Free-text fields (`pattern` labels, `question` strings) can contain apostrophes, which terminate the single-quoted bash arg and corrupt/truncate the JSON. Same shell-quoting class fixed for `update-alert-state.ts` in #441.

Chosen fix: **dual-mode script + migrate only the at-risk free-text sites** (B′+). Leaving enum/id/count/slug/numeric sites on argv avoids (a) the `$X`-expansion trap at `reflect:32` where single-quotes currently make `$X` literal, and (b) silent telemetry loss from a missed migration at any of the 13 prose-rendered call sites.

## Changes

- **`scripts/append-metrics.ts`** — dual-mode: `argv[3]` present → use it synchronously (back-compat); absent → read stdin + `buf.trim()`, mirroring `update-alert-state.ts`. Empty payload now emits `Error: event payload is empty` instead of the usage string.
- **`skills/reflect/SKILL.md`** — sites :18 (pattern slug), :89 (model-emitted `metrics_event`), :288 (free-text pattern), :352 (micro-queued `question`) → quoted heredoc `<<'HERMIT_METRICS_JSON'`
- **`skills/reflect-scheduled-checks/SKILL.md`** — site :111 (micro-queued `question`) → heredoc
- **`skills/channel-responder/SKILL.md`**, **`skills/brief/SKILL.md`** — prose sites updated to mandate stdin heredoc for `question`-bearing events
- Left on argv: `reflect:32` (`$`-numeric cost spike), `proposal-act`, `proposal-create`, `session-close`, `domain-brainstorm` (all enum/id/count — no apostrophe risk)

## Tests

- stdin apostrophe round-trip for `pattern` and `question` fields
- stdin `$`-sign survival (`cost_spike: $5.00 vs 7d median $3.50` passes verbatim)
- dual-mode parity: argv and stdin paths write identical bytes
- argv back-compat: existing `skill-correction-ledger` tests unchanged
- **lint guard**: greps `skills/**/SKILL.md` and fails if any single-quoted-argv `append-metrics` call carries a free-text field (`question`/`note`/`message`/`text`); passes today with zero violations, blocks future copy-paste regressions

## Test plan

```
cd plugins/claude-code-hermit && bun test
```

1171 tests, 0 failures. New `describe('append-metrics (dual-mode)')` block covers all the above cases.

Closes #442