### PR TITLE
fix(laravel-forge-hermit): correct Forge API token URL in hatch and forge.php

### DIFF
--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Fixed
+- **hatch: correct Forge API token URL** — was `/user-profile/api`, now `/profile/api` (also corrected in `forge.php` "no orgs found" error).
+
 ## [0.0.1] — 2026-06-22
 
 ### Added

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -102,7 +102,7 @@ function requireOrg(string $org, Forge $forge): string {
     $count = count($orgs);
     if ($count === 1) return $orgs[0]->slug;
     if ($count === 0) {
-        fwrite(STDERR, "No organizations found for this token. Check the token at https://forge.laravel.com/user-profile/api.\n");
+        fwrite(STDERR, "No organizations found for this token. Check the token at https://forge.laravel.com/profile/api.\n");
         exit(1);
     }
     fwrite(STDERR, "Multiple organizations found. Set FORGE_ORG in .env to one of:\n");

--- a/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
@@ -99,7 +99,7 @@ Tell the operator:
 > FORGE_ORG=your-org-slug        # optional if you have exactly one org
 > ```
 >
-> Get your token at https://forge.laravel.com/user-profile/api. Reply 'done' when set, or 'skip' to continue (credential check happens in Step 5)."
+> Get your token at https://forge.laravel.com/profile/api. Reply 'done' when set, or 'skip' to continue (credential check happens in Step 5)."
 
 Use `AskUserQuestion`: "(done / skip)"
 
@@ -119,7 +119,7 @@ Append any missing patterns via Edit.
 Run: `php ${CLAUDE_PLUGIN_ROOT}/php/forge.php check`
 
 - **`missing`** → tell the operator to add `FORGE_API_TOKEN` to `.env` and re-run Step 4.
-- **`invalid`** → token found but API rejected it; tell the operator to check the token at https://forge.laravel.com/user-profile/api.
+- **`invalid`** → token found but API rejected it; tell the operator to check the token at https://forge.laravel.com/profile/api.
 - **`unreachable`** → token present but the API could not be reached (network/egress blocked). In Docker, verify the DNS allowlist in DOCKER.md (`forge.laravel.com`). Re-run once connectivity is confirmed.
 - **`ok`** → continue.
 


### PR DESCRIPTION
## Summary
The Forge API token page URL was wrong at all three operator-facing locations. `/user-profile/api` does not resolve to the token page — the correct path is `/profile/api`. Operators following the link during `hatch` onboarding couldn't find where to generate a token.

## Changes
- `skills/hatch/SKILL.md` — fix URL in the Step 4 token-setup prompt and the Step 5 `invalid` error branch
- `php/forge.php` — fix URL in the "no organizations found" stderr error message
- `CHANGELOG.md` — add `[Unreleased] ### Fixed` entry

## Test plan
- `grep -rn "user-profile/api" plugins/laravel-forge-hermit/` returns no hits (only the CHANGELOG description of the old path)
- All three corrected sites point to `https://forge.laravel.com/profile/api`
- `bun test` inside the plugin dir: 42 passed, 0 failed