### PR TITLE
fix(claude-code-hermit): docker entrypoint — marketplace registration via list --json

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **docker-entrypoint: marketplace registration via `list --json`, not dir existence** — `marketplace_registered()` helper reads `known_marketplaces.json`; fixes "No marketplaces configured" when dir exists but isn't registered (partial add, fresh named volume, bind-mount). Decoupled hermit install from marketplace-add so prior install failures self-heal on next boot.
+
+### Upgrade Instructions
+
+**Docker entrypoint — marketplace registration fix.** Existing Docker hermits must refresh their **on-disk** `docker-entrypoint.hermit.sh` before the fix takes effect, because `hermit-docker update` rebuilds the image from the on-disk entrypoint, not the template.
+
+**Step 1 — Existence check.** Check for `docker-entrypoint.hermit.sh` at the project root. If it does not exist, skip — Docker not set up.
+
+**Step 2 — Already patched?** If `docker-entrypoint.hermit.sh` already contains `marketplace_registered()`, skip to Step 4.
+
+**Step 3 — Refresh on-disk entrypoint.** Copy the updated template into place:
+
+```
+cp "${CLAUDE_PLUGIN_ROOT}/state-templates/docker/docker-entrypoint.hermit.sh.template" docker-entrypoint.hermit.sh
+```
+
+If `${CLAUDE_PLUGIN_ROOT}` is not set (non-Docker session), derive from `claude plugin list --json` to locate the hermit plugin root.
+
+**Step 4 — Re-record the entrypoint baseline** so the drift detector clears:
+
+```
+bun -e '
+  const fs=require("node:fs"), c=require("node:crypto");
+  const [tmpl, ver]=process.argv.slice(2);
+  const mp=".claude-code-hermit/state/template-manifest.json";
+  if(!fs.existsSync(mp)) process.exit(0);
+  const m=JSON.parse(fs.readFileSync(mp,"utf8")); m.files ??= {};
+  const h=c.createHash("sha256").update(fs.readFileSync(tmpl)).digest("hex");
+  m.files["docker/docker-entrypoint.hermit.sh"]={sha256:h, plugin_version:ver};
+  fs.writeFileSync(mp, JSON.stringify(m,null,2)+"\n");
+' "${CLAUDE_PLUGIN_ROOT}/state-templates/docker/docker-entrypoint.hermit.sh.template" "<to>"
+```
+
+Replace `<to>` with the current plugin version.
+
+**Step 5 — Rebuild the image** (only if Docker hermit is running):
+
+```
+.claude-code-hermit/bin/hermit-docker update
+```
+
+Non-Docker hermits: nothing to do.
+
 ## [1.2.9] - 2026-06-22
 
 ### Added

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **docker-entrypoint: marketplace registration via `list --json`, not dir existence** — `marketplace_registered()` helper reads `known_marketplaces.json`; fixes "No marketplaces configured" when dir exists but isn't registered (partial add, fresh named volume, bind-mount). Decoupled hermit install from marketplace-add so prior install failures self-heal on next boot.
+- **docker-entrypoint: genuine plugin-enable failures are logged** — boot-time enable goes through an `enable_plugin` helper that suppresses only the benign "already enabled" exit and warns on any other failure. Previously `|| true` swallowed every non-zero enable, and the post-install check greps `plugin list` for presence (which includes disabled plugins), so a failed enable left a plugin present-but-disabled with no signal.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -257,16 +257,29 @@ for var_name in DISCORD_STATE_DIR TELEGRAM_STATE_DIR; do
 done
 
 # --- 3. Install plugins (named volume starts empty on first run) ---
-# Marketplace directory check is used only for "has the marketplace been added yet?"
-# Plugin installation is verified via `claude plugin list` — the marketplace catalog
-# populates external_plugins/ for ALL plugins on add, so directory checks can't
-# distinguish "cataloged" from "installed".
+# Registration is checked via `marketplace list --json` (reads known_marketplaces.json),
+# not by directory existence. A dir can exist while the marketplace is unregistered:
+# partial add, a bind-mount, or a prior install that cloned the dir but didn't write
+# the registration. Directory existence ≠ registered state.
 MARKETPLACE_DIR="${CLAUDE_CONFIG_DIR}/plugins/marketplaces"
 
