### PR TITLE
fix(hatch): harden domain auto-resume init gate and resume guards

### DIFF
--- a/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/hatch/SKILL.md
@@ -17,7 +17,7 @@ Check if `.claude-code-hermit/` exists in the current project.
 
 - Missing: ask the operator (`AskUserQuestion`) "Core hermit isn't set up yet. Run `/claude-code-hermit:hatch` now?" with options `Yes — run now` / `No — I'll do it later`.
   - If yes, follow the domain hatch continuation protocol (documented in `claude-code-hermit:hatch`):
-    1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "claude-code-dev-hermit:hatch", "requested_at": "<current ISO 8601 timestamp with timezone offset>" }`.
+    1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "claude-code-dev-hermit:hatch" }`.
     2. Print: "(If setup doesn't continue automatically when core finishes, re-run `/claude-code-dev-hermit:hatch`.)"
     3. Invoke `/claude-code-hermit:hatch` **via the Skill tool** — terminal action, stop after the call.
   - If no, stop.

--- a/plugins/claude-code-fitness-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/hatch/SKILL.md
@@ -20,7 +20,7 @@ If the file does not exist or `_hermit_versions["claude-code-hermit"]` is absent
 Use `AskUserQuestion`: "Would you like to run `/claude-code-hermit:hatch` now? (yes / no)"
 
 - **yes** → Follow the domain hatch continuation protocol (documented in `claude-code-hermit:hatch`):
-  1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "claude-code-fitness-hermit:hatch", "requested_at": "<current ISO 8601 timestamp with timezone offset>" }`.
+  1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "claude-code-fitness-hermit:hatch" }`.
   2. Print: "(If setup doesn't continue automatically when core finishes, re-run `/claude-code-fitness-hermit:hatch`.)"
   3. Invoke `/claude-code-hermit:hatch` **via the Skill tool** — terminal action, stop after the call.
 - **no** → stop.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Fixed
 - **hatch: domain auto-resume** — domain hatch writes a state marker before delegating to core; core terminus reads, deletes, and invokes the pending domain hatch via the Skill tool. Removes the dead printed-command return hop and the competing-signal freeze. Adds the domain hatch continuation protocol doc.
 - **hermit-docker login: re-authenticate on expired token** — gate the "already authenticated" short-circuit on credential freshness (`claudeAiOauth.expiresAt < Date.now()`), not just presence; an expired OAuth token now opens the login REPL instead of falsely reporting success.
+- **hatch: init gate keys on `config.json`** — Step 1 now treats `config.json` (not bare directory content) as the "already initialized" signal, so a pre-core resume marker, an empty `state/` tree, or a half-written aborted run no longer trips the reinit prompt on a genuine first hatch.
+- **hatch: Quick auto-chain vs resume** — the Quick auto-chain is suppressed when a resume marker is present, so it and the resume terminus can't both fire and drop each other. Resume marker no longer carries an unused `requested_at` field.
 
 ## [1.2.10] - 2026-06-23
 

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -11,10 +11,10 @@ Set up the autonomous agent for this project. This creates the per-project state
 
 ### 1. Check if already initialized
 
-Check if `.claude-code-hermit/` exists in the current project.
+Check whether `.claude-code-hermit/config.json` exists in the current project. That file (written at Step 5) is the authoritative "already initialized" signal — not the bare presence of the `.claude-code-hermit/` directory. A lone `state/hatch-resume.json` marker (written by a domain hatch before it delegates here), an empty `state/` tree, or a half-written tree left by an aborted prior run all count as **not** initialized.
 
-- If it exists and has content: inform the operator that the agent is already initialized. Ask if they want to reinitialize (which resets templates but preserves sessions, proposals, config, and OPERATOR.md). Record the choice as `is_reinit` (true if operator opted to reinitialize).
-- If it doesn't exist: `is_reinit = false`, proceed with initialization.
+- If `.claude-code-hermit/config.json` exists: inform the operator that the agent is already initialized. Ask if they want to reinitialize (which resets templates but preserves sessions, proposals, config, and OPERATOR.md). Record the choice as `is_reinit` (true if operator opted to reinitialize).
+- Otherwise: `is_reinit = false`, proceed with initialization.
 
 ### 1.5. Pre-flight (silent — no operator interaction)
 
