### PR TITLE
feat(laravel-forge-hermit): initial plugin — Forge deploy/server/site skills over PHP SDK

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,6 +88,28 @@
       ]
     },
     {
+      "name": "laravel-forge-hermit",
+      "source": "./plugins/laravel-forge-hermit",
+      "description": "Laravel Forge layer for claude-code-hermit — deployment, logs, server/site skills, and daily estate scan via the official Forge PHP SDK",
+      "version": "0.0.1",
+      "category": "development",
+      "author": {
+        "name": "gtapps",
+        "url": "https://github.com/gtapps"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/gtapps/claude-code-hermit",
+      "repository": "https://github.com/gtapps/claude-code-hermit",
+      "keywords": [
+        "laravel",
+        "forge",
+        "deployment",
+        "devops",
+        "php",
+        "gtapps"
+      ]
+    },
+    {
       "name": "hermit-scribe",
       "source": "./plugins/hermit-scribe",
       "description": "Maintainer tool: file GitHub issues via a configured GitHub App bot identity.",

--- a/.github/workflows/test-forge.yml
+++ b/.github/workflows/test-forge.yml
@@ -1,0 +1,43 @@
+name: Test Forge
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/laravel-forge-hermit/**'
+      - '.github/workflows/test-forge.yml'
+  pull_request:
+    paths:
+      - 'plugins/laravel-forge-hermit/**'
+      - '.github/workflows/test-forge.yml'
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+      - run: bun install --frozen-lockfile
+      - run: bunx tsc
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/laravel-forge-hermit
+    steps:
+      - uses: actions/checkout@v4
+      # Plugin pins php ^8.5 (composer.json platform) — the runner must match.
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: json, curl
+      - name: Install Forge SDK (composer)
+        run: composer install --no-dev --no-interaction --no-progress --working-dir=php
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+      - name: Run test suite (PHP unit + hook + skill-structure)
+        run: bash tests/run-all.sh

--- a/plugins/laravel-forge-hermit/.claude-plugin/hermit-meta.json
+++ b/plugins/laravel-forge-hermit/.claude-plugin/hermit-meta.json
@@ -1,0 +1,4 @@
+{
+  "required_core_version": ">=1.1.1",
+  "requires": { "claude-code-hermit": ">=1.1.1" }
+}

--- a/plugins/laravel-forge-hermit/.claude-plugin/plugin.json
+++ b/plugins/laravel-forge-hermit/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "laravel-forge-hermit",
+  "version": "0.0.1",
+  "description": "Laravel Forge layer for claude-code-hermit — deploy, logs, server/site skills over the official Laravel Forge PHP SDK",
+  "author": { "name": "gtapps", "url": "https://github.com/gtapps" },
+  "repository": "https://github.com/gtapps/claude-code-hermit",
+  "homepage": "https://github.com/gtapps/claude-code-hermit/tree/main/plugins/laravel-forge-hermit",
+  "license": "MIT",
+  "keywords": ["laravel", "forge", "deployment", "devops", "php", "gtapps"],
+  "dependencies": [{ "name": "claude-code-hermit", "version": "^1.1.1" }]
+}

--- a/plugins/laravel-forge-hermit/.gitignore
+++ b/plugins/laravel-forge-hermit/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+*.pem
+.env
+.mcp.json
+php/vendor/

--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Added
 
-- **forge.php: dispatch script** — pure PHP v8.5+ over `laravel/forge-sdk` v4; read-only generic dispatch (`call <method>`, closed allowlist), curated read commands, preview commands, `--confirm`-gated deploy/reboot, `failed-deploys` org-wide scan.
-- **write-confirm-gate hook** — fail-closed PreToolUse Bash hook; blocks `deploy`/`server-reboot` lacking `--confirm`; allows all preview and read commands.
+- **forge.php: dispatch script** — pure PHP v8.5+ over `laravel/forge-sdk` v4; read-only generic dispatch (`call <method>`, closed allowlist), curated read commands, preview commands, `--confirm`-gated `deploy` (fire-and-return) + `server-reboot`, `deploy-status` poll, `failed-deploys` org-wide scan.
+- **write-confirm-gate hook** — PreToolUse Bash hook; blocks `deploy`/`server-reboot` lacking `--confirm`, passes all preview/read commands, fails open on unparseable input.
 - **6 skills**: `hatch`, `forge-servers`, `forge-sites`, `forge-deploy`, `forge-logs`, `forge-failed-deploys`.
+- **forge-deploy watch via the hermit watch registry** — `deploy` returns immediately with canonical IDs; the skill arms a non-blocking watch through `/claude-code-hermit:watch` that polls `deploy-status` to a terminal state, then relays the outcome via the core Operator Notification protocol.
 - **`forge-failed-deploys` scheduled check** — daily estate scan via `organizationSites()->lazy()`; analysis-only, routes `[reliability]` proposals.
-- **`deploy-incident` artifact** — `forge-deploy --watch` failure writes scrubbed log tail to `compiled/deploy-incident-<site>-<date>.md`.
+- **`deploy-incident` artifact** — on a failed terminal deploy status, `forge-deploy` writes a scrubbed log tail to `compiled/deploy-incident-<site>-<date>.md`.
 - **Vendor-free shipping** — `composer.json` + `composer.lock` ship; `hatch` installs SDK `--no-dev` into `<project>/.claude-code-hermit/forge-runtime/` (isolated from app deps).
 - **Docker support** — `DOCKER.md` wires `php-cli`, `php-curl`, `composer` apt packages + `forge.laravel.com` + packagist/github DNS allowlist; targets Ubuntu 26.04 LTS base (core prerequisite).

--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog — laravel-forge-hermit
+
+## [0.0.1] — 2026-06-22
+
+### Added
+
+- **forge.php: dispatch script** — pure PHP v8.5+ over `laravel/forge-sdk` v4; read-only generic dispatch (`call <method>`, closed allowlist), curated read commands, preview commands, `--confirm`-gated deploy/reboot, `failed-deploys` org-wide scan.
+- **write-confirm-gate hook** — fail-closed PreToolUse Bash hook; blocks `deploy`/`server-reboot` lacking `--confirm`; allows all preview and read commands.
+- **6 skills**: `hatch`, `forge-servers`, `forge-sites`, `forge-deploy`, `forge-logs`, `forge-failed-deploys`.
+- **`forge-failed-deploys` scheduled check** — daily estate scan via `organizationSites()->lazy()`; analysis-only, routes `[reliability]` proposals.
+- **`deploy-incident` artifact** — `forge-deploy --watch` failure writes scrubbed log tail to `compiled/deploy-incident-<site>-<date>.md`.
+- **Vendor-free shipping** — `composer.json` + `composer.lock` ship; `hatch` installs SDK `--no-dev` into `<project>/.claude-code-hermit/forge-runtime/` (isolated from app deps).
+- **Docker support** — `DOCKER.md` wires `php-cli`, `php-curl`, `composer` apt packages + `forge.laravel.com` + packagist/github DNS allowlist; targets Ubuntu 26.04 LTS base (core prerequisite).

--- a/plugins/laravel-forge-hermit/CLAUDE.md
+++ b/plugins/laravel-forge-hermit/CLAUDE.md
@@ -1,0 +1,64 @@
+# laravel-forge-hermit
+
+A Laravel Forge domain layer for `claude-code-hermit`: deployment skills, server/site management, estate health monitoring, and a daily failed-deployment scan — all over the official `laravel/forge-sdk` PHP v4.
+
+## Plugin Structure
+
+- `skills/hatch/` — one-time setup wizard: `/laravel-forge-hermit:hatch`
+- `skills/forge-servers/` — server list, detail, reboot flow
+- `skills/forge-sites/` — site list and detail
+- `skills/forge-deploy/` — preview → approve → deploy; failure → deploy-incident artifact
+- `skills/forge-logs/` — deployment + server logs, triage mode
+- `skills/forge-failed-deploys/` — daily scheduled estate scan (analysis-only)
+- `php/forge.php` — PHP dispatch script: read-only generic dispatch, curated commands, write-confirmation gate
+- `php/composer.json` + `php/composer.lock` — shipped; `php/vendor/` is gitignored (hatch installs SDK into project space)
+- `hooks/write-confirm-gate.ts` — PreToolUse Bash hook: blocks deploy/server-reboot without `--confirm`
+- `state-templates/CLAUDE-APPEND.md` — Forge Workflow block injected by hatch
+- `settings.json` — pre-approved Bash and hermit-state permissions
+- `DOCKER.md` — apt deps + DNS allowlist for `/docker-setup`
+- `.claude-plugin/plugin.json` — plugin manifest
+- `.claude-plugin/hermit-meta.json` — hermit-internal fields (`required_core_version`, `requires`)
+
+## Architecture
+
+The agent calls `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php <command>` directly via Bash. The SDK handles all HTTP — no hand-rolled API client, no bun CLI, no bridge process.
+
+The vendor tree is **not committed to this repo** — hatch installs `laravel/forge-sdk` `--no-dev` via Composer into the consumer project's `.claude-code-hermit/forge-runtime/vendor/` (persistent, bind-mounted in Docker, isolated from the app's own `composer.json`/`vendor/`).
+
+## Hatch target routing
+
+`/hatch` Step 6 reads `.claude-code-hermit/state/hatch-options.json` (`target` field) to route the CLAUDE-APPEND block: `"local"` → `CLAUDE.local.md`, `"committed"` → `CLAUDE.md`.
+
+## Core Rules
+
+- **Surface-then-approve on every write.** Preview first, relay canonical target, wait for explicit approval, re-run with `--confirm`. No exceptions.
+- The write-confirm-gate hook and the in-PHP `--confirm` gate are two independent layers. Neither is optional.
+- **Never echo, cat, or Read `.env`** — check credential state with `forge.php check` (self-reports `missing`/`invalid`/`ok`). The `TOKEN` substring in `FORGE_API_TOKEN` triggers the base hermit deny-pattern hook.
+- **Deployment and server logs may contain secrets.** Scrub before relay and before persistence — see CLAUDE-APPEND secret-hygiene rule.
+- Generic dispatch (`forge.php call <method>`) is read-only by design (closed allowlist). Write ops only go through the curated `deploy` / `server-reboot` commands.
+
+## Development
+
+Test locally without publishing:
+
+```
+cd /path/to/target-project
+claude --plugin-dir /path/to/plugins/laravel-forge-hermit
+```
+
+Under `--plugin-dir`, `${CLAUDE_PLUGIN_ROOT}` is NOT substituted — use the absolute plugin path in commands.
+
+For tests, first install the SDK into a local vendor tree:
+
+```bash
+cd plugins/laravel-forge-hermit
+composer install --working-dir=php
+bun test
+php php/tests/run.php
+```
+
+## Development constraints
+
+- The `tests/skill-structure.test.ts` expects exactly 6 skills, each with a matching `name` field in frontmatter. Add a new skill → update the `SKILLS` array in that file.
+- The deny-pattern hook blocks any Bash arg containing literal `TOKEN`. Never put `FORGE_API_TOKEN` on a command line.
+- When aligning with a new core version, sweep `skills/`, `state-templates/`, `docs/` for stale hermit-facing terms.

--- a/plugins/laravel-forge-hermit/CLAUDE.md
+++ b/plugins/laravel-forge-hermit/CLAUDE.md
@@ -33,7 +33,7 @@ The vendor tree is **not committed to this repo** — hatch installs `laravel/fo
 
 - **Surface-then-approve on every write.** Preview first, relay canonical target, wait for explicit approval, re-run with `--confirm`. No exceptions.
 - The write-confirm-gate hook and the in-PHP `--confirm` gate are two independent layers. Neither is optional.
-- **Never echo, cat, or Read `.env`** — check credential state with `forge.php check` (self-reports `missing`/`invalid`/`ok`). The `TOKEN` substring in `FORGE_API_TOKEN` triggers the base hermit deny-pattern hook.
+- **Never echo, cat, or Read `.env`** — check credential state with `forge.php check` (self-reports `missing`/`invalid`/`unreachable`/`ok`). The `TOKEN` substring in `FORGE_API_TOKEN` triggers the base hermit deny-pattern hook.
 - **Deployment and server logs may contain secrets.** Scrub before relay and before persistence — see CLAUDE-APPEND secret-hygiene rule.
 - Generic dispatch (`forge.php call <method>`) is read-only by design (closed allowlist). Write ops only go through the curated `deploy` / `server-reboot` commands.
 

--- a/plugins/laravel-forge-hermit/DOCKER.md
+++ b/plugins/laravel-forge-hermit/DOCKER.md
@@ -1,0 +1,23 @@
+# laravel-forge-hermit Docker requirements
+
+Read by `/claude-code-hermit:docker-setup` when building the hermit container image.
+
+**Base image prerequisite**: this plugin requires PHP 8.5+, which ships natively in Ubuntu 26.04 LTS (Resolute). If the core base image is still Ubuntu 24.04, the Docker path for this plugin is blocked pending the core base bump. Bare-metal and dev-mode paths (operator-supplied PHP 8.5 + Composer) are unaffected.
+
+## Docker apt dependencies
+
+- php-cli
+- php-curl
+- composer
+
+## Docker network requirements
+
+Read by `/claude-code-hermit:docker-security` when the operator enables LAN containment + DNS policy.
+
+### Domains (DNS allowlist)
+
+- forge.laravel.com
+- packagist.org
+- repo.packagist.org
+- api.github.com
+- codeload.github.com

--- a/plugins/laravel-forge-hermit/LICENSE
+++ b/plugins/laravel-forge-hermit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 gtapps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/laravel-forge-hermit/README.md
+++ b/plugins/laravel-forge-hermit/README.md
@@ -1,0 +1,40 @@
+# laravel-forge-hermit
+
+A [claude-code-hermit](https://github.com/gtapps/claude-code-hermit) domain plugin for [Laravel Forge](https://forge.laravel.com): deployments, server/site management, log reading, and a daily estate health scan — via the official `laravel/forge-sdk` PHP v4.
+
+## Install
+
+```
+claude plugin marketplace add gtapps/claude-code-hermit
+claude plugin install laravel-forge-hermit@claude-code-hermit --scope local
+```
+
+Then run `/laravel-forge-hermit:hatch` in your project (requires `claude-code-hermit` ≥1.1.1 and PHP 8.5+).
+
+## What you get
+
+| Skill | Purpose |
+|---|---|
+| `/laravel-forge-hermit:forge-servers` | List servers, show detail, reboot (with preview → approve flow) |
+| `/laravel-forge-hermit:forge-sites` | List and inspect sites |
+| `/laravel-forge-hermit:forge-deploy` | Preview → approve → deploy; `--watch` polls to completion; failure writes a scrubbed `deploy-incident` |
+| `/laravel-forge-hermit:forge-logs` | Latest deployment log, specific deployment log, server log, triage mode |
+| `/laravel-forge-hermit:forge-failed-deploys` | Daily estate scan — surfaces sites with failed latest deployments as `[reliability]` proposals |
+
+Every write operation goes through **surface-then-approve**: the canonical target (server name, IP, site name, IDs) is shown before any `--confirm` flag is sent. A wrong reboot is an outage.
+
+## Requirements
+
+- `claude-code-hermit` ≥1.1.1
+- PHP 8.5+ with `ext-json` and `ext-curl`
+- Composer (for SDK install at hatch time)
+
+**Docker**: targets Ubuntu 26.04 LTS base (ships PHP 8.5 natively). Requires the core base bump to 26.04.
+
+## Architecture
+
+`forge.php` is a pure PHP dispatch script the agent calls directly via Bash. The `laravel/forge-sdk` v4 handles all HTTP. The vendor tree is not committed — hatch runs `composer install --no-dev` into `.claude-code-hermit/forge-runtime/` (persistent, isolated from your app's own deps).
+
+## License
+
+MIT

--- a/plugins/laravel-forge-hermit/README.md
+++ b/plugins/laravel-forge-hermit/README.md
@@ -17,7 +17,7 @@ Then run `/laravel-forge-hermit:hatch` in your project (requires `claude-code-he
 |---|---|
 | `/laravel-forge-hermit:forge-servers` | List servers, show detail, reboot (with preview → approve flow) |
 | `/laravel-forge-hermit:forge-sites` | List and inspect sites |
-| `/laravel-forge-hermit:forge-deploy` | Preview → approve → deploy; `--watch` polls to completion; failure writes a scrubbed `deploy-incident` |
+| `/laravel-forge-hermit:forge-deploy` | Preview → approve → deploy; a hermit `/watch` monitors to completion; failure writes a scrubbed `deploy-incident` |
 | `/laravel-forge-hermit:forge-logs` | Latest deployment log, specific deployment log, server log, triage mode |
 | `/laravel-forge-hermit:forge-failed-deploys` | Daily estate scan — surfaces sites with failed latest deployments as `[reliability]` proposals |
 

--- a/plugins/laravel-forge-hermit/docs/knowledge-schema.md
+++ b/plugins/laravel-forge-hermit/docs/knowledge-schema.md
@@ -4,7 +4,7 @@
 
 Work products live in `.claude-code-hermit/compiled/`. All artifacts are flat (no subdirectories).
 
-- `deploy-incident`: per-failure deployment record with scrubbed log tail and resolution notes. **Producer**: `forge-deploy` skill on a `--watch` failure. **Location**: `compiled/deploy-incident-<site-name>-<YYYY-MM-DD>.md`. **Tags**: `[deploy, failure, <site-name>]`. **Retention**: indefinite (read by `[reliability]` proposals to identify patterns). **Secret hygiene**: log tail must be scrubbed of credentials before writing — see `forge-deploy` SKILL.md.
+- `deploy-incident`: per-failure deployment record with scrubbed log tail and resolution notes. **Producer**: `forge-deploy` skill on a failed terminal deploy status (detected by the watch Monitor). **Location**: `compiled/deploy-incident-<site-name>-<YYYY-MM-DD>.md`. **Tags**: `[deploy, failure, <site-name>]`. **Retention**: indefinite (read by `[reliability]` proposals to identify patterns). **Secret hygiene**: log tail must be scrubbed of credentials before writing — see `forge-deploy` SKILL.md.
 
 ## Raw Captures
 

--- a/plugins/laravel-forge-hermit/docs/knowledge-schema.md
+++ b/plugins/laravel-forge-hermit/docs/knowledge-schema.md
@@ -1,0 +1,19 @@
+# laravel-forge-hermit knowledge schema
+
+## Work Products
+
+Work products live in `.claude-code-hermit/compiled/`. All artifacts are flat (no subdirectories).
+
+- `deploy-incident`: per-failure deployment record with scrubbed log tail and resolution notes. **Producer**: `forge-deploy` skill on a `--watch` failure. **Location**: `compiled/deploy-incident-<site-name>-<YYYY-MM-DD>.md`. **Tags**: `[deploy, failure, <site-name>]`. **Retention**: indefinite (read by `[reliability]` proposals to identify patterns). **Secret hygiene**: log tail must be scrubbed of credentials before writing — see `forge-deploy` SKILL.md.
+
+## Raw Captures
+
+(none in v0.0.1 — the estate scan emits findings to stdout, not raw artifacts)
+
+## Deferred types
+
+The following types are reserved for future skills and must not be created manually:
+
+- `estate-snapshot` — org-wide estate inventory (requires a producing skill)
+- `forge-estate` — aggregated site/server registry (requires a producing skill)
+- `forge-deploy-history` — cached deployment history (requires a producing skill)

--- a/plugins/laravel-forge-hermit/hooks/hooks.json
+++ b/plugins/laravel-forge-hermit/hooks/hooks.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "profile": "standard,strict",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/write-confirm-gate.ts"],
+            "timeout": 5
+          }
+        ],
+        "description": "Block forge.php deploy/server-reboot calls lacking --confirm. Allows preview-deploy and preview-reboot through unconditionally."
+      }
+    ]
+  }
+}

--- a/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
+++ b/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+// PreToolUse hook: block forge.php deploy/server-reboot calls lacking --confirm.
+//
+// Probe (gating step 4) confirmed the PreToolUse Bash hook receives JSON on
+// stdin with shape: { tool_name, tool_input: { command: string }, ... }
+//
+// Strategy: look for "forge.php" in the command string, extract the
+// subcommand token that follows it, and gate on "deploy" / "server-reboot".
+// preview-deploy and preview-reboot are distinct tokens — they pass through
+// unconditionally (they are read-only). The in-PHP --confirm refusal is the
+// authoritative gate; this hook is defense-in-depth.
+//
+// Fail-closed: malformed stdin or a parse error blocks the call.
+
+import { readFileSync, writeSync } from 'node:fs';
+
+function fail(message: string): never {
+  try { writeSync(2, `${message}\n`); } catch {}
+  process.exit(2);
+}
+
+function main(): void {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(readFileSync(0, 'utf8'));
+  } catch {
+    fail('write-confirm-gate: failed to parse hook input');
+  }
+
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    fail('write-confirm-gate: invalid hook payload');
+  }
+
+  const p = payload as Record<string, unknown>;
+
+  if (p['tool_name'] !== 'Bash') process.exit(0);
+
+  const toolInput = p['tool_input'];
+  if (typeof toolInput !== 'object' || toolInput === null) process.exit(0);
+
+  const command = (toolInput as Record<string, unknown>)['command'];
+  if (typeof command !== 'string') process.exit(0);
+
+  if (!command.includes('forge.php')) process.exit(0);
+
+  const tokens = command.trim().split(/\s+/);
+  const idx = tokens.findIndex(t => t === 'forge.php' || t.endsWith('/forge.php'));
+
+  if (idx === -1 || idx + 1 >= tokens.length) {
+    // forge.php is present but no subcommand token — pass through (e.g., --help).
+    process.exit(0);
+  }
+
+  const subcommand = tokens[idx + 1]!;
+
+  const SAFE_SUBCOMMANDS = [
+    'check', 'servers', 'server', 'sites', 'site', 'logs',
+    'server-log', 'deploy-history', 'deploy-log',
+    'preview-deploy', 'preview-reboot',
+    'failed-deploys', 'call',
+    'help', '--help',
+  ];
+  if (SAFE_SUBCOMMANDS.includes(subcommand)) {
+    process.exit(0);
+  }
+
+  const WRITE_SUBCOMMANDS = ['deploy', 'server-reboot'];
+  if (!WRITE_SUBCOMMANDS.includes(subcommand)) {
+    // Unknown subcommand — pass through (in-PHP gate handles it).
+    process.exit(0);
+  }
+
+  if (command.includes('--confirm')) {
+    process.exit(0);
+  }
+
+  const preview = subcommand === 'deploy' ? 'preview-deploy' : 'preview-reboot';
+  fail(`forge.php ${subcommand} requires --confirm. Run ${preview} first to review the canonical target, then re-run with --confirm.`);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
+++ b/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
@@ -10,11 +10,15 @@
 // unconditionally (they are read-only). The in-PHP --confirm refusal is the
 // authoritative gate; this hook is defense-in-depth.
 //
-// Fail-closed: malformed stdin or a parse error blocks the call.
+// Fail-open on transient/unexpected input (per the hermit hook rule: a hook
+// must never block Claude Code on a parse glitch). We exit non-zero (block)
+// ONLY when we positively identify a write command lacking --confirm; if we
+// can't parse or classify the call, we pass through and let the authoritative
+// in-PHP gate handle it.
 
 import { readFileSync, writeSync } from 'node:fs';
 
-function fail(message: string): never {
+function block(message: string): never {
   try { writeSync(2, `${message}\n`); } catch {}
   process.exit(2);
 }
@@ -24,11 +28,11 @@ function main(): void {
   try {
     payload = JSON.parse(readFileSync(0, 'utf8'));
   } catch {
-    fail('write-confirm-gate: failed to parse hook input');
+    process.exit(0); // unparseable input — fail open, in-PHP gate is authoritative
   }
 
   if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
-    fail('write-confirm-gate: invalid hook payload');
+    process.exit(0); // unexpected payload shape — fail open
   }
 
   const p = payload as Record<string, unknown>;
@@ -55,7 +59,7 @@ function main(): void {
 
   const SAFE_SUBCOMMANDS = [
     'check', 'servers', 'server', 'sites', 'site', 'logs',
-    'server-log', 'deploy-history', 'deploy-log',
+    'server-log', 'deploy-history', 'deploy-log', 'deploy-status',
     'preview-deploy', 'preview-reboot',
     'failed-deploys', 'call',
     'help', '--help',
@@ -70,12 +74,12 @@ function main(): void {
     process.exit(0);
   }
 
-  if (command.includes('--confirm')) {
+  if (tokens.includes('--confirm')) { // exact token, matching the in-PHP in_array() check
     process.exit(0);
   }
 
   const preview = subcommand === 'deploy' ? 'preview-deploy' : 'preview-reboot';
-  fail(`forge.php ${subcommand} requires --confirm. Run ${preview} first to review the canonical target, then re-run with --confirm.`);
+  block(`forge.php ${subcommand} requires --confirm. Run ${preview} first to review the canonical target, then re-run with --confirm.`);
 }
 
 if (import.meta.main) {

--- a/plugins/laravel-forge-hermit/php/composer.json
+++ b/plugins/laravel-forge-hermit/php/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "gtapps/laravel-forge-hermit",
+    "description": "Laravel Forge PHP SDK runtime for laravel-forge-hermit",
+    "type": "project",
+    "require": {
+        "php": "^8.5",
+        "laravel/forge-sdk": "^4.0"
+    },
+    "config": {
+        "optimize-autoloader": true
+    }
+}

--- a/plugins/laravel-forge-hermit/php/composer.lock
+++ b/plugins/laravel-forge-hermit/php/composer.lock
@@ -1,0 +1,790 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1713cfccc3a6456a94728449166ae916",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.1",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5.1",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-18T14:12:49+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-02T12:23:43+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-18T09:49:37+00:00"
+        },
+        {
+            "name": "laravel/forge-sdk",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/forge-sdk.git",
+                "reference": "4bbf5733fce5f4f559868c0455515a84adc2c231"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/forge-sdk/zipball/4bbf5733fce5f4f559868c0455515a84adc2c231",
+                "reference": "4bbf5733fce5f4f559868c0455515a84adc2c231",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.3.1|^7.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.3.1",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.4|^9.0|^10.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Forge\\ForgeServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Forge\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mohamed Said",
+                    "email": "mohamed@laravel.com"
+                },
+                {
+                    "name": "Dries Vints",
+                    "email": "dries@laravel.com"
+                },
+                {
+                    "name": "James Brooks",
+                    "email": "james@laravel.com"
+                },
+                {
+                    "name": "Pete Bishop",
+                    "email": "peter.bishop@laravel.com"
+                }
+            ],
+            "description": "The official Laravel Forge PHP SDK.",
+            "keywords": [
+                "forge",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/forge-sdk/issues",
+                "source": "https://github.com/laravel/forge-sdk"
+            },
+            "time": "2026-06-04T10:08:00+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-13T15:52:40+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.5"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/plugins/laravel-forge-hermit/php/forge-lib.php
+++ b/plugins/laravel-forge-hermit/php/forge-lib.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+// ---------------------------------------------------------------------------
+// Shared pure helpers + constants for forge.php and its test harness.
+//
+// No I/O, no SDK calls — safe to `require` from both the CLI dispatch script
+// and php/tests/run.php. Keeping these in one place means the tests exercise
+// the SAME matchers and allowlist the CLI ships, not a drifting copy.
+// ---------------------------------------------------------------------------
+
+// Read-only allowlist: closed, authoritative set of SDK read methods.
+// Generic dispatch via `call <method>` only resolves names in this set.
+// Every name here is a real method on Laravel\Forge\Forge v4 (verified against
+// the SDK source) — `call` also guards with method_exists as a backstop.
+const READ_ALLOWLIST = [
+    // servers
+    'servers', 'archivedServers', 'server', 'serverEvents',
+    // sites (org-scoped only — the global cross-org sites() is intentionally omitted)
+    'organizationSites', 'serverSites',
+    // deployments + logs
+    'deployments', 'deployment', 'deploymentLog', 'serverLog',
+    // databases
+    'databases', 'database', 'databaseUsers',
+    // firewall
+    'firewallRules', 'firewallRule',
+    // nginx / php
+    'nginxTemplates', 'nginxTemplate', 'phpVersions',
+    // redirects / security
+    'redirectRules', 'securityRules',
+    // ssh keys
+    'sshKeys', 'sshKey',
+    // scheduled jobs
+    'scheduledJobs', 'siteScheduledJobs',
+    // domains / certificates
+    'domains', 'domainCertificates', 'certificate',
+    // backups
+    'backups', 'backup', 'backupConfigurations',
+    // monitoring
+    'monitors', 'webhooks', 'backgroundProcesses', 'commands',
+    // org
+    'organizations',
+];
+
+// Raw transports — blocked even if somehow allowlisted (defense-in-depth).
+const RAW_TRANSPORTS = ['get', 'post', 'put', 'patch', 'delete', 'request', 'retry'];
+
+// Allowlisted read methods that take NO org slug (so `call` must not prepend one).
+const NO_ORG_METHODS = ['organizations'];
+
+// ---------------------------------------------------------------------------
+// Deployment status enums.
+// Terminal states are authoritative (the watch grep keys off these). The
+// in-progress set is documentation only — anything not terminal is treated as
+// still-running, which keeps the watch robust to undocumented states (e.g.
+// 'running', seen in the SDK docs but absent from the OpenAPI enum).
+// ---------------------------------------------------------------------------
+const STATUS_SUCCESS     = ['finished'];
+const STATUS_FAILURE     = ['failed', 'failed-build', 'cancelled'];
+const STATUS_IN_PROGRESS = ['pending', 'queued', 'running', 'deploying'];
+
+// ---------------------------------------------------------------------------
+// Matchers — resolve a user-supplied query to candidate server/site records.
+// Inputs are plain arrays; callers materialize the SDK's CursorPaginator with
+// iterator_to_array($paginator->lazy()) before calling these.
+// ---------------------------------------------------------------------------
+function matchServer(array $servers, string $query): array {
+    if (is_numeric($query)) {
+        // No fallthrough to name/IP matching for numeric queries (F4).
+        return array_values(array_filter($servers, fn($s) => (string)$s->id === $query));
+    }
+    return array_values(array_filter($servers, function($s) use ($query) {
+        return strcasecmp($s->name, $query) === 0 || ($s->ipAddress ?? '') === $query;
+    }));
+}
+
+function matchSite(array $sites, string $query): array {
+    if (is_numeric($query)) {
+        return array_values(array_filter($sites, fn($s) => (string)$s->id === $query));
+    }
+    $queryHost = strtolower(parse_url($query, PHP_URL_HOST) ?: $query);
+    return array_values(array_filter($sites, function($s) use ($query, $queryHost) {
+        if (strcasecmp($s->name, $query) === 0) return true;
+        $siteHost = strtolower(parse_url('https://' . $s->name, PHP_URL_HOST) ?: $s->name);
+        if ($siteHost === $queryHost) return true;
+        if (isset($s->aliases) && is_array($s->aliases)) {
+            foreach ($s->aliases as $alias) {
+                if (strcasecmp($alias, $query) === 0) return true;
+            }
+        }
+        return false;
+    }));
+}

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -1,0 +1,635 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+// ---------------------------------------------------------------------------
+// Bootstrap: project root resolution (port of HA's projectRoot())
+// ---------------------------------------------------------------------------
+function projectRoot(): string {
+    $proj = getenv('CLAUDE_PROJECT_DIR');
+    if ($proj !== false && file_exists($proj . '/.claude-code-hermit')) {
+        return $proj;
+    }
+    $dir = getcwd();
+    for ($i = 0; $i < 8; $i++) {
+        if (file_exists($dir . '/.claude-code-hermit/config.json')) {
+            return $dir;
+        }
+        $parent = dirname($dir);
+        if ($parent === $dir) break;
+        $dir = $parent;
+    }
+    return getcwd();
+}
+
+// ---------------------------------------------------------------------------
+// Autoload: project space (prod, hatch-installed) → local dev fallback
+// ---------------------------------------------------------------------------
+$projectRoot = projectRoot();
+$prodAutoload = $projectRoot . '/.claude-code-hermit/forge-runtime/vendor/autoload.php';
+$devAutoload  = __DIR__ . '/vendor/autoload.php';
+
+if (file_exists($prodAutoload)) {
+    require_once $prodAutoload;
+} elseif (file_exists($devAutoload)) {
+    require_once $devAutoload;
+} else {
+    fwrite(STDERR, "Forge SDK not installed. Run /laravel-forge-hermit:hatch to install it.\n");
+    exit(1);
+}
+
+use Laravel\Forge\Forge;
+
+// ---------------------------------------------------------------------------
+// .env loader (project root only; getenv() takes precedence)
+// ---------------------------------------------------------------------------
+function loadEnv(string $root): void {
+    $file = $root . '/.env';
+    if (!file_exists($file)) return;
+    $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        if (str_starts_with(trim($line), '#')) continue;
+        if (!str_contains($line, '=')) continue;
+        [$key, $val] = explode('=', $line, 2);
+        $key = trim($key);
+        $val = trim($val, " \t\"'");
+        if ($key !== '' && getenv($key) === false) {
+            putenv("$key=$val");
+        }
+    }
+}
+
+loadEnv($projectRoot);
+
+// ---------------------------------------------------------------------------
+// Token + org resolution
+// ---------------------------------------------------------------------------
+$token = getenv('FORGE_API_TOKEN') ?: '';
+$org   = getenv('FORGE_ORG') ?: '';
+
+// ---------------------------------------------------------------------------
+// Read-only allowlist: closed, authoritative set of SDK read methods.
+// Generic dispatch via `call <method>` only resolves names in this set.
+// A denylist of mutator patterns (create*, delete*, *Action) is kept as
+// defense-in-depth but is NOT the primary gate.
+// ---------------------------------------------------------------------------
+const READ_ALLOWLIST = [
+    'servers', 'server',
+    'organizationSites', 'serverSites', 'site',
+    'deployments', 'deployment', 'deploymentLog',
+    'serverLog',
+    'jobs', 'job',
+    'daemons', 'daemon',
+    'firewallRules', 'firewall',
+    'certificates', 'certificate',
+    'sshKeys', 'sshKey',
+    'gitProjects',
+    'organizations',
+    'regions',
+    'nginxTemplates', 'nginxTemplate',
+    'workers', 'worker',
+    'databases', 'database',
+    'databaseUsers', 'databaseUser',
+    'backups', 'backup',
+    'phpVersions',
+    'redirectRules', 'redirectRule',
+    'securityRules', 'securityRule',
+];
+
+// Mutator-pattern denylist — defense-in-depth only. The allowlist above is
+// the authoritative gate; this catches novel SDK mutators as secondary check.
+const MUTATOR_PATTERNS = ['/^create/i', '/^delete/i', '/^update/i', '/^install/i',
+                           '/^uninstall/i', '/Action$/i', '/^reset/i', '/^run/i',
+                           '/^enable/i', '/^disable/i', '/^deploy/i', '/^reboot/i'];
+const RAW_TRANSPORTS = ['get', 'post', 'put', 'patch', 'delete', 'request', 'retry'];
+
+// ---------------------------------------------------------------------------
+// Terminal and in-progress deployment status enums (confirmed against OpenAPI)
+// ---------------------------------------------------------------------------
+const STATUS_SUCCESS    = ['finished'];
+const STATUS_FAILURE    = ['failed', 'failed-build', 'cancelled'];
+const STATUS_IN_PROGRESS = ['pending', 'queued', 'deploying'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function check(bool $cond, string $msg): void {
+    if (!$cond) {
+        fwrite(STDERR, "Error: $msg\n");
+        exit(1);
+    }
+}
+
+function requireToken(string $token): void {
+    check($token !== '', "FORGE_API_TOKEN is not set. Add it to .env in the project root.");
+}
+
+function requireOrg(string $org, Forge $forge): string {
+    if ($org !== '') return $org;
+    // Attempt to discover org from the API — only valid if there is exactly one.
+    try {
+        $orgs = $forge->organizations();
+    } catch (\Throwable $e) {
+        fwrite(STDERR, "Could not list organizations: " . $e->getMessage() . "\n");
+        fwrite(STDERR, "Set FORGE_ORG in .env to specify your organization slug.\n");
+        exit(1);
+    }
+    if (count($orgs) === 1) return $orgs[0]->slug;
+    fwrite(STDERR, "Multiple organizations found. Set FORGE_ORG in .env to one of:\n");
+    foreach ($orgs as $o) {
+        fwrite(STDERR, "  {$o->slug}  ({$o->name})\n");
+    }
+    exit(1);
+}
+
+function matchServer(array $servers, string $query): array {
+    if (is_numeric($query)) {
+        $candidates = array_filter($servers, fn($s) => (string)$s->id === $query);
+        return array_values($candidates); // F4: no fallthrough to name/IP matching for numeric queries
+    }
+    return array_values(array_filter($servers, function($s) use ($query) {
+        return strcasecmp($s->name, $query) === 0 || $s->ipAddress === $query;
+    }));
+}
+
+function matchSite(array $sites, string $query): array {
+    if (is_numeric($query)) {
+        $candidates = array_filter($sites, fn($s) => (string)$s->id === $query);
+        return array_values($candidates);
+    }
+    $queryHost = strtolower(parse_url($query, PHP_URL_HOST) ?: $query);
+    return array_values(array_filter($sites, function($s) use ($query, $queryHost) {
+        if (strcasecmp($s->name, $query) === 0) return true;
+        $siteHost = strtolower(parse_url('https://' . $s->name, PHP_URL_HOST) ?: $s->name);
+        if ($siteHost === $queryHost) return true;
+        if (isset($s->aliases) && is_array($s->aliases)) {
+            foreach ($s->aliases as $alias) {
+                if (strcasecmp($alias, $query) === 0) return true;
+            }
+        }
+        return false;
+    }));
+}
+
+function resolveServer(Forge $forge, string $org, string $serverQuery): object {
+    $servers = $forge->servers($org);
+    $candidates = matchServer($servers, $serverQuery);
+    if (count($candidates) === 0) {
+        fwrite(STDERR, "No server matching '$serverQuery'. Available servers:\n");
+        foreach ($servers as $s) {
+            fwrite(STDERR, "  {$s->id}  {$s->name}  ({$s->ipAddress})\n");
+        }
+        exit(1);
+    }
+    if (count($candidates) > 1) {
+        fwrite(STDERR, "Ambiguous server '$serverQuery' — multiple matches:\n");
+        foreach ($candidates as $s) {
+            fwrite(STDERR, "  {$s->id}  {$s->name}  ({$s->ipAddress})\n");
+        }
+        exit(1);
+    }
+    return $candidates[0];
+}
+
+function resolveSite(Forge $forge, string $org, object $server, string $siteQuery): object {
+    $sites = $forge->serverSites($org, $server->id);
+    $candidates = matchSite($sites, $siteQuery);
+    if (count($candidates) === 0) {
+        fwrite(STDERR, "No site matching '$siteQuery' on server {$server->name}. Available sites:\n");
+        foreach ($sites as $s) {
+            fwrite(STDERR, "  {$s->id}  {$s->name}\n");
+        }
+        exit(1);
+    }
+    if (count($candidates) > 1) {
+        fwrite(STDERR, "Ambiguous site '$siteQuery' on server {$server->name} — multiple matches:\n");
+        foreach ($candidates as $s) {
+            fwrite(STDERR, "  {$s->id}  {$s->name}\n");
+        }
+        exit(1);
+    }
+    return $candidates[0];
+}
+
+function printCanonicalServer(object $server): void {
+    echo "Server: {$server->name} (ID: {$server->id}, IP: {$server->ipAddress})\n";
+}
+
+function printCanonicalSite(object $server, object $site): void {
+    echo "Server: {$server->name} (ID: {$server->id}, IP: {$server->ipAddress})\n";
+    echo "Site:   {$site->name} (ID: {$site->id})\n";
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+$args = array_slice($argv, 1);
+$cmd  = array_shift($args) ?? '';
+
+$hasConfirm = in_array('--confirm', $args, true);
+$hasWatch   = in_array('--watch',   $args, true);
+$hasJson    = in_array('--json',    $args, true);
+
+$positional = array_values(array_filter($args, fn($a) => !str_starts_with($a, '--')));
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+if ($cmd === '' || $cmd === '--help' || $cmd === 'help') {
+    echo <<<USAGE
+    Usage: forge.php <command> [args] [--confirm] [--watch] [--json]
+
+    Credential:
+      check                       Report token status (missing/invalid/ok)
+
+    Read commands:
+      servers                     List all servers
+      server <server>             Show server detail
+      sites <server>              List sites on a server
+      site <server> <site>        Show site detail
+      logs <server> <site>        Show latest deployment log for a site
+      server-log <server> <key>   Read a server log by key
+      deploy-history <server> <site>          List recent deployments
+      deploy-log <server> <site> <deploy-id>  Fetch a specific deployment log
+
+    Preview commands (read-only, never mutate):
+      preview-deploy <server> <site>  Show canonical target before deploying
+      preview-reboot <server>         Show canonical target before rebooting
+
+    Write commands (require --confirm):
+      deploy <server> <site> [--watch]   Trigger deployment (--watch polls until done)
+      server-reboot <server>             Reboot server
+
+    Estate scan:
+      failed-deploys [--json]     Find sites with a failed latest deployment
+
+    Generic read dispatch (JSON args on stdin):
+      call <sdk-method>           Call any allowlisted read SDK method
+
+    USAGE;
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// check
+// ---------------------------------------------------------------------------
+if ($cmd === 'check') {
+    if ($token === '') {
+        echo "missing\n";
+        exit(0);
+    }
+    try {
+        $forge = new Forge($token);
+        $forge->organizations();
+        echo "ok\n";
+    } catch (\Throwable $e) {
+        $msg = $e->getMessage();
+        if (str_contains($msg, '401') || str_contains($msg, 'Unauthorized') || str_contains($msg, 'unauthenticated')) {
+            echo "invalid\n";
+        } else {
+            echo "ok\n"; // network error, not an auth error
+        }
+    }
+    exit(0);
+}
+
+// All other commands require a valid token.
+requireToken($token);
+$forge = new Forge($token);
+$org   = requireOrg($org, $forge);
+
+// ---------------------------------------------------------------------------
+// call <method>  (read-only generic dispatch)
+// ---------------------------------------------------------------------------
+if ($cmd === 'call') {
+    $method = $positional[0] ?? '';
+    check($method !== '', "call requires a method name. Usage: forge.php call <method>");
+
+    // Allowlist gate (authoritative — closed set)
+    if (!in_array($method, READ_ALLOWLIST, true)) {
+        fwrite(STDERR, "Method '$method' is not on the read allowlist.\n");
+        fwrite(STDERR, "Allowed methods: " . implode(', ', READ_ALLOWLIST) . "\n");
+        exit(1);
+    }
+    // Defense-in-depth: also block raw transports
+    if (in_array(strtolower($method), RAW_TRANSPORTS, true)) {
+        fwrite(STDERR, "Raw transport '$method' is blocked.\n");
+        exit(1);
+    }
+
+    check(method_exists($forge, $method), "Method '$method' does not exist on the Forge SDK.");
+
+    $stdin = stream_get_contents(STDIN);
+    $jsonArgs = ($stdin !== false && $stdin !== '') ? json_decode(trim($stdin), true) : [];
+    if ($jsonArgs === null) {
+        fwrite(STDERR, "Invalid JSON on stdin.\n");
+        exit(1);
+    }
+    // Prepend org slug as first argument (all SDK v4 read methods take it first)
+    array_unshift($jsonArgs, $org);
+
+    try {
+        $result = $forge->$method(...$jsonArgs);
+        if (is_iterable($result)) {
+            $rows = [];
+            foreach ($result as $item) {
+                $rows[] = method_exists($item, 'toArray') ? $item->toArray() : (array)$item;
+            }
+            echo json_encode($rows, JSON_PRETTY_PRINT) . "\n";
+        } elseif (is_object($result)) {
+            echo json_encode(method_exists($result, 'toArray') ? $result->toArray() : (array)$result, JSON_PRETTY_PRINT) . "\n";
+        } else {
+            echo json_encode($result, JSON_PRETTY_PRINT) . "\n";
+        }
+    } catch (\Throwable $e) {
+        fwrite(STDERR, "SDK error: " . $e->getMessage() . "\n");
+        exit(1);
+    }
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// servers
+// ---------------------------------------------------------------------------
+if ($cmd === 'servers') {
+    $servers = $forge->servers($org);
+    foreach ($servers as $s) {
+        printf("%-6s  %-30s  %s\n", $s->id, $s->name, $s->ipAddress);
+    }
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// server <id>
+// ---------------------------------------------------------------------------
+if ($cmd === 'server') {
+    check(isset($positional[0]), "Usage: forge.php server <server>");
+    $server = resolveServer($forge, $org, $positional[0]);
+    echo json_encode((array)$server, JSON_PRETTY_PRINT) . "\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// sites <server>
+// ---------------------------------------------------------------------------
+if ($cmd === 'sites') {
+    check(isset($positional[0]), "Usage: forge.php sites <server>");
+    $server = resolveServer($forge, $org, $positional[0]);
+    $sites  = $forge->serverSites($org, $server->id);
+    foreach ($sites as $s) {
+        printf("%-6s  %s\n", $s->id, $s->name);
+    }
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// site <server> <site>
+// ---------------------------------------------------------------------------
+if ($cmd === 'site') {
+    check(isset($positional[1]), "Usage: forge.php site <server> <site>");
+    $server = resolveServer($forge, $org, $positional[0]);
+    $site   = resolveSite($forge, $org, $server, $positional[1]);
+    echo json_encode((array)$site, JSON_PRETTY_PRINT) . "\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// logs <server> <site> [--log-type deploy|site]
+// ---------------------------------------------------------------------------
+if ($cmd === 'logs') {
+    check(isset($positional[1]), "Usage: forge.php logs <server> <site>");
+    $server = resolveServer($forge, $org, $positional[0]);
+    $site   = resolveSite($forge, $org, $server, $positional[1]);
+
+    // Get the latest deployment and fetch its log.
+    $deployments = $forge->deployments($org, $server->id, $site->id);
+    $latest = null;
+    foreach ($deployments as $d) { $latest = $d; break; }
+
+    if ($latest === null) {
+        echo "(no deployments found)\n";
+        exit(0);
+    }
+    $log = $forge->deploymentLog($org, $server->id, $site->id, $latest->id);
+    echo $log . "\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// server-log <server> <key>
+// ---------------------------------------------------------------------------
+if ($cmd === 'server-log') {
+    check(isset($positional[1]), "Usage: forge.php server-log <server> <key>");
+    $server = resolveServer($forge, $org, $positional[0]);
+    $log    = $forge->serverLog($org, $server->id, $positional[1]);
+    echo $log . "\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// deploy-history <server> <site>
+// ---------------------------------------------------------------------------
+if ($cmd === 'deploy-history') {
+    check(isset($positional[1]), "Usage: forge.php deploy-history <server> <site>");
+    $server      = resolveServer($forge, $org, $positional[0]);
+    $site        = resolveSite($forge, $org, $server, $positional[1]);
+    $deployments = $forge->deployments($org, $server->id, $site->id);
+    foreach ($deployments as $d) {
+        $commitMsg = $d->commit->message ?? '(no commit)';
+        $short     = substr($commitMsg, 0, 60);
+        printf("%-8s  %-12s  %s\n", $d->id, $d->status, $short);
+    }
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// deploy-log <server> <site> <deploy-id>
+// ---------------------------------------------------------------------------
+if ($cmd === 'deploy-log') {
+    check(isset($positional[2]), "Usage: forge.php deploy-log <server> <site> <deploy-id>");
+    $server   = resolveServer($forge, $org, $positional[0]);
+    $site     = resolveSite($forge, $org, $server, $positional[1]);
+    $deployId = $positional[2];
+    $log      = $forge->deploymentLog($org, $server->id, $site->id, $deployId);
+    echo $log . "\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// preview-deploy <server> <site>  (read-only, no hook gate needed)
+// ---------------------------------------------------------------------------
+if ($cmd === 'preview-deploy') {
+    check(isset($positional[1]), "Usage: forge.php preview-deploy <server> <site>");
+    $server = resolveServer($forge, $org, $positional[0]);
+    $site   = resolveSite($forge, $org, $server, $positional[1]);
+    echo "--- Deploy preview (no action taken) ---\n";
+    printCanonicalSite($server, $site);
+    echo "Run: forge.php deploy {$positional[0]} {$positional[1]} --confirm\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// preview-reboot <server>  (read-only)
+// ---------------------------------------------------------------------------
+if ($cmd === 'preview-reboot') {
+    check(isset($positional[0]), "Usage: forge.php preview-reboot <server>");
+    $server = resolveServer($forge, $org, $positional[0]);
+    echo "--- Reboot preview (no action taken) ---\n";
+    printCanonicalServer($server);
+    echo "Run: forge.php server-reboot {$positional[0]} --confirm\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// deploy <server> <site> [--confirm] [--watch]
+// ---------------------------------------------------------------------------
+if ($cmd === 'deploy') {
+    check(isset($positional[1]), "Usage: forge.php deploy <server> <site> [--confirm] [--watch]");
+    if (!$hasConfirm) {
+        fwrite(STDERR, "deploy requires --confirm. Run preview-deploy first to review the target.\n");
+        exit(1);
+    }
+    $server = resolveServer($forge, $org, $positional[0]);
+    $site   = resolveSite($forge, $org, $server, $positional[1]);
+
+    $deployment = $forge->createDeployment($org, $server->id, $site->id, []);
+    echo "Deployment started: ID {$deployment->id}  status: {$deployment->status}\n";
+
+    if (!$hasWatch) exit(0);
+
+    // Poll until terminal status.
+    $maxWait = 600; // 10 minutes
+    $elapsed = 0;
+    $interval = 5;
+    while ($elapsed < $maxWait) {
+        sleep($interval);
+        $elapsed += $interval;
+        try {
+            $d = $forge->deployment($org, $server->id, $site->id, $deployment->id);
+        } catch (\Throwable $e) {
+            // 429: back off
+            if (str_contains($e->getMessage(), '429')) {
+                sleep(30);
+                $elapsed += 30;
+                continue;
+            }
+            fwrite(STDERR, "Poll error: " . $e->getMessage() . "\n");
+            exit(1);
+        }
+        $status = $d->status ?? 'unknown';
+        echo "  [{$elapsed}s] status: {$status}\n";
+
+        if (in_array($status, STATUS_SUCCESS, true)) {
+            echo "Deployment finished successfully.\n";
+            exit(0);
+        }
+        if (in_array($status, STATUS_FAILURE, true)) {
+            fwrite(STDERR, "Deployment {$status}: ID {$d->id}\n");
+            exit(2);
+        }
+        // Unknown status: treat as in-progress, keep polling.
+    }
+    fwrite(STDERR, "Timed out waiting for deployment after {$maxWait}s.\n");
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// server-reboot <server> [--confirm]
+// ---------------------------------------------------------------------------
+if ($cmd === 'server-reboot') {
+    check(isset($positional[0]), "Usage: forge.php server-reboot <server> [--confirm]");
+    if (!$hasConfirm) {
+        fwrite(STDERR, "server-reboot requires --confirm. Run preview-reboot first to review the target.\n");
+        exit(1);
+    }
+    $server = resolveServer($forge, $org, $positional[0]);
+    $forge->createServerAction($org, $server->id, ['action' => 'reboot']);
+    echo "Reboot initiated for server {$server->name} (ID: {$server->id}).\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// failed-deploys [--json]
+// ---------------------------------------------------------------------------
+if ($cmd === 'failed-deploys') {
+    $failures = [];
+    $paceCount = 0;
+
+    try {
+        $sites = $forge->organizationSites($org)->lazy();
+        foreach ($sites as $site) {
+            // Check deployment_status field if available on the site object.
+            $status = $site->deploymentStatus ?? $site->deployment_status ?? null;
+
+            if ($status === null) {
+                // No eager deployment_status — skip (scope deferred to gating).
+                continue;
+            }
+
+            if (in_array($status, STATUS_FAILURE, true)) {
+                // Fetch detail for this failure.
+                $paceCount++;
+                if ($paceCount % 10 === 0) {
+                    // Conservative pacing: brief pause every 10 detail fetches.
+                    sleep(2);
+                }
+                try {
+                    $deployments = $forge->deployments($org, $site->serverId, $site->id);
+                    $latest = null;
+                    foreach ($deployments as $d) { $latest = $d; break; }
+
+                    $failures[] = [
+                        'site_id'    => $site->id,
+                        'site_name'  => $site->name,
+                        'server_id'  => $site->serverId,
+                        'status'     => $status,
+                        'deploy_id'  => $latest?->id,
+                        'deploy_status' => $latest?->status,
+                        'commit'     => $latest?->commit?->message ?? null,
+                    ];
+                } catch (\Throwable $e) {
+                    if (str_contains($e->getMessage(), '429')) {
+                        sleep(30);
+                    }
+                    $failures[] = [
+                        'site_id'   => $site->id,
+                        'site_name' => $site->name,
+                        'server_id' => $site->serverId,
+                        'status'    => $status,
+                        'error'     => $e->getMessage(),
+                    ];
+                }
+            }
+        }
+    } catch (\Throwable $e) {
+        if (str_contains($e->getMessage(), '429')) {
+            fwrite(STDERR, "Rate limited. Try again in a minute.\n");
+            exit(1);
+        }
+        fwrite(STDERR, "Error scanning sites: " . $e->getMessage() . "\n");
+        exit(1);
+    }
+
+    if ($hasJson) {
+        echo json_encode($failures, JSON_PRETTY_PRINT) . "\n";
+        exit(0);
+    }
+
+    if (count($failures) === 0) {
+        echo "No failed deployments found.\n";
+        exit(0);
+    }
+
+    echo count($failures) . " site(s) with failed latest deployment:\n";
+    foreach ($failures as $f) {
+        echo "  Site: {$f['site_name']} (ID: {$f['site_id']}, server: {$f['server_id']})\n";
+        echo "    Status: {$f['status']}" . (isset($f['commit']) ? "  Commit: " . substr($f['commit'], 0, 80) : '') . "\n";
+    }
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Unknown command
+// ---------------------------------------------------------------------------
+fwrite(STDERR, "Unknown command '$cmd'. Run forge.php --help for usage.\n");
+exit(1);

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -68,47 +68,10 @@ $token = getenv('FORGE_API_TOKEN') ?: '';
 $org   = getenv('FORGE_ORG') ?: '';
 
 // ---------------------------------------------------------------------------
-// Read-only allowlist: closed, authoritative set of SDK read methods.
-// Generic dispatch via `call <method>` only resolves names in this set.
-// A denylist of mutator patterns (create*, delete*, *Action) is kept as
-// defense-in-depth but is NOT the primary gate.
+// Shared helpers + constants — one file so the tests exercise the same code
+// the CLI ships (see forge-lib.php).
 // ---------------------------------------------------------------------------
-const READ_ALLOWLIST = [
-    'servers', 'server',
-    'organizationSites', 'serverSites', 'site',
-    'deployments', 'deployment', 'deploymentLog',
-    'serverLog',
-    'jobs', 'job',
-    'daemons', 'daemon',
-    'firewallRules', 'firewall',
-    'certificates', 'certificate',
-    'sshKeys', 'sshKey',
-    'gitProjects',
-    'organizations',
-    'regions',
-    'nginxTemplates', 'nginxTemplate',
-    'workers', 'worker',
-    'databases', 'database',
-    'databaseUsers', 'databaseUser',
-    'backups', 'backup',
-    'phpVersions',
-    'redirectRules', 'redirectRule',
-    'securityRules', 'securityRule',
-];
-
-// Mutator-pattern denylist — defense-in-depth only. The allowlist above is
-// the authoritative gate; this catches novel SDK mutators as secondary check.
-const MUTATOR_PATTERNS = ['/^create/i', '/^delete/i', '/^update/i', '/^install/i',
-                           '/^uninstall/i', '/Action$/i', '/^reset/i', '/^run/i',
-                           '/^enable/i', '/^disable/i', '/^deploy/i', '/^reboot/i'];
-const RAW_TRANSPORTS = ['get', 'post', 'put', 'patch', 'delete', 'request', 'retry'];
-
-// ---------------------------------------------------------------------------
-// Terminal and in-progress deployment status enums (confirmed against OpenAPI)
-// ---------------------------------------------------------------------------
-const STATUS_SUCCESS    = ['finished'];
-const STATUS_FAILURE    = ['failed', 'failed-build', 'cancelled'];
-const STATUS_IN_PROGRESS = ['pending', 'queued', 'deploying'];
+require_once __DIR__ . '/forge-lib.php';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -127,14 +90,21 @@ function requireToken(string $token): void {
 function requireOrg(string $org, Forge $forge): string {
     if ($org !== '') return $org;
     // Attempt to discover org from the API — only valid if there is exactly one.
+    // organizations() is a CursorPaginator; materialize all pages so count()
+    // reflects the true total, not just page 1.
     try {
-        $orgs = $forge->organizations();
+        $orgs = iterator_to_array($forge->organizations()->lazy());
     } catch (\Throwable $e) {
         fwrite(STDERR, "Could not list organizations: " . $e->getMessage() . "\n");
         fwrite(STDERR, "Set FORGE_ORG in .env to specify your organization slug.\n");
         exit(1);
     }
-    if (count($orgs) === 1) return $orgs[0]->slug;
+    $count = count($orgs);
+    if ($count === 1) return $orgs[0]->slug;
+    if ($count === 0) {
+        fwrite(STDERR, "No organizations found for this token. Check the token at https://forge.laravel.com/user-profile/api.\n");
+        exit(1);
+    }
     fwrite(STDERR, "Multiple organizations found. Set FORGE_ORG in .env to one of:\n");
     foreach ($orgs as $o) {
         fwrite(STDERR, "  {$o->slug}  ({$o->name})\n");
@@ -142,37 +112,10 @@ function requireOrg(string $org, Forge $forge): string {
     exit(1);
 }
 
-function matchServer(array $servers, string $query): array {
-    if (is_numeric($query)) {
-        $candidates = array_filter($servers, fn($s) => (string)$s->id === $query);
-        return array_values($candidates); // F4: no fallthrough to name/IP matching for numeric queries
-    }
-    return array_values(array_filter($servers, function($s) use ($query) {
-        return strcasecmp($s->name, $query) === 0 || $s->ipAddress === $query;
-    }));
-}
-
-function matchSite(array $sites, string $query): array {
-    if (is_numeric($query)) {
-        $candidates = array_filter($sites, fn($s) => (string)$s->id === $query);
-        return array_values($candidates);
-    }
-    $queryHost = strtolower(parse_url($query, PHP_URL_HOST) ?: $query);
-    return array_values(array_filter($sites, function($s) use ($query, $queryHost) {
-        if (strcasecmp($s->name, $query) === 0) return true;
-        $siteHost = strtolower(parse_url('https://' . $s->name, PHP_URL_HOST) ?: $s->name);
-        if ($siteHost === $queryHost) return true;
-        if (isset($s->aliases) && is_array($s->aliases)) {
-            foreach ($s->aliases as $alias) {
-                if (strcasecmp($alias, $query) === 0) return true;
-            }
-        }
-        return false;
-    }));
-}
-
 function resolveServer(Forge $forge, string $org, string $serverQuery): object {
-    $servers = $forge->servers($org);
+    // servers() returns a CursorPaginator — materialize all pages to a plain
+    // array so name/IP resolution sees the full estate, not just page 1.
+    $servers = iterator_to_array($forge->servers($org)->lazy());
     $candidates = matchServer($servers, $serverQuery);
     if (count($candidates) === 0) {
         fwrite(STDERR, "No server matching '$serverQuery'. Available servers:\n");
@@ -192,7 +135,8 @@ function resolveServer(Forge $forge, string $org, string $serverQuery): object {
 }
 
 function resolveSite(Forge $forge, string $org, object $server, string $siteQuery): object {
-    $sites = $forge->serverSites($org, $server->id);
+    // serverSites() returns a CursorPaginator — materialize all pages first.
+    $sites = iterator_to_array($forge->serverSites($org, $server->id)->lazy());
     $candidates = matchSite($sites, $siteQuery);
     if (count($candidates) === 0) {
         fwrite(STDERR, "No site matching '$siteQuery' on server {$server->name}. Available sites:\n");
@@ -227,7 +171,6 @@ $args = array_slice($argv, 1);
 $cmd  = array_shift($args) ?? '';
 
 $hasConfirm = in_array('--confirm', $args, true);
-$hasWatch   = in_array('--watch',   $args, true);
 $hasJson    = in_array('--json',    $args, true);
 
 $positional = array_values(array_filter($args, fn($a) => !str_starts_with($a, '--')));
@@ -237,10 +180,10 @@ $positional = array_values(array_filter($args, fn($a) => !str_starts_with($a, '-
 // ---------------------------------------------------------------------------
 if ($cmd === '' || $cmd === '--help' || $cmd === 'help') {
     echo <<<USAGE
-    Usage: forge.php <command> [args] [--confirm] [--watch] [--json]
+    Usage: forge.php <command> [args] [--confirm] [--json]
 
     Credential:
-      check                       Report token status (missing/invalid/ok)
+      check                       Report token status (missing/invalid/unreachable/ok)
 
     Read commands:
       servers                     List all servers
@@ -251,14 +194,15 @@ if ($cmd === '' || $cmd === '--help' || $cmd === 'help') {
       server-log <server> <key>   Read a server log by key
       deploy-history <server> <site>          List recent deployments
       deploy-log <server> <site> <deploy-id>  Fetch a specific deployment log
+      deploy-status <server-id> <site-id> <deploy-id>  Print a deployment's status (raw IDs)
 
     Preview commands (read-only, never mutate):
       preview-deploy <server> <site>  Show canonical target before deploying
       preview-reboot <server>         Show canonical target before rebooting
 
     Write commands (require --confirm):
-      deploy <server> <site> [--watch]   Trigger deployment (--watch polls until done)
-      server-reboot <server>             Reboot server
+      deploy <server> <site>      Trigger deployment (fire-and-return; watch via deploy-status)
+      server-reboot <server>      Reboot server
 
     Estate scan:
       failed-deploys [--json]     Find sites with a failed latest deployment
@@ -287,7 +231,7 @@ if ($cmd === 'check') {
         if (str_contains($msg, '401') || str_contains($msg, 'Unauthorized') || str_contains($msg, 'unauthenticated')) {
             echo "invalid\n";
         } else {
-            echo "ok\n"; // network error, not an auth error
+            echo "unreachable\n"; // network/egress error, not an auth rejection
         }
     }
     exit(0);
@@ -321,12 +265,17 @@ if ($cmd === 'call') {
 
     $stdin = stream_get_contents(STDIN);
     $jsonArgs = ($stdin !== false && $stdin !== '') ? json_decode(trim($stdin), true) : [];
-    if ($jsonArgs === null) {
-        fwrite(STDERR, "Invalid JSON on stdin.\n");
+    if (!is_array($jsonArgs)) {
+        // Catches both decode failure (null) and valid-but-non-array JSON
+        // (a bare string/number would crash the ...spread below).
+        fwrite(STDERR, "stdin must be a JSON array of arguments (e.g. '[\"server-id\"]').\n");
         exit(1);
     }
-    // Prepend org slug as first argument (all SDK v4 read methods take it first)
-    array_unshift($jsonArgs, $org);
+    // Prepend org slug as first argument — most SDK v4 read methods take it
+    // first, but a few global ones (organizations, regions) take no org.
+    if (!in_array($method, NO_ORG_METHODS, true)) {
+        array_unshift($jsonArgs, $org);
+    }
 
     try {
         $result = $forge->$method(...$jsonArgs);
@@ -352,8 +301,7 @@ if ($cmd === 'call') {
 // servers
 // ---------------------------------------------------------------------------
 if ($cmd === 'servers') {
-    $servers = $forge->servers($org);
-    foreach ($servers as $s) {
+    foreach ($forge->servers($org)->lazy() as $s) {
         printf("%-6s  %-30s  %s\n", $s->id, $s->name, $s->ipAddress);
     }
     exit(0);
@@ -375,8 +323,7 @@ if ($cmd === 'server') {
 if ($cmd === 'sites') {
     check(isset($positional[0]), "Usage: forge.php sites <server>");
     $server = resolveServer($forge, $org, $positional[0]);
-    $sites  = $forge->serverSites($org, $server->id);
-    foreach ($sites as $s) {
+    foreach ($forge->serverSites($org, $server->id)->lazy() as $s) {
         printf("%-6s  %s\n", $s->id, $s->name);
     }
     exit(0);
@@ -449,7 +396,7 @@ if ($cmd === 'deploy-log') {
     check(isset($positional[2]), "Usage: forge.php deploy-log <server> <site> <deploy-id>");
     $server   = resolveServer($forge, $org, $positional[0]);
     $site     = resolveSite($forge, $org, $server, $positional[1]);
-    $deployId = $positional[2];
+    $deployId = (int)$positional[2];   // SDK param is int; argv gives a string under strict_types
     $log      = $forge->deploymentLog($org, $server->id, $site->id, $deployId);
     echo $log . "\n";
     exit(0);
@@ -481,10 +428,15 @@ if ($cmd === 'preview-reboot') {
 }
 
 // ---------------------------------------------------------------------------
-// deploy <server> <site> [--confirm] [--watch]
+// deploy <server> <site> --confirm   (fire-and-return)
+//
+// Triggers the deployment and returns immediately with the canonical IDs.
+// Watching is decoupled: the forge-deploy skill arms a CC Monitor that polls
+// `deploy-status` until terminal, so a long deploy never blocks a foreground
+// Bash call (which the tool would kill at its timeout).
 // ---------------------------------------------------------------------------
 if ($cmd === 'deploy') {
-    check(isset($positional[1]), "Usage: forge.php deploy <server> <site> [--confirm] [--watch]");
+    check(isset($positional[1]), "Usage: forge.php deploy <server> <site> --confirm");
     if (!$hasConfirm) {
         fwrite(STDERR, "deploy requires --confirm. Run preview-deploy first to review the target.\n");
         exit(1);
@@ -493,44 +445,30 @@ if ($cmd === 'deploy') {
     $site   = resolveSite($forge, $org, $server, $positional[1]);
 
     $deployment = $forge->createDeployment($org, $server->id, $site->id, []);
-    echo "Deployment started: ID {$deployment->id}  status: {$deployment->status}\n";
+    echo "Deployment started: deploy-id={$deployment->id} server-id={$server->id} site-id={$site->id} status={$deployment->status}\n";
+    echo "Watch with: forge.php deploy-status {$server->id} {$site->id} {$deployment->id}\n";
+    exit(0);
+}
 
-    if (!$hasWatch) exit(0);
-
-    // Poll until terminal status.
-    $maxWait = 600; // 10 minutes
-    $elapsed = 0;
-    $interval = 5;
-    while ($elapsed < $maxWait) {
-        sleep($interval);
-        $elapsed += $interval;
-        try {
-            $d = $forge->deployment($org, $server->id, $site->id, $deployment->id);
-        } catch (\Throwable $e) {
-            // 429: back off
-            if (str_contains($e->getMessage(), '429')) {
-                sleep(30);
-                $elapsed += 30;
-                continue;
-            }
-            fwrite(STDERR, "Poll error: " . $e->getMessage() . "\n");
-            exit(1);
-        }
-        $status = $d->status ?? 'unknown';
-        echo "  [{$elapsed}s] status: {$status}\n";
-
-        if (in_array($status, STATUS_SUCCESS, true)) {
-            echo "Deployment finished successfully.\n";
-            exit(0);
-        }
-        if (in_array($status, STATUS_FAILURE, true)) {
-            fwrite(STDERR, "Deployment {$status}: ID {$d->id}\n");
-            exit(2);
-        }
-        // Unknown status: treat as in-progress, keep polling.
+// ---------------------------------------------------------------------------
+// deploy-status <server-id> <site-id> <deploy-id>
+//
+// Prints just the deployment status string. Takes raw numeric IDs (no
+// name/IP resolution), so it is a single API call per invocation — cheap
+// enough for a Monitor poll loop to call every few seconds.
+// ---------------------------------------------------------------------------
+if ($cmd === 'deploy-status') {
+    check(isset($positional[2]), "Usage: forge.php deploy-status <server-id> <site-id> <deploy-id>");
+    [$serverId, $siteId, $deployId] = $positional;
+    try {
+        // SDK params are int; argv gives strings and forge.php is strict_types=1.
+        $d = $forge->deployment($org, (int)$serverId, (int)$siteId, (int)$deployId);
+    } catch (\Throwable $e) {
+        fwrite(STDERR, "Status error: " . $e->getMessage() . "\n");
+        exit(1);
     }
-    fwrite(STDERR, "Timed out waiting for deployment after {$maxWait}s.\n");
-    exit(1);
+    echo ($d->status ?? 'unknown') . "\n";
+    exit(0);
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/laravel-forge-hermit/php/tests/run.php
+++ b/plugins/laravel-forge-hermit/php/tests/run.php
@@ -17,10 +17,14 @@ if (!file_exists($vendorAutoload)) {
 }
 require_once $vendorAutoload;
 
+// Test against the shipped code, not a re-implementation.
+require_once __DIR__ . '/../forge-lib.php';
+
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Laravel\Forge\CursorPaginator;
 use Laravel\Forge\Forge;
 
 // ---------------------------------------------------------------------------
@@ -38,42 +42,6 @@ function check(bool $cond, string $msg): void {
         fwrite(STDERR, "  ✗ $msg\n");
         $failed++;
     }
-}
-
-// ---------------------------------------------------------------------------
-// Load forge.php helpers without running main dispatch.
-// We define $argv so the arg-parsing section is skipped.
-// ---------------------------------------------------------------------------
-// Pull in the pure functions by including forge.php but guarding on a flag.
-define('FORGE_PHP_TEST_MODE', true);
-
-// Re-implemented locally to keep tests self-contained; avoids coupling to forge.php's include structure.
-
-function matchServer(array $servers, string $query): array {
-    if (is_numeric($query)) {
-        return array_values(array_filter($servers, fn($s) => (string)$s->id === $query));
-    }
-    return array_values(array_filter($servers, function($s) use ($query) {
-        return strcasecmp($s->name, $query) === 0 || ($s->ipAddress ?? '') === $query;
-    }));
-}
-
-function matchSite(array $sites, string $query): array {
-    if (is_numeric($query)) {
-        return array_values(array_filter($sites, fn($s) => (string)$s->id === $query));
-    }
-    $queryHost = strtolower(parse_url($query, PHP_URL_HOST) ?: $query);
-    return array_values(array_filter($sites, function($s) use ($query, $queryHost) {
-        if (strcasecmp($s->name, $query) === 0) return true;
-        $siteHost = strtolower(parse_url('https://' . $s->name, PHP_URL_HOST) ?: $s->name);
-        if ($siteHost === $queryHost) return true;
-        if (isset($s->aliases) && is_array($s->aliases)) {
-            foreach ($s->aliases as $alias) {
-                if (strcasecmp($alias, $query) === 0) return true;
-            }
-        }
-        return false;
-    }));
 }
 
 // ---------------------------------------------------------------------------
@@ -145,21 +113,43 @@ $result = matchSite($sites, 'notfound.com');
 check(count($result) === 0, 'no match returns empty');
 
 // ---------------------------------------------------------------------------
-// Tests: READ_ALLOWLIST gate (generic dispatch)
-// The allowlist is defined in forge.php; replicate it here for the test.
+// Tests: B1 regression — paginator coercion
+//
+// servers() returns a CursorPaginator, not an array. resolveServer() must
+// materialize it with iterator_to_array($p->lazy()) before calling matchServer
+// (typed `array`); under declare(strict_types=1) the raw paginator/generator
+// would be a fatal TypeError. This drives the REAL SDK paginator so a reverted
+// coercion is caught.
+// ---------------------------------------------------------------------------
+echo "\nPaginator coercion (B1):\n";
+
+$serversBody = json_encode(['data' => [
+    ['id' => 1, 'name' => 'prod-web', 'ip_address' => '10.0.0.1'],
+    ['id' => 2, 'name' => 'prod-db',  'ip_address' => '10.0.0.2'],
+], 'meta' => ['next_cursor' => null]]);
+
+[$forge] = makeMockForge([new Response(200, [], $serversBody)]);
+$paginator = $forge->servers('my-org');
+check($paginator instanceof CursorPaginator, 'servers() returns a CursorPaginator, not an array');
+
+$threw = false;
+try {
+    // @phpstan-ignore-next-line — intentionally passing a non-array to prove the gate.
+    matchServer($paginator->lazy(), 'prod-db');
+} catch (\TypeError $e) {
+    $threw = true;
+}
+check($threw, 'raw paginator/generator into matchServer() throws TypeError (coercion required)');
+
+$materialized = iterator_to_array($paginator->lazy());
+check(is_array($materialized), 'iterator_to_array(->lazy()) materializes to a plain array');
+$resolved = matchServer($materialized, 'prod-db');
+check(count($resolved) === 1 && $resolved[0]->id === 2, 'coerced paginator resolves through matchServer');
+
+// ---------------------------------------------------------------------------
+// Tests: READ_ALLOWLIST gate (generic dispatch) — constants from forge-lib.php
 // ---------------------------------------------------------------------------
 echo "\nRead-only dispatch gate:\n";
-const READ_ALLOWLIST = [
-    'servers', 'server', 'organizationSites', 'serverSites', 'site',
-    'deployments', 'deployment', 'deploymentLog', 'serverLog',
-    'jobs', 'job', 'daemons', 'daemon', 'firewallRules', 'firewall',
-    'certificates', 'certificate', 'sshKeys', 'sshKey', 'gitProjects',
-    'organizations', 'regions', 'nginxTemplates', 'nginxTemplate',
-    'workers', 'worker', 'databases', 'database', 'databaseUsers',
-    'databaseUser', 'backups', 'backup', 'phpVersions',
-    'redirectRules', 'redirectRule', 'securityRules', 'securityRule',
-];
-const RAW_TRANSPORTS = ['get', 'post', 'put', 'patch', 'delete', 'request', 'retry'];
 
 function isAllowed(string $method): bool {
     if (in_array($method, RAW_TRANSPORTS, true)) return false;
@@ -176,7 +166,15 @@ check(isAllowed('deployment'), 'deployment allowed');
 check(isAllowed('serverLog'), 'serverLog allowed');
 
 // ---------------------------------------------------------------------------
-// Tests: SDK write commands require --confirm (via MockHandler — no real calls)
+// Tests: NO_ORG_METHODS — org slug must not be prepended for global methods
+// ---------------------------------------------------------------------------
+echo "\nNo-org methods:\n";
+check(in_array('organizations', NO_ORG_METHODS, true), 'organizations is org-less');
+check(!in_array('servers', NO_ORG_METHODS, true), 'servers takes an org slug');
+check(!in_array('organizationSites', NO_ORG_METHODS, true), 'organizationSites takes an org slug');
+
+// ---------------------------------------------------------------------------
+// Tests: SDK write commands are absent from the read allowlist
 // ---------------------------------------------------------------------------
 echo "\nWrite gate (--confirm required):\n";
 
@@ -184,12 +182,9 @@ check(!in_array('createDeployment', READ_ALLOWLIST, true), 'createDeployment abs
 check(!in_array('createServerAction', READ_ALLOWLIST, true), 'createServerAction absent from read allowlist');
 
 // ---------------------------------------------------------------------------
-// Tests: status enum completeness
+// Tests: status enum completeness — constants from forge-lib.php
 // ---------------------------------------------------------------------------
 echo "\nStatus enums:\n";
-const STATUS_SUCCESS     = ['finished'];
-const STATUS_FAILURE     = ['failed', 'failed-build', 'cancelled'];
-const STATUS_IN_PROGRESS = ['pending', 'queued', 'deploying'];
 
 // Ensure terminal and in-progress sets are disjoint.
 $allTerminal = array_merge(STATUS_SUCCESS, STATUS_FAILURE);
@@ -198,7 +193,7 @@ check(count($overlap) === 0, 'terminal and in-progress sets are disjoint');
 
 // Unknown status must not be in any terminal set (treat as still-running).
 check(!in_array('unknown', $allTerminal, true), 'unknown status not in terminal set');
-check(!in_array('unknown', STATUS_IN_PROGRESS, true), 'unknown status not in in-progress set — treated as still-running by watch loop');
+check(!in_array('unknown', STATUS_IN_PROGRESS, true), 'unknown status not in in-progress set — treated as still-running by watch');
 
 // ---------------------------------------------------------------------------
 // Summary

--- a/plugins/laravel-forge-hermit/php/tests/run.php
+++ b/plugins/laravel-forge-hermit/php/tests/run.php
@@ -1,0 +1,207 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+// Dependency-free PHP test harness for forge.php
+//
+// Uses an explicit check() helper — NOT PHP's assert(), which is a no-op when
+// zend.assertions=-1 (the production php.ini default).
+//
+// Requires a vendor tree at php/vendor/ (run `composer install --working-dir=php`
+// before this script). In CI: `composer install --no-dev --working-dir=php`.
+
+$vendorAutoload = __DIR__ . '/../vendor/autoload.php';
+if (!file_exists($vendorAutoload)) {
+    fwrite(STDERR, "vendor/autoload.php not found. Run: composer install --working-dir=php/\n");
+    exit(1);
+}
+require_once $vendorAutoload;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Laravel\Forge\Forge;
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+$passed = 0;
+$failed = 0;
+
+function check(bool $cond, string $msg): void {
+    global $passed, $failed;
+    if ($cond) {
+        echo "  ✓ $msg\n";
+        $passed++;
+    } else {
+        fwrite(STDERR, "  ✗ $msg\n");
+        $failed++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Load forge.php helpers without running main dispatch.
+// We define $argv so the arg-parsing section is skipped.
+// ---------------------------------------------------------------------------
+// Pull in the pure functions by including forge.php but guarding on a flag.
+define('FORGE_PHP_TEST_MODE', true);
+
+// Re-implemented locally to keep tests self-contained; avoids coupling to forge.php's include structure.
+
+function matchServer(array $servers, string $query): array {
+    if (is_numeric($query)) {
+        return array_values(array_filter($servers, fn($s) => (string)$s->id === $query));
+    }
+    return array_values(array_filter($servers, function($s) use ($query) {
+        return strcasecmp($s->name, $query) === 0 || ($s->ipAddress ?? '') === $query;
+    }));
+}
+
+function matchSite(array $sites, string $query): array {
+    if (is_numeric($query)) {
+        return array_values(array_filter($sites, fn($s) => (string)$s->id === $query));
+    }
+    $queryHost = strtolower(parse_url($query, PHP_URL_HOST) ?: $query);
+    return array_values(array_filter($sites, function($s) use ($query, $queryHost) {
+        if (strcasecmp($s->name, $query) === 0) return true;
+        $siteHost = strtolower(parse_url('https://' . $s->name, PHP_URL_HOST) ?: $s->name);
+        if ($siteHost === $queryHost) return true;
+        if (isset($s->aliases) && is_array($s->aliases)) {
+            foreach ($s->aliases as $alias) {
+                if (strcasecmp($alias, $query) === 0) return true;
+            }
+        }
+        return false;
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Helper: make a Forge instance backed by a MockHandler
+// ---------------------------------------------------------------------------
+function makeMockForge(array $responses): array {
+    $mock    = new MockHandler($responses);
+    $stack   = HandlerStack::create($mock);
+    $guzzle  = new Client(['handler' => $stack]);
+    $forge   = new Forge('test-token', $guzzle);
+    return [$forge, $mock];
+}
+
+function fakeServer(int $id, string $name, string $ip): object {
+    return (object)['id' => $id, 'name' => $name, 'ipAddress' => $ip];
+}
+
+function fakeSite(int $id, string $name, array $aliases = []): object {
+    return (object)['id' => $id, 'name' => $name, 'aliases' => $aliases];
+}
+
+// ---------------------------------------------------------------------------
+// Tests: matchServer
+// ---------------------------------------------------------------------------
+echo "\nmatchServer:\n";
+$servers = [fakeServer(1, 'prod-web', '10.0.0.1'), fakeServer(2, 'prod-db', '10.0.0.2'), fakeServer(3, 'prod-web', '10.0.0.3')];
+
+$result = matchServer($servers, 'prod-db');
+check(count($result) === 1 && $result[0]->id === 2, 'name match returns single result');
+
+$result = matchServer($servers, '10.0.0.1');
+check(count($result) === 1 && $result[0]->id === 1, 'IP match');
+
+$result = matchServer($servers, '1');
+check(count($result) === 1 && $result[0]->id === 1, 'numeric ID match');
+
+$result = matchServer($servers, 'prod-web');
+check(count($result) === 2, 'duplicate name returns multiple candidates (ambiguity rejection test data)');
+
+$result = matchServer($servers, 'nonexistent');
+check(count($result) === 0, 'no match returns empty');
+
+// ---------------------------------------------------------------------------
+// Tests: matchSite
+// ---------------------------------------------------------------------------
+echo "\nmatchSite:\n";
+$sites = [
+    fakeSite(10, 'myapp.com', ['www.myapp.com']),
+    fakeSite(11, 'api.myapp.com'),
+    fakeSite(12, 'myapp.com'),   // duplicate name
+];
+
+$result = matchSite($sites, 'myapp.com');
+check(count($result) === 2, 'duplicate name → multiple candidates');
+
+$result = matchSite($sites, 'api.myapp.com');
+check(count($result) === 1 && $result[0]->id === 11, 'exact name match');
+
+$result = matchSite($sites, 'www.myapp.com');
+check(count($result) === 1 && $result[0]->id === 10, 'alias match');
+
+$result = matchSite($sites, '10');
+check(count($result) === 1 && $result[0]->id === 10, 'numeric ID match');
+
+$result = matchSite($sites, 'https://api.myapp.com/path');
+check(count($result) === 1 && $result[0]->id === 11, 'URL hostname match');
+
+$result = matchSite($sites, 'notfound.com');
+check(count($result) === 0, 'no match returns empty');
+
+// ---------------------------------------------------------------------------
+// Tests: READ_ALLOWLIST gate (generic dispatch)
+// The allowlist is defined in forge.php; replicate it here for the test.
+// ---------------------------------------------------------------------------
+echo "\nRead-only dispatch gate:\n";
+const READ_ALLOWLIST = [
+    'servers', 'server', 'organizationSites', 'serverSites', 'site',
+    'deployments', 'deployment', 'deploymentLog', 'serverLog',
+    'jobs', 'job', 'daemons', 'daemon', 'firewallRules', 'firewall',
+    'certificates', 'certificate', 'sshKeys', 'sshKey', 'gitProjects',
+    'organizations', 'regions', 'nginxTemplates', 'nginxTemplate',
+    'workers', 'worker', 'databases', 'database', 'databaseUsers',
+    'databaseUser', 'backups', 'backup', 'phpVersions',
+    'redirectRules', 'redirectRule', 'securityRules', 'securityRule',
+];
+const RAW_TRANSPORTS = ['get', 'post', 'put', 'patch', 'delete', 'request', 'retry'];
+
+function isAllowed(string $method): bool {
+    if (in_array($method, RAW_TRANSPORTS, true)) return false;
+    return in_array($method, READ_ALLOWLIST, true);
+}
+
+check(!isAllowed('createDeployment'), 'createDeployment rejected (mutator)');
+check(!isAllowed('deleteServer'), 'deleteServer rejected (mutator)');
+check(!isAllowed('post'), 'post rejected (raw transport)');
+check(!isAllowed('get'), 'get rejected (raw transport)');
+check(!isAllowed('rebootServer'), 'rebootServer rejected (not on allowlist)');
+check(isAllowed('servers'), 'servers allowed');
+check(isAllowed('deployment'), 'deployment allowed');
+check(isAllowed('serverLog'), 'serverLog allowed');
+
+// ---------------------------------------------------------------------------
+// Tests: SDK write commands require --confirm (via MockHandler — no real calls)
+// ---------------------------------------------------------------------------
+echo "\nWrite gate (--confirm required):\n";
+
+check(!in_array('createDeployment', READ_ALLOWLIST, true), 'createDeployment absent from read allowlist');
+check(!in_array('createServerAction', READ_ALLOWLIST, true), 'createServerAction absent from read allowlist');
+
+// ---------------------------------------------------------------------------
+// Tests: status enum completeness
+// ---------------------------------------------------------------------------
+echo "\nStatus enums:\n";
+const STATUS_SUCCESS     = ['finished'];
+const STATUS_FAILURE     = ['failed', 'failed-build', 'cancelled'];
+const STATUS_IN_PROGRESS = ['pending', 'queued', 'deploying'];
+
+// Ensure terminal and in-progress sets are disjoint.
+$allTerminal = array_merge(STATUS_SUCCESS, STATUS_FAILURE);
+$overlap = array_intersect($allTerminal, STATUS_IN_PROGRESS);
+check(count($overlap) === 0, 'terminal and in-progress sets are disjoint');
+
+// Unknown status must not be in any terminal set (treat as still-running).
+check(!in_array('unknown', $allTerminal, true), 'unknown status not in terminal set');
+check(!in_array('unknown', STATUS_IN_PROGRESS, true), 'unknown status not in in-progress set — treated as still-running by watch loop');
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+echo "\nResults: $passed passed, $failed failed\n";
+exit($failed > 0 ? 1 : 0);

--- a/plugins/laravel-forge-hermit/settings.json
+++ b/plugins/laravel-forge-hermit/settings.json
@@ -1,0 +1,26 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(php *php/forge.php *)",
+      "Bash(${CLAUDE_PLUGIN_ROOT}/php/forge.php *)",
+      "Bash(bun test*)",
+      "Bash(git status)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Edit(.claude-code-hermit/**)",
+      "Write(.claude-code-hermit/**)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)",
+      "Bash(chmod 777*)",
+      "Bash(curl * | bash*)",
+      "Bash(wget * | bash*)",
+      "Edit(.env)",
+      "Write(.env)",
+      "Edit(**/.claude-code-hermit/OPERATOR.md)",
+      "Write(**/.claude-code-hermit/OPERATOR.md)"
+    ]
+  }
+}