-# Hermit marketplace + plugin
-if [ ! -d "${MARKETPLACE_DIR}/claude-code-hermit" ]; then
+# Fetch registered marketplace names once; reused for all checks this boot.
+MARKETPLACE_LIST_JSON=$(claude plugin marketplace list --json 2>/dev/null || echo '[]')
+
+# Returns 0 if the marketplace whose canonical name matches $1 is already registered.
+marketplace_registered() {
+  echo "$MARKETPLACE_LIST_JSON" \
+    | jq -e --arg n "$1" 'any(.[]?; .name == $n)' >/dev/null 2>&1
+}
+
+# Hermit marketplace + plugin (checks are independent so a prior install failure self-heals)
+if ! marketplace_registered claude-code-hermit; then
   echo "[docker-entrypoint] Adding hermit marketplace..."
-  claude plugin marketplace add gtapps/claude-code-hermit || true
+  if ! claude plugin marketplace add gtapps/claude-code-hermit; then
+    echo "[docker-entrypoint] ERROR: failed to add hermit marketplace — plugin install will fail."
+  fi
+fi
+if ! claude plugin list 2>/dev/null | grep -qF 'claude-code-hermit@claude-code-hermit'; then
   echo "[docker-entrypoint] Installing hermit plugin..."
   if claude plugin install claude-code-hermit@claude-code-hermit --scope project; then
     audit_install "gtapps/claude-code-hermit" "claude-code-hermit" "project"
@@ -281,7 +294,7 @@ claude plugin enable claude-code-hermit@claude-code-hermit --scope project 2>/de
 # Official marketplace (needed by channel plugins)
 NEEDS_OFFICIAL=false
 [ -n "$CHANNELS" ] && NEEDS_OFFICIAL=true
-if [ "$NEEDS_OFFICIAL" = true ] && [ ! -d "${MARKETPLACE_DIR}/claude-plugins-official" ]; then
+if [ "$NEEDS_OFFICIAL" = true ] && ! marketplace_registered claude-plugins-official; then
   echo "[docker-entrypoint] Adding official plugins marketplace..."
   if ! claude plugin marketplace add anthropics/claude-plugins-official; then
     echo "[docker-entrypoint] ERROR: failed to add claude-plugins-official marketplace."
@@ -315,10 +328,9 @@ if [ "$NEEDS_OFFICIAL" = true ] && [ -n "$CHANNELS" ]; then
       continue
     fi
     audit_install "claude-plugins-official" "$plugin" "local"
-    if ! claude plugin enable "$target" --scope local; then
-      echo "[docker-entrypoint] ERROR: 'claude plugin enable ${target}' failed — see stderr above."
-      continue
-    fi
+    # install --scope already auto-enables; this self-heal may report "already enabled"
+    # (non-zero) — non-fatal, fall through to verification.
+    claude plugin enable "$target" --scope local || true
     # Post-install verification — re-query list and confirm the entry landed.
     # Catches the "CLI exits 0 but nothing was fetched" silent-failure mode.
     if ! claude plugin list | grep -qF "$target"; then
@@ -442,13 +454,11 @@ for (const entry of plugins) {
     continue;
   }
   audit(marketplace, plugin, scope);
+  // install --scope already auto-enables; the enable below self-heals the "listed but
+  // disabled" case. "already enabled" (status !== 0) is benign — not logged as a warning.
   result = spawnSync("claude", ["plugin", "enable", installTarget, "--scope", scope], INHERIT);
   if (result.error) {
     console.log(`[docker-entrypoint] Warning: claude not found enabling ${plugin} — plugin installed but enable skipped; will self-heal on next restart`);
-    continue;
-  }
-  if (result.status !== 0) {
-    console.log(`[docker-entrypoint] Warning: failed to enable ${plugin} — run: claude plugin enable ${installTarget}`);
   }
 }
 JSEOF

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -157,6 +157,22 @@ else
   audit_install() { :; }
 fi
 
