### PR TITLE
feat(claude-code-hermit): flag Completed-vs-Artifacts mismatch at session close

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **session-close: Completed-vs-Artifacts closeout check** — a quality-check item flags when `## Completed` claims a deliverable a skill persists to `compiled/` but it's absent from `## Artifacts`, catching silently-dropped outputs at close instead of in a later session. Report template now labels `## Completed` as narrative. (#465)
+
 ## [1.2.11] - 2026-06-24
 
 ### Added

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -103,6 +103,7 @@ Verify these before proceeding with close (applies to both modes):
 - [ ] All changed files are listed in the Changed section
 - [ ] Blockers are described with enough context for a cold start
 - [ ] Cost data is recorded (if available from the cost-tracker hook)
+- [ ] If `## Completed` claims a deliverable that a skill persists to `compiled/` (e.g. a deep-dive, briefing, or decision doc), confirm it appears in `## Artifacts`. If it doesn't, the deliverable was dropped: record it in `## Blockers` rather than leaving `## Completed` asserting success.
 - [ ] If status is `blocked`: have you run `/debug` to check for tool/hook failures? Include diagnosis in blockers if relevant
 
 **Full shutdown only:**

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -103,7 +103,7 @@ Verify these before proceeding with close (applies to both modes):
 - [ ] All changed files are listed in the Changed section
 - [ ] Blockers are described with enough context for a cold start
 - [ ] Cost data is recorded (if available from the cost-tracker hook)
-- [ ] If `## Completed` claims a deliverable that a skill persists to `compiled/` (e.g. a deep-dive, briefing, or decision doc), confirm it appears in `## Artifacts`. If it doesn't, the deliverable was dropped: record it in `## Blockers` rather than leaving `## Completed` asserting success.
+- [ ] If `## Completed` claims a deliverable that a skill persists to `compiled/` (e.g. a deep-dive, briefing, or decision doc), confirm it appears in `## Artifacts`. If it doesn't, verify whether the output actually reached `compiled/`: if it did, add it to `## Artifacts`; if it didn't, the deliverable was dropped, so record it in `## Blockers` rather than leaving `## Completed` asserting success.
 - [ ] If status is `blocked`: have you run `/debug` to check for tool/hook failures? Include diagnosis in blockers if relevant
 
 **Full shutdown only:**

--- a/plugins/claude-code-hermit/state-templates/SESSION-REPORT.md.template
+++ b/plugins/claude-code-hermit/state-templates/SESSION-REPORT.md.template
@@ -18,7 +18,7 @@ closed_via: operator  # operator | auto
 <!-- One-line task description -->
 
 ## Completed
-<!-- What was accomplished -->
+<!-- What was accomplished (narrative). Durable outputs must also be listed under ## Artifacts. -->
 
 ## Changed
 <!-- Files modified/created/deleted -->


### PR DESCRIPTION
## Summary
- Adds a closeout quality-check item so a session that claims a deliverable in `## Completed` which a skill persists to `compiled/` but never lists under `## Artifacts` is caught at close, not in a later session.
- Labels `## Completed` as narrative in the session-report template, so readers don't treat it as a persistence guarantee.

## Context
Closes #465 (filed by hermit-scribe). A real archived report claimed an `activity-deep-dive` ran and was sent to the channel, while `## Artifacts` said "none" and `## Blockers` said the routine never executed. The contradiction passed unflagged; the next session recomputed the deep-dive from scratch and found a stale sync cursor.

## Approach
Deliberately scoped down from the issue's proposal. The issue suggested an active reconciliation mechanism that parses `## Completed` for skill-specific persistence claims. That was rejected as overengineering: it would need core's closeout to know every domain plugin's skill->artifact contract (a cross-plugin registry that does not exist), and its generic fallback false-positives on every legitimate artifact-less close. The minimal nudge runs on the model that already holds full session context (it judges, it does not pattern-match), so it gets most of the catch at near-zero cost with zero coupling.

**Caveat:** this is a model-judgment nudge, not a hard gate. It will not reliably catch a closing model that already wrote an internally contradictory report (the exact failure in the cited example). It raises the odds of a catch; it does not guarantee one. It also does nothing for the example's domain-side bugs (un-advanced strava cursor, dropped routine), which belong in a separate fitness-hermit issue.

## Changes
- `skills/session-close/SKILL.md` - one item added to the existing "Quality Check Before Closing" list.
- `state-templates/SESSION-REPORT.md.template` - annotated the `## Completed` comment.
- `CHANGELOG.md` - `[Unreleased]` entry.

## Verification
- `bun test` from `plugins/claude-code-hermit/`: **1222 pass, 0 fail** (38 files).
- No test asserts on the edited text (confirmed against template-skill-sync, hatch-scaffold, eval-success-signal).
- No runtime/behavioral assertion is meaningful - this is a prompt-level nudge.