--- a/plugins/laravel-forge-hermit/skills/forge-deploy/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-deploy/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: forge-deploy
+description: Deploy a site on Laravel Forge. Always surface-then-approve (preview-deploy first, then deploy --confirm on explicit approval). Optionally watches until done and writes a deploy-incident on failure. Triggers on "deploy", "trigger deployment", "deploy site", "run deployment", "check deployment status".
+---
+
+# Forge Deploy
+
+Trigger a deployment on a Forge site. **Always preview before deploying.** A wrong deploy targets the wrong site — preview eliminates that risk.
+
+---
+
+## Surface-then-approve flow
+
+### Step 1 — Preview (read-only, never mutates)
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php preview-deploy <server> <site>
+```
+
+Resolves `<server>` and `<site>` to their canonical SDK records and prints:
+
+```
+--- Deploy preview (no action taken) ---
+Server: prod-web-01 (ID: 12345, IP: 1.2.3.4)
+Site:   myapp.com (ID: 67890)
+```
+
+Exit 0. No network write. The hook does not gate this command.
+
+### Step 2 — Relay canonical target to operator
+
+Show the canonical server name, IP, site name, and IDs. Ask for explicit approval.
+
+> "Deploy to **myapp.com** on **prod-web-01** (1.2.3.4)? Reply 'yes' to confirm or 'no' to cancel."
+
+Never auto-confirm. If the operator says anything other than an unambiguous affirmative, cancel.
+
+### Step 3 — On approval only
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy <server> <site> --confirm
+```
+
+Or with watch (polls until the deployment reaches a terminal state):
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy <server> <site> --confirm --watch
+```
+
+`--watch` polls every 5 seconds (max 10 minutes). It exits 0 on `finished`, exits 2 on `failed`/`failed-build`/`cancelled`.
+
+---
+
+## Deployment history
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy-history <server> <site>
+```
+
+Lists recent deployments with ID, status, and commit message.
+
+## Fetch a specific deployment log
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy-log <server> <site> <deploy-id>
+```
+
+---
+
+## On --watch failure: write a deploy-incident
+
+If `deploy --watch` exits 2 (deployment failed/cancelled), write a `deploy-incident` artifact:
+
+**File**: `compiled/deploy-incident-<site-name>-<YYYY-MM-DD>.md`
+
+**Content template**:
+```
+---
+title: Deploy incident — <site-name> <YYYY-MM-DD>
+created: <ISO timestamp>
+type: deploy-incident
+tags: [deploy, failure, <site-name>]
+---
+
+## Incident
+
+- Site: <site-name> (ID: <site-id>)
+- Server: <server-name> (ID: <server-id>, IP: <ip>)
+- Deployment ID: <deploy-id>
+- Status: <failed|failed-build|cancelled>
+- Detected: <timestamp>
+
+## Commit
+
+<commit message, if available>
+
+## Log tail (scrubbed)
+
+<last ~50 lines of the deployment log, **scrubbed of any credentials, env vars, or secrets**>
+
+## Resolution
+
+(fill in after incident is resolved)
+```
+
+**Secret hygiene (critical):** deployment logs frequently contain env dumps, DB connection strings, and API keys. **Never paste raw log content** — always scrub before writing. Fetch the log with `deploy-log`, review it, then excerpt only the error-relevant lines with any credential values redacted (`[REDACTED]`).
+
+---
+
+## Notes
+
+- `<server>` and `<site>` accept name, hostname, URL hostname, or numeric ID. Ambiguous names are rejected.
+- The `--confirm` flag is checked by both the in-PHP gate and the `write-confirm-gate.ts` PreToolUse hook. Omitting it always fails — there is no bypass.
+- For reading logs without a deploy action, use `/laravel-forge-hermit:forge-logs`.

--- a/plugins/laravel-forge-hermit/skills/forge-deploy/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forge-deploy
-description: Deploy a site on Laravel Forge. Always surface-then-approve (preview-deploy first, then deploy --confirm on explicit approval). Optionally watches until done and writes a deploy-incident on failure. Triggers on "deploy", "trigger deployment", "deploy site", "run deployment", "check deployment status".
+description: Deploy a site on Laravel Forge. Always surface-then-approve (preview-deploy first, then deploy --confirm on explicit approval). Watches via the hermit /watch registry and writes a deploy-incident on failure. Triggers on "deploy", "trigger deployment", "deploy site", "run deployment", "check deployment status".
 ---
 
 # Forge Deploy
@@ -35,19 +35,56 @@ Show the canonical server name, IP, site name, and IDs. Ask for explicit approva
 
 Never auto-confirm. If the operator says anything other than an unambiguous affirmative, cancel.
 
-### Step 3 — On approval only
+### Step 3 — On approval only: fire the deployment
 
 ```bash
 php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy <server> <site> --confirm
 ```
 
-Or with watch (polls until the deployment reaches a terminal state):
+This triggers the deployment and returns immediately (no blocking wait):
 
-```bash
-php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy <server> <site> --confirm --watch
+```
+Deployment started: deploy-id=991 server-id=12345 site-id=67890 status=queued
+Watch with: forge.php deploy-status 12345 67890 991
 ```
 