+# Enable a plugin, suppressing only the benign "already enabled" non-zero exit
+# (`claude plugin install --scope` auto-enables, so the self-heal enable usually
+# hits that). Any other failure is logged — visible in `docker compose logs` —
+# but non-fatal. `claude plugin list` shows disabled plugins too, so a presence
+# grep can't catch a failed enable; this warning is the actual signal.
+enable_plugin() {
+  local out
+  if out=$(claude plugin enable "$1" --scope "$2" 2>&1); then
+    return 0
+  fi
+  case "$out" in
+    *"already enabled"*) return 0 ;;
+    *) echo "[docker-entrypoint] Warning: failed to enable ${1} (scope ${2}): ${out}" ;;
+  esac
+}
+
 # --- 1. Bypass onboarding, pre-approve MCP servers, patch permission_mode ---
 CLAUDE_JSON="${CLAUDE_CONFIG_DIR}/.claude.json"
 CC_VERSION=$(claude --version 2>/dev/null | grep -oP '[\d.]+' | head -1 || echo "0.0.0")
@@ -289,7 +305,7 @@ if ! claude plugin list 2>/dev/null | grep -qF 'claude-code-hermit@claude-code-h
 fi
 
 # Idempotent enable — runs every boot to self-heal if plugin was disabled.
-claude plugin enable claude-code-hermit@claude-code-hermit --scope project 2>/dev/null || true
+enable_plugin claude-code-hermit@claude-code-hermit project
 
 # Official marketplace (needed by channel plugins)
 NEEDS_OFFICIAL=false
@@ -319,7 +335,7 @@ if [ "$NEEDS_OFFICIAL" = true ] && [ -n "$CHANNELS" ]; then
     target="${plugin}@claude-plugins-official"
     if echo "$INSTALLED_PLUGINS" | grep -qF "$target"; then
       # Idempotent re-enable covers the "listed but disabled" case.
-      claude plugin enable "$target" --scope local || true
+      enable_plugin "$target" local
       continue
     fi
     echo "[docker-entrypoint] Installing channel plugin: ${plugin}"
@@ -328,9 +344,8 @@ if [ "$NEEDS_OFFICIAL" = true ] && [ -n "$CHANNELS" ]; then
       continue
     fi
     audit_install "claude-plugins-official" "$plugin" "local"
-    # install --scope already auto-enables; this self-heal may report "already enabled"
-    # (non-zero) — non-fatal, fall through to verification.
-    claude plugin enable "$target" --scope local || true
+    # Self-heal enable; warns only on a genuine failure (see enable_plugin).
+    enable_plugin "$target" local
     # Post-install verification — re-query list and confirm the entry landed.
     # Catches the "CLI exits 0 but nothing was fetched" silent-failure mode.
     if ! claude plugin list | grep -qF "$target"; then
@@ -454,11 +469,17 @@ for (const entry of plugins) {
     continue;
   }
   audit(marketplace, plugin, scope);
-  // install --scope already auto-enables; the enable below self-heals the "listed but
-  // disabled" case. "already enabled" (status !== 0) is benign — not logged as a warning.
-  result = spawnSync("claude", ["plugin", "enable", installTarget, "--scope", scope], INHERIT);
+  // Self-heal enable — mirrors shell enable_plugin(): suppress the benign "already enabled"
+  // exit, warn on a genuine failure. Output captured (stdin still ignored) to match the message.
+  result = spawnSync("claude", ["plugin", "enable", installTarget, "--scope", scope],
+    { stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" });
   if (result.error) {
     console.log(`[docker-entrypoint] Warning: claude not found enabling ${plugin} — plugin installed but enable skipped; will self-heal on next restart`);
+  } else if (result.status !== 0) {
+    const enableOut = (result.stdout ?? "") + (result.stderr ?? "");
+    if (!enableOut.includes("already enabled")) {
+      console.log(`[docker-entrypoint] Warning: failed to enable ${plugin} — run: claude plugin enable ${installTarget}`);
+    }
   }
 }
 JSEOF

--- a/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
@@ -219,3 +219,19 @@ describe('Entrypoint: Python retired, PATH covers bun', () => {
     expect(entrypoint).toContain('npm install -g @anthropic-ai/claude-code');
   });
 });
