### PR TITLE
fix(hermit): reconcile heartbeat monitor after hermit-settings change

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **hermit-settings: reconcile the heartbeat monitor on change** — after writing a `heartbeat` change, auto-runs `/heartbeat start` (if enabled) or `/heartbeat stop` (if disabled) so the live Monitor's cadence and `config.json` can't silently desync. (#452)
+
 ## [1.2.11] - 2026-06-24
 
 ### Added

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -198,7 +198,10 @@ Update `permission_mode` in config.json.
   ```
   Then ask each field in sequence.
 - Update `heartbeat` object in config.json.
-  - Note: "Heartbeat changes take effect on next `/claude-code-hermit:heartbeat start` or `hermit-start.ts` run."
+- **After the change is written**, reconcile the live Monitor with the new state via the Skill tool. The monitor's poll interval is baked in at `start` time from `heartbeat.every`, so a config-only change otherwise leaves the running monitor on the old cadence (and `/hermit-doctor` would flag the mismatch). Surface the result inline:
+  - If heartbeat is now **enabled**: invoke `/claude-code-hermit:heartbeat start` (idempotent — stops the old monitor and re-registers at the new interval). Success: "Heartbeat monitor restarted at new interval (`<every>`). Active immediately."
+  - If heartbeat is now **disabled**: invoke `/claude-code-hermit:heartbeat stop`. Success: "Heartbeat monitor stopped."
+  - Failure (either): "Settings saved to config.json, but `/claude-code-hermit:heartbeat <start|stop>` failed: <reason>. Run it manually to apply."
 
 **If argument is "watchdog":**
 - Show current watchdog config from `config.json`:


### PR DESCRIPTION
## Summary
- Reconcile the live heartbeat Monitor after a `hermit-settings` heartbeat change.

## Context
Closes #452. The heartbeat Monitor bakes its poll interval in at `start` time from `heartbeat.every`, and `heartbeat-precheck.ts` never re-reads it live. So changing heartbeat config via `hermit-settings` left the running Monitor on its old cadence until a manual restart, desyncing from `config.json` and tripping a spurious `/hermit-doctor` heartbeat failure (which judges staleness against the *current* config interval).

## Changes
- **`skills/hermit-settings/SKILL.md`** — the heartbeat branch now reconciles the live Monitor after writing config: invoke `/heartbeat start` if heartbeat is now enabled (idempotent restart at the new interval), or `/heartbeat stop` if disabled, surfacing the result inline. Mirrors the existing routines branch, which already auto-runs `hermit-routines load`.
- **`CHANGELOG.md`** — `[Unreleased]` › Fixed entry.

## Scope note (deviation from the issue)
The issue proposed unconditionally invoking `/heartbeat start`. That's wrong for the disable path: `heartbeat-precheck.ts` gates only on `HEARTBEAT.md` presence and `active_hours`, never on `heartbeat.enabled`, so a bare `start` would resurrect a Monitor the operator just turned off (and disabling today leaves it running until restart). The fix is therefore conditional — start if enabled, stop if disabled.

## Verification
- Tests: **pass** (62.7s) — `cd plugins/claude-code-hermit && bun test`, 1222 pass / 0 fail.
- This is skill-instruction prose wiring `hermit-settings` to existing, unchanged `heartbeat start`/`stop` subcommands; the suite covers regression. The full live tmux probe of the start/stop machinery (config-change → runtime.json re-registration → doctor `ok`) was not run since no runtime code changed.