@@ -793,14 +793,14 @@ This file is read by `hermit-evolve`, `docker-setup`, and `claude-code-dev-hermi
 When a domain plugin's hatch detects that core is not yet set up, it uses this protocol to resume automatically after core's terminus:
 
 **Writer (domain hatch, "yes" branch):**
-1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "<domain-slug>:hatch", "requested_at": "<ISO 8601 timestamp with timezone offset>" }`.
+1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "<domain-slug>:hatch" }`.
 2. Print one fallback line: "(If setup doesn't continue automatically when core finishes, re-run `/<domain>:hatch`.)"
 3. Invoke `/claude-code-hermit:hatch` **via the Skill tool** — terminal action, stop after the call.
 
 **Consumer (core terminus — "Resume pending domain hatch" at end of this skill):**
 Read, immediately delete, then invoke the named skill via the Skill tool.
 
-**Idempotency and fail-open:** The marker is self-consuming (delete-before-invoke). The domain hatch's Step 1/2 re-checks `_hermit_versions` independently, so a plain manual re-run is always the fallback. Every failure mode (Esc mid-core, core error, stale marker, un-bumped core) degrades to today's manual behavior.
+**Idempotency and fail-open:** The marker is self-consuming (delete-before-invoke). Core's Step 1 keys "already initialized" on `config.json`, never on the marker, so writing the marker before delegating here cannot trip the reinit prompt. The domain hatch's Step 1/2 re-checks `_hermit_versions` independently, so a plain manual re-run is always the fallback. Every failure mode (Esc mid-core, core error, un-bumped core) degrades to today's manual behavior. One residual edge: if core is aborted before its terminus, the marker persists and the *next* core hatch consumes it — surfacing one domain-hatch re-prompt the operator didn't explicitly ask for. That re-prompt is itself idempotent (the domain hatch re-checks state) and Esc-able, so it's a benign annoyance, not a failure — which is why no staleness timestamp is tracked.
 
 **5th-domain authors:** follow this pattern exactly. Core's terminus handles the return hop.
 
@@ -967,6 +967,8 @@ Quick replaces Step 4 entirely and applies these defaults silently at the shared
 
 ### Quick — auto-chain at end of Step 10
 
+**Skip this entire auto-chain if `.claude-code-hermit/state/hatch-resume.json` exists.** A domain hatch is pending, and the "Resume pending domain hatch" terminus below will drive continuation instead — the two continuations must never both fire (whichever runs first drops the other). When a marker is present, emit no auto-chain slash command and fall straight through to the terminus.
+
 After Step 10 prints the standard report, output the next slash command on its own line so Claude Code's harness can pick it up and run it. Map from Turn 3's deployment + channel:
 
 | Deployment | Channel | Output |
@@ -1055,7 +1057,7 @@ Next steps:
 
 ### Resume pending domain hatch
 
-Applies on **both** Quick and Advanced paths — runs after Step 10's report (and after Quick's auto-chain output for the Quick branch).
+Applies on **both** Quick and Advanced paths and is the **last** action of the skill. On Quick, when a marker is present the Step-10 auto-chain is skipped (see above), so this terminus is the sole continuation — the two never both fire.
 
 1. Attempt to read `.claude-code-hermit/state/hatch-resume.json`. If the file does not exist or is empty, stop — no domain hatch is pending.
 2. Read the `skill` field (e.g. `"laravel-forge-hermit:hatch"`).

--- a/plugins/claude-code-hermit/tests/hatch-resume-contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-resume-contract.test.ts
@@ -1,0 +1,94 @@
+// hatch-resume.json contract test.
+//
+// Asserts the domain-hatch auto-resume protocol stays consistent across the
+// five SKILL.md files that implement it:
+// 1. Every domain hatch (writer) references the canonical marker path AND the
+//    "skill" field. Catches a path typo or a renamed field in one writer.
+// 2. Core hatch (consumer) references the path and keeps delete-BEFORE-invoke
+//    ordering in its terminus — reordering would re-resume forever on a failed
+//    invoke.
+// 3. Core Step 1 keys "already initialized" on config.json, not on bare
+//    directory content — the regression that let a pre-core marker trip the
+//    reinit prompt.
+// 4. The marker stays minimal: no writer reintroduces the dead `requested_at`
+//    field (there is no consumer for it; staleness is not tracked).
+//
+// Scope: monorepo-internal. Reads core hatch + the four sibling domain hatches.
+//
+// Usage: bun test tests/hatch-resume-contract.test.ts   (from the plugin root)
+
+import { describe, test, expect } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { PLUGIN_ROOT } from './helpers/run';
+
+const CANONICAL_PATH = '.claude-code-hermit/state/hatch-resume.json';
+const SKILL_KEY = '"skill"';
+
+const CORE_HATCH = path.join(PLUGIN_ROOT, 'skills', 'hatch', 'SKILL.md');
+
+const DOMAIN_SLUGS = [
+  'claude-code-dev-hermit',
+  'claude-code-fitness-hermit',
+  'claude-code-homeassistant-hermit',
+  'laravel-forge-hermit',
+];
+
+function domainHatch(slug: string): string {
+  return path.join(PLUGIN_ROOT, '..', slug, 'skills', 'hatch', 'SKILL.md');
+}
+
+for (const slug of DOMAIN_SLUGS) {
+  describe(`${slug}:hatch (writer)`, () => {
+    const file = domainHatch(slug);
+
+    test(`${slug}:hatch skill exists`, () => {
+      expect(fs.existsSync(file)).toBe(true);
+    });
+
+    const content = fs.readFileSync(file, 'utf-8');
+
+    test(`references ${CANONICAL_PATH}`, () => {
+      expect(content).toContain(CANONICAL_PATH);
+    });
+
+    test(`references ${SKILL_KEY} field`, () => {
+      expect(content).toContain(SKILL_KEY);
+    });
+
+    test('does not reintroduce the dead requested_at field', () => {
+      expect(content).not.toContain('requested_at');
+    });
+  });
+}
+
+// Consumer: core hatch.
+describe('claude-code-hermit:hatch (consumer + init gate)', () => {
+  test('core hatch skill exists', () => {
+    expect(fs.existsSync(CORE_HATCH)).toBe(true);
+  });
+
+  const content = fs.readFileSync(CORE_HATCH, 'utf-8');
+
+  test(`terminus references ${CANONICAL_PATH}`, () => {
+    expect(content).toContain(CANONICAL_PATH);
+  });
+
+  test('terminus deletes the marker before invoking (no re-resume loop)', () => {
+    const deleteIdx = content.lastIndexOf('Immediately delete');
+    const invokeIdx = content.lastIndexOf('Invoke the named skill');
+    expect(deleteIdx).toBeGreaterThan(-1);
+    expect(invokeIdx).toBeGreaterThan(-1);
+    expect(deleteIdx).toBeLessThan(invokeIdx);
+  });
+
+  test('Step 1 keys "already initialized" on config.json, not directory content', () => {
+    expect(content).toContain('.claude-code-hermit/config.json');
+    expect(content).toContain('already initialized');
+  });
+
+  test('core hatch does not reintroduce the dead requested_at field', () => {
+    expect(content).not.toContain('requested_at');
+  });
+});

--- a/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
@@ -16,7 +16,7 @@ Read `.claude-code-hermit/config.json`.
 - If the file is missing or `_hermit_versions["claude-code-hermit"]` is absent or less than `1.0.16`:
   - `AskUserQuestion`: "Core hermit is not initialized. Run `/claude-code-hermit:hatch` now?"
   - Yes → Follow the domain hatch continuation protocol (documented in `claude-code-hermit:hatch`):
-    1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "claude-code-homeassistant-hermit:hatch", "requested_at": "<current ISO 8601 timestamp with timezone offset>" }`.
+    1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "claude-code-homeassistant-hermit:hatch" }`.
     2. Print: "(If setup doesn't continue automatically when core finishes, re-run `/claude-code-homeassistant-hermit:hatch`.)"
     3. Invoke `/claude-code-hermit:hatch` **via the Skill tool** — terminal action, stop after the call.
   - No → stop and explain what is required.

--- a/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
@@ -20,7 +20,7 @@ If the file does not exist or `_hermit_versions["claude-code-hermit"]` is absent
 Use `AskUserQuestion`: "Would you like to run `/claude-code-hermit:hatch` now? (yes / no)"
 
 - **yes** → Follow the domain hatch continuation protocol (documented in `claude-code-hermit:hatch`):
-  1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "laravel-forge-hermit:hatch", "requested_at": "<current ISO 8601 timestamp with timezone offset>" }`.
+  1. Write `.claude-code-hermit/state/hatch-resume.json` with `{ "skill": "laravel-forge-hermit:hatch" }`.
   2. Print: "(If setup doesn't continue automatically when core finishes, re-run `/laravel-forge-hermit:hatch`.)"
   3. Invoke `/claude-code-hermit:hatch` **via the Skill tool** — terminal action, stop after the call.
 - **no** → stop.