+
+describe('Entrypoint: marketplace registration uses list --json, not dir existence', () => {
+  test('entrypoint: marketplace_registered helper present', () => {
+    expect(entrypoint).toContain('marketplace_registered()');
+    expect(entrypoint).toContain('marketplace list --json');
+    expect(entrypoint).toContain('.name == $n');
+  });
+
+  test('entrypoint: no [ -d MARKETPLACE_DIR ] registration checks remain', () => {
+    expect(entrypoint).not.toMatch(/\[ ! -d "\$\{MARKETPLACE_DIR\}/);
+  });
+
+  test('entrypoint: hermit install decoupled from marketplace add', () => {
+    expect(entrypoint).toContain("grep -qF 'claude-code-hermit@claude-code-hermit'");
+  });
+});

--- a/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
@@ -234,4 +234,12 @@ describe('Entrypoint: marketplace registration uses list --json, not dir existen
   test('entrypoint: hermit install decoupled from marketplace add', () => {
     expect(entrypoint).toContain("grep -qF 'claude-code-hermit@claude-code-hermit'");
   });
+
+  test('entrypoint: enable failures distinguish benign "already enabled" from genuine', () => {
+    // Shared shell helper suppresses only the benign case and warns otherwise.
+    expect(entrypoint).toContain('enable_plugin()');
+    expect(entrypoint).toContain('already enabled');
+    // No enable site silently swallows failures via `|| true` anymore.
+    expect(entrypoint).not.toMatch(/plugin enable[^\n]*\|\| true/);
+  });
 });


### PR DESCRIPTION
## Summary

The Docker entrypoint used `[ -d MARKETPLACE_DIR/<name> ]` to decide whether a marketplace needed adding. A dir can exist while the marketplace is unregistered (partial add, bind-mount, fresh named volume where a prior run cloned the dir but registration wasn't written). When this happens the entrypoint skips `marketplace add`, `known_marketplaces.json` stays empty, and every plugin install fails with "No marketplaces configured" — silently, because of the `|| true`.

## Changes

- **`marketplace_registered()` helper** — reads registration state from `marketplace list --json` (`.name` match via jq) rather than dir existence. Cached in `MARKETPLACE_LIST_JSON` before first use so both calls share one subprocess.
- **Decoupled hermit install from marketplace-add** — `plugin install` is now gated on `claude plugin list`, not nested inside the marketplace-add branch. A prior install failure self-heals on next boot.
- **Surface marketplace-add failure** — replaced `|| true` on hermit marketplace add with an `if ! ...; then echo ERROR` pattern. Non-fatal (PID 1 keeps running), but visible in `docker compose logs`.
- **Channel enable noise removed** — post-install `enable` call after channel install demoted to `|| true`; "already enabled" (non-zero) no longer logs as ERROR and no longer skips post-install verification.
- **Recommended-plugins enable warning dropped** — the `status !== 0` warning after recommended-plugin enable was always "already enabled" (fresh installs short-circuit before reaching it). Removed.
- **Tests** — three new `docker-baseline-content.test.ts` assertions lock in the fix: helper present, no `-d` dir checks remain, install decoupled.

## Test plan

- `cd plugins/claude-code-hermit && bun test` — 1176+ pass, 0 fail (new assertions included)
- `bash -n docker-entrypoint.hermit.sh.template` — syntax ok
- End-to-end: build against a fresh named volume; simulate desync by truncating `known_marketplaces.json` while leaving `marketplaces/claude-code-hermit/` on disk; restart — should re-register and install instead of "No marketplaces configured"