### PR TITLE
fix(claude-code-hermit): suppress duplicate heartbeat-restart fired metric (#464)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **routines: suppress duplicate `fired` metric** — heartbeat-restart's self-re-arm (`hermit-routines load` at its own prompt tail) could log a second `fired` with no intervening `started` (#464); `log-routine-event.sh` now skips a `fired` that immediately follows another `fired` for the same routine.
+
 ## [1.2.11] - 2026-06-24
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/log-routine-event.sh
+++ b/plugins/claude-code-hermit/scripts/log-routine-event.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 
 id="$1"
 event="$2"
-ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 # CronCreate prompts fire with $PWD set to the session's primary working
 # directory, which may be a subdirectory of the hermit project root. Walk up
@@ -22,6 +21,19 @@ if [[ "$dir" == "/" ]]; then
   exit 1
 fi
 
+metrics="$dir/.claude-code-hermit/state/routine-metrics.jsonl"
+
+# Dedup guard (issue #464): heartbeat-restart re-invokes `hermit-routines load`
+# at its own prompt tail, which can re-trigger the cron and emit a second
+# `fired` with no intervening `started`. The prompt always logs `started`
+# immediately before `fired`, so a `fired` whose latest same-routine event is
+# already `fired` can only be the spurious re-trigger. Portable; no date math.
+if [[ "$event" == "fired" && -f "$metrics" ]]; then
+  last="$(grep -F "\"routine_id\":\"$id\"" "$metrics" | tail -n 1 || true)"
+  [[ "$last" == *'"event":"fired"'* ]] && exit 0
+fi
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 printf '{"ts":"%s","routine_id":"%s","event":"%s","delivery":"cron-create"}\n' \
   "$ts" "$id" "$event" \
-  >> "$dir/.claude-code-hermit/state/routine-metrics.jsonl"
+  >> "$metrics"

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -1591,6 +1591,35 @@ describe('log-routine-event', () => {
     });
   });
 
+  describe('duplicate fired guard (#464)', () => {
+    let wd: Workdir;
+    const metrics = () => hermit(wd.dir, 'state', 'routine-metrics.jsonl');
+    const firedCount = () =>
+      fs
+        .readFileSync(metrics(), 'utf-8')
+        .split('\n')
+        .filter((l) => l.includes('"routine_id":"heartbeat-restart","event":"fired"')).length;
+
+    beforeAll(() => {
+      wd = setupWorkdir();
+    });
+    afterAll(() => wd.cleanup());
+
+    test('suppresses a fired that immediately follows another fired', async () => {
+      await runBash(SCRIPT, { args: ['heartbeat-restart', 'started'], cwd: wd.dir });
+      await runBash(SCRIPT, { args: ['heartbeat-restart', 'fired'], cwd: wd.dir });
+      await runBash(SCRIPT, { args: ['heartbeat-restart', 'fired'], cwd: wd.dir });
+      expect(firedCount()).toBe(1);
+    });
+
+    test('allows the next legitimate started→fired cycle', async () => {
+      const before = firedCount();
+      await runBash(SCRIPT, { args: ['heartbeat-restart', 'started'], cwd: wd.dir });
+      await runBash(SCRIPT, { args: ['heartbeat-restart', 'fired'], cwd: wd.dir });
+      expect(firedCount()).toBe(before + 1);
+    });
+  });
+
   describe('no hermit ancestor', () => {
     // No .claude-code-hermit/ ancestor → non-zero exit with a clear diagnostic
     let exitCode = 0;


### PR DESCRIPTION
## Summary
In always-on deployments the `heartbeat-restart` routine re-invokes `/claude-code-hermit:hermit-routines load` as the last step of its own cron prompt. That `load` deletes+recreates every routine cron — including heartbeat-restart itself — mid-turn, which intermittently (~weekly) re-triggers the prompt tail and writes a **second `fired`** to `routine-metrics.jsonl` with no intervening `started`. Impact is cosmetic (inflated fire counts); no consumer is functionally harmed.

This adds a mechanism-independent dedup guard in `log-routine-event.sh`: since the prompt always logs `started` immediately before `fired`, a `fired` whose latest same-routine event is already `fired` can only be the spurious re-trigger, and is dropped. It fixes the symptom regardless of the exact cron re-delivery mechanism (which is not fully pinned down), and is fully portable — no GNU-only `date -d`.

Three fix angles were weighed; prompt reordering is provably impossible (the re-delivered span always includes `fired`) and load-loop reordering depends on unconfirmed CronCreate next-run semantics. The script-level guard was the only option robust to the unknown mechanism. Reordering/load changes are deliberately out of scope.

## Changes
- **`scripts/log-routine-event.sh`** — skip a `fired` that immediately follows another `fired` for the same `routine_id` (portable `grep -F | tail` check); `ts` now computed after the guard so it isn't wasted on guarded-away calls.
- **`tests/scripts.test.ts`** — new `duplicate fired guard (#464)` block: asserts suppression of back-to-back fireds and that the next legitimate `started`→`fired` cycle still logs.
- **`CHANGELOG.md`** — `[Unreleased]` → `### Fixed` entry.

## Test plan
- `cd plugins/claude-code-hermit && bun test tests/scripts.test.ts` → **234 pass, 0 fail** (2 new + 3 pre-existing `log-routine-event` tests unchanged).
- Manual scratch-dir run: `started,fired,fired` → ledger holds 1 `fired`; subsequent `started,fired` → 2 `fired`.

Closes #464