### PR TITLE
fix(claude-code-hermit): state terse-output rationale in judge subagents

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **judge subagents: state terse-output rationale explicitly** — `proposal-triage`, `reflection-judge`, and `quality-gate-judge` now say their final message lands verbatim in the caller's long-lived context and re-read from cache each turn, so reasoning belongs in thinking, not the response (#468).
+
 ## [1.2.11] - 2026-06-24
 
 ### Added

--- a/plugins/claude-code-hermit/agents/proposal-triage.md
+++ b/plugins/claude-code-hermit/agents/proposal-triage.md
@@ -123,6 +123,8 @@ Rules:
 
 Your response is not complete without the verdict line. If you have finished reading files and have not yet emitted a verdict, emit it now before stopping.
 
+Your final message is read verbatim into the caller's long-lived main-session context and re-read from cache on every subsequent turn. Emit **only** the verdict line and any applicable metadata lines — never your step-by-step analysis or a narration of Steps 1–5. Do your reasoning in thinking; it must not appear in the response.
+
 ## Memory curation
 
 After returning your verdict: if you suppressed a candidate and the suppression shape generalizes (the same structural kind of candidate keeps failing the same condition), record or update one terse heuristic in your private `MEMORY.md`. Keep entries short and grounded in the three-condition test. Prune entries that no longer match current conditions.

--- a/plugins/claude-code-hermit/agents/quality-gate-judge.md
+++ b/plugins/claude-code-hermit/agents/quality-gate-judge.md
@@ -90,6 +90,8 @@ RUN: <≤15 words explaining why>
 SKIP: <≤15 words explaining why>
 ```
 
+Your final message is read verbatim into the caller's long-lived main-session context and re-read from cache on every subsequent turn. Emit **only** the verdict line with its ≤15-word reason — never your step-by-step analysis. Do your reasoning in thinking; it must not appear in the response.
+
 Examples:
 - `RUN: bug fix touched hooks/precheck.js and added a near-duplicate guard block`
 - `RUN: capability proposal created a new SKILL.md with overlapping instruction paragraphs`

--- a/plugins/claude-code-hermit/agents/reflection-judge.md
+++ b/plugins/claude-code-hermit/agents/reflection-judge.md
@@ -49,7 +49,7 @@ Your private memory is invisible to the operator. Do not quote it in verdict lin
 
 ## For Each Candidate
 
-Reason carefully about each candidate's evidence and tier before emitting its verdict — this batch gates what reaches the proposal pipeline.
+Reason carefully about each candidate's evidence and tier in your thinking before emitting its verdict — keep that reasoning out of the response. This batch gates what reaches the proposal pipeline.
 
 ### 0. Evidence Source dispatch
 
@@ -154,6 +154,8 @@ SUPPRESS (current-session): <title> — no-evidence: <reason>
 ```
 
 One line per candidate. Nothing else.
+
+Your final message is read verbatim into the caller's long-lived main-session context and re-read from cache on every subsequent turn. Emit **only** one verdict line per candidate — never your three-condition evaluation or any other analysis. Do your reasoning in thinking; it must not appear in the response.
 
 ## Memory curation
 


### PR DESCRIPTION
## Summary
The `proposal-triage`, `reflection-judge`, and `quality-gate-judge` subagents already mandate line-1 verdict output, but never explained *why* terseness matters. Their final message lands verbatim in the caller's long-lived main-session context and is re-read from cache every turn, so this attaches that consequence to the existing instruction and directs reasoning into thinking rather than the response. Addresses the context-bloat concern in #468.

## Changes
- **`agents/proposal-triage.md`** — added a rationale sentence in `## Output`: final message lands in caller context; emit only the verdict + metadata lines, reason in thinking.
- **`agents/quality-gate-judge.md`** — same rationale, scoped to the verdict line + ≤15-word reason.
- **`agents/reflection-judge.md`** — tightened the "reason carefully before emitting" line to route reasoning into thinking, plus the same rationale sentence in `## Output Format`.
- **`CHANGELOG.md`** — one terse `[Unreleased]` bullet under `### Changed`.

## Scope corrections vs the issue (from `/tackle-issue` triage)
- The issue's claim that "nothing constrains the final message" is inaccurate — all three agents already say "No prose / verdict on line 1 / Nothing else." The real gap was the missing *rationale*, which is what this PR adds.
- Dropped the issue's structured-output-schema suggestion: these agents are dispatched by skills via natural-language `Agent` calls, not `Workflow` with a `schema` option, so there is no schema-enforcement hook in this path.
- Honest scope note: this is a *nudge*, not enforcement. Expect no measurable token delta — harmless reinforcement if the agents never emit prose, helpful if they sometimes do.

## Test plan
- `cd plugins/claude-code-hermit && bun test` — 1222 pass / 0 fail (run before push).
- No automated output-length assertion exists; not worth adding for a prompt nudge.

Closes #468