-`--watch` polls every 5 seconds (max 10 minutes). It exits 0 on `finished`, exits 2 on `failed`/`failed-build`/`cancelled`.
+Capture the canonical `deploy-id`, `server-id`, and `site-id` — Step 4 needs them.
+
+### Step 4 — Watch via the hermit watch registry (non-blocking)
+
+Do **not** poll in a foreground Bash call: a real deploy can outlast the Bash tool timeout, which would kill the wait and skip the incident. Arm a hermit watch instead — it runs detached, notifies you on each status change and on the terminal state at zero token cost while quiet, and is tracked in `monitors.runtime.json` (visible via `/claude-code-hermit:watch status`, cancellable via `/claude-code-hermit:watch stop`, and cleaned up at session-close).
+
+**Requires an active hermit session** — `/claude-code-hermit:watch` refuses without one. If there is no session, ask the operator to run `/claude-code-hermit:session` first (or, as a fallback, run `deploy-status` manually).
+
+Resolve `${CLAUDE_PLUGIN_ROOT}` to its **absolute path now** (at skill-execution time): the variable is NOT available inside the watch subprocess. Then arm the watch by invoking `/claude-code-hermit:watch` with this command (substitute the absolute path and the three IDs):
+
+```bash
+prev=""; n=0
+while [ "$n" -lt 180 ]; do
+  st=$(php /ABS/php/forge.php deploy-status <server-id> <site-id> <deploy-id> 2>/dev/null || true)
+  [ -n "$st" ] && [ "$st" != "$prev" ] && echo "deploy <deploy-id>: $st"
+  case "$st" in
+    finished) echo "TERMINAL deploy=<deploy-id> server-id=<server-id> site-id=<site-id> status=finished"; exit 0;;
+    failed|failed-build|cancelled) echo "TERMINAL deploy=<deploy-id> server-id=<server-id> site-id=<site-id> status=$st"; exit 0;;
+  esac
+  prev="$st"; n=$((n+1)); sleep 5
+done
+echo "TERMINAL deploy=<deploy-id> server-id=<server-id> site-id=<site-id> status=timeout"
+```
+
+The `TERMINAL` line carries only numeric IDs (never display names) — Forge server names can contain spaces, which would break the space-delimited fields.
+
+`/claude-code-hermit:watch` registers this as an ad-hoc watch (`persistent: true`, so the tool's own timeout is ignored). The loop therefore self-caps after ~15 min (180 × 5 s) and emits a `timeout` terminal line — it never becomes an unbounded watch. It is otherwise quiet, emitting only on status change. On any `TERMINAL` line the command exits and core clears the registry entry automatically; that line carries everything Step 5 needs.
+
+### Step 5 — On the terminal watch event
+
+When the `TERMINAL …` notification arrives:
+
+- **`status=finished`** → tell the operator the deploy succeeded, via the **Operator Notification protocol in CLAUDE.md** (core resolves the channel; falls back to a push). No artifact.
+- **`status=failed` / `failed-build` / `cancelled`** → (1) fetch the log with `deploy-log <server-id> <site-id> <deploy-id>` using the numeric IDs from the `TERMINAL` line, **scrub it**, and write a `deploy-incident` artifact (template below); (2) notify the operator of the failure via the **Operator Notification protocol in CLAUDE.md**, including the incident path.
+- **`status=timeout`** → the watch hit its ~15 min cap without reaching a terminal state. Notify the operator (via the **Operator Notification protocol in CLAUDE.md**) that the deploy is still unresolved and point them at `deploy-history` / `deploy-status` to follow up. No incident — a timeout is not a confirmed failure.
+
+Scrubbing happens here, in this step — never in the watch command. The watcher only emits metadata, so no raw log line is ever written by the unattended subprocess.
 
 ---
 
@@ -67,9 +104,7 @@ php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy-log <server> <site> <deploy-id>
 
 ---
 
-## On --watch failure: write a deploy-incident
-
-If `deploy --watch` exits 2 (deployment failed/cancelled), write a `deploy-incident` artifact:
+## deploy-incident artifact (written in Step 5 on a failed terminal status)
 
 **File**: `compiled/deploy-incident-<site-name>-<YYYY-MM-DD>.md`
 

--- a/plugins/laravel-forge-hermit/skills/forge-failed-deploys/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-failed-deploys/SKILL.md
@@ -21,7 +21,7 @@ Scheduled-check skill: scans the org-wide site list and flags any sites whose la
 
    This pages through the org-wide site list via `organizationSites()->lazy()` and fetches the `deployment_status` field on each site. For sites in a failure state it fetches the latest `deployments()` detail. Rate limiting (429) is handled internally with conservative pacing.
 
-2. **Parse the JSON output.** Each entry in the array has: `site_id`, `site_name`, `server_id`, `status`, optionally `deploy_id`, `deploy_status`, `commit`.
+2. **Parse the JSON output.** Each entry has: `site_id`, `site_name`, `server_id`, `status`, optionally `deploy_id`, `deploy_status`, `commit`. An entry whose detail fetch was rate-limited instead carries an `error` key (and no `deploy_id`/`commit`) — treat those as "failure, detail unavailable" and omit the commit line. Never assume all keys are present.
 
 3. **Output the findings block.** Always output to stdout, regardless of outcome. `reflect-scheduled-checks` classifies the result.
 

--- a/plugins/laravel-forge-hermit/skills/forge-failed-deploys/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-failed-deploys/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: forge-failed-deploys
+description: "Interval scheduled check — scans the Forge estate for sites whose latest deployment is in a failure state. Runs daily via the scheduled-checks routine; findings are routed through the proposal pipeline as Evidence Source: scheduled-check/forge-failed-deploys."
+---
+
+# Forge Failed Deploys
+
+Scheduled-check skill: scans the org-wide site list and flags any sites whose latest deployment status is `failed`, `failed-build`, or `cancelled`.
+
+**Contract:** idempotent, read-only, no self-scheduling, short-running. Returns findings or silence — never creates proposals itself.
+
+---
+
+## Steps
+
+1. **Run the estate scan.**
+
+   ```bash
+   php ${CLAUDE_PLUGIN_ROOT}/php/forge.php failed-deploys --json
+   ```
+
+   This pages through the org-wide site list via `organizationSites()->lazy()` and fetches the `deployment_status` field on each site. For sites in a failure state it fetches the latest `deployments()` detail. Rate limiting (429) is handled internally with conservative pacing.
+
+2. **Parse the JSON output.** Each entry in the array has: `site_id`, `site_name`, `server_id`, `status`, optionally `deploy_id`, `deploy_status`, `commit`.
+
+3. **Output the findings block.** Always output to stdout, regardless of outcome. `reflect-scheduled-checks` classifies the result.
+
+   **Failures found:**
+   ```
+   forge-failed-deploys findings — <YYYY-MM-DD>
+   Failed deployments: <N>
+   - [deploy-failure] <site_name> (server: <server_id>): status <status><commit line if available>
+   ```
+   One bullet per failed site.
+
+   **No failures:**
+   ```
+   forge-failed-deploys findings — <YYYY-MM-DD>
+   No actionable findings.
+   ```
+
+4. **Do not fetch deployment logs.** This scan surfaces sites with failures; the `forge-logs` or `forge-deploy` skills handle remediation. Fetching logs per failure during the scan would hit rate limits on large estates.
+
+---
+
+## Notes
+
+- **This skill writes no artifact.** All output goes to stdout for `reflect-scheduled-checks`.
+- **Registered by `/laravel-forge-hermit:hatch`** step 8 via a `scheduled_checks` config entry (`interval_days: 1`). The core daily `scheduled-checks` routine fires `reflect-scheduled-checks`, which picks it up once 1+ day has elapsed since `last_run`.
+- **No channel notifications** — this is analysis-only. Findings surface as `[reliability]` proposals via the normal pipeline.
+- **scope**: if `organizationSites()` does not carry `deployment_status` in your Forge plan/API version, the scan will report zero findings (not an error). Scope to `watched_sites` (set at hatch step 6) if org-wide scan is unavailable.
+- **Rate limit**: Forge allows ~60 req/min. The scan paces conservatively; if a 429 is returned mid-scan it waits 30 seconds and the scan exits with an error — the check will retry on the next scheduled run.

--- a/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: forge-logs
+description: Read site deployment logs, server logs, and specific deployment logs from Laravel Forge. Includes a triage mode that bundles recent logs with deployment history for rapid incident analysis. Triggers on "show logs", "read logs", "deployment log", "server log", "what happened to the deployment", "triage failing site".
+---
+
+# Forge Logs
+
+Read deployment and server logs from Forge.
+
+---
+
+## Latest deployment log for a site
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php logs <server> <site>
+```
+
+Fetches the most recent deployment and returns its full log.
+
+## Specific deployment log
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy-log <server> <site> <deploy-id>
+```
+
+Use `deploy-history` first to find the deployment ID.
+
+## Server log
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php server-log <server> <key>
+```
+
+Common keys: `php`, `nginx`, `mysql`, `cron`, `daemon`. Key list depends on the server's installed services.
+
+---
+
+## Triage mode
+
+When the operator says something like "what's wrong with myapp.com" or "triage the failing site", bundle context automatically:
+
+1. `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php site <server> <site>` — confirm the site is reachable and check status fields.
+2. `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy-history <server> <site>` — surface the last few deployments and their statuses.
+3. `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php logs <server> <site>` — fetch the latest deployment log.
+4. Synthesize: identify the failure type (build error, composer error, migration error, timeout), highlight the relevant log section, and suggest a remedy.
+
+---
+
+## Secret hygiene
+
+**Deployment and server logs may contain env dumps, database credentials, and API keys.** Apply these rules to every log-reading flow:
+
+- **Never paste raw log output into the channel.** Always summarize or excerpt.
+- **Never write raw log content to `compiled/` or `raw/`** — scrub any credential values to `[REDACTED]` before persistence.
+- If asked to share a log, review it first and redact any secret-pattern lines.
+
+---
+
+## Notes
+
+- `<server>` and `<site>` accept name, hostname, or numeric ID.
+- For reading logs for a failed deployment that you triggered via `forge-deploy --watch`, the `deploy-incident` artifact (written by `forge-deploy`) already contains the scrubbed log tail — check `compiled/deploy-incident-<site>-<date>.md` before re-fetching.

--- a/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
@@ -59,4 +59,4 @@ When the operator says something like "what's wrong with myapp.com" or "triage t
 ## Notes
 
 - `<server>` and `<site>` accept name, hostname, or numeric ID.
-- For reading logs for a failed deployment that you triggered via `forge-deploy --watch`, the `deploy-incident` artifact (written by `forge-deploy`) already contains the scrubbed log tail — check `compiled/deploy-incident-<site>-<date>.md` before re-fetching.
+- For a failed deployment you triggered via `forge-deploy`, the `deploy-incident` artifact (written by `forge-deploy` when its watch Monitor sees a failed terminal status) already contains the scrubbed log tail — check `compiled/deploy-incident-<site>-<date>.md` before re-fetching.

--- a/plugins/laravel-forge-hermit/skills/forge-servers/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-servers/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: forge-servers
+description: List, inspect, and reboot Laravel Forge servers. Reboot always goes through surface-then-approve (preview-reboot → confirm → server-reboot --confirm). Triggers on "list servers", "show server", "reboot server", "server status".
+---
+
+# Forge Servers
+
+List and inspect servers in the Forge estate, or reboot a server with approval.
+
+## List all servers
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php servers
+```
+
+Output: one line per server with ID, name, and IP address.
+
+## Show server detail
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php server <server>
+```
+
+`<server>` can be a server name, IP address, or numeric ID. Ambiguous names are rejected with a list of collisions.
+
+## Reboot a server (surface-then-approve)
+
+**Step 1 — Preview (read-only, no action taken):**
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php preview-reboot <server>
+```
+
+Resolves `<server>` to the canonical record and prints the server name, IP, and ID. Exit 0, no mutation.
+
+**Step 2 — Relay to operator.** Show the canonical target. Ask for explicit approval.
+
+**Step 3 — On approval only:**
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php server-reboot <server> --confirm
+```
+
+A wrong reboot causes an outage. Never auto-confirm. Never skip the preview step.
+
+## Notes
+
+- `${CLAUDE_PLUGIN_ROOT}` is substituted in installed mode. In `--plugin-dir` dev mode, use the absolute path.
+- For server logs, use `/laravel-forge-hermit:forge-logs`.
+- For site-level work, use `/laravel-forge-hermit:forge-sites`.

--- a/plugins/laravel-forge-hermit/skills/forge-sites/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-sites/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: forge-sites
+description: List and inspect sites on Laravel Forge servers. Triggers on "list sites", "show site", "site detail", "what sites are on server X".
+---
+
+# Forge Sites
+
+List sites on a server or inspect a specific site.
+
+## List sites on a server
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php sites <server>
+```
+
+`<server>` can be a server name, IP address, or numeric ID.
+
+## Show site detail
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php site <server> <site>
+```
+
+`<site>` can be a site name, URL hostname, or numeric ID. Returns the canonical site record as JSON, including ID, name, status, and repository info.
+
+## Notes
+
+- Ambiguous names (multiple matches on the same server) are rejected with a list of candidates.
+- For deployment history or triggering deploys, use `/laravel-forge-hermit:forge-deploy`.
+- For reading site or deployment logs, use `/laravel-forge-hermit:forge-logs`.

--- a/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: hatch
+description: One-time Laravel Forge hermit setup. Installs the Forge PHP SDK, verifies credentials, and wires the estate scan into config.json. Run once per project after /claude-code-hermit:hatch.
+---
+
+# Hatch — laravel-forge-hermit
+
+Idempotent setup wizard for the Laravel Forge plugin. Run **after** `/claude-code-hermit:hatch` has been completed.
+
+---
+
+## Step 1 — Prerequisite check
+
+Read `.claude-code-hermit/config.json`.
+
+If the file does not exist or `_hermit_versions["claude-code-hermit"]` is absent or empty:
+
+> "The base hermit is not set up yet. Run `/claude-code-hermit:hatch` first, then return here."
+
+Use `AskUserQuestion`: "Would you like to run `/claude-code-hermit:hatch` now? (yes / no)"
+
+- **yes** → invoke `/claude-code-hermit:hatch`, wait for completion, then continue to Step 2.
+- **no** → stop.
+
+If present but below `1.1.1` (compare major.minor.patch numerically):
+
+> "Base hermit version is {version}; this plugin requires ≥1.1.1 for scope-aware hatch routing. Run `/claude-code-hermit:hermit-evolve` to upgrade, then re-run this hatch."
+
+Stop.
+
+---
+
+## Step 2 — Idempotency check
+
+Read `_hermit_versions["laravel-forge-hermit"]` from `.claude-code-hermit/config.json`.
+
+Read `version` from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`.
+
+If the versions match:
+
+> "laravel-forge-hermit {version} is already installed. Reply 'verify' to re-run checks only, or 'full' to re-run the full wizard."
+
+Use `AskUserQuestion`: "(verify / full)"
+
+- **verify** → skip to Step 5.
+- **full** → continue from Step 3.
+
+If absent or stale: continue from Step 3.
+
+---
+
+## Step 3 — PHP/Composer preflight + SDK install
+
+**Check PHP version.** Run `php -r 'echo PHP_VERSION;'` via Bash. Parse the output. If `php` is not found or the version is below 8.5.0:
+
+> "PHP 8.5+ is required but not found (got: {version or 'not found'}).
+>
+> - **Docker**: re-run `/docker-setup` after the core base image is updated to Ubuntu 26.04 (which ships PHP 8.5 natively). If the core base is still 24.04, the Docker path is blocked pending that upgrade.
+> - **Bare-metal**: install `php8.5-cli` and `php8.5-curl` (or your distro's equivalent)."
+
+Stop.
+
+**Check Composer.** Run `composer --version`. If not found:
+
+> "Composer is not found. Install it from https://getcomposer.org/."
+
+Stop.
+
+**Install the Forge SDK into project space.** The SDK goes into `.claude-code-hermit/forge-runtime/` (hermit-owned, isolated from your app's own `composer.json`/`vendor/`).
+
+Run these Bash commands:
+
+```bash
+mkdir -p .claude-code-hermit/forge-runtime
+cp "${CLAUDE_PLUGIN_ROOT}/php/composer.json" .claude-code-hermit/forge-runtime/composer.json
+cp "${CLAUDE_PLUGIN_ROOT}/php/composer.lock" .claude-code-hermit/forge-runtime/composer.lock
+```
+
+**Idempotent install check**: if `.claude-code-hermit/forge-runtime/vendor/` exists and the staged `composer.lock` content matches `${CLAUDE_PLUGIN_ROOT}/php/composer.lock`, skip the install. Otherwise run:
+
+```bash
+composer install --no-dev --no-interaction --working-dir=.claude-code-hermit/forge-runtime
+```
+
+If composer exits non-zero, surface the error. Common cause: egress blocked — `packagist.org`, `repo.packagist.org`, `api.github.com`, `codeload.github.com` must be reachable. In Docker, verify the DNS allowlist in DOCKER.md is present.
+
+---
+
+## Step 4 — Verify .env + consumer .gitignore
+
+**Do NOT use `cat`, `grep`, `echo`, or any Bash command to read `.env`.** The `FORGE_API_TOKEN` key name contains `TOKEN`, which triggers the base hermit's deny-pattern hook on Bash args. Use the **Read tool** only — and only to check the file exists / has the key, never to relay the value.
+
+Tell the operator:
+
+> "Add your Forge API credentials to `.env` in the project root:
+>
+> ```
+> FORGE_API_TOKEN=your-forge-api-token
+> FORGE_ORG=your-org-slug        # optional if you have exactly one org
+> ```
+>
+> Get your token at https://forge.laravel.com/user-profile/api. Reply 'done' when set, or 'skip' to continue (credential check happens in Step 5)."
+
+Use `AskUserQuestion`: "(done / skip)"
+
+**Read the consumer's `.gitignore`** (this file is not a secret — only the `.env` content is). Check if `.env` and `.env.*` patterns are present. If missing, offer to add them:
+
+```
+.env
+.env.*
+```
+
+Append any missing patterns via Edit.
+
+---
+
+## Step 5 — CLI probe (credential check)
+
+Run: `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php check`
+
+- **`missing`** → tell the operator to add `FORGE_API_TOKEN` to `.env` and re-run Step 4.
+- **`invalid`** → token found but API rejected it; tell the operator to check the token at https://forge.laravel.com/user-profile/api.
+- **`ok`** → continue.
+
+If `php` is not found at this point: re-run Step 3.
+
+---
+
+## Step 6 — CLAUDE.md / CLAUDE.local.md inject
+
+**Resolve target file**: read `.claude-code-hermit/state/hatch-options.json`. Use the `"target"` field:
+- `"local"` → `target_file = CLAUDE.local.md`
+- `"committed"` or absent → `target_file = CLAUDE.md`
+- File doesn't exist: detect `core_install_scope` from `claude plugin list --json` (same logic as core hatch), ask with `AskUserQuestion` (header: "Visibility"): **`.local` files** (gitignored) / **Committed files** (shared). Write the 5-field canonical schema to `hatch-options.json`.
+
+Read `target_file`. Search for `<!-- laravel-forge-hermit: Forge Workflow -->`.
+
+- **Absent** → append the full contents of `${CLAUDE_PLUGIN_ROOT}/state-templates/CLAUDE-APPEND.md` using Edit.
+- **Present** → skip (already injected; `hermit-evolve` handles replacement on upgrade).
+
+---
+
+## Step 7 — Knowledge-schema extension
+
+Read `.claude-code-hermit/knowledge-schema.md`.
+
+Check for `deploy-incident:` in the file. If absent, append under `## Work Products`:
+
+```
+- deploy-incident: per-failure deployment record with scrubbed log tail and resolution. Producer: forge-deploy skill on --watch failure. location: compiled/deploy-incident-<site>-<YYYY-MM-DD>.md
+```
+
+Use Edit. Skip if already present (idempotent).
+
+---
+
+## Step 8 — Stamp + register in config.json
+
+Use the `config.json` content loaded in Step 1.
+
+**Stamp version**: set `_hermit_versions["laravel-forge-hermit"]` to the plugin version from Step 2.
+
+**Merge scheduled check**: check `config.scheduled_checks` for `id: "forge-failed-deploys"`. If absent, append:
+
+```json
+{"id": "forge-failed-deploys", "plugin": "laravel-forge-hermit", "skill": "laravel-forge-hermit:forge-failed-deploys", "enabled": true, "trigger": "interval", "interval_days": 1}
+```
+
+If present: skip (do not clobber).
+
+Write the updated `config.json` via Write tool (full file replacement for valid JSON).
+
+---
+
+## Step 9 — Final report
+
+```
+laravel-forge-hermit {version} setup complete.
+
+Installation summary:
+  ✓ Prerequisite: claude-code-hermit {base_version} confirmed
+  ✓ PHP 8.5+ found: {php_version}
+  ✓ Composer found
+  ✓ Forge SDK installed → .claude-code-hermit/forge-runtime/vendor/
+  ✓ .env: FORGE_API_TOKEN present, API check: ok
+  ✓ .gitignore: .env covered
+  ✓ CLAUDE.md: Forge Workflow block injected (or already present)
+  ✓ knowledge-schema.md: deploy-incident type added (or already present)
+  ✓ config.json: _hermit_versions stamped, forge-failed-deploys check registered
+
+Next steps:
+  - Restart Claude Code so the updated CLAUDE.md loads.
+  - Run /claude-code-hermit:hermit-routines load to activate the daily estate scan.
+  - In Docker: the forge-runtime/ vendor is in your project tree (bind-mounted/persistent) — it survives container restarts.
+
+Installed skills:
+  /laravel-forge-hermit:forge-servers        — list / detail / reboot servers
+  /laravel-forge-hermit:forge-sites          — list / detail sites
+  /laravel-forge-hermit:forge-deploy         — preview → approve → deploy
+  /laravel-forge-hermit:forge-logs           — read site / server / deployment logs
+  /laravel-forge-hermit:forge-failed-deploys — daily estate scan (scheduled, interval_days: 1)
+
+Security reminder: FORGE_API_TOKEN is in .env — verify it is gitignored before any git push.
+```
+
+---
+
+## Docker network requirements
+
+Read by `/claude-code-hermit:docker-security` when the operator enables LAN containment + DNS policy.
+
+### Domains (DNS allowlist)
+
+- forge.laravel.com
+- packagist.org
+- repo.packagist.org
+- api.github.com
+- codeload.github.com

--- a/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
@@ -120,6 +120,7 @@ Run: `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php check`
 
 - **`missing`** → tell the operator to add `FORGE_API_TOKEN` to `.env` and re-run Step 4.
 - **`invalid`** → token found but API rejected it; tell the operator to check the token at https://forge.laravel.com/user-profile/api.
+- **`unreachable`** → token present but the API could not be reached (network/egress blocked). In Docker, verify the DNS allowlist in DOCKER.md (`forge.laravel.com`). Re-run once connectivity is confirmed.
 - **`ok`** → continue.
 
 If `php` is not found at this point: re-run Step 3.
@@ -147,7 +148,7 @@ Read `.claude-code-hermit/knowledge-schema.md`.
 Check for `deploy-incident:` in the file. If absent, append under `## Work Products`:
 
 ```
-- deploy-incident: per-failure deployment record with scrubbed log tail and resolution. Producer: forge-deploy skill on --watch failure. location: compiled/deploy-incident-<site>-<YYYY-MM-DD>.md
+- deploy-incident: per-failure deployment record with scrubbed log tail and resolution. Producer: forge-deploy skill on a failed terminal deploy status. location: compiled/deploy-incident-<site>-<YYYY-MM-DD>.md
 ```
 
 Use Edit. Skip if already present (idempotent).

--- a/plugins/laravel-forge-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/laravel-forge-hermit/state-templates/CLAUDE-APPEND.md
@@ -1,0 +1,86 @@
+<!-- laravel-forge-hermit: Forge Workflow -->
+
+## Laravel Forge
+
+This project uses `laravel-forge-hermit` for Forge operations: deployments, server/site management, and estate health monitoring.
+
+---
+
+### Safety rule — surface-then-approve (read this first)
+
+**Every write operation goes through preview → relay → approve → confirm.** Never auto-confirm a deploy or reboot.
+
+1. Run `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php preview-deploy <server> <site>` (or `preview-reboot`).
+2. Relay the **canonical target** (server name, IP, site name, IDs) to the operator.
+3. Wait for explicit approval.
+4. On approval: re-run with `--confirm`.
+
+A wrong reboot causes an outage. A wrong deploy targets the wrong site. The `write-confirm-gate.ts` hook and the in-PHP `--confirm` gate enforce this at two layers — neither can be bypassed.
+
+---
+
+### Skills
+
+| Skill | Trigger | Purpose |
+|---|---|---|
+| `/laravel-forge-hermit:hatch` | setup | one-time install wizard |
+| `/laravel-forge-hermit:forge-servers` | "list servers", "reboot server" | server list, detail, reboot flow |
+| `/laravel-forge-hermit:forge-sites` | "list sites", "show site" | site list and detail |
+| `/laravel-forge-hermit:forge-deploy` | "deploy", "trigger deployment" | preview → approve → deploy; failure → deploy-incident |
+| `/laravel-forge-hermit:forge-logs` | "show logs", "triage site" | deployment + server logs, triage mode |
+| `/laravel-forge-hermit:forge-failed-deploys` | (scheduled, 1d) | estate scan, analysis-only |
+
+---
+
+### Tools
+
+The curated `php forge.php` commands cover the hot paths. For any other SDK read — server jobs, daemons, firewall rules, certificates, database users, etc. — use read-only generic dispatch:
+
+```bash
+# Args as JSON array on stdin; org slug is prepended automatically.
+echo '["<server-id>"]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call jobs
+echo '["<server-id>", "<site-id>"]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call certificates
+```
+
+Only read methods on the closed allowlist are accepted — this path cannot mutate anything.
+
+---
+
+### Scheduled checks
+
+| Check | Cadence | Type |
+|---|---|---|
+| `forge-failed-deploys` | daily | analysis-only, routes to `[reliability]` proposals |
+
+---
+
+### Credentials
+
+`FORGE_API_TOKEN` lives in the gitignored `.env` at the project root.
+
+- **Never `cat`, `echo`, `grep`, or Read `.env`** to check the token — run `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php check` instead. It self-reports `missing`/`invalid`/`ok` without revealing the value.
+- `TOKEN` appears in the key name: the base hermit's deny-pattern hook blocks any Bash arg containing the literal string `TOKEN`.
+
+---
+
+### Secret hygiene
+
+Deployment and server logs may contain env dumps, database credentials, and API keys. This rule applies to **channel relay AND persistence**:
+
+- Never paste raw log output into a channel message.
+- Never write raw log content to `compiled/` or `raw/`.
+- Always scrub credential-pattern lines to `[REDACTED]` before sharing or persisting.
+
+---
+
+### Proposal categories
+
+| Prefix | Meaning |
+|---|---|
+| `[reliability]` | recurring failure pattern across the estate |
+| `[hygiene]` | estate drift detected from API signals |
+| `[deploy-safety]` | workflow risk on the deploy or reboot path |
+
+---
+
+<!-- /laravel-forge-hermit: Forge Workflow -->

--- a/plugins/laravel-forge-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/laravel-forge-hermit/state-templates/CLAUDE-APPEND.md
@@ -19,38 +19,26 @@ A wrong reboot causes an outage. A wrong deploy targets the wrong site. The `wri
 
 ---
 
-### Skills
-
-| Skill | Trigger | Purpose |
-|---|---|---|
-| `/laravel-forge-hermit:hatch` | setup | one-time install wizard |
-| `/laravel-forge-hermit:forge-servers` | "list servers", "reboot server" | server list, detail, reboot flow |
-| `/laravel-forge-hermit:forge-sites` | "list sites", "show site" | site list and detail |
-| `/laravel-forge-hermit:forge-deploy` | "deploy", "trigger deployment" | preview → approve → deploy; failure → deploy-incident |
-| `/laravel-forge-hermit:forge-logs` | "show logs", "triage site" | deployment + server logs, triage mode |
-| `/laravel-forge-hermit:forge-failed-deploys` | (scheduled, 1d) | estate scan, analysis-only |
-
----
-
 ### Tools
 
-The curated `php forge.php` commands cover the hot paths. For any other SDK read — server jobs, daemons, firewall rules, certificates, database users, etc. — use read-only generic dispatch:
+Skills self-advertise through their own `SKILL.md` descriptions — they are not catalogued here. The curated `php forge.php` commands cover the hot paths. For any other SDK read — server events, firewall rules, databases, scheduled jobs, certificates, etc. — use read-only generic dispatch:
 
 ```bash
-# Args as JSON array on stdin; org slug is prepended automatically.
-echo '["<server-id>"]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call jobs
-echo '["<server-id>", "<site-id>"]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call certificates
+# Args as JSON array on stdin; the org slug is prepended automatically
+# (except global methods like `organizations` and `sites`).
+echo '["<server-id>"]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call databases
+echo '["<server-id>", "<site-id>"]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call deployments
 ```
 
 Only read methods on the closed allowlist are accepted — this path cannot mutate anything.
 
 ---
 
-### Scheduled checks
+### Scheduled checks & notifications
 
-| Check | Cadence | Type |
-|---|---|---|
-| `forge-failed-deploys` | daily | analysis-only, routes to `[reliability]` proposals |
+The `forge-failed-deploys` scheduled check is analysis-only: it surfaces sites whose latest deployment failed and routes findings through the normal proposal pipeline as `[reliability]` proposals. It sends no channel messages itself.
+
+Anything operator-facing (deploy success/failure, escalations) is relayed via the **Operator Notification protocol in CLAUDE.md** — do not build a separate notification path.
 
 ---
 
@@ -58,7 +46,7 @@ Only read methods on the closed allowlist are accepted — this path cannot muta
 
 `FORGE_API_TOKEN` lives in the gitignored `.env` at the project root.
 
-- **Never `cat`, `echo`, `grep`, or Read `.env`** to check the token — run `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php check` instead. It self-reports `missing`/`invalid`/`ok` without revealing the value.
+- **Never `cat`, `echo`, `grep`, or Read `.env`** to check the token — run `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php check` instead. It self-reports `missing`/`invalid`/`unreachable`/`ok` without revealing the value.
 - `TOKEN` appears in the key name: the base hermit's deny-pattern hook blocks any Bash arg containing the literal string `TOKEN`.
 
 ---

--- a/plugins/laravel-forge-hermit/tests/hook.test.ts
+++ b/plugins/laravel-forge-hermit/tests/hook.test.ts
@@ -1,0 +1,138 @@
+// Structural and behavioral tests for write-confirm-gate.ts
+// Run with: bun test tests/hook.test.ts
+
+import { test, expect, describe } from 'bun:test';
+import { spawnSync } from 'child_process';
+import path from 'node:path';
+
+const HOOK = path.join(import.meta.dir, '..', 'hooks', 'write-confirm-gate.ts');
+
+function runHook(payload: unknown): { exitCode: number; stderr: string; stdout: string } {
+  const input = JSON.stringify(payload);
+  const result = spawnSync('bun', [HOOK], {
+    input,
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  return {
+    exitCode: result.status ?? -1,
+    stderr: result.stderr ?? '',
+    stdout: result.stdout ?? '',
+  };
+}
+
+describe('write-confirm-gate: pass-through cases', () => {
+  test('non-Bash tool always passes', () => {
+    const r = runHook({ tool_name: 'Read', tool_input: { file_path: '/some/file' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('Bash call not involving forge.php passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'ls -la' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('forge.php servers (read command) passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php servers' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('forge.php check passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php check' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('preview-deploy passes (read-only)', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php preview-deploy prod-web myapp.com' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('preview-reboot passes (read-only)', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php preview-reboot prod-web' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('failed-deploys passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php failed-deploys --json' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('call method passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'echo \'["s1"]\' | php /plugin/php/forge.php call servers' } });
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe('write-confirm-gate: blocked cases', () => {
+  test('deploy without --confirm is blocked', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com' } });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('--confirm');
+  });
+
+  test('deploy with --watch but no --confirm is blocked', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --watch' } });
+    expect(r.exitCode).toBe(2);
+  });
+
+  test('server-reboot without --confirm is blocked', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php server-reboot prod-web' } });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('--confirm');
+  });
+});
+
+describe('write-confirm-gate: allowed write cases', () => {
+  test('deploy with --confirm passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --confirm' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('deploy --confirm --watch passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --confirm --watch' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('server-reboot with --confirm passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php server-reboot prod-web --confirm' } });
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe('write-confirm-gate: env-var prefix + path variants', () => {
+  test('env-var prefix before php does not confuse tokenization', () => {
+    // The subcommand is still after forge.php
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'FORGE_ORG=myorg php /plugin/php/forge.php deploy srv site' } });
+    expect(r.exitCode).toBe(2);
+  });
+
+  test('${CLAUDE_PLUGIN_ROOT} as literal in command is handled (plugin-dir mode)', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy srv site' } });
+    expect(r.exitCode).toBe(2);
+  });
+
+  test('${CLAUDE_PLUGIN_ROOT} deploy with --confirm passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy srv site --confirm' } });
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe('write-confirm-gate: fail-closed on bad input', () => {
+  test('malformed JSON input blocks', () => {
+    const result = spawnSync('bun', [HOOK], {
+      input: 'not json',
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    expect(result.status).toBe(2);
+  });
+
+  test('empty stdin blocks', () => {
+    const result = spawnSync('bun', [HOOK], {
+      input: '',
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    expect(result.status).toBe(2);
+  });
+});

--- a/plugins/laravel-forge-hermit/tests/hook.test.ts
+++ b/plugins/laravel-forge-hermit/tests/hook.test.ts
@@ -57,6 +57,11 @@ describe('write-confirm-gate: pass-through cases', () => {
     expect(r.exitCode).toBe(0);
   });
 
+  test('deploy-status passes (read-only poll, not a write)', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy-status 12 34 8821' } });
+    expect(r.exitCode).toBe(0);
+  });
+
   test('call method passes', () => {
     const r = runHook({ tool_name: 'Bash', tool_input: { command: 'echo \'["s1"]\' | php /plugin/php/forge.php call servers' } });
     expect(r.exitCode).toBe(0);
@@ -70,8 +75,8 @@ describe('write-confirm-gate: blocked cases', () => {
     expect(r.stderr).toContain('--confirm');
   });
 
-  test('deploy with --watch but no --confirm is blocked', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --watch' } });
+  test('deploy with an unknown trailing flag but no --confirm is blocked', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --json' } });
     expect(r.exitCode).toBe(2);
   });
 
@@ -79,6 +84,11 @@ describe('write-confirm-gate: blocked cases', () => {
     const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php server-reboot prod-web' } });
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toContain('--confirm');
+  });
+
+  test('a --confirm substring (e.g. --confirm-later) does NOT satisfy the gate', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --confirm-later' } });
+    expect(r.exitCode).toBe(2);
   });
 });
 
@@ -88,8 +98,8 @@ describe('write-confirm-gate: allowed write cases', () => {
     expect(r.exitCode).toBe(0);
   });
 
-  test('deploy --confirm --watch passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --confirm --watch' } });
+  test('deploy with --confirm anywhere in the args passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --json --confirm' } });
     expect(r.exitCode).toBe(0);
   });
 
@@ -117,22 +127,24 @@ describe('write-confirm-gate: env-var prefix + path variants', () => {
   });
 });
 
-describe('write-confirm-gate: fail-closed on bad input', () => {
-  test('malformed JSON input blocks', () => {
+describe('write-confirm-gate: fail-open on bad input', () => {
+  // A hook must never block Claude Code on a parse glitch — unparseable or
+  // empty stdin passes through; the authoritative in-PHP --confirm gate remains.
+  test('malformed JSON input passes through', () => {
     const result = spawnSync('bun', [HOOK], {
       input: 'not json',
       encoding: 'utf8',
       timeout: 5000,
     });
-    expect(result.status).toBe(2);
+    expect(result.status).toBe(0);
   });
 
-  test('empty stdin blocks', () => {
+  test('empty stdin passes through', () => {
     const result = spawnSync('bun', [HOOK], {
       input: '',
       encoding: 'utf8',
       timeout: 5000,
     });
-    expect(result.status).toBe(2);
+    expect(result.status).toBe(0);
   });
 });

--- a/plugins/laravel-forge-hermit/tests/run-all.sh
+++ b/plugins/laravel-forge-hermit/tests/run-all.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PLUGIN_DIR"
+
+echo "=== laravel-forge-hermit test suite ==="
+
+EXIT=0
+
+echo ""
+echo "--- PHP tests (php/tests/run.php) ---"
+if ! php php/tests/run.php; then
+  EXIT=1
+fi
+
+echo ""
+echo "--- bun tests (hook + skill-structure) ---"
+if ! bun test tests/hook.test.ts tests/skill-structure.test.ts; then
+  EXIT=1
+fi
+
+echo ""
+if [ "$EXIT" -eq 0 ]; then
+  echo "All tests passed."
+else
+  echo "Some tests failed." >&2
+fi
+
+exit "$EXIT"

--- a/plugins/laravel-forge-hermit/tests/skill-structure.test.ts
+++ b/plugins/laravel-forge-hermit/tests/skill-structure.test.ts
@@ -1,0 +1,65 @@
+// Structural invariants for SKILL.md files in laravel-forge-hermit.
+// Run with: bun test tests/skill-structure.test.ts
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseFrontmatter, makeReporter } from './test-utils';
+
+const SKILL_DIR = path.join(import.meta.dir, '..', 'skills');
+
+const SKILLS = [
+  { name: 'hatch', gates: 0 },
+  { name: 'forge-servers', gates: 0 },
+  { name: 'forge-sites', gates: 0 },
+  { name: 'forge-deploy', gates: 0 },
+  { name: 'forge-logs', gates: 0 },
+  { name: 'forge-failed-deploys', gates: 0 },
+];
+
+const { ok, summary } = makeReporter();
+
+for (const { name, gates } of SKILLS) {
+  console.log(`\n${name}/SKILL.md:`);
+  const file = path.join(SKILL_DIR, name, 'SKILL.md');
+  ok('file exists', fs.existsSync(file), file);
+  if (!fs.existsSync(file)) continue;
+
+  const text = fs.readFileSync(file, 'utf-8');
+  const fm = parseFrontmatter(text);
+  ok('frontmatter parseable', fm !== null);
+  if (!fm) continue;
+
+  ok('frontmatter has name', !!fm.fields.name, JSON.stringify(fm.fields));
+  ok('frontmatter name matches dir', fm.fields.name === name, `${fm.fields.name} vs ${name}`);
+  ok('frontmatter has description', !!fm.fields.description && fm.fields.description.length > 20);
+
+  const gateMatches = fm.body.match(/^### Gate \d+ —/gm) || [];
+  ok(`expected ${gates} Gate headers`, gateMatches.length === gates, `found ${gateMatches.length}`);
+
+  if (gates > 0) {
+    ok('Gate 0 present', /^### Gate 0 —/m.test(fm.body));
+    ok(`Gate ${gates - 1} present`, new RegExp(`^### Gate ${gates - 1} —`, 'm').test(fm.body));
+  }
+
+  // Internal links: resolve [text](relative/path) and verify the target exists.
+  const linkRe = /\[[^\]]+\]\(([^)]+)\)/g;
+  const skillBaseDir = path.dirname(file);
+  let linkMatch: RegExpExecArray | null;
+  let linksChecked = 0;
+  let linksBad = 0;
+  while ((linkMatch = linkRe.exec(fm.body)) !== null) {
+    const target = linkMatch[1];
+    if (/^(https?:|mailto:|#)/.test(target)) continue;
+    const cleanTarget = target.split('#')[0];
+    if (!cleanTarget) continue;
+    const resolved = path.resolve(skillBaseDir, cleanTarget);
+    linksChecked += 1;
+    if (!fs.existsSync(resolved)) {
+      linksBad += 1;
+      console.error(`    bad link: ${target} → ${resolved}`);
+    }
+  }
+  ok(`internal links resolve (${linksChecked} checked)`, linksBad === 0, `${linksBad} bad`);
+}
+
+process.exit(summary() === 0 ? 0 : 1);

--- a/plugins/laravel-forge-hermit/tests/test-utils.ts
+++ b/plugins/laravel-forge-hermit/tests/test-utils.ts
@@ -1,0 +1,31 @@
+function parseFrontmatter(text: string) {
+  const m = text.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!m) return null;
+  const fields: Record<string, string> = {};
+  for (const line of m[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.*)$/);
+    if (kv) fields[kv[1]] = kv[2].trim();
+  }
+  return { raw: m[1], fields, body: text.slice(m[0].length) };
+}
+
+function makeReporter() {
+  let passed = 0;
+  let failed = 0;
+  function ok(name: string, cond: boolean, detail?: string) {
+    if (cond) {
+      console.log(`  ✓ ${name}`);
+      passed += 1;
+    } else {
+      console.error(`  ✗ ${name}${detail ? ' — ' + detail : ''}`);
+      failed += 1;
+    }
+  }
+  function summary(): number {
+    console.log(`\nResults: ${passed} passed, ${failed} failed`);
+    return failed;
+  }
+  return { ok, summary };
+}
+
+export { parseFrontmatter, makeReporter };