### PR DESCRIPTION
## Summary

Follow-up to #456 (merged). A review + 3-agent pressure-test of that PR surfaced a first-run regression and two narrower issues in the domain-hatch auto-resume mechanism. This hardens it.

The architecture (on-disk marker + core terminus, two terminal Skill-tool invocations) is correct and stays — an empirical tmux probe (`--model haiku`) confirmed that relying on the Skill tool *returning control to its caller* is unreliable (it dropped the caller's post-invoke step in 1 of 2 trials, with no compaction), so the marker is justified. This PR fixes the bugs around it rather than redesigning it.

## Changes

- **Init gate keys on `config.json`** (`plugins/claude-code-hermit/skills/hatch/SKILL.md` Step 1) — the blocker. The domain hatch writes the resume marker *before* delegating to core, which creates `.claude-code-hermit/`. Step 1 previously treated any non-empty directory as "already initialized" and detoured into the reinit prompt on a genuine first hatch (forcing Advanced, skipping the Quick gate). It now keys on `config.json` (written at Step 5); a lone marker, an empty `state/` tree, or a half-written aborted run all read as **not** initialized. Verified live: a project seeded with only the marker now resolves to "NOT INITIALIZED (fresh)".
- **Quick auto-chain vs resume terminus** — on the Quick path, core emitted printed auto-chain slash commands *and* the resume terminus both as "terminal"; whichever fired first dropped the other. The auto-chain is now suppressed when a resume marker is present, so the terminus is the sole continuation.
- **Dropped the unused `requested_at` field** from all four domain writers + the protocol doc (no consumer; staleness deliberately not tracked — documented that an aborted core surfaces at most one benign, Esc-able re-prompt).
- **Contract test** (`tests/hatch-resume-contract.test.ts`) — locks the writer path/`skill`-key across all four domains, the terminus delete-before-invoke ordering, the config.json-keyed init gate, and that `requested_at` stays gone.

## Verification

- Core `bun test`: 1217 pass (incl. 21 new), 0 fail.
- Domain suites unaffected: dev 12, fitness 44, HA 480, forge 42.
- Live tmux check on real Claude Code (Haiku): pre-core marker no longer trips the reinit prompt.

## Note

The `config.json` gate also changes the *normal* reinit path: a project that crashed mid-hatch before the config write now reads as "fresh" rather than "reinit". That's more correct (no operator customizations to preserve yet), but it touches the path every deliberate second `/hatch` hits, so calling it out.