### PR TITLE
fix(hermit): atomic alert-state writes + corrupt-file quarantine

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+- **session-close: Completed-vs-Artifacts closeout check** — a quality-check item flags when `## Completed` claims a deliverable a skill persists to `compiled/` but it's absent from `## Artifacts`, catching silently-dropped outputs at close instead of in a later session. Report template now labels `## Completed` as narrative. (#465)
+
+### Changed
+- **judge subagents: state terse-output rationale explicitly** — `proposal-triage`, `reflection-judge`, and `quality-gate-judge` now say their final message lands verbatim in the caller's long-lived context and re-read from cache each turn, so reasoning belongs in thinking, not the response (#468).
+
 ### Fixed
 - **heartbeat/alert-state: atomic writes + corrupt-file quarantine** — `heartbeat-precheck.ts` and `update-alert-state.ts` write `alert-state.json` via temp+rename and quarantine an unparseable existing file to `alert-state.json.corrupt-<ts>` instead of reinitializing skill-owned `alerts`/`self_eval` to empty. Reads split the file read from the JSON parse (shared `scripts/lib/alert-state.ts`), so a transient read error (EACCES/EMFILE/EIO) on a healthy file is never mistaken for corruption and never quarantined or reset. Stops silent loss of accumulated alert/self-eval telemetry on an interrupted or partial write (#463).
 - **hermit-settings: reconcile the heartbeat monitor on change** — after writing a `heartbeat` change, auto-runs `/heartbeat start` (if enabled) or `/heartbeat stop` (if disabled) so the live Monitor's cadence and `config.json` can't silently desync. (#452)
-### Changed
-- **judge subagents: state terse-output rationale explicitly** — `proposal-triage`, `reflection-judge`, and `quality-gate-judge` now say their final message lands verbatim in the caller's long-lived context and re-read from cache each turn, so reasoning belongs in thinking, not the response (#468).
-### Added
-- **session-close: Completed-vs-Artifacts closeout check** — a quality-check item flags when `## Completed` claims a deliverable a skill persists to `compiled/` but it's absent from `## Artifacts`, catching silently-dropped outputs at close instead of in a later session. Report template now labels `## Completed` as narrative. (#465)
-### Fixed
 - **routines: suppress duplicate `fired` metric** — heartbeat-restart's self-re-arm (`hermit-routines load` at its own prompt tail) could log a second `fired` with no intervening `started` (#464); `log-routine-event.sh` now skips a `fired` that immediately follows another `fired` for the same routine.
 
 ## [1.2.11] - 2026-06-24

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **heartbeat/alert-state: atomic writes + corrupt-file quarantine** — `heartbeat-precheck.ts` and `update-alert-state.ts` write `alert-state.json` via temp+rename and quarantine an unparseable existing file to `alert-state.json.corrupt-<ts>` instead of reinitializing skill-owned `alerts`/`self_eval` to empty. Stops silent loss of accumulated alert/self-eval telemetry on an interrupted or partial write (#463).
+
 ## [1.2.11] - 2026-06-24
 
 ### Added

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **heartbeat/alert-state: atomic writes + corrupt-file quarantine** — `heartbeat-precheck.ts` and `update-alert-state.ts` write `alert-state.json` via temp+rename and quarantine an unparseable existing file to `alert-state.json.corrupt-<ts>` instead of reinitializing skill-owned `alerts`/`self_eval` to empty. Stops silent loss of accumulated alert/self-eval telemetry on an interrupted or partial write (#463).
+- **heartbeat/alert-state: atomic writes + corrupt-file quarantine** — `heartbeat-precheck.ts` and `update-alert-state.ts` write `alert-state.json` via temp+rename and quarantine an unparseable existing file to `alert-state.json.corrupt-<ts>` instead of reinitializing skill-owned `alerts`/`self_eval` to empty. Reads split the file read from the JSON parse (shared `scripts/lib/alert-state.ts`), so a transient read error (EACCES/EMFILE/EIO) on a healthy file is never mistaken for corruption and never quarantined or reset. Stops silent loss of accumulated alert/self-eval telemetry on an interrupted or partial write (#463).
 
 ## [1.2.11] - 2026-06-24
 

--- a/plugins/claude-code-hermit/scripts/heartbeat-precheck.ts
+++ b/plugins/claude-code-hermit/scripts/heartbeat-precheck.ts
@@ -29,8 +29,11 @@ const readJSON = (p: string): Json => {
 };
 
 const writeJSON = (p: string, obj: Json): void => {
-  try { fs.writeFileSync(p, JSON.stringify(obj, null, 2) + '\n', 'utf-8'); }
-  catch { /* fail-open */ }
+  try {
+    const tmp = `${p}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, p);
+  } catch { /* fail-open */ }
 };
 
 // Normalises a HEARTBEAT.md checklist item to its dedup key.
@@ -108,7 +111,16 @@ if (activeHours?.start && activeHours?.end) {
 }
 
 const alertStatePath = path.join(stateDir, 'state', 'alert-state.json');
-const alertState = readJSON(alertStatePath) ?? { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
+let alertState = readJSON(alertStatePath);
+if (alertState === null) {
+  // null = first run (absent) OR present-but-unparseable. Never reinit skill-owned
+  // alerts/self_eval over a file that exists: quarantine the corrupt bytes and let a
+  // full EVALUATE rebuild it. Quarantine skipped in --peek (read-only).
+  const isCorrupt = fs.existsSync(alertStatePath);
+  if (isCorrupt && !peek) { try { fs.renameSync(alertStatePath, `${alertStatePath}.corrupt-${now}`); } catch { /* fail-open */ } }
+  if (isCorrupt) emit('EVALUATE');
+  alertState = { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
+}
 if (typeof alertState.total_ticks !== 'number' || !Number.isFinite(alertState.total_ticks)) {
   alertState.total_ticks = 0;
 }

--- a/plugins/claude-code-hermit/scripts/heartbeat-precheck.ts
+++ b/plugins/claude-code-hermit/scripts/heartbeat-precheck.ts
@@ -11,6 +11,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { currentHHMM, todayYMD, parseDuration } from './lib/time';
+import { readAlertState, defaultAlertState, quarantineAlertState, writeAlertState } from './lib/alert-state';
 
 type Json = any;
 
@@ -26,14 +27,6 @@ if (!stateDir) emit('EVALUATE');
 const readJSON = (p: string): Json => {
   try { return JSON.parse(fs.readFileSync(p, 'utf-8')); }
   catch { return null; }
-};
-
-const writeJSON = (p: string, obj: Json): void => {
-  try {
-    const tmp = `${p}.${process.pid}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + '\n', 'utf-8');
-    fs.renameSync(tmp, p);
-  } catch { /* fail-open */ }
 };
 
 // Normalises a HEARTBEAT.md checklist item to its dedup key.
@@ -111,22 +104,28 @@ if (activeHours?.start && activeHours?.end) {
 }
 
 const alertStatePath = path.join(stateDir, 'state', 'alert-state.json');
-let alertState = readJSON(alertStatePath);
-if (alertState === null) {
-  // null = first run (absent) OR present-but-unparseable. Never reinit skill-owned
-  // alerts/self_eval over a file that exists: quarantine the corrupt bytes and let a
-  // full EVALUATE rebuild it. Quarantine skipped in --peek (read-only).
-  const isCorrupt = fs.existsSync(alertStatePath);
-  if (isCorrupt && !peek) { try { fs.renameSync(alertStatePath, `${alertStatePath}.corrupt-${now}`); } catch { /* fail-open */ } }
-  if (isCorrupt) emit('EVALUATE');
-  alertState = { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
+// Split read from parse so a transient read error never destroys a healthy file:
+// only a genuine parse failure (corrupt) quarantines and rebuilds. ioerror
+// (EACCES/EMFILE/EIO) leaves the file untouched and re-evaluates next tick.
+const r = readAlertState(alertStatePath);
+let alertState: Json;
+if (r.kind === 'ok') {
+  alertState = r.value;
+} else if (r.kind === 'missing') {
+  alertState = defaultAlertState();
+} else if (r.kind === 'corrupt') {
+  if (!peek) quarantineAlertState(alertStatePath, now);
+  emit('EVALUATE');
+} else {
+  // ioerror — never reinit skill-owned alerts/self_eval over a file we couldn't read.
+  emit('EVALUATE');
 }
 if (typeof alertState.total_ticks !== 'number' || !Number.isFinite(alertState.total_ticks)) {
   alertState.total_ticks = 0;
 }
 if (!peek) {
   alertState.total_ticks += 1;
-  writeJSON(alertStatePath, alertState);
+  writeAlertState(alertStatePath, alertState);
 }
 
 // peek fires one tick early; the subsequent mutating call lands on the multiple-of-20
@@ -185,7 +184,7 @@ if (sessionState === 'in_progress') {
     if (wakeDue) {
       if (!peek) {
         alertState.last_stale_wake_at = new Date(now).toISOString();
-        writeJSON(alertStatePath, alertState);
+        writeAlertState(alertStatePath, alertState);
       }
       emit('EVALUATE');
     }

--- a/plugins/claude-code-hermit/scripts/lib/alert-state.ts
+++ b/plugins/claude-code-hermit/scripts/lib/alert-state.ts
@@ -1,0 +1,43 @@
+// Shared read/write helpers for alert-state.json, used by both writers
+// (heartbeat-precheck.ts, update-alert-state.ts). Atomic write mirrors lib/runtime.ts;
+// the read splits the file read from the JSON parse so callers can tell a transient read
+// error (healthy file — never destroy it) from genuine corruption (quarantine + rebuild).
+// Path-parameterized: precheck derives the path from stateDir, update-alert-state takes argv.
+
+import fs from 'node:fs';
+
+type Json = any;
+
+export const defaultAlertState = (): Json =>
+  ({ alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 });
+
+export type AlertRead =
+  | { kind: 'ok'; value: Json }
+  | { kind: 'missing' }                  // ENOENT — first run, seed default
+  | { kind: 'corrupt' }                  // bytes read, parse failed / not an object — quarantine
+  | { kind: 'ioerror'; code?: string };  // EACCES/EMFILE/EIO/EISDIR — healthy file, DO NOT destroy
+
+export function readAlertState(p: string): AlertRead {
+  let raw: string;
+  try { raw = fs.readFileSync(p, 'utf-8'); }            // separate the read…
+  catch (err: any) {
+    return err?.code === 'ENOENT' ? { kind: 'missing' } : { kind: 'ioerror', code: err?.code };
+  }
+  try {
+    const value = JSON.parse(raw);                       // …from the parse
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return { kind: 'corrupt' };
+    return { kind: 'ok', value };
+  } catch { return { kind: 'corrupt' }; }
+}
+
+export function quarantineAlertState(p: string, stamp: number): void {
+  try { fs.renameSync(p, `${p}.corrupt-${stamp}`); } catch { /* fail-open */ }
+}
+
+export function writeAlertState(p: string, obj: Json): void {
+  try {
+    const tmp = `${p}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, p);
+  } catch { /* fail-open */ }
+}

--- a/plugins/claude-code-hermit/scripts/update-alert-state.ts
+++ b/plugins/claude-code-hermit/scripts/update-alert-state.ts
@@ -24,12 +24,16 @@ function apply(payloadJson: string): void {
     process.exit(1);
   }
 
-  let state: Json = {};
+  let state: Json = { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
   try {
     state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
-  } catch {
-    // first run or unreadable — seed with the precheck's default shape
-    state = { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
+  } catch (err: any) {
+    // ENOENT = first run, seed with the precheck's default shape. Anything else =
+    // present-but-unparseable: quarantine the corrupt bytes for forensics rather than
+    // silently merging the payload onto a blank state and dropping accumulated alerts.
+    if (err?.code !== 'ENOENT') {
+      try { fs.renameSync(stateFile, `${stateFile}.corrupt-${Date.now()}`); } catch { /* fail-open */ }
+    }
   }
 
   const alerts: Json = {
@@ -62,7 +66,9 @@ function apply(payloadJson: string): void {
   };
 
   try {
-    fs.writeFileSync(stateFile, JSON.stringify(updated, null, 2) + '\n', 'utf-8');
+    const tmp = `${stateFile}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(updated, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, stateFile);
   } catch (err: any) {
     console.error(`update-alert-state: write failed: ${err.message}`);
   }

--- a/plugins/claude-code-hermit/scripts/update-alert-state.ts
+++ b/plugins/claude-code-hermit/scripts/update-alert-state.ts
@@ -4,7 +4,7 @@
 // The eval JSON is read from stdin (not argv) so free-text alert content can't break shell quoting.
 // Usage: bun update-alert-state.ts <state-file-path>   # eval-json on stdin
 
-import fs from 'node:fs';
+import { readAlertState, defaultAlertState, quarantineAlertState, writeAlertState } from './lib/alert-state';
 
 type Json = any;
 
@@ -24,16 +24,21 @@ function apply(payloadJson: string): void {
     process.exit(1);
   }
 
-  let state: Json = { alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 0 };
-  try {
-    state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
-  } catch (err: any) {
-    // ENOENT = first run, seed with the precheck's default shape. Anything else =
-    // present-but-unparseable: quarantine the corrupt bytes for forensics rather than
-    // silently merging the payload onto a blank state and dropping accumulated alerts.
-    if (err?.code !== 'ENOENT') {
-      try { fs.renameSync(stateFile, `${stateFile}.corrupt-${Date.now()}`); } catch { /* fail-open */ }
-    }
+  // Split read from parse: a transient read error (ioerror) must not clobber a healthy
+  // file. ENOENT = first run → seed default. corrupt = bytes read but unparseable →
+  // quarantine for forensics, then merge onto a default. ioerror = bail without writing.
+  let state: Json;
+  const r = readAlertState(stateFile);
+  if (r.kind === 'ok') {
+    state = r.value;
+  } else if (r.kind === 'missing') {
+    state = defaultAlertState();
+  } else if (r.kind === 'corrupt') {
+    quarantineAlertState(stateFile, Date.now());
+    state = defaultAlertState();
+  } else {
+    console.error(`update-alert-state: read failed (${r.code ?? 'unknown'}); skipping write`);
+    process.exit(0);
   }
 
   const alerts: Json = {
@@ -65,13 +70,7 @@ function apply(payloadJson: string): void {
     last_clean_eval_at,
   };
 
-  try {
-    const tmp = `${stateFile}.${process.pid}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(updated, null, 2) + '\n', 'utf-8');
-    fs.renameSync(tmp, stateFile);
-  } catch (err: any) {
-    console.error(`update-alert-state: write failed: ${err.message}`);
-  }
+  writeAlertState(stateFile, updated);
 
   process.exit(0);
 }

--- a/plugins/claude-code-hermit/tests/alert-state-durability.test.ts
+++ b/plugins/claude-code-hermit/tests/alert-state-durability.test.ts
@@ -1,0 +1,123 @@
+// Durability of alert-state.json against interrupted/concurrent writes (issue #463).
+// Both writers (heartbeat-precheck.ts, update-alert-state.ts) must (a) write atomically
+// via temp+rename so a killed write never leaves a truncated file, and (b) never reinit
+// the skill-owned alerts{}/self_eval{} over a file that exists — a present-but-unparseable
+// file is quarantined to alert-state.json.corrupt-<ts>, not silently overwritten.
+//
+// Scripts are exercised as subprocesses (via runScript) — the boundary hooks/routines see.
+//
+// Usage: bun test tests/alert-state-durability.test.ts   (from the plugin root)
+
+import { describe, test, expect } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { runScript } from './helpers/run';
+
+const hermit = (dir: string, ...p: string[]) => path.join(dir, '.claude-code-hermit', ...p);
+const alertPath = (dir: string) => hermit(dir, 'state', 'alert-state.json');
+const stateFiles = (dir: string) => fs.readdirSync(hermit(dir, 'state'));
+
+const HEARTBEAT_MD = '# Heartbeat\n\n- [ ] Check system\n';
+const NOW = '2026-05-20T22:00:00+00:00';
+const CORRUPT = '{"alerts":{"x":{"suppressed":true}},"self_eval":{"a":1},"total_ticks":686';
+
+interface Tmp { dir: string; cleanup(): void }
+
+function makeDir(): Tmp {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-alertdur-'));
+  fs.mkdirSync(hermit(dir, 'state'), { recursive: true });
+  fs.writeFileSync(hermit(dir, 'HEARTBEAT.md'), HEARTBEAT_MD);
+  return { dir, cleanup: () => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch {} } };
+}
+
+function withTmp(fn: (dir: string) => Promise<void> | void) {
+  return async () => {
+    const t = makeDir();
+    try { await fn(t.dir); } finally { t.cleanup(); }
+  };
+}
+
+/** Run heartbeat-precheck from inside the workdir, return verdict. */
+async function precheck(dir: string, peek = false): Promise<string> {
+  const r = await runScript('heartbeat-precheck.ts', {
+    args: [...(peek ? ['--peek'] : []), '.claude-code-hermit'],
+    cwd: dir,
+    env: { HERMIT_NOW: NOW },
+  });
+  return r.stdout.trim();
+}
+
+/** Run update-alert-state against the workdir's alert-state.json with a stdin payload. */
+async function updateAlertState(dir: string, payload: object): Promise<void> {
+  await runScript('update-alert-state.ts', {
+    args: [alertPath(dir)],
+    stdin: JSON.stringify(payload),
+  });
+}
+
+describe('heartbeat-precheck alert-state durability', () => {
+  test('atomic write leaves a complete file and no .tmp sibling', withTmp(async (dir) => {
+    fs.writeFileSync(alertPath(dir), JSON.stringify({ alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 5 }));
+
+    await precheck(dir);
+
+    const written = JSON.parse(fs.readFileSync(alertPath(dir), 'utf-8'));
+    expect(written.total_ticks).toBe(6);
+    expect(stateFiles(dir).some(f => f.endsWith('.tmp'))).toBe(false);
+  }));
+
+  test('present-but-corrupt file is quarantined, not wiped to total_ticks:1', withTmp(async (dir) => {
+    fs.writeFileSync(alertPath(dir), CORRUPT);
+
+    const verdict = await precheck(dir);
+
+    expect(verdict).toBe('EVALUATE');
+    // live file moved aside — never overwritten with a fresh total_ticks:1 object
+    expect(fs.existsSync(alertPath(dir))).toBe(false);
+    const backups = stateFiles(dir).filter(f => f.startsWith('alert-state.json.corrupt-'));
+    expect(backups.length).toBe(1);
+    expect(fs.readFileSync(hermit(dir, 'state', backups[0]), 'utf-8')).toBe(CORRUPT);
+  }));
+
+  test('--peek never quarantines or mutates a corrupt file', withTmp(async (dir) => {
+    fs.writeFileSync(alertPath(dir), CORRUPT);
+
+    const verdict = await precheck(dir, true);
+
+    expect(verdict).toBe('EVALUATE');
+    expect(fs.readFileSync(alertPath(dir), 'utf-8')).toBe(CORRUPT);
+    expect(stateFiles(dir).some(f => f.startsWith('alert-state.json.corrupt-'))).toBe(false);
+  }));
+});
+
+describe('update-alert-state durability', () => {
+  test('quarantines a present-but-corrupt file instead of merging onto a blank state', withTmp(async (dir) => {
+    fs.writeFileSync(alertPath(dir), CORRUPT);
+
+    await updateAlertState(dir, { new_entries: { k: { suppressed: false } } });
+
+    const backups = stateFiles(dir).filter(f => f.startsWith('alert-state.json.corrupt-'));
+    expect(backups.length).toBe(1);
+    expect(fs.readFileSync(hermit(dir, 'state', backups[0]), 'utf-8')).toBe(CORRUPT);
+
+    const written = JSON.parse(fs.readFileSync(alertPath(dir), 'utf-8'));
+    expect(written.alerts.k).toEqual({ suppressed: false });
+  }));
+
+  test('preserves precheck-owned total_ticks under atomic write, no .tmp leak', withTmp(async (dir) => {
+    fs.writeFileSync(alertPath(dir), JSON.stringify({
+      alerts: {}, last_digest_date: null, self_eval: { a: 1 }, total_ticks: 686, last_stale_wake_at: '2026-05-19T00:00:00Z',
+    }));
+
+    await updateAlertState(dir, { new_entries: { k: { suppressed: false } }, self_eval_updates: { b: 2 } });
+
+    const written = JSON.parse(fs.readFileSync(alertPath(dir), 'utf-8'));
+    expect(written.total_ticks).toBe(686);
+    expect(written.last_stale_wake_at).toBe('2026-05-19T00:00:00Z');
+    expect(written.self_eval).toEqual({ a: 1, b: 2 });
+    expect(written.alerts.k).toEqual({ suppressed: false });
+    expect(stateFiles(dir).some(f => f.endsWith('.tmp'))).toBe(false);
+  }));
+});

--- a/plugins/claude-code-hermit/tests/alert-state-durability.test.ts
+++ b/plugins/claude-code-hermit/tests/alert-state-durability.test.ts
@@ -90,6 +90,39 @@ describe('heartbeat-precheck alert-state durability', () => {
     expect(fs.readFileSync(alertPath(dir), 'utf-8')).toBe(CORRUPT);
     expect(stateFiles(dir).some(f => f.startsWith('alert-state.json.corrupt-'))).toBe(false);
   }));
+
+  // A transient read error (EACCES/EMFILE/EIO) on a HEALTHY file must NOT be treated as
+  // corruption. Simulated portably by making the path a directory → readFileSync throws
+  // EISDIR (works regardless of test UID, unlike chmod 000).
+  test('transient read error (EISDIR) is not quarantined or reset', withTmp(async (dir) => {
+    fs.mkdirSync(alertPath(dir));
+
+    const verdict = await precheck(dir);
+
+    expect(verdict).toBe('EVALUATE');
+    expect(fs.statSync(alertPath(dir)).isDirectory()).toBe(true);
+    expect(stateFiles(dir).some(f => f.startsWith('alert-state.json.corrupt-'))).toBe(false);
+  }));
+
+  test('non-object JSON is treated as corrupt, not crashed on', withTmp(async (dir) => {
+    fs.writeFileSync(alertPath(dir), '5');
+
+    const verdict = await precheck(dir);
+
+    expect(verdict).toBe('EVALUATE');
+    expect(fs.existsSync(alertPath(dir))).toBe(false);
+    expect(stateFiles(dir).filter(f => f.startsWith('alert-state.json.corrupt-')).length).toBe(1);
+  }));
+
+  test('array JSON is treated as corrupt (not a valid state object)', withTmp(async (dir) => {
+    fs.writeFileSync(alertPath(dir), '[]');
+
+    const verdict = await precheck(dir);
+
+    expect(verdict).toBe('EVALUATE');
+    expect(fs.existsSync(alertPath(dir))).toBe(false);
+    expect(stateFiles(dir).filter(f => f.startsWith('alert-state.json.corrupt-')).length).toBe(1);
+  }));
 });
 
 describe('update-alert-state durability', () => {
@@ -104,6 +137,15 @@ describe('update-alert-state durability', () => {
 
     const written = JSON.parse(fs.readFileSync(alertPath(dir), 'utf-8'));
     expect(written.alerts.k).toEqual({ suppressed: false });
+  }));
+
+  test('transient read error (EISDIR) declines to write, does not clobber', withTmp(async (dir) => {
+    fs.mkdirSync(alertPath(dir));
+
+    await updateAlertState(dir, { new_entries: { k: { suppressed: false } } });
+
+    expect(fs.statSync(alertPath(dir)).isDirectory()).toBe(true);
+    expect(stateFiles(dir).some(f => f.startsWith('alert-state.json.corrupt-'))).toBe(false);
   }));
 
   test('preserves precheck-owned total_ticks under atomic write, no .tmp leak', withTmp(async (dir) => {


### PR DESCRIPTION
## Summary
Fixes silent data loss in `.claude-code-hermit/state/alert-state.json` (#463). The two writers used a bare `fs.writeFileSync` (truncate-then-write) and reinitialized the skill-owned `alerts`/`self_eval` fields whenever the read failed to parse, so an interrupted or partial write could silently wipe weeks of accumulated alert / self-eval telemetry. Observed once in a live always-on deployment (`total_ticks: 686` → `1`, `self_eval` and `alerts` emptied in a single tick).

## Changes
- **`scripts/heartbeat-precheck.ts`** — `writeJSON` now writes via a temp file + `renameSync` (atomic on one filesystem), so an interrupted write leaves the prior complete file intact. The alert-state read distinguishes absent (first run → fresh seed) from present-but-unparseable: a corrupt existing file is quarantined to `alert-state.json.corrupt-<ts>` and the tick emits `EVALUATE` to rebuild cleanly — the precheck never zeroes the `alerts`/`self_eval` it explicitly disclaims ownership of. Quarantine is skipped under `--peek` (read-only preserved).
- **`scripts/update-alert-state.ts`** — atomic temp+rename write; a corrupt existing file is quarantined for forensics instead of silently merging the payload onto a blank state.
- **`tests/alert-state-durability.test.ts`** — 5 new tests: atomic write leaves no `.tmp` sibling, corrupt-file quarantine (mutating + `--peek`), corrupt-file handling in `update-alert-state`, and preservation of precheck-owned fields under atomic write.

## Test plan
- `cd plugins/claude-code-hermit && bun test` — full suite **1227 pass / 0 fail**, including the 5 new durability tests.

Closes #463