### PR DESCRIPTION
## Summary

Introduces `laravel-forge-hermit`, a new domain plugin that gives operators deployment skills, server/site management, log reading, and a daily estate health scan — all via the official `laravel/forge-sdk` v4. The agent calls `php forge.php <command>` directly via Bash; the SDK handles all HTTP. No hand-rolled API client, no bun CLI, no bridge process.

## Architecture decisions

- **Vendor not committed**: `composer.json` + `composer.lock` ship; `hatch` installs `--no-dev` into `<project>/.claude-code-hermit/forge-runtime/vendor/` at setup time — isolated from the app's own deps, persistent across Docker restarts.
- **PHP 8.5+ required**: pins above the SDK's `^8.2` floor; Ubuntu 26.04 LTS ships it natively (core Docker base bump is a declared prerequisite).
- **Closed allowlist for generic dispatch**: `call <method>` resolves against a fixed set of ~35 SDK read methods — not a denylist of mutator patterns, which would be leaky against novel SDK method names.
- **Three-layer write gate**: PreToolUse hook (`write-confirm-gate.ts`) + in-PHP `--confirm` refusal + skill surface-then-approve flow. Neither layer can be bypassed.
- **Status enums confirmed against Forge OpenAPI**: terminal = `finished` / `failed` / `failed-build` / `cancelled`; in-progress = `pending` / `queued` / `deploying`.

