### PR TITLE
perf(install): move mechanical file ops off the LLM in hatch/docker-setup

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### Added
 - **hatch: idle_behavior choice in Quick** — Quick Turn 3 now asks proactive (`discover`) vs reactive (`wait`) instead of silently defaulting to `discover`, so operators pick deliberately.
 - **cost-reflect: per-model cost breakdown** — adds a "Cost by model" section so mixed-model (Sonnet main + Haiku subagent) operators can attribute spend per model without reading raw logs. Section is omitted for single-model windows.
+- **scripts/docker-preflight.ts** — single-call probe for docker-setup Step 1 (docker presence, config/WSL/existing-file checks, host gitconfig, auto-memory seed) returned as one JSON blob, replacing fanned-out Bash round-trips.
+- **scripts/hatch-scaffold.ts** — deterministic state-tree scaffolder for hatch Step 2 (dirs, templates, `bin/` chmod, state files with a live `reflection-state.since`). Mode-aware: `--reinit=true` refreshes hermit-owned pristine files only and never clobbers operator/state artifacts.
+
+### Changed
+- **docker-setup: copy the static entrypoint with `cp`** — `docker-entrypoint.hermit.sh` (26 KB, no placeholders) is copied verbatim from the template instead of regenerated line-by-line through the model — cuts the slowest step of every docker-setup with zero transcription risk. Manifest baseline unchanged (cp is byte-identical).
+- **docker-setup: Step 1 prerequisites via docker-preflight.ts** — one probe call; Steps 4/5 reuse its `gitconfig`/`memory` fields instead of re-probing.
+- **hatch: Step 2 state tree via hatch-scaffold.ts** — replaces the enumerated mkdir/cp/chmod/init prose with one scaffold call; reasoned artifacts (config.json, OPERATOR.md content, CLAUDE block) keep their own steps.
+- **hatch: append the session-discipline block with `cat`** — the placeholder-free CLAUDE-APPEND template is appended/created via `cat` instead of LLM regeneration (the replace path still removes the prior block first).
+- **hatch: Phase 3/5 question specs as tables** — the verbose `questions: [...]` JSON examples collapse to compact, content-identical tables, trimming the resident SKILL.md. Verified a live Haiku run still builds the batched AskUserQuestion correctly from the table form.
 
 ### Fixed
 - **hatch: domain auto-resume** — domain hatch writes a state marker before delegating to core; core terminus reads, deletes, and invokes the pending domain hatch via the Skill tool. Removes the dead printed-command return hop and the competing-signal freeze. Adds the domain hatch continuation protocol doc.

--- a/plugins/claude-code-hermit/scripts/docker-preflight.ts
+++ b/plugins/claude-code-hermit/scripts/docker-preflight.ts
@@ -8,8 +8,10 @@
  * fanning out. The skill still owns every DECISION these signals feed — this
  * script only gathers facts.
  *
- * Usage: bun docker-preflight.ts [hermit-state-dir]   # default .claude-code-hermit
- *   probes run relative to process.cwd() (the project root the operator ran from).
+ * Usage: bun docker-preflight.ts [project-root] [hermit-state-dir]
+ *   project-root defaults to process.cwd(); the skill passes the shell's `$(pwd)`
+ *   so the auto-memory path key matches Claude Code's logical-path key.
+ *   hermit-state-dir defaults to .claude-code-hermit.
  *
  * Prints a single JSON object to stdout and always exits 0 — callers inspect
  * fields, not the exit code. Any probe that errors degrades to null/false.
@@ -36,19 +38,21 @@ function dockerVersion(): string | null {
   return null;
 }
 
