### PR TITLE
feat(claude-code-hermit): cost-reflect per-model breakdown for mixed-model deployments

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **cost-reflect: per-model cost breakdown** — adds a "Cost by model" section so mixed-model (Sonnet main + Haiku subagent) operators can attribute spend per model without reading raw logs. Section is omitted for single-model windows.
+
 ## [1.2.10] - 2026-06-23
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/cost-reflect.ts
+++ b/plugins/claude-code-hermit/scripts/cost-reflect.ts
@@ -62,6 +62,7 @@ function run() {
   let coldStartCost = 0;
   const sessionMap: Record<string, Json> = {}; // session_id -> { cost, turns, byType }
   const sourceMap: Record<string, number> = {};
+  const modelMap: Record<string, { cost: number; byType: { input: number; cacheWrite: number; cacheRead: number; output: number } }> = {};
 
   for (const e of window) {
     const model = e.model || 'sonnet';
@@ -101,6 +102,15 @@ function run() {
     // Per-source attribution; legacy entries without 'source' bucket to 'other'
     const src = e.source || 'other';
     sourceMap[src] = (sourceMap[src] || 0) + entryCost;
+
+    // subagent lines included intentionally — they carry a resolved model unlike the cold-start guard above
+    if (!modelMap[model]) modelMap[model] = { cost: 0, byType: { input: 0, cacheWrite: 0, cacheRead: 0, output: 0 } };
+    const mm = modelMap[model];
+    mm.cost += entryCost;
+    mm.byType.input      += types.input;
+    mm.byType.cacheWrite += types.cacheWrite;
+    mm.byType.cacheRead  += types.cacheRead;
+    mm.byType.output     += types.output;
   }
 
   const total = totals.input + totals.cacheWrite + totals.cacheRead + totals.output;
@@ -145,6 +155,30 @@ function run() {
     return `\n### Cost by source\n${rows.join('\n')}\n${footnote}`;
   }
 
+  function buildModelSection() {
+    // Only render when ≥2 distinct models are present — a single-model window learns
+    // nothing new from this vs the combined token-type header.
+    const entries = Object.entries(modelMap);
+    if (entries.length < 2) return '';
+    const rows = entries
+      .sort((a, b) => b[1].cost - a[1].cost)
+      .map(([mdl, { cost, byType }]) => {
+        const components = (
+          [
+            ['cache_read',  byType.cacheRead],
+            ['cache_write', byType.cacheWrite],
+            ['output',      byType.output],
+            ['input',       byType.input],
+          ] as [string, number][]
+        )
+          .filter(([, v]) => v > 0)
+          .map(([label, v]) => `${label} ${formatCost(v)}`)
+          .join(', ');
+        return `- ${mdl} ${formatCost(cost)} (${pct(cost, total)})${components ? ` — ${components}` : ''}`;
+      });
+    return `\n### Cost by model\n${rows.join('\n')}\n`;
+  }
+
   function buildTopSection(n: number) {
     if (n <= 0 || topSessions.length === 0) return '';
     const lines = topSessions.slice(0, n).map(s =>
@@ -153,17 +187,19 @@ function run() {
     return `\n### Top sessions\n${lines}\n`;
   }
 
+  const modelSection = buildModelSection();
+
   // Enforce ≤1500 chars. Shed source rows first (lowest-value for operators with
   // many routines) down to zero, then shed top-sessions — a single monotonic path.
   for (let m = MAX_TOP_SOURCES; m >= 1; m--) {
-    const body = header + coldSection + buildSourceSection(m) + buildTopSection(MAX_TOP_SESSIONS);
+    const body = header + modelSection + coldSection + buildSourceSection(m) + buildTopSection(MAX_TOP_SESSIONS);
     if (body.length <= MAX_CHARS) {
       process.stdout.write(body);
       return;
     }
   }
   for (let n = MAX_TOP_SESSIONS; n >= 0; n--) {
-    const body = header + coldSection + buildTopSection(n);
+    const body = header + modelSection + coldSection + buildTopSection(n);
     if (body.length <= MAX_CHARS || n === 0) {
       process.stdout.write(body);
       return;

--- a/plugins/claude-code-hermit/skills/cost-reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/cost-reflect/SKILL.md
@@ -39,4 +39,4 @@ When this skill fires from a routine or proactively (i.e., not from a direct ope
 ## Notes
 
 - **Scheduling:** this skill doesn't self-register a routine. To run it weekly, add it via `/claude-code-hermit:hermit-settings` — a Sunday 22:00 cadence (`0 22 * * 0`) before weekly-review works well.
-- **What it measures:** token-type cost composition (cache_read / cache_write / output / input), cold-start turns (context warm-ups with no prior cache hit), and per-session cost attribution. For week-over-week totals and autonomy trends, use `/claude-code-hermit:hermit-evolution` instead.
+- **What it measures:** token-type cost composition (cache_read / cache_write / output / input), per-model breakdown (shown when ≥2 models appear, e.g. Sonnet main + Haiku heartbeat), cold-start turns (context warm-ups with no prior cache hit), and per-session cost attribution. For week-over-week totals and autonomy trends, use `/claude-code-hermit:hermit-evolution` instead.

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -1995,7 +1995,29 @@ describe('cost-reflect', () => {
     test('cost-reflect: output ≤1500 chars', () => {
       expect(out.length).toBeLessThanOrEqual(1500);
     });
+
+    // Per-model section: fixture mixes sonnet, haiku, opus → section must appear
+    test('cost-reflect: Cost by model section present for mixed-model window', () => {
+      expect(out).toContain('Cost by model');
+    });
+    test('cost-reflect: per-model section contains sonnet row', () => {
+      expect(out).toMatch(/- sonnet /);
+    });
+    test('cost-reflect: per-model section contains haiku row', () => {
+      expect(out).toMatch(/- haiku /);
+    });
   });
+
+  // Single-model window: Cost by model section must be absent
+  test('cost-reflect: Cost by model section absent for single-model window', withDir(async (dir) => {
+    const inWindow = utcDate(daysAgo(1));
+    write(path.join(dir, '.claude', 'cost-log.jsonl'), [
+      `{"timestamp":"${inWindow}T10:00:00.000Z","session_id":"s1","model":"sonnet","input_tokens":0,"cache_write_tokens":10000,"cache_read_tokens":0,"output_tokens":500,"total_tokens":10500,"estimated_cost_usd":0.05}`,
+      `{"timestamp":"${inWindow}T10:01:00.000Z","session_id":"s1","model":"sonnet","input_tokens":0,"cache_write_tokens":0,"cache_read_tokens":50000,"output_tokens":200,"total_tokens":50200,"estimated_cost_usd":0.018}`,
+    ].join('\n'));
+    const o = await runCostReflect(dir);
+    expect(o).not.toContain('Cost by model');
+  }));
 
   // Empty log: no entries at all
   test("cost-reflect: empty log → 'No cost data'", withDir(async (dir) => {


### PR DESCRIPTION
## Summary
- Adds a "Cost by model" section to `cost-reflect` output so operators running Sonnet main + Haiku heartbeat subagents can attribute spend per model without reading raw `cost-log.jsonl`
- Section is gated to ≥2 distinct models in the window — omitted for single-model setups to avoid redundant noise

## Verification
- Tests: **pass** (232 pass, 8.08s — `tests/scripts.test.ts`; 1196 pass, 42s — full suite)
- Smoke-tested manually: mixed sonnet+haiku log renders the section; single-model log omits it; output stays ≤1500 chars

Closes #451.