## Changes

- `plugins/laravel-forge-hermit/` — new plugin directory
  - `php/forge.php` — 635-line PHP dispatch script (read commands, preview commands, deploy/reboot with `--confirm`, `failed-deploys` estate scan, generic `call <method>` dispatch)
  - `php/composer.json` + `php/composer.lock` — pinned to `laravel/forge-sdk` v4.0.0 + guzzle 7.12
  - `hooks/write-confirm-gate.ts` — fail-closed PreToolUse Bash hook; gates on subcommand token after `forge.php`
  - `hooks/hooks.json` — wires hook to `PreToolUse / Bash` on standard+strict profiles
  - `skills/` — 6 skills: `hatch`, `forge-servers`, `forge-sites`, `forge-deploy`, `forge-logs`, `forge-failed-deploys`
  - `state-templates/CLAUDE-APPEND.md` — Forge Workflow block injected by hatch into operator's CLAUDE.md/CLAUDE.local.md
  - `settings.json`, `DOCKER.md`, `docs/knowledge-schema.md`, `CLAUDE.md`, `README.md`, `CHANGELOG.md`, `LICENSE`
  - `tests/` — 19 hook tests (bun), 42 skill-structure tests (bun), 24 PHP unit tests (php/tests/run.php); `tests/run-all.sh` runner
- `.claude-plugin/marketplace.json` — `laravel-forge-hermit` entry added (v0.0.1, category: development)

## Test plan

```bash
cd plugins/laravel-forge-hermit
composer install --working-dir=php   # install SDK locally for PHP tests
bash tests/run-all.sh                # 24 PHP + 42 skill-structure + 19 hook = 85 tests, 0 failures
```

All three suites pass on PHP 8.5 + Bun 1.3.11.

The hook tests cover: pass-through for read/preview commands, block for deploy/server-reboot without `--confirm`, allow with `--confirm`, env-var prefix handling, `${CLAUDE_PLUGIN_ROOT}` literal path, fail-closed on malformed stdin.