### PR TITLE
fix(hermit-docker): re-authenticate on expired OAuth token

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - **cost-reflect: per-model cost breakdown** — adds a "Cost by model" section so mixed-model (Sonnet main + Haiku subagent) operators can attribute spend per model without reading raw logs. Section is omitted for single-model windows.
 
+### Fixed
+- **hermit-docker login: re-authenticate on expired token** — gate the "already authenticated" short-circuit on credential freshness (`claudeAiOauth.expiresAt < Date.now()`), not just presence; an expired OAuth token now opens the login REPL instead of falsely reporting success.
+
 ## [1.2.10] - 2026-06-23
 
 ### Added

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -174,17 +174,22 @@ case "$CMD" in
   login)
     _require_running
     AUTH_STATUS=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" claude auth status --json 2>/dev/null || echo '{}')
-    PARSED=$(echo "$AUTH_STATUS" | bun -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(d.loggedIn ?? 'false'); console.log(d.email ?? 'unknown');" 2>/dev/null || printf 'false\nunknown')
+    PARSED=$(echo "$AUTH_STATUS" | bun -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(d.loggedIn ?? 'false'); console.log(d.email ?? 'unknown'); console.log(d.authMethod ?? 'unknown');" 2>/dev/null || printf 'false\nunknown\nunknown')
     LOGGED_IN="${PARSED%%$'\n'*}"
-    EMAIL="${PARSED#*$'\n'}"
-    # Token freshness — mirrors docker-entrypoint.hermit.sh §0b (expiresAt vs Date.now()).
-    # Duplicated intentionally: the two scripts are cp'd independently with no sourcing path.
-    # The ANTHROPIC_API_KEY guard is evaluated in-container (where the var lives, unlike the
-    # host that runs this wrapper) so api_key auth — which has no expiresAt — short-circuits to "ok".
-    # Outputs: "ok" (api_key auth, valid token, or no expiresAt field), "expired" (access token lapsed), "unknown" (read/parse error).
-    FRESH=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" sh -c \
-      '[ -n "${ANTHROPIC_API_KEY:-}" ] && { echo ok; exit; }; bun -e "try{const f=(process.env.CLAUDE_CONFIG_DIR||\"/home/claude/.claude\")+\"/.credentials.json\";const e=(JSON.parse(require(\"fs\").readFileSync(f,\"utf8\")).claudeAiOauth??{}).expiresAt;if(!e){console.log(\"ok\")}else{const ms=Number(e);if(Number.isNaN(ms))throw 0;console.log(ms<Date.now()?\"expired\":\"ok\")}}catch{console.log(\"unknown\")}"' \
-      2>/dev/null || echo "unknown")
+    REST="${PARSED#*$'\n'}"
+    EMAIL="${REST%%$'\n'*}"
+    AUTH_METHOD="${REST##*$'\n'}"
+    # api_key auth has no OAuth expiresAt and never opens the REPL — it's fresh by definition.
+    if [ "$AUTH_METHOD" = "api_key" ]; then
+      FRESH=ok
+    else
+      # Token freshness — mirrors docker-entrypoint.hermit.sh §0b (expiresAt vs Date.now()).
+      # Duplicated intentionally: the two scripts are cp'd independently with no sourcing path.
+      # Outputs: "ok" (valid token or no expiresAt field), "expired" (access token lapsed), "unknown" (read/parse error).
+      FRESH=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" sh -c \
+        'bun -e "try{const f=(process.env.CLAUDE_CONFIG_DIR||\"/home/claude/.claude\")+\"/.credentials.json\";const e=(JSON.parse(require(\"fs\").readFileSync(f,\"utf8\")).claudeAiOauth??{}).expiresAt;if(!e){console.log(\"ok\")}else{const ms=Number(e);if(Number.isNaN(ms))throw 0;console.log(ms<Date.now()?\"expired\":\"ok\")}}catch{console.log(\"unknown\")}"' \
+        2>/dev/null || echo "unknown")
+    fi
     if { [ "$LOGGED_IN" = "True" ] || [ "$LOGGED_IN" = "true" ]; } && [ "$FRESH" = "ok" ]; then
       echo "[hermit] Already authenticated as ${EMAIL}."
       echo "[hermit] To switch accounts: hermit-docker bash → claude auth logout, then re-run hermit-docker login."

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -179,9 +179,11 @@ case "$CMD" in
     EMAIL="${PARSED#*$'\n'}"
     # Token freshness — mirrors docker-entrypoint.hermit.sh §0b (expiresAt vs Date.now()).
     # Duplicated intentionally: the two scripts are cp'd independently with no sourcing path.
-    # Outputs: "ok" (valid or no expiresAt field), "expired" (access token lapsed), "unknown" (read/parse error).
+    # The ANTHROPIC_API_KEY guard is evaluated in-container (where the var lives, unlike the
+    # host that runs this wrapper) so api_key auth — which has no expiresAt — short-circuits to "ok".
+    # Outputs: "ok" (api_key auth, valid token, or no expiresAt field), "expired" (access token lapsed), "unknown" (read/parse error).
     FRESH=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" sh -c \
-      'bun -e "try{const f=(process.env.CLAUDE_CONFIG_DIR||\"/home/claude/.claude\")+\"/.credentials.json\";const e=(JSON.parse(require(\"fs\").readFileSync(f,\"utf8\")).claudeAiOauth??{}).expiresAt;if(!e){console.log(\"ok\")}else{const ms=Number(e);if(Number.isNaN(ms))throw 0;console.log(ms<Date.now()?\"expired\":\"ok\")}}catch{console.log(\"unknown\")}"' \
+      '[ -n "${ANTHROPIC_API_KEY:-}" ] && { echo ok; exit; }; bun -e "try{const f=(process.env.CLAUDE_CONFIG_DIR||\"/home/claude/.claude\")+\"/.credentials.json\";const e=(JSON.parse(require(\"fs\").readFileSync(f,\"utf8\")).claudeAiOauth??{}).expiresAt;if(!e){console.log(\"ok\")}else{const ms=Number(e);if(Number.isNaN(ms))throw 0;console.log(ms<Date.now()?\"expired\":\"ok\")}}catch{console.log(\"unknown\")}"' \
       2>/dev/null || echo "unknown")
     if { [ "$LOGGED_IN" = "True" ] || [ "$LOGGED_IN" = "true" ]; } && [ "$FRESH" = "ok" ]; then
       echo "[hermit] Already authenticated as ${EMAIL}."

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -177,10 +177,17 @@ case "$CMD" in
     PARSED=$(echo "$AUTH_STATUS" | bun -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(d.loggedIn ?? 'false'); console.log(d.email ?? 'unknown');" 2>/dev/null || printf 'false\nunknown')
     LOGGED_IN="${PARSED%%$'\n'*}"
     EMAIL="${PARSED#*$'\n'}"
-    if [ "$LOGGED_IN" = "True" ] || [ "$LOGGED_IN" = "true" ]; then
+    # Token freshness — mirrors docker-entrypoint.hermit.sh §0b (expiresAt vs Date.now()).
+    # Duplicated intentionally: the two scripts are cp'd independently with no sourcing path.
+    # Outputs: "ok" (valid or no expiresAt field), "expired" (access token lapsed), "unknown" (read/parse error).
+    FRESH=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" sh -c \
+      'bun -e "try{const f=(process.env.CLAUDE_CONFIG_DIR||\"/home/claude/.claude\")+\"/.credentials.json\";const e=(JSON.parse(require(\"fs\").readFileSync(f,\"utf8\")).claudeAiOauth??{}).expiresAt;if(!e){console.log(\"ok\")}else{const ms=Number(e);if(Number.isNaN(ms))throw 0;console.log(ms<Date.now()?\"expired\":\"ok\")}}catch{console.log(\"unknown\")}"' \
+      2>/dev/null || echo "unknown")
+    if { [ "$LOGGED_IN" = "True" ] || [ "$LOGGED_IN" = "true" ]; } && [ "$FRESH" = "ok" ]; then
       echo "[hermit] Already authenticated as ${EMAIL}."
       echo "[hermit] To switch accounts: hermit-docker bash → claude auth logout, then re-run hermit-docker login."
     else
+      [ "$FRESH" = "expired" ] && echo "[hermit] Stored login for ${EMAIL} has expired. Re-authenticating."
       echo "[hermit] Opening Claude Code REPL for login..."
       echo "[hermit] → Type /login and press Enter"
       echo "[hermit] → Open the URL in your browser and complete OAuth"


### PR DESCRIPTION
## Summary

`hermit-docker login` falsely reported "Already authenticated as X" and exited without opening the login REPL whenever the OAuth token had silently expired (~8h after `/login`). The `loggedIn` field from `claude auth status --json` reflects credential **presence**, not validity — so an expired-but-present token produces the same false positive as a valid one.

## Changes

- `state-templates/bin/hermit-docker` — added a `FRESH` probe to the `login)` case: reads `claudeAiOauth.expiresAt` from `.credentials.json` inside the container and compares to `Date.now()`. Short-circuits to "Already authenticated" only when `loggedIn AND token not expired`. Expired or unknown tokens fall through to open the REPL with an explanatory note ("Stored login for X has expired. Re-authenticating."). Mirrors the same check already in `docker-entrypoint.hermit.sh` §0b.
- `CHANGELOG.md` — `### Fixed` bullet under `[Unreleased]`.

## Test plan

- Valid token: `hermit-docker login` still prints "Already authenticated as …" and exits 0. No regression.
- Expired token (the bug): `hermit-docker login` now prints the expiry note and opens the REPL instead of the false wall. Simulate by temporarily using a credentials file whose `expiresAt` is in the past (never mutate real creds).
- Not logged in: unchanged — login walkthrough + REPL.
- Propagation: no Upgrade Instructions needed; hermit-evolve Step 5b auto-refreshes drifted `bin/` wrappers on next `/claude-code-hermit:hermit-evolve`.