-function probe(hermitDir: string) {
-  const cwd = process.cwd();
+function probe(projectRoot: string, hermitDir: string) {
   const home = os.homedir();
-  // Auto-memory seed path key — matches Claude Code's `pwd | sed 's|/|-|g'` (leading dash kept).
-  const pathKey = cwd.replace(/\//g, '-');
+  // Auto-memory seed path key — derived from the project root the skill passes in
+  // (the shell's logical `$(pwd)`, the same path Claude Code keys
+  // ~/.claude/projects/<key> off), so it matches even when the root is reached
+  // through a symlink. Mirrors the original `pwd | sed 's|/|-|g'` (leading dash kept).
+  const pathKey = projectRoot.replace(/\//g, '-');
   return {
     dockerVersion: dockerVersion(),
-    configExists: fs.existsSync(path.join(cwd, hermitDir, 'config.json')),
-    isWSL: cwd.startsWith('/mnt/c/') || cwd.startsWith('/mnt/d/'),
+    configExists: fs.existsSync(path.join(projectRoot, hermitDir, 'config.json')),
+    isWSL: projectRoot.startsWith('/mnt/c/') || projectRoot.startsWith('/mnt/d/'),
     existing: {
-      dockerfile: fs.existsSync(path.join(cwd, 'Dockerfile.hermit')),
-      entrypoint: fs.existsSync(path.join(cwd, 'docker-entrypoint.hermit.sh')),
-      compose: fs.existsSync(path.join(cwd, 'docker-compose.hermit.yml')),
+      dockerfile: fs.existsSync(path.join(projectRoot, 'Dockerfile.hermit')),
+      entrypoint: fs.existsSync(path.join(projectRoot, 'docker-entrypoint.hermit.sh')),
+      compose: fs.existsSync(path.join(projectRoot, 'docker-compose.hermit.yml')),
     },
     gitconfigExists: fs.existsSync(path.join(home, '.gitconfig')),
     memory: {
@@ -61,7 +65,8 @@ function probe(hermitDir: string) {
 export { probe };
 
 if (import.meta.main) {
-  const hermitDir = process.argv[2] || '.claude-code-hermit';
-  console.log(JSON.stringify(probe(hermitDir)));
+  const projectRoot = process.argv[2] || process.cwd();
+  const hermitDir = process.argv[3] || '.claude-code-hermit';
+  console.log(JSON.stringify(probe(projectRoot, hermitDir)));
   process.exit(0);
 }

--- a/plugins/claude-code-hermit/scripts/docker-preflight.ts
+++ b/plugins/claude-code-hermit/scripts/docker-preflight.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env bun
+/**
+ * Pre-flight probe for /docker-setup Step 1.
+ *
+ * Collapses the skill's read-only Step 1 shell probes (docker presence, config
+ * existence, WSL path, existing docker files, host ~/.gitconfig, auto-memory
+ * seed) into one call so the wizard makes a single Bash round-trip instead of
+ * fanning out. The skill still owns every DECISION these signals feed — this
+ * script only gathers facts.
+ *
+ * Usage: bun docker-preflight.ts [hermit-state-dir]   # default .claude-code-hermit
+ *   probes run relative to process.cwd() (the project root the operator ran from).
+ *
+ * Prints a single JSON object to stdout and always exits 0 — callers inspect
+ * fields, not the exit code. Any probe that errors degrades to null/false.
+ *   {
+ *     "dockerVersion": "Docker version 27.0.3, build ..." | null,
+ *     "configExists": true,
+ *     "isWSL": false,
+ *     "existing": { "dockerfile": false, "entrypoint": false, "compose": false },
+ *     "gitconfigExists": true,
+ *     "memory": { "pathKey": "-home-user-project", "seedExists": false }
+ *   }
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function dockerVersion(): string | null {
+  try {
+    const r = spawnSync('docker', ['--version'], { timeout: 5000, encoding: 'utf8' });
+    if (r.status === 0 && r.stdout.trim()) return r.stdout.trim();
+  } catch {}
+  return null;
+}
+
+function probe(hermitDir: string) {
+  const cwd = process.cwd();
+  const home = os.homedir();
+  // Auto-memory seed path key — matches Claude Code's `pwd | sed 's|/|-|g'` (leading dash kept).
+  const pathKey = cwd.replace(/\//g, '-');
+  return {
+    dockerVersion: dockerVersion(),
+    configExists: fs.existsSync(path.join(cwd, hermitDir, 'config.json')),
+    isWSL: cwd.startsWith('/mnt/c/') || cwd.startsWith('/mnt/d/'),
+    existing: {
+      dockerfile: fs.existsSync(path.join(cwd, 'Dockerfile.hermit')),
+      entrypoint: fs.existsSync(path.join(cwd, 'docker-entrypoint.hermit.sh')),
+      compose: fs.existsSync(path.join(cwd, 'docker-compose.hermit.yml')),
+    },
+    gitconfigExists: fs.existsSync(path.join(home, '.gitconfig')),
+    memory: {
+      pathKey,
+      seedExists: fs.existsSync(path.join(home, '.claude', 'projects', pathKey, 'memory', 'MEMORY.md')),
+    },
+  };
+}
+
+export { probe };
+
+if (import.meta.main) {
+  const hermitDir = process.argv[2] || '.claude-code-hermit';
+  console.log(JSON.stringify(probe(hermitDir)));
+  process.exit(0);
+}

--- a/plugins/claude-code-hermit/scripts/hatch-scaffold.ts
+++ b/plugins/claude-code-hermit/scripts/hatch-scaffold.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+/**
+ * Scaffolds the static `.claude-code-hermit/` state tree for /hatch Step 2.
+ *
+ * Step 2 is otherwise many mechanical mkdir/cp/chmod calls building a tree that
+ * is byte-identical for every hatch — zero per-project reasoning. This collapses
+ * it into one deterministic call. The reasoned artifacts (config.json, OPERATOR.md
+ * *content*, CLAUDE.local.md) are NOT scaffolded here; they keep their own steps.
+ *
+ * Usage: bun hatch-scaffold.ts <PROJECT_ROOT> [--reinit=true|false]
+ *
+ * File classes (resolves the ambiguous re-init semantics in hatch SKILL.md L16
+ * toward MAXIMAL PRESERVATION — never clobber anything an operator could have
+ * edited or accumulated):
+ *   - REFRESH (hermit-owned pristine, operator never hand-edits): overwritten on
+ *     --reinit=true, created on fresh. = templates/* and bin/* .
+ *   - PRESERVE (operator-editable or accumulated state): created only if absent,
+ *     in BOTH modes. = OPERATOR.md, HEARTBEAT.md, knowledge-schema.md, and every
+ *     state/* file (reflection-state, alert-state, micro-proposals, *.jsonl).
+ *   - NEVER created: state/pending-close.json (lazily created by daily-auto-close).
+ * On a FRESH hatch every class is created, so behaviour is identical to today;
+ * the classes only diverge on --reinit.
+ *
+ * `state/template-manifest.json` is NOT seeded here — that stays deferred to the
+ * end of hatch Step 8 (it needs the bun-script permission Step 8 merges).
+ *
+ * Prints { created, overwritten, preserved, operator_existed } JSON to stdout.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { localISOStamp } from './lib/time';
+
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(import.meta.dir, '..');
+const TEMPLATES = path.join(PLUGIN_ROOT, 'state-templates');
+
+function die(msg: string): never {
+  console.error(`hatch-scaffold: ${msg}`);
+  process.exit(1);
+}
+
+const projectRoot = process.argv[2];
+if (!projectRoot) die('usage: bun hatch-scaffold.ts <PROJECT_ROOT> [--reinit=true|false]');
+const reinit = process.argv.slice(3).some((a) => a === '--reinit=true' || a === '--reinit');
+
+const hermit = path.join(projectRoot, '.claude-code-hermit');
+
+const created: string[] = [];
+const overwritten: string[] = [];
+const preserved: string[] = [];
+
+function rel(p: string): string {
+  return path.relative(hermit, p);
+}
+
+// REFRESH-class: write/overwrite from a producer. Overwrite only on reinit.
+function refresh(dest: string, produce: () => void): void {
+  const had = fs.existsSync(dest);
+  if (had && !reinit) {
+    preserved.push(rel(dest));
+    return;
+  }
+  produce();
+  (had ? overwritten : created).push(rel(dest));
+}
+
+// PRESERVE-class: only ever create when absent (both modes).
+function seedIfAbsent(dest: string, produce: () => void): boolean {
+  if (fs.existsSync(dest)) {
+    preserved.push(rel(dest));
+    return true; // already existed
+  }
+  produce();
+  created.push(rel(dest));
+  return false;
+}
+
+function copy(src: string, dest: string): void {
+  fs.copyFileSync(src, dest);
+}
+
+// --- directory tree (mkdir -p is idempotent; not counted) ---
+for (const d of ['sessions', 'proposals', 'templates', 'state', 'raw/.archive', 'compiled', 'bin']) {
+  fs.mkdirSync(path.join(hermit, d), { recursive: true });
+}
+
+// --- REFRESH: hermit-owned pristine templates ---
+for (const name of ['SHELL.md.template', 'SESSION-REPORT.md.template', 'PROPOSAL.md.template']) {
+  const dest = path.join(hermit, 'templates', name);
+  refresh(dest, () => copy(path.join(TEMPLATES, name), dest));
+}
+
+// --- REFRESH: bin/ executables (enumerate source, never hardcode) ---
+for (const name of fs.readdirSync(path.join(TEMPLATES, 'bin')).sort()) {
+  const src = path.join(TEMPLATES, 'bin', name);
+  if (!fs.statSync(src).isFile()) continue;
+  const dest = path.join(hermit, 'bin', name);
+  refresh(dest, () => {
+    copy(src, dest);
+    fs.chmodSync(dest, 0o755);
+  });
+}
+
+// --- PRESERVE: operator-editable files seeded from templates ---
+const operatorExisted = seedIfAbsent(path.join(hermit, 'OPERATOR.md'), () =>
+  copy(path.join(TEMPLATES, 'OPERATOR.md'), path.join(hermit, 'OPERATOR.md')),
+);
+seedIfAbsent(path.join(hermit, 'HEARTBEAT.md'), () =>
+  copy(path.join(TEMPLATES, 'HEARTBEAT.md.template'), path.join(hermit, 'HEARTBEAT.md')),
+);
+seedIfAbsent(path.join(hermit, 'knowledge-schema.md'), () =>
+  copy(path.join(TEMPLATES, 'knowledge-schema.md.template'), path.join(hermit, 'knowledge-schema.md')),
+);
+
+// --- PRESERVE: state files (accumulated runtime/learning/proposal data) ---
+seedIfAbsent(path.join(hermit, 'state', 'alert-state.json'), () =>
+  copy(path.join(TEMPLATES, 'alert-state.json.template'), path.join(hermit, 'state', 'alert-state.json')),
+);
+seedIfAbsent(path.join(hermit, 'state', 'micro-proposals.json'), () =>
+  copy(path.join(TEMPLATES, 'micro-proposals.json.template'), path.join(hermit, 'state', 'micro-proposals.json')),
+);
+seedIfAbsent(path.join(hermit, 'state', 'reflection-state.json'), () => {
+  const reflectionState = {
+    last_reflection: null,
+    counters: {
+      total_runs: 0,
+      empty_runs: 0,
+      runs_with_candidates: 0,
+      judge_accept: 0,
+      judge_downgrade: 0,
+      judge_suppress: 0,
+      proposals_created: 0,
+      micro_proposals_queued: 0,
+      last_run_at: null,
+      last_output_at: null,
+      since: localISOStamp(),
+    },
+  };
+  fs.writeFileSync(
+    path.join(hermit, 'state', 'reflection-state.json'),
+    JSON.stringify(reflectionState, null, 2) + '\n',
+  );
+});
+for (const jsonl of [
+  'routine-metrics.jsonl',
+  'proposal-metrics.jsonl',
+  'observations.jsonl',
+  'update-history.jsonl',
+  'channel-replies.jsonl',
+]) {
+  const dest = path.join(hermit, 'state', jsonl);
+  seedIfAbsent(dest, () => fs.writeFileSync(dest, ''));
+}
+// state/pending-close.json: deliberately never created.
+
+console.log(JSON.stringify({ created, overwritten, preserved, operator_existed: operatorExisted }));
+process.exit(0);

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -8,7 +8,7 @@ Generate Docker scaffolding for running hermit as an always-on autonomous agent 
 
 **Tone:** Friendly guided wizard. Celebrate progress. When something fails, help fix it.
 
-**Important:** Step 0's container check is a hard short-circuit — run it first and abort on `container` before anything else. After confirming host execution, batch the remaining read-only **shell** probes (Step 1's `docker --version` / config.json existence / WSL-path / existing-file checks, and the `~/.gitconfig` existence check) into a single Bash call to save round-trips. Step 2's project-dependency scan stays normal file reads (Read tool) plus analysis — do not cram it into the Bash batch. Everything that mutates state or drives the container (file backups, `docker compose`, `tmux`, `mkdir`/`touch` setup-mode, status polls, channel `send-keys`) must run strictly sequentially in its documented order — never batch those.
+**Important:** Step 0's container check is a hard short-circuit — run it first and abort on `container` before anything else. After confirming host execution, run `docker-preflight.ts` once (Step 1) — it gathers all the read-only signals (docker presence, config existence, WSL path, existing docker files, host `~/.gitconfig`, auto-memory seed) as a single JSON blob, so don't fan those probes out into separate Bash calls. Reuse its result for the git-identity (Step 4) and auto-memory (Step 5) decisions rather than re-probing. Step 2's project-dependency scan stays normal file reads (Read tool) plus analysis. Everything that mutates state or drives the container (file backups, `docker compose`, `tmux`, `mkdir`/`touch` setup-mode, status polls, channel `send-keys`) must run strictly sequentially in its documented order — never batch those.
 
 Templates live in `${CLAUDE_SKILL_DIR}/../../state-templates/docker/`.
 
@@ -26,10 +26,12 @@ If the output is `container`, **stop immediately** — do not proceed to step 1.
 
 ### 1. Prerequisites
 
-1. Run `docker --version`. If missing: "Docker isn't installed — grab it from https://docs.docker.com/get-docker/ and come back!"
-2. Verify `.claude-code-hermit/config.json` exists. If missing: "Run `/claude-code-hermit:hatch` first, then come back."
-3. If working dir starts with `/mnt/c/` or `/mnt/d/`: abort — "Clone inside WSL2 (e.g. `/home/you/project`) and run from there."
-4. Check for existing `Dockerfile.hermit`, `docker-entrypoint.hermit.sh`, `docker-compose.hermit.yml` at project root. If any found:
+Run the pre-flight probe once and parse its JSON: `bun ${CLAUDE_PLUGIN_ROOT}/scripts/docker-preflight.ts`. It returns `{ dockerVersion, configExists, isWSL, existing: {dockerfile, entrypoint, compose}, gitconfigExists, memory: {pathKey, seedExists} }`. Hold the result — Steps 4 and 5 reuse `gitconfigExists` and `memory` instead of re-probing. Apply these gates:
+
+1. If `dockerVersion` is null: "Docker isn't installed — grab it from https://docs.docker.com/get-docker/ and come back!"
+2. If `configExists` is false: "Run `/claude-code-hermit:hatch` first, then come back."
+3. If `isWSL` is true: abort — "Clone inside WSL2 (e.g. `/home/you/project`) and run from there."
+4. If any of `existing.dockerfile` / `existing.entrypoint` / `existing.compose` is true:
    - List them, then ask with `AskUserQuestion` (header: "Docker files"): **No — keep existing** (abort; remove or rename manually, then re-run) / **Yes — back up** (move to docker-backup/ and regenerate).
    - "Yes — back up" → move to `docker-backup/`, continue
    - "No — keep existing" → abort
@@ -146,16 +148,14 @@ The three templates live in `${CLAUDE_SKILL_DIR}/../../state-templates/docker/`.
 - `{{AGENT_HOOK_PROFILE}}` — always `strict` for Docker (enforces `always_on` deny patterns inside the container)
 - `{{TMUX_SESSION_NAME}}` — resolved session name
 - `{{NETWORK_MODE_LINE}}` — If `docker.network_mode` is `"host"`: replace with `    # WARNING: host networking exposes all host-local services to the container.\n    network_mode: host`. If `"bridge"` (default): remove the line entirely (bridge is Docker's default — no directive needed).
-- **Git identity:** Check if `~/.gitconfig` exists on the host. If it does not exist, remove the `.gitconfig` bind-mount line from the rendered file and add a note in the summary: "No ~/.gitconfig found — git commits inside the container will have no author identity. Create one on the host and re-run docker-setup, or set git config manually inside the container."
+- **Git identity:** Use `gitconfigExists` from the Step 1 preflight. If false, remove the `.gitconfig` bind-mount line from the rendered file and add a note in the summary: "No ~/.gitconfig found — git commits inside the container will have no author identity. Create one on the host and re-run docker-setup, or set git config manually inside the container."
 
 ### 5. Auto-memory seed
 
-Resolve the path key: `pwd | sed 's|/|-|g'` (keeps leading dash — matches Claude Code's format, e.g. `-home-user-myproject`).
+The Step 1 preflight already resolved `memory.pathKey` (`pwd | sed 's|/|-|g'` — keeps leading dash, matches Claude Code's format, e.g. `-home-user-myproject`) and `memory.seedExists` (whether `~/.claude/projects/<pathKey>/memory/MEMORY.md` exists). Reuse those:
 
-Check if `~/.claude/projects/<path-key>/memory/MEMORY.md` exists on the host:
-
-- **If it exists:** Copy to `.claude-code-hermit/MEMORY-SEED.md`. Tell the operator: "Found existing Claude Code memory for this project — seeding it into the container so your hermit starts with full context." Then ensure `.claude-code-hermit/MEMORY-SEED.md` is in `.gitignore` (append if missing).
-- **If it doesn't exist:** Do nothing. No message, no prompt.
+- **If `memory.seedExists` is true:** Copy `~/.claude/projects/<memory.pathKey>/memory/MEMORY.md` to `.claude-code-hermit/MEMORY-SEED.md`. Tell the operator: "Found existing Claude Code memory for this project — seeding it into the container so your hermit starts with full context." Then ensure `.claude-code-hermit/MEMORY-SEED.md` is in `.gitignore` (append if missing).
+- **If false:** Do nothing. No message, no prompt.
 
 Only the top-level project memory is seeded — not agent-scoped memories at `<path-key>/<agent-name>/`.
 
@@ -333,7 +333,7 @@ After plugin selection is finalized, union the two sources of apt package candid
 Now that `docker.packages` (Step 7b.packages), `docker.recommended_plugins` (Step 7b), channel state dirs (Step 7), and the auth/network choices (Step 2) are all finalized, perform the template rendering described in Step 4 above. Write the three rendered files to project root:
 
 - `Dockerfile.hermit` — substitute `{{PACKAGES_BLOCK}}` with the finalized `docker.packages`.
-- `docker-entrypoint.hermit.sh` — copy verbatim; no placeholder substitution (session name is resolved from `config.json` at container startup).
+- `docker-entrypoint.hermit.sh` — **copy with `cp`, do not regenerate it by hand** (it is a large static file with no placeholders; the session name is resolved from `config.json` at container startup). Run: `cp "${CLAUDE_SKILL_DIR}/../../state-templates/docker/docker-entrypoint.hermit.sh.template" <PROJECT_ROOT>/docker-entrypoint.hermit.sh`. The copied bytes are correct without any edits.
 - `docker-compose.hermit.yml` — substitute `{{AUTH_ENV_LINE}}`, `{{CHANNEL_ENV_LINES}}`, `{{CHANNEL_VOLUME_LINES}}`, `{{AGENT_HOOK_PROFILE}}`, `{{TMUX_SESSION_NAME}}`, `{{NETWORK_MODE_LINE}}`, plus the git-identity bind-mount handling.
 
 Use the placeholder rules from Step 4 verbatim.

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -26,7 +26,7 @@ If the output is `container`, **stop immediately** — do not proceed to step 1.
 
 ### 1. Prerequisites
 
-Run the pre-flight probe once and parse its JSON: `bun ${CLAUDE_PLUGIN_ROOT}/scripts/docker-preflight.ts`. It returns `{ dockerVersion, configExists, isWSL, existing: {dockerfile, entrypoint, compose}, gitconfigExists, memory: {pathKey, seedExists} }`. Hold the result — Steps 4 and 5 reuse `gitconfigExists` and `memory` instead of re-probing. Apply these gates:
+Run the pre-flight probe once and parse its JSON: `bun ${CLAUDE_PLUGIN_ROOT}/scripts/docker-preflight.ts "$(pwd)"` — pass `"$(pwd)"` so the auto-memory path key is keyed off the shell's logical path, matching Claude Code even through a symlinked project root. It returns `{ dockerVersion, configExists, isWSL, existing: {dockerfile, entrypoint, compose}, gitconfigExists, memory: {pathKey, seedExists} }`. Hold the result — Steps 4 and 5 reuse `gitconfigExists` and `memory` instead of re-probing. Apply these gates:
 
 1. If `dockerVersion` is null: "Docker isn't installed — grab it from https://docs.docker.com/get-docker/ and come back!"
 2. If `configExists` is false: "Run `/claude-code-hermit:hatch` first, then come back."

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -106,42 +106,22 @@ Create the following directories and files:
 └── knowledge-schema.md
 ```
 
-Initialize state files (inline — shape-insensitive or append-only):
+Run the scaffold script once — it builds the directory tree above and seeds every static file deterministically (this is pure mechanical I/O; the *reasoned* artifacts are written by their own steps):
 
-- `.claude-code-hermit/state/reflection-state.json`: initialize with the schema below. Use the current ISO timestamp (with offset) for `counters.since`.
-  ```json
-  {
-    "last_reflection": null,
-    "counters": {
-      "total_runs": 0,
-      "empty_runs": 0,
-      "runs_with_candidates": 0,
-      "judge_accept": 0,
-      "judge_downgrade": 0,
-      "judge_suppress": 0,
-      "proposals_created": 0,
-      "micro_proposals_queued": 0,
-      "last_run_at": null,
-      "last_output_at": null,
-      "since": "<current-iso-timestamp>"
-    }
-  }
-  ```
-- `.claude-code-hermit/state/proposal-metrics.jsonl`: empty file — append-only, not schema-sensitive JSON state
-- `.claude-code-hermit/state/observations.jsonl`: empty file — append-only sub-threshold observation ledger (`{ts, pattern, session_id, source}`; read by `reflect` for recurrence graduation, pruned by `scripts/prune-observations.ts`)
-- `.claude-code-hermit/state/routine-metrics.jsonl`: empty file — append-only routine fire log (`fired` events written by `scripts/log-routine-event.sh` from CronCreate prompts)
-- `.claude-code-hermit/state/update-history.jsonl`: empty file — append-only log of `hermit-docker update` and `hermit-update` runs
-- `.claude-code-hermit/state/channel-replies.jsonl`: empty file — append-only channel reply log (routine-ROI join source; written by `channel-hook.ts`)
-- `.claude-code-hermit/state/pending-close.json`: do NOT initialize — created lazily by the `daily-auto-close` skill when the midnight routine fires while the operator is currently active. Deleted by `session-close --auto` after the archive succeeds.
+```
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/hatch-scaffold.ts <PROJECT_ROOT> --reinit=<is_reinit>
+```
 
-- Read the template files from `${CLAUDE_SKILL_DIR}/../../state-templates/`
-- Copy `alert-state.json.template` → `.claude-code-hermit/state/alert-state.json`
-- Copy `micro-proposals.json.template` → `.claude-code-hermit/state/micro-proposals.json`
-- Copy `SHELL.md.template`, `SESSION-REPORT.md.template`, `PROPOSAL.md.template` into `templates/`
-- **OPERATOR.md guard:** If `.claude-code-hermit/OPERATOR.md` already exists, do NOT copy the template over it. Remember this fact as `operator_existed = true` for use in step 5a. If it does not exist, copy `OPERATOR.md` from the templates into the state directory root.
-- Copy `HEARTBEAT.md.template` → `.claude-code-hermit/HEARTBEAT.md` (the operator's editable checklist)
-- **Enumerate** all files under `${CLAUDE_SKILL_DIR}/../../state-templates/bin/` (do not hardcode the list). Copy each one into `.claude-code-hermit/bin/`. Ensure all are executable (`chmod +x`). Current set: hermit-attach, hermit-docker, hermit-run, hermit-start, hermit-status, hermit-stop, hermit-update, hermit-watchdog.
-- Copy `knowledge-schema.md.template` → `.claude-code-hermit/knowledge-schema.md` (the operator's behavioral schema for domain outputs).
+Pass `--reinit=true` only when Step 1 recorded `is_reinit = true`; otherwise `--reinit=false`. The script:
+
+- Seeds `state/reflection-state.json` (with a live ISO `counters.since`), the empty append-only ledgers `state/routine-metrics.jsonl`, `state/proposal-metrics.jsonl`, `state/observations.jsonl`, `state/update-history.jsonl`, `state/channel-replies.jsonl`, plus `state/alert-state.json`, `state/micro-proposals.json`, the `templates/` files, `HEARTBEAT.md`, `knowledge-schema.md`, `OPERATOR.md`, and copies + `chmod +x` every file under `state-templates/bin/` (enumerated, not hardcoded).
+- **Preserves operator/state artifacts** — `OPERATOR.md`, `HEARTBEAT.md`, `knowledge-schema.md`, and every `state/*` file are created only if absent (in both modes), so re-init never clobbers accumulated learning/proposal state or operator edits. `--reinit=true` only refreshes the hermit-owned pristine files (`templates/*`, `bin/*`).
+- Never creates `state/pending-close.json` (lazily created by `daily-auto-close` when the midnight routine fires while the operator is active).
+
+Parse the JSON it prints — `{ created, overwritten, preserved, operator_existed }` — and **remember `operator_existed` for Step 5a** (the OPERATOR.md guard).
+
+The reasoned artifacts are NOT scaffolded here: `config.json` (Step 5), the OPERATOR.md *content* draft (Step 5a), and the CLAUDE.local.md / CLAUDE.md block (Step 6) keep their own steps.
+
 - **Seed `state/template-manifest.json`** via `manifest-seed.ts` — records the sha256 pristine-baseline the `hermit-evolve` drift signals depend on. **Deferred to the end of Step 8** (see the seeding sub-step there): the call needs the `bun */scripts/manifest-seed.ts*` permission that Step 8 merges. The source template files are stable, so running it after the permission merge records the same hashes it would record now. Do not run it here.
 
 ### 3. Hermit activation prompt (Advanced branch only)
@@ -183,37 +163,13 @@ Step 1.5 already ran the language/timezone detection silently. Reuse those value
 
 #### Phase 3 — Behavior (AskUserQuestion batch, 3 questions)
 
-Ask all three in a single `AskUserQuestion` call:
+Ask all three in a single `AskUserQuestion` call (first option listed is the default):
 
-```
-questions: [
-  {
-    header: "Autonomy",
-    question: "How autonomous should your assistant be?",
-    options: [
-      { label: "Balanced", description: "Act on routine tasks, escalate significant changes (default)" },
-      { label: "Conservative", description: "Ask before most non-trivial actions" },
-      { label: "Autonomous", description: "Proceed unless blocked, minimize interruptions" }
-    ]
-  },
-  {
-    header: "Remote ctrl",
-    question: "Enable remote control via claude.ai/code?",
-    options: [
-      { label: "Yes", description: "Connect from claude.ai/code or phone (default)" },
-      { label: "No", description: "Local terminal only" }
-    ]
-  },
-  {
-    header: "Idle",
-    question: "What should hermit do when idle between tasks?",
-    options: [
-      { label: "Discover", description: "Maintenance and reflection (default)" },
-      { label: "Wait", description: "Passive — only check for new tasks and messages" }
-    ]
-  }
-]
-```
+| Header | Question | Options (`label`: description) |
+|---|---|---|
+| Autonomy | How autonomous should your assistant be? | `Balanced`: act on routine tasks, escalate significant changes (default) / `Conservative`: ask before most non-trivial actions / `Autonomous`: proceed unless blocked, minimize interruptions |
+| Remote ctrl | Enable remote control via claude.ai/code? | `Yes`: connect from claude.ai/code or phone (default) / `No`: local terminal only |
+| Idle | What should hermit do when idle between tasks? | `Discover`: maintenance and reflection (default) / `Wait`: passive, only check for new tasks and messages |
 
 Record: `escalation` (conservative/balanced/autonomous), `remote` (true/false), `idle_behavior` (wait/discover).
 
@@ -299,28 +255,12 @@ questions: [
   > - **Interactive (just trying it):** run `/claude-code-hermit:channel-setup` for token + pairing, then restart with `claude --channels plugin:<channel>@claude-plugins-official` so the channel is active in your session.
   > - Full guide: https://code.claude.com/docs/en/channels
 
-**Channel follow-ups (only if Discord or Telegram was selected above — AskUserQuestion batch, 2 questions):**
+**Channel follow-ups (only if Discord or Telegram was selected above — AskUserQuestion batch, 2 questions; first option listed is the default):**
 
-```
-questions: [
-  {
-    header: "Access ctrl",
-    question: "Restrict who can send commands via this channel?",
-    options: [
-      { label: "Allow everyone", description: "No restrictions on who can message (default)" },
-      { label: "Restrict", description: "Type your Discord/Telegram user ID via Other" }
-    ]
-  },
-  {
-    header: "Brief",
-    question: "Enable morning brief delivery via channel?",
-    options: [
-      { label: "Yes — 07:00", description: "Daily summary delivered each morning" },
-      { label: "No", description: "No automated brief delivery (default)" }
-    ]
-  }
-]
-```
+| Header | Question | Options (`label`: description) |
+|---|---|---|
+| Access ctrl | Restrict who can send commands via this channel? | `Allow everyone`: no restrictions on who can message (default) / `Restrict`: type your Discord/Telegram user ID via Other |
+| Brief | Enable morning brief delivery via channel? | `Yes — 07:00`: daily summary delivered each morning / `No`: no automated brief delivery (default) |
 
 - **Access control:** If "Restrict" and a numeric ID was typed via Other, record in `channels.<channel>.allowed_users` as `["<id>"]`. If "Allow everyone" or no ID provided, omit the key (absent = accept all). Note: "Add more user IDs later with `/claude-code-hermit:hermit-settings channels`. An empty array [] blocks all messages."
 - **Morning brief:** If "Yes — 07:00", record as `channels.<channel>.morning_brief: { "enabled": true, "time": "07:00" }`. If "No", omit the key (or set to `null`).
@@ -544,13 +484,13 @@ The target file is determined by `hatch_target` (computed in Step 1.5):
 
 Perform the idempotency check across both files first: if the marker `claude-code-hermit: Session Discipline` exists in the non-target file, surface a conflict — ask operator: **Move to target file** (diff-and-confirm) / **Keep both** (warn that both load) / **Skip conflict**. Never silently leave duplicate markers.
 
-For the target file:
+For the target file (the block is static — **copy it with `cat`, never regenerate it by hand**):
 - If it exists: check if it already contains `claude-code-hermit: Session Discipline`
   - If yes: ask with `AskUserQuestion` (header: "CLAUDE block") — options: **Yes — replace** (update to latest) / **No — keep** (preserve current, default)
-    - If "Yes — replace": remove everything between `<!-- claude-code-hermit: Session Discipline -->` and `<!-- /claude-code-hermit: Session Discipline -->` (inclusive), then append the fresh contents of `${CLAUDE_SKILL_DIR}/../../state-templates/CLAUDE-APPEND.md`
+    - If "Yes — replace": remove the existing hermit block (from its `<!-- claude-code-hermit: Session Discipline -->` marker — and any blank line / `---` separator immediately above it — through the end of that block; the template carries no closing marker, so identify the block end by content), then re-append the fresh template: `cat "${CLAUDE_SKILL_DIR}/../../state-templates/CLAUDE-APPEND.md" >> <target>`
     - If "No — keep": skip
-  - If no: read `${CLAUDE_SKILL_DIR}/../../state-templates/CLAUDE-APPEND.md` and append its contents to the end of the target file
-- If the target file doesn't exist: create it with the append block as the initial content
+  - If no: `cat "${CLAUDE_SKILL_DIR}/../../state-templates/CLAUDE-APPEND.md" >> <target>`
+- If the target file doesn't exist: `cat "${CLAUDE_SKILL_DIR}/../../state-templates/CLAUDE-APPEND.md" > <target>`
 
 If a hermit was activated in step 3, also append `<activated_hermit.installPath>/state-templates/CLAUDE-APPEND.md` to the same target file (using the same skip/overwrite logic if its marker already exists).
 

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -163,7 +163,7 @@ Step 1.5 already ran the language/timezone detection silently. Reuse those value
 
 #### Phase 3 — Behavior (AskUserQuestion batch, 3 questions)
 
-Ask all three in a single `AskUserQuestion` call (first option listed is the default):
+Ask all three in a single `AskUserQuestion` call (the option marked `(default)` is the Recommended pre-selection):
 
 | Header | Question | Options (`label`: description) |
 |---|---|---|
@@ -255,7 +255,7 @@ questions: [
   > - **Interactive (just trying it):** run `/claude-code-hermit:channel-setup` for token + pairing, then restart with `claude --channels plugin:<channel>@claude-plugins-official` so the channel is active in your session.
   > - Full guide: https://code.claude.com/docs/en/channels
 
-**Channel follow-ups (only if Discord or Telegram was selected above — AskUserQuestion batch, 2 questions; first option listed is the default):**
+**Channel follow-ups (only if Discord or Telegram was selected above — AskUserQuestion batch, 2 questions; the option marked `(default)` is the Recommended pre-selection):**
 
 | Header | Question | Options (`label`: description) |
 |---|---|---|

--- a/plugins/claude-code-hermit/tests/docker-preflight.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-preflight.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript } from './helpers/run';
+
+const tmpdirs: string[] = [];
+function freshDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-dpf-'));
+  tmpdirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmpdirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+});
+
+async function run(cwd: string) {
+  const r = await runScript('docker-preflight.ts', { cwd });
+  expect(r.exitCode).toBe(0);
+  return JSON.parse(r.stdout);
+}
+
+describe('docker-preflight.ts', () => {
+  test('clean project: stable shape, fail-open fields', async () => {
+    const dir = freshDir();
+    const out = await run(dir);
+
+    // dockerVersion is host-dependent — string or null, never throws.
+    expect(out.dockerVersion === null || typeof out.dockerVersion === 'string').toBe(true);
+    expect(out.configExists).toBe(false);
+    expect(out.existing).toEqual({ dockerfile: false, entrypoint: false, compose: false });
+    expect(typeof out.gitconfigExists).toBe('boolean');
+    // path key mirrors `pwd | sed 's|/|-|g'` (leading dash retained).
+    expect(out.memory.pathKey).toBe(fs.realpathSync(dir).replace(/\//g, '-'));
+    expect(typeof out.memory.seedExists).toBe('boolean');
+  });
+
+  test('detects config.json and existing docker files', async () => {
+    const dir = freshDir();
+    fs.mkdirSync(path.join(dir, '.claude-code-hermit'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.claude-code-hermit', 'config.json'), '{}');
+    fs.writeFileSync(path.join(dir, 'Dockerfile.hermit'), 'FROM ubuntu\n');
+    fs.writeFileSync(path.join(dir, 'docker-compose.hermit.yml'), 'services: {}\n');
+
+    const out = await run(dir);
+    expect(out.configExists).toBe(true);
+    expect(out.existing.dockerfile).toBe(true);
+    expect(out.existing.compose).toBe(true);
+    expect(out.existing.entrypoint).toBe(false);
+  });
+});

--- a/plugins/claude-code-hermit/tests/docker-preflight.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-preflight.test.ts
@@ -16,8 +16,8 @@ afterEach(() => {
   }
 });
 
-async function run(cwd: string) {
-  const r = await runScript('docker-preflight.ts', { cwd });
+async function run(projectRoot: string) {
+  const r = await runScript('docker-preflight.ts', { args: [projectRoot] });
   expect(r.exitCode).toBe(0);
   return JSON.parse(r.stdout);
 }
@@ -32,8 +32,9 @@ describe('docker-preflight.ts', () => {
     expect(out.configExists).toBe(false);
     expect(out.existing).toEqual({ dockerfile: false, entrypoint: false, compose: false });
     expect(typeof out.gitconfigExists).toBe('boolean');
-    // path key mirrors `pwd | sed 's|/|-|g'` (leading dash retained).
-    expect(out.memory.pathKey).toBe(fs.realpathSync(dir).replace(/\//g, '-'));
+    // path key is derived from the project root passed in (mirrors `pwd | sed 's|/|-|g'`,
+    // leading dash retained) — keyed off the supplied logical path, not a resolved one.
+    expect(out.memory.pathKey).toBe(dir.replace(/\//g, '-'));
     expect(typeof out.memory.seedExists).toBe('boolean');
   });
 

--- a/plugins/claude-code-hermit/tests/hatch-scaffold.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-scaffold.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript, PLUGIN_ROOT } from './helpers/run';
+
+const TEMPLATES = path.join(PLUGIN_ROOT, 'state-templates');
+const ISO_OFFSET = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}$/;
+
+const tmpdirs: string[] = [];
+function freshDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-scaffold-'));
+  tmpdirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmpdirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+});
+
+async function scaffold(projectRoot: string, reinit = false) {
+  const args = reinit ? [projectRoot, '--reinit=true'] : [projectRoot];
+  const r = await runScript('hatch-scaffold.ts', { args });
+  expect(r.exitCode).toBe(0);
+  return JSON.parse(r.stdout);
+}
+
+describe('hatch-scaffold.ts', () => {
+  test('fresh project: builds the full tree, stamps a live timestamp', async () => {
+    const dir = freshDir();
+    const hermit = path.join(dir, '.claude-code-hermit');
+    const out = await scaffold(dir);
+
+    expect(out.operator_existed).toBe(false);
+
+    // dirs
+    for (const d of ['sessions', 'proposals', 'templates', 'state', 'raw/.archive', 'compiled', 'bin']) {
+      expect(fs.existsSync(path.join(hermit, d))).toBe(true);
+    }
+    // pristine templates
+    for (const f of ['SHELL.md.template', 'SESSION-REPORT.md.template', 'PROPOSAL.md.template']) {
+      expect(fs.existsSync(path.join(hermit, 'templates', f))).toBe(true);
+    }
+    // bin/ enumerated + executable
+    const binNames = fs.readdirSync(path.join(TEMPLATES, 'bin'));
+    expect(binNames.length).toBeGreaterThan(0);
+    for (const name of binNames) {
+      const dest = path.join(hermit, 'bin', name);
+      expect(fs.existsSync(dest)).toBe(true);
+      expect(fs.statSync(dest).mode & 0o111).toBeGreaterThan(0);
+    }
+    // operator-editable + state files
+    for (const f of ['OPERATOR.md', 'HEARTBEAT.md', 'knowledge-schema.md']) {
+      expect(fs.existsSync(path.join(hermit, f))).toBe(true);
+    }
+    for (const f of [
+      'alert-state.json', 'micro-proposals.json', 'reflection-state.json',
+      'routine-metrics.jsonl', 'proposal-metrics.jsonl', 'observations.jsonl',
+      'update-history.jsonl', 'channel-replies.jsonl',
+    ]) {
+      expect(fs.existsSync(path.join(hermit, 'state', f))).toBe(true);
+    }
+    // live timestamp on reflection-state
+    const rs = JSON.parse(fs.readFileSync(path.join(hermit, 'state', 'reflection-state.json'), 'utf8'));
+    expect(rs.counters.since).toMatch(ISO_OFFSET);
+
+    // never created
+    expect(fs.existsSync(path.join(hermit, 'state', 'pending-close.json'))).toBe(false);
+  });
+
+  test('--reinit preserves operator/state artifacts, refreshes pristine files', async () => {
+    const dir = freshDir();
+    const hermit = path.join(dir, '.claude-code-hermit');
+    fs.mkdirSync(path.join(hermit, 'templates'), { recursive: true });
+    fs.mkdirSync(path.join(hermit, 'state'), { recursive: true });
+    fs.mkdirSync(path.join(hermit, 'sessions'), { recursive: true });
+
+    // operator/state artifacts with custom content
+    fs.writeFileSync(path.join(hermit, 'OPERATOR.md'), 'CUSTOM operator profile\n');
+    fs.writeFileSync(path.join(hermit, 'state', 'micro-proposals.json'), '{"custom":true}');
+    fs.writeFileSync(path.join(hermit, 'state', 'reflection-state.json'), '{"counters":{"since":"CUSTOM"}}');
+    fs.writeFileSync(path.join(hermit, 'sessions', 'SHELL.md'), 'live session\n');
+    // a stale pristine template that SHOULD be refreshed
+    fs.writeFileSync(path.join(hermit, 'templates', 'SHELL.md.template'), 'OLD STALE TEMPLATE\n');
+
+    const out = await scaffold(dir, true);
+    expect(out.operator_existed).toBe(true);
+
+    // preserved
+    expect(fs.readFileSync(path.join(hermit, 'OPERATOR.md'), 'utf8')).toBe('CUSTOM operator profile\n');
+    expect(fs.readFileSync(path.join(hermit, 'state', 'micro-proposals.json'), 'utf8')).toBe('{"custom":true}');
+    expect(JSON.parse(fs.readFileSync(path.join(hermit, 'state', 'reflection-state.json'), 'utf8')).counters.since).toBe('CUSTOM');
+    expect(fs.readFileSync(path.join(hermit, 'sessions', 'SHELL.md'), 'utf8')).toBe('live session\n');
+
+    // refreshed to pristine upstream content
+    const pristine = fs.readFileSync(path.join(TEMPLATES, 'SHELL.md.template'), 'utf8');
+    expect(fs.readFileSync(path.join(hermit, 'templates', 'SHELL.md.template'), 'utf8')).toBe(pristine);
+
+    expect(fs.existsSync(path.join(hermit, 'state', 'pending-close.json'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

A live Haiku probe of the install skills showed `docker-setup` and `hatch` spend most of their time and tokens on **mechanical file emission** (regenerating static files, fanning out probes), not on project reasoning. This moves that mechanical work off the LLM while leaving every project-analysis path intact.

## Changes

- **docker-setup:** `cp` the static 26 KB `docker-entrypoint.hermit.sh` from its template instead of regenerating it line-by-line through the model (the slowest step of every run; byte-identical, so the `manifest-seed` baseline is unchanged). `Dockerfile`/`compose` stay LLM-rendered.
- **docker-setup:** new `scripts/docker-preflight.ts` collapses Step 1's read-only probes into one JSON call; Steps 4/5 reuse its `gitconfig`/`memory` fields instead of re-probing.
- **hatch:** new `scripts/hatch-scaffold.ts` builds the Step 2 state tree in one deterministic call. Mode-aware — `--reinit=true` refreshes only hermit-owned pristine files (`templates/`, `bin/`) and never clobbers operator/state artifacts; stamps a live `reflection-state.since`.
- **hatch:** append the placeholder-free CLAUDE-APPEND block via `cat` instead of LLM regeneration (the replace path still strips the prior block first).
- **hatch:** Phase 3/5 question specs collapsed from verbose `questions: [...]` JSON to content-identical tables, trimming the resident SKILL.md.

## Verification

- Tests: **pass** (38.3s) — 1221 tests across 38 files, including new `docker-preflight.test.ts` and `hatch-scaffold.test.ts`.
- `bunx tsc --noEmit`: 0 errors.
- Live Haiku tmux probe confirmed the table-form question specs still build a correct batched 3-question `AskUserQuestion` (headers, options, and `(default)` → `(Recommended)` mapping all intact).

## Notes

- **Reasoning preserved.** The project-analysis paths existing-project hatches depend on — apt-package inference (incl. Python `requirements.txt`/`pyproject` and native-addon detection), OPERATOR.md drafting, project scan, sandbox-probe interpretation — are deliberately untouched. Only mechanical emission moved.
- **`render.ts` deferred (scoped out).** The entrypoint `cp` captures ~90% of the docker win on its own, and editing the `docker-compose` template to suit a placeholder-only renderer would change its manifest hash and fire a spurious "template changed upstream" notice on every existing install. Revisit only if a re-probe shows the two small templated files (`Dockerfile`, `compose`) still cost materially.
- **Re-init semantics.** `hatch-scaffold` resolves an ambiguity in the current re-init prose (SKILL.md L16 "preserves proposals" vs the previously-unguarded copies) toward maximal preservation — flagged here for confirmation.
