### PR TITLE
feat(hermit): bump Docker base image to Ubuntu 26.04 LTS

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -10,6 +10,52 @@
 
 - **reflect/append-metrics: free-text JSON events delivered via stdin heredoc** — apostrophes in pattern labels and question strings no longer corrupt the metrics ledger (same shell-quoting class as #441). `append-metrics.ts` is now dual-mode: argv for enum/id/count/slug payloads, stdin for free-text. Call sites in reflect, reflect-scheduled-checks, channel-responder, and brief updated accordingly.
 
+### Changed
+
+- **docker: base image bumped to Ubuntu 26.04 LTS** — was 24.04; 26.04 is the current LTS. Existing hermits migrate via a surgical `FROM` patch that preserves Dockerfile customizations; evolve suppresses the now-stale docker-setup drift notice for this release.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `state-templates/docker/Dockerfile.hermit.template` | `FROM ubuntu:26.04`; version comment updated |
+| `docs/always-on.md` | Ubuntu version references updated to 26.04 |
+| `docs/troubleshooting.md` | Ubuntu version reference updated to 26.04 |
+| `tests/docker-baseline-content.test.ts` | Add `FROM ubuntu:26.04` regression assertion |
+| `skills/hermit-evolve/SKILL.md` | Step 2b note; Step 10 `base-patched` bullet + suppression rule |
+| `agents/evolve-runner.md` | `Docker rebuild: base-patched` contract; delegated-rule note |
+
+### Upgrade Instructions
+
+**Docker base image bump to Ubuntu 26.04.** Existing hermits with a deployed `Dockerfile.hermit` need a surgical `FROM` patch and rebuild. Non-Docker hermits: nothing to do.
+
+**Step 1 — Existence / idempotency.** Check for `Dockerfile.hermit` at the project root. If it does not exist, skip to Step 4 (Docker not set up). If it already contains `FROM ubuntu:26.04`, skip to Step 3 (already patched; still re-record the baseline so the drift detector clears).
+
+**Step 2 — Surgical patch.** Replace the exact line `FROM ubuntu:24.04` with `FROM ubuntu:26.04` in `Dockerfile.hermit`. If a comment line containing `Ubuntu 24.04 ships a default` is present, update it to `Ubuntu 26.04 ships a default` (cosmetic; tolerate absence). If `FROM ubuntu:24.04` is **not** found (operator changed the base image to something else), this is a genuine either/or with no safe non-destructive default — record a deferred-migration block with the instruction "manually set the base image to `ubuntu:26.04` in `Dockerfile.hermit`, then rebuild", skip this patch, and **continue the remaining evolve steps** (do not abort).
+
+**Step 3 — Re-record the template baseline** so `classifyDockerTemplates` clears the drift and won't nag on future evolves. Run:
+
+```
+bun -e '
+  const fs=require("node:fs"), c=require("node:crypto");
+  const [tmpl, ver]=process.argv.slice(2);
+  const mp=".claude-code-hermit/state/template-manifest.json";
+  if(!fs.existsSync(mp)) process.exit(0);
+  const m=JSON.parse(fs.readFileSync(mp,"utf8")); m.files ??= {};
+  const h=c.createHash("sha256").update(fs.readFileSync(tmpl)).digest("hex");
+  m.files["docker/Dockerfile.hermit.template"]={sha256:h, plugin_version:ver};
+  fs.writeFileSync(mp, JSON.stringify(m,null,2)+"\n");
+' "${CLAUDE_PLUGIN_ROOT}/state-templates/docker/Dockerfile.hermit.template" "<to>"
+```
+
+(`<to>` is the plan's `to` version string, available from the pre-pass result.)
+
+If `.claude-code-hermit/state/template-manifest.json` does not exist, skip this step — drift was `unknown` and the patch alone is sufficient (docker-setup was never run, so there is no baseline to update).
+
+**Step 4 — Report.** Set the report's `Docker rebuild` field to `base-patched`. Step 10 will emit a rebuild-only notice and suppress the generic "re-run /docker-setup" drift bullet for `Dockerfile.hermit`.
+
+No `config.json` changes required.
+
 ## [1.2.8] - 2026-06-20
 
 ### Fixed

--- a/plugins/claude-code-hermit/agents/evolve-runner.md
+++ b/plugins/claude-code-hermit/agents/evolve-runner.md
@@ -46,6 +46,11 @@ never block:
 - **`### Upgrade Instructions` migrations (steps 2b, 7):** execute every non-interactive instruction. If a
   step poses a genuine either/or with **no safe non-destructive default**, do **not** guess — record it
   as a deferred-migration block (below) and **skip that step only**. This is the sole escalation path.
+- **Surgical docker-template migrations:** an Upgrade Instruction may patch a wizard-rendered docker
+  template (`Dockerfile.hermit`) and re-record its `template-manifest.json` baseline. On success, set
+  `Docker rebuild: base-patched` in the report and do not double-report that file as unresolved drift.
+  When the CHANGELOG step's anchor line is absent (operator-customized base), follow the standard
+  deferred-migration path: skip this step only and continue.
 - **Version bump (step 9):** run `evolve-finalize.ts` and parse its stdout JSON. Use `core.confirmed` as
   `vNEW` in the report — NOT `plan.to`. If the script exits non-zero, `core.matched` is false, or `errors`
   is non-empty, return `Upgrade: blocked: config version bump failed — <joined error messages>` and omit
@@ -66,7 +71,7 @@ Settings added: <keys | none>
 Templates: <refreshed/restored/kept-N/conflicts-parked-N | none>
 Bin wrappers: <restored/replaced(.bak) | none>
 Docker entrypoint: <refreshed | conflict-replaced(<backup path>) | n/a>
-Docker rebuild: <needed + order | no>
+Docker rebuild: <needed + order | base-patched | no>
 CLAUDE-APPEND: <updated | unchanged>
 Sibling hermits: <name vOLD->vNEW ... | none>
 Permissions added: <entries | none>

--- a/plugins/claude-code-hermit/docs/always-on.md
+++ b/plugins/claude-code-hermit/docs/always-on.md
@@ -35,7 +35,7 @@ The wizard scans your project for dependencies, asks about auth, and generates f
 
 | File                          | Purpose                                               |
 | ----------------------------- | ----------------------------------------------------- |
-| `Dockerfile.hermit`           | Ubuntu 24.04, Node 24, Bun, Claude Code, project packages, host UID matching |
+| `Dockerfile.hermit`           | Ubuntu 26.04, Node 24, Bun, Claude Code, project packages, host UID matching |
 | `docker-entrypoint.hermit.sh` | Onboarding bypass, MCP approval, permission patch, channel symlinks, graceful SIGTERM handling, PID 1 keepalive |
 | `docker-compose.hermit.yml`   | Named volume, bind mounts, env vars, healthcheck, restart policy, kernel-enforced hardening (`no-new-privileges`, `cap_drop: ALL`, `pids_limit`) |
 | `.env`                        | Auth token (appended if file already exists)           |
@@ -233,7 +233,7 @@ Adjust with `/hermit-settings env`.
 
 | Issue | Fix |
 | --- | --- |
-| Ubuntu 24.04 default user conflicts at UID 1000 | `userdel -r ubuntu` before `useradd` — handled by Dockerfile |
+| Ubuntu 26.04 default user conflicts at UID 1000 | `userdel -r ubuntu` before `useradd` — handled by Dockerfile |
 | Volume paths must match host | `${PWD}:${PWD}`, not `/app` or `/project` |
 | OAuth credentials expired | Re-run `.claude-code-hermit/bin/hermit-docker login` and restart with `hermit-docker restart` |
 | Entrypoint exits after tmux spawns | Entrypoint polls `tmux has-session` to keep PID 1 alive. SIGTERM trap handles graceful close. |

--- a/plugins/claude-code-hermit/docs/troubleshooting.md
+++ b/plugins/claude-code-hermit/docs/troubleshooting.md
@@ -130,7 +130,7 @@ Common causes:
 - **UID mismatch:** The Dockerfile matches your host UID. If you're not UID 1000, rebuild after checking `id -u`. The generated Dockerfile should handle this, but manual edits may break it.
 - **Network issues during build:** `apt-get` or `npm install` fails. Check your network, proxy settings, and Docker DNS config.
 - **npm permission errors:** Claude Code installs globally. The Dockerfile sets `NPM_CONFIG_PREFIX` for the `claude` user — if you modified the Dockerfile, ensure this is preserved.
-- **Ubuntu 24.04 default user conflict:** UID 1000 is taken by the default `ubuntu` user. The generated Dockerfile runs `userdel -r ubuntu` first — don't remove this line.
+- **Ubuntu 26.04 default user conflict:** UID 1000 is taken by the default `ubuntu` user. The generated Dockerfile runs `userdel -r ubuntu` first — don't remove this line.
 - **Rebuild after config changes:** If you changed `docker.packages` in config.json, rebuild: `docker compose -f docker-compose.hermit.yml build --no-cache`
 
 ## Upgrade Says Nothing to Update

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -110,6 +110,8 @@ Within `changelog_slice` (already ordered oldest-first), each version entry may 
 
 The CHANGELOG.md `### Upgrade Instructions` sections are the single source of truth for migrations — do not skip or merely display them. The same pattern applies to sibling-hermit upgrades in Step 7.
 
+**Surgical docker-template migrations.** An Upgrade Instruction may surgically patch a wizard-rendered docker template (`Dockerfile.hermit`) and re-record its `template-manifest.json` baseline. When it does, it sets the report's `Docker rebuild` field to `base-patched`. Treat the corresponding `docker_templates` drift entry as resolved — do **not** surface it as unresolved upstream drift in Step 10.
+
 ### 3. New config keys
 
 The plan's `new_config_keys` array lists every key in the current `config.json.template` that is missing from the project's config, each as `{path, default}` — a dotted `path` for a nested leaf, or a fully-absent parent carrying its whole default subtree. Operator-set values are never listed, so acting on these never overwrites them.
@@ -279,7 +281,7 @@ Settings added: <keys | none>
 Templates: <refreshed/restored/kept-N/conflicts-parked-N | none>
 Bin wrappers: <restored/replaced(.bak) | none>
 Docker entrypoint: <refreshed | conflict-replaced(<backup path>) | n/a>
-Docker rebuild: <needed + order | no>
+Docker rebuild: <needed + order | base-patched | no>
 CLAUDE-APPEND: <updated | unchanged>
 Sibling hermits: <name vOLD->vNEW ... | none>
 Permissions added: <entries | none>
@@ -304,6 +306,7 @@ Deferred for operator: <none | one or more verbatim blocks, each:>
 
 **Docker rebuild notice.** From the report's `Docker entrypoint` / `Docker rebuild` fields, append a `Docker:` section when a rebuild is needed:
 - Entrypoint refreshed → "Docker entrypoint refreshed. Rebuild to apply: `.claude-code-hermit/bin/hermit-docker update`."
+- `Docker rebuild: base-patched` → "Docker base image updated. Rebuild to apply: `.claude-code-hermit/bin/hermit-docker update`. Do **not** re-run `/docker-setup` — your Dockerfile customizations are preserved." When this value is present, **suppress** the "Compose/Dockerfile changed upstream" bullet below for `Dockerfile.hermit` (the migration already handled it).
 - Compose/Dockerfile changed upstream → "Docker template(s) changed upstream. Refresh FIRST, then rebuild: (1) re-run `/claude-code-hermit:docker-setup`, (2) THEN `hermit-docker update`. Rebuilding first bakes stale on-disk files into the image."
 - Baseline not recorded → "Docker template baseline not recorded. Run `/claude-code-hermit:docker-setup` once to arm the drift signal."
 - Never auto-rebuild.

--- a/plugins/claude-code-hermit/state-templates/docker/Dockerfile.hermit.template
+++ b/plugins/claude-code-hermit/state-templates/docker/Dockerfile.hermit.template
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 {{PACKAGES_BLOCK}}
 
-# Match host UID for volume permissions. Ubuntu 24.04 ships a default
+# Match host UID for volume permissions. Ubuntu 26.04 ships a default
 # 'ubuntu' user at UID 1000 — remove it first.
 ARG HOST_UID=1000
 ARG CLAUDE_CODE_VERSION=latest

--- a/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
@@ -194,6 +194,15 @@ describe('Entrypoint: placeholder-free session name resolution', () => {
   });
 });
 
+// -------------------------------------------------------
+// Dockerfile: base image (regression guard — prevent accidental downgrade)
+// -------------------------------------------------------
+describe('Dockerfile: base image', () => {
+  test('Dockerfile: FROM ubuntu:26.04', () => {
+    expect(dockerfile).toContain('FROM ubuntu:26.04');
+  });
+});
+
 describe('Entrypoint: Python retired, PATH covers bun', () => {
   test('entrypoint: no python3 invocations remain', () => {
     expect(entrypoint).not.toContain('python3');


### PR DESCRIPTION
## Summary

Bumps the hermit Docker base image from Ubuntu 24.04 to 26.04 (current LTS). Existing installed hermits get a surgical `FROM` patch via `hermit-evolve` that preserves any operator Dockerfile customizations, with the template-manifest baseline re-recorded so the drift detector doesn't nag on the next evolve.

## Changes

- **`Dockerfile.hermit.template`**: `FROM ubuntu:26.04`; version comment updated
- **`agents/evolve-runner.md`**: new "Surgical docker-template migrations" contract rule; `Docker rebuild` report field gains `base-patched` value
- **`skills/hermit-evolve/SKILL.md`**: Step 2b note for surgical template migrations; Step 10 `base-patched` bullet + suppression of the generic drift notice when migration handled it
- **`docs/always-on.md`**, **`docs/troubleshooting.md`**: Ubuntu version references updated to 26.04
- **`tests/docker-baseline-content.test.ts`**: regression assertion `FROM ubuntu:26.04` to prevent silent downgrade

## Test plan

- `bun test` from `plugins/claude-code-hermit/` passes with the new regression assertion
- `hermit-evolve` on an existing 24.04 hermit: verify surgical patch applied, manifest re-recorded, no "re-run /docker-setup" drift notice emitted
- `hermit-evolve` on a hermit with a non-Ubuntu base: verify deferred-migration block recorded, evolve continues