### PR TITLE
feat(homeassistant-hermit): WebSocket client for scenes, helpers, areas, registries

### DIFF
--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **CLI: `scene` config domain** — `validate-apply --reload scene`, plus scene create/remove, via the existing REST config path (`/api/config/scene/config/{id}` + `scene.reload`). (#466)
+- **WebSocket client (`src/ha-ws.ts`)** — single-shot `wss://<host>/api/websocket` client reusing the REST URL selection and token; auth handshake + id-correlated commands. Reaches HA surfaces REST cannot. (#466)
+- **CLI: helpers, areas, registries** — `list/create/delete-helper` (8 helper types), `list/create/delete-area`, `list-entities --registry`, `rename-entity`, `set-entity-area`, `set-entity-enabled`, `list-devices`, `set-device-area`, `rename-device`. (#466)
+- **Safety: WS mutations gated by `ha_safety_mode`** — reads always allowed; under `strict` writes are blocked (surface as proposal), under `ask` writes require `--confirm`. Each mutation writes an `audit-ha-ws-*` report. (#466)
+
 ## [0.2.3] - 2026-06-24
 
 ### Fixed

--- a/plugins/claude-code-homeassistant-hermit/CLAUDE.md
+++ b/plugins/claude-code-homeassistant-hermit/CLAUDE.md
@@ -52,7 +52,7 @@ MCP tool IDs follow the pattern `mcp__homeassistant__*`. The `homeassistant` nam
 ```
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha refresh-context [--incremental]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha simulate <artifact>
-${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <artifact> [--reload automation|script]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <artifact> [--reload automation|script|scene]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha policy-check <entity_id_or_yaml>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha audit-automations
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha audit-scripts
@@ -65,6 +65,20 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha get-script-config <id>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha integration-health
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha fetch-history [--window-days N] [--entities <glob> …] [--include-transitions]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha probe <path>
+# WebSocket-backed structural commands (helpers, areas, registries). Writes are gated by ha_safety_mode.
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-helpers [--type <helper_type>]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha create-helper <type> <json> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-helper <type> <id> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-areas
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha create-area <name> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-area <id> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-entities --registry
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha rename-entity <entity_id> --name <name> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha set-entity-area <entity_id> --area <area_id> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha set-entity-enabled <entity_id> --enabled true|false [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-devices
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha set-device-area <device_id> --area <area_id> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha rename-device <device_id> --name <name> [--confirm]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab boot status [--probe]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab boot store --language <locale> --url <url> [--token <token>]
 bun test
@@ -83,7 +97,14 @@ Before changing HA endpoint usage, verify against upstream (WebFetch or the `fin
 - `POST /api/config/{automation|script}/config/{id}` — create/update (upsert). URL `id` is sufficient; body `id` field is ignored by HA. Returns `{"result":"ok"}` on success. Returns 403 if HA is in YAML config mode (REST config API unavailable).
 - `DELETE /api/config/{automation|script}/config/{id}` — remove config. **A missing id returns 400** (not 404) with `{"message":"Resource not found"}` — do not special-case 404. All HA error responses carry `{"message":"..."}` — surface it verbatim.
 - After `POST`, `GET` reflects the change synchronously (verified against HA 2026.x). No retry or delay needed for verify calls.
-- `--reload {automation|script}` in `ha validate-apply` is overloaded: it controls both the REST push endpoint and the reload service call. There is no push-only mode; add `--no-reload` if that use case arises.
+- `--reload {automation|script|scene}` in `ha validate-apply` is overloaded: it controls both the REST push endpoint and the reload service call. There is no push-only mode; add `--no-reload` if that use case arises. Scenes use the same REST config API (`/api/config/scene/config/{id}`) and `scene.reload` service as automation/script — no special path.
+
+### WebSocket commands (`src/ha-ws.ts` + `src/structure.ts`)
+
+- Helpers, areas, and entity/device registries have **no REST endpoint** — they are reachable only over `wss://<host>/api/websocket`. `HomeAssistantWsClient` opens a single-shot connection per CLI invocation (auth handshake → commands → close), reusing the same URL selection and token as the REST client.
+- Command types: helpers `<type>/create|list|delete` (8 types: `input_boolean|input_number|input_text|input_select|input_datetime|timer|counter|schedule`); areas `config/area_registry/create|list|delete`; registries `config/entity_registry/list|update` and `config/device_registry/list|update`.
+- **Confirm the exact command `type` and payload fields against a live instance before relying on them** (the docs index documents only the auth/result envelope). Probe pattern: run the new commands against a real HA and read the responses.
+- **All WS mutations are gated by `ha_safety_mode`** (`gateStructuralMutation` in `policy.ts`). Reads are never gated. Under `strict` (default) a mutation is refused (`blocked: true`) — surface it as a proposal. Under `ask` it requires `--confirm`, which the main session passes after prompting the operator (the CLI is non-interactive). Every mutation writes an audit report to `.claude-code-hermit/raw/` (`audit-ha-ws-*`).
 
 ## Development constraints
 

--- a/plugins/claude-code-homeassistant-hermit/src/apply.ts
+++ b/plugins/claude-code-homeassistant-hermit/src/apply.ts
@@ -24,7 +24,7 @@ import { canReloadDomain } from './policy';
 import { SimulationResult, simulateArtifact } from './simulate';
 import { parseYaml } from './yaml';
 
-const CONFIG_DOMAINS = new Set(['automation', 'script']);
+const CONFIG_DOMAINS = new Set(['automation', 'script', 'scene']);
 
 /** The slice of HomeAssistantClient the apply path needs (tests inject a fake). */
 export interface ApplyClient {

--- a/plugins/claude-code-homeassistant-hermit/src/cli.ts
+++ b/plugins/claude-code-homeassistant-hermit/src/cli.ts
@@ -29,15 +29,32 @@ import { auditAutomations, auditScripts } from './audits';
 import { bootStatus, saveBootPreferences } from './boot';
 import { AppConfig, loadConfig, normalizedContextPath, projectRoot } from './config';
 import { HomeAssistantClient, HomeAssistantError } from './ha-api';
+import { HomeAssistantWsClient } from './ha-ws';
 import { fetchHistorySnapshot } from './history';
 import {
   computeDegradedDomains,
   formatIntegrationHealthStdout,
   writeDegradedDomainsArtifact,
 } from './integration-health';
-import { checkEntity, normalizeEntityIndex } from './policy';
+import { checkEntity, gateStructuralMutation, normalizeEntityIndex } from './policy';
 import { evaluateYamlPolicy, simulateArtifact } from './simulate';
 import { computeSilenceSummary } from './silence';
+import {
+  HELPER_TYPES,
+  type WsCommandClient,
+  type WsMutationResult,
+  type WsReadResult,
+  createArea,
+  createHelper,
+  deleteArea,
+  deleteHelper,
+  listAreas,
+  listDevices,
+  listEntities,
+  listHelpers,
+  updateDevice,
+  updateEntity,
+} from './structure';
 
 // ---------------------------------------------------------------------------
 // JSON output helpers — Python json.dumps parity
@@ -94,6 +111,7 @@ export interface CliClient {
 export interface CliDeps {
   loadConfig: (root?: string | null) => AppConfig;
   createClient: (config: AppConfig) => Promise<CliClient>;
+  createWsClient: (config: AppConfig) => Promise<WsCommandClient>;
   refreshContext: (root: string, client: CliClient) => Promise<Record<string, any>>;
 }
 
@@ -101,6 +119,7 @@ function resolveDeps(overrides: Partial<CliDeps>): CliDeps {
   return {
     loadConfig: overrides.loadConfig ?? loadConfig,
     createClient: overrides.createClient ?? ((config) => HomeAssistantClient.create(config)),
+    createWsClient: overrides.createWsClient ?? ((config) => HomeAssistantWsClient.create(config)),
     refreshContext: overrides.refreshContext ?? refreshContext,
   };
 }
@@ -133,6 +152,19 @@ const HA_COMMANDS = [
   'delete-script',
   'get-automation-config',
   'get-script-config',
+  'list-helpers',
+  'create-helper',
+  'delete-helper',
+  'list-areas',
+  'create-area',
+  'delete-area',
+  'list-entities',
+  'rename-entity',
+  'set-entity-area',
+  'set-entity-enabled',
+  'list-devices',
+  'set-device-area',
+  'rename-device',
 ] as const;
 const HA_USAGE = [
   'usage: ha_agent_lab ha [-h]',
@@ -177,6 +209,20 @@ positional arguments:
     get-automation-config
                         Read an automation's stored config from HA.
     get-script-config   Read a script's stored config from HA.
+    list-helpers        List helpers (input_*, timer, counter, schedule) via
+                        WebSocket. Optional --type to scope to one.
+    create-helper       Create a helper from JSON via WebSocket (gated write).
+    delete-helper       Delete a helper by id via WebSocket (gated write).
+    list-areas          List areas via WebSocket.
+    create-area         Create an area by name via WebSocket (gated write).
+    delete-area         Delete an area by id via WebSocket (gated write).
+    list-entities       List the entity registry via WebSocket (--registry).
+    rename-entity       Set an entity's friendly name (gated write).
+    set-entity-area     Assign an entity to an area (gated write).
+    set-entity-enabled  Enable/disable an entity (gated write).
+    list-devices        List the device registry via WebSocket.
+    set-device-area     Assign a device to an area (gated write).
+    rename-device       Set a device's user name (gated write).
 
 options:
   -h, --help            show this help message and exit`;
@@ -328,10 +374,10 @@ const LEAF_SPECS: Record<string, LeafSpec> = {
   'ha validate-apply': {
     prog: 'ha_agent_lab ha validate-apply',
     usage:
-      'usage: ha_agent_lab ha validate-apply [-h] [--reload {automation,script}]\n' +
+      'usage: ha_agent_lab ha validate-apply [-h] [--reload {automation,script,scene}]\n' +
       '                                      artifact',
     positionals: ['artifact'],
-    flags: { '--reload': { kind: 'value', choices: ['automation', 'script'] } },
+    flags: { '--reload': { kind: 'value', choices: ['automation', 'script', 'scene'] } },
   },
   'ha policy-check': {
     prog: 'ha_agent_lab ha policy-check',
@@ -411,6 +457,84 @@ const LEAF_SPECS: Record<string, LeafSpec> = {
     usage: 'usage: ha_agent_lab ha get-script-config [-h] id',
     positionals: ['id'],
     flags: {},
+  },
+  'ha list-helpers': {
+    prog: 'ha_agent_lab ha list-helpers',
+    usage: `usage: ha_agent_lab ha list-helpers [-h] [--type {${HELPER_TYPES.join(',')}}]`,
+    positionals: [],
+    flags: { '--type': { kind: 'value', choices: HELPER_TYPES } },
+  },
+  'ha create-helper': {
+    prog: 'ha_agent_lab ha create-helper',
+    usage: `usage: ha_agent_lab ha create-helper [-h] [--confirm] {${HELPER_TYPES.join(',')}} json`,
+    positionals: ['type', 'json'],
+    flags: { '--confirm': { kind: 'store_true' } },
+  },
+  'ha delete-helper': {
+    prog: 'ha_agent_lab ha delete-helper',
+    usage: `usage: ha_agent_lab ha delete-helper [-h] [--confirm] {${HELPER_TYPES.join(',')}} id`,
+    positionals: ['type', 'id'],
+    flags: { '--confirm': { kind: 'store_true' } },
+  },
+  'ha list-areas': {
+    prog: 'ha_agent_lab ha list-areas',
+    usage: 'usage: ha_agent_lab ha list-areas [-h]',
+    positionals: [],
+    flags: {},
+  },
+  'ha create-area': {
+    prog: 'ha_agent_lab ha create-area',
+    usage: 'usage: ha_agent_lab ha create-area [-h] [--confirm] name',
+    positionals: ['name'],
+    flags: { '--confirm': { kind: 'store_true' } },
+  },
+  'ha delete-area': {
+    prog: 'ha_agent_lab ha delete-area',
+    usage: 'usage: ha_agent_lab ha delete-area [-h] [--confirm] id',
+    positionals: ['id'],
+    flags: { '--confirm': { kind: 'store_true' } },
+  },
+  'ha list-entities': {
+    prog: 'ha_agent_lab ha list-entities',
+    usage: 'usage: ha_agent_lab ha list-entities [-h] --registry',
+    positionals: [],
+    flags: { '--registry': { kind: 'store_true' } },
+  },
+  'ha rename-entity': {
+    prog: 'ha_agent_lab ha rename-entity',
+    usage: 'usage: ha_agent_lab ha rename-entity [-h] [--confirm] --name NAME entity_id',
+    positionals: ['entity_id'],
+    flags: { '--name': { kind: 'value' }, '--confirm': { kind: 'store_true' } },
+  },
+  'ha set-entity-area': {
+    prog: 'ha_agent_lab ha set-entity-area',
+    usage: 'usage: ha_agent_lab ha set-entity-area [-h] [--confirm] --area AREA entity_id',
+    positionals: ['entity_id'],
+    flags: { '--area': { kind: 'value' }, '--confirm': { kind: 'store_true' } },
+  },
+  'ha set-entity-enabled': {
+    prog: 'ha_agent_lab ha set-entity-enabled',
+    usage: 'usage: ha_agent_lab ha set-entity-enabled [-h] [--confirm] --enabled {true,false} entity_id',
+    positionals: ['entity_id'],
+    flags: { '--enabled': { kind: 'value', choices: ['true', 'false'] }, '--confirm': { kind: 'store_true' } },
+  },
+  'ha list-devices': {
+    prog: 'ha_agent_lab ha list-devices',
+    usage: 'usage: ha_agent_lab ha list-devices [-h]',
+    positionals: [],
+    flags: {},
+  },
+  'ha set-device-area': {
+    prog: 'ha_agent_lab ha set-device-area',
+    usage: 'usage: ha_agent_lab ha set-device-area [-h] [--confirm] --area AREA device_id',
+    positionals: ['device_id'],
+    flags: { '--area': { kind: 'value' }, '--confirm': { kind: 'store_true' } },
+  },
+  'ha rename-device': {
+    prog: 'ha_agent_lab ha rename-device',
+    usage: 'usage: ha_agent_lab ha rename-device [-h] [--confirm] --name NAME device_id',
+    positionals: ['device_id'],
+    flags: { '--name': { kind: 'value' }, '--confirm': { kind: 'store_true' } },
   },
 };
 
@@ -683,9 +807,180 @@ export async function main(argv: string[], overrides: Partial<CliDeps> = {}): Pr
     }
   }
 
+  // --- WebSocket structural commands (helpers, areas, registries) ---
+
+  if (args.command === 'ha' && args.sub === 'list-helpers') {
+    return runWsRead(deps, config, (ws) => listHelpers(ws, args.flags['--type'] as string | undefined));
+  }
+  if (args.command === 'ha' && args.sub === 'create-helper') {
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      createHelper(root, ws, args.positionals[0]!, args.positionals[1]!),
+    );
+  }
+  if (args.command === 'ha' && args.sub === 'delete-helper') {
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      deleteHelper(root, ws, args.positionals[0]!, args.positionals[1]!),
+    );
+  }
+  if (args.command === 'ha' && args.sub === 'list-areas') {
+    return runWsRead(deps, config, listAreas);
+  }
+  if (args.command === 'ha' && args.sub === 'create-area') {
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      createArea(root, ws, args.positionals[0]!),
+    );
+  }
+  if (args.command === 'ha' && args.sub === 'delete-area') {
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      deleteArea(root, ws, args.positionals[0]!),
+    );
+  }
+  if (args.command === 'ha' && args.sub === 'list-entities') {
+    if (!args.flags['--registry']) {
+      console.log(jsonDumps({ ok: false, message: 'Only registry mode is supported; pass --registry.' }));
+      return 1;
+    }
+    return runWsRead(deps, config, listEntities);
+  }
+  if (args.command === 'ha' && args.sub === 'rename-entity') {
+    const name = requireFlag(args.flags['--name'], '--name');
+    if (name === null) return 1;
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      updateEntity(root, ws, args.positionals[0]!, { name }, 'rename-entity'),
+    );
+  }
+  if (args.command === 'ha' && args.sub === 'set-entity-area') {
+    const area = requireFlag(args.flags['--area'], '--area');
+    if (area === null) return 1;
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      updateEntity(root, ws, args.positionals[0]!, { area_id: area }, 'set-entity-area'),
+    );
+  }
+  if (args.command === 'ha' && args.sub === 'set-entity-enabled') {
+    const enabled = requireFlag(args.flags['--enabled'], '--enabled');
+    if (enabled === null) return 1;
+    const disabledBy = enabled === 'true' ? null : 'user';
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      updateEntity(root, ws, args.positionals[0]!, { disabled_by: disabledBy }, 'set-entity-enabled'),
+    );
+  }
+  if (args.command === 'ha' && args.sub === 'list-devices') {
+    return runWsRead(deps, config, listDevices);
+  }
+  if (args.command === 'ha' && args.sub === 'set-device-area') {
+    const area = requireFlag(args.flags['--area'], '--area');
+    if (area === null) return 1;
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      updateDevice(root, ws, args.positionals[0]!, { area_id: area }, 'set-device-area'),
+    );
+  }
+  if (args.command === 'ha' && args.sub === 'rename-device') {
+    const name = requireFlag(args.flags['--name'], '--name');
+    if (name === null) return 1;
+    return runWsMutation(deps, config, root, Boolean(args.flags['--confirm']), (ws) =>
+      updateDevice(root, ws, args.positionals[0]!, { name_by_user: name }, 'rename-device'),
+    );
+  }
+
   // Unreachable: every subcommand is handled above (argparse parity guard).
   console.error(`${TOP_USAGE}\nha_agent_lab: error: Unsupported command.`);
   return 2;
+}
+
+/** A value flag the handler needs but argparse treats as optional. Prints and returns null when absent. */
+function requireFlag(value: unknown, name: string): string | null {
+  if (typeof value === 'string') return value;
+  console.log(jsonDumps({ ok: false, message: `${name} is required.` }));
+  return null;
+}
+
+/** Acquire a WS client, run a read, print {ok,data,message}, then close. */
+async function runWsRead(
+  deps: CliDeps,
+  config: AppConfig,
+  run: (ws: WsCommandClient) => Promise<WsReadResult>,
+): Promise<number> {
+  let ws: WsCommandClient;
+  try {
+    ws = await deps.createWsClient(config);
+  } catch (exc) {
+    if (!(exc instanceof HomeAssistantError)) throw exc;
+    console.log(exc.message);
+    return 1;
+  }
+  try {
+    const result = await run(ws);
+    console.log(jsonDumps({ ok: result.ok, data: result.data, message: result.message }, { ensureAscii: false }));
+    return result.ok ? 0 : 1;
+  } catch (exc) {
+    if (!(exc instanceof HomeAssistantError)) throw exc;
+    console.log(exc.message);
+    return 1;
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * Apply the safety gate *before* opening a connection. If blocked, print the
+ * verdict and return without touching the network. Otherwise connect, run the
+ * mutation, print, and close.
+ */
+async function runWsMutation(
+  deps: CliDeps,
+  config: AppConfig,
+  root: string,
+  confirmed: boolean,
+  run: (ws: WsCommandClient) => Promise<WsMutationResult>,
+): Promise<number> {
+  const gate = gateStructuralMutation(root, confirmed);
+  if (!gate.allowed) {
+    console.log(
+      jsonDumps({
+        ok: false,
+        blocked: true,
+        requires_confirm: gate.requiresConfirm,
+        mode: gate.mode,
+        data: null,
+        message: gate.reason,
+        report_path: null,
+      }),
+    );
+    return 1;
+  }
+
+  let ws: WsCommandClient;
+  try {
+    ws = await deps.createWsClient(config);
+  } catch (exc) {
+    if (!(exc instanceof HomeAssistantError)) throw exc;
+    console.log(exc.message);
+    return 1;
+  }
+  try {
+    const r = await run(ws);
+    console.log(
+      jsonDumps(
+        {
+          ok: r.ok,
+          blocked: false,
+          requires_confirm: false,
+          mode: gate.mode,
+          data: r.data,
+          message: r.message,
+          report_path: r.reportPath ? relative(root, r.reportPath) : null,
+        },
+        { ensureAscii: false },
+      ),
+    );
+    return r.ok ? 0 : 1;
+  } catch (exc) {
+    if (!(exc instanceof HomeAssistantError)) throw exc;
+    console.log(exc.message);
+    return 1;
+  } finally {
+    ws.close();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/claude-code-homeassistant-hermit/src/ha-ws.ts
+++ b/plugins/claude-code-homeassistant-hermit/src/ha-ws.ts
@@ -1,0 +1,199 @@
+// Home Assistant WebSocket client — the transport REST cannot reach (helpers,
+// areas, entity/device registries). Companion to the REST client in ha-api.ts.
+//
+// Design: single-shot connection per CLI invocation (connect → auth → run a few
+// commands → close). No long-lived connection, reconnect, or keepalive — the CLI
+// runs short bulk operations and exits. Bun ships a global WebSocket, so this
+// adds zero runtime dependencies.
+//
+// Protocol (https://developers.home-assistant.io/docs/api/websocket/):
+//   1. Server sends {"type":"auth_required"}.
+//   2. Client sends {"type":"auth","access_token":<token>}.
+//   3. Server replies {"type":"auth_ok"} or {"type":"auth_invalid","message"}.
+//   4. Commands carry an incrementing integer `id`; results come back as
+//      {"id","type":"result","success",("result"|"error")}.
+//
+// Error semantics mirror ha-api.ts: failures throw HomeAssistantError carrying
+// HA's {"message"} verbatim, so callers get the same surface as the REST path.
+
+import type { AppConfig } from './config';
+import { HomeAssistantError, selectHomeAssistantUrl } from './ha-api';
+
+/**
+ * Injectable transport seam (mirrors ha-api.ts's FetchLike). The default wraps
+ * Bun's global WebSocket; tests inject a fake that scripts server messages.
+ * The factory resolves once the socket is OPEN.
+ */
+export interface WsTransport {
+  send(data: string): void;
+  onMessage(cb: (data: string) => void): void;
+  onClose(cb: () => void): void;
+  close(): void;
+}
+
+export type WsTransportFactory = (url: string) => Promise<WsTransport>;
+
+/** http(s) base URL → ws(s) WebSocket endpoint. */
+export function httpToWs(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, '');
+  return `${trimmed.replace(/^https:/i, 'wss:').replace(/^http:/i, 'ws:')}/api/websocket`;
+}
+
+/** Default transport: wrap Bun's global WebSocket, resolving once OPEN. */
+function openWebSocket(url: string): Promise<WsTransport> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.addEventListener('open', () =>
+      resolve({
+        send: (data) => ws.send(data),
+        onMessage: (cb) =>
+          ws.addEventListener('message', (ev: MessageEvent) =>
+            cb(typeof ev.data === 'string' ? ev.data : String(ev.data)),
+          ),
+        onClose: (cb) => ws.addEventListener('close', () => cb()),
+        close: () => ws.close(),
+      }),
+    );
+    ws.addEventListener('error', () =>
+      reject(new HomeAssistantError('Failed to open Home Assistant WebSocket.')),
+    );
+  });
+}
+
+interface Pending {
+  resolve: (value: any) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class HomeAssistantWsClient {
+  private nextId = 1;
+  private readonly pending = new Map<number, Pending>();
+  private closed = false;
+  private authResolve: (() => void) | null = null;
+  private authReject: ((err: Error) => void) | null = null;
+
+  private constructor(
+    private readonly config: AppConfig,
+    private readonly transport: WsTransport,
+  ) {}
+
+  /**
+   * Resolve the base URL (reusing the REST client's local/remote selection),
+   * open the socket, and complete the auth handshake. Throws
+   * HomeAssistantError if the URL/token is missing or auth fails.
+   */
+  static async create(
+    config: AppConfig,
+    transportFactory: WsTransportFactory = openWebSocket,
+  ): Promise<HomeAssistantWsClient> {
+    const [baseUrl] = await selectHomeAssistantUrl(config);
+    const transport = await transportFactory(httpToWs(baseUrl));
+    const client = new HomeAssistantWsClient(config, transport);
+    transport.onMessage((raw) => client.handleMessage(raw));
+    transport.onClose(() => client.handleClose());
+    await client.authenticate();
+    return client;
+  }
+
+  /** Send a command and resolve its `result` (or throw HA's error message). */
+  command(type: string, payload: Record<string, unknown> = {}): Promise<any> {
+    if (this.closed) {
+      return Promise.reject(new HomeAssistantError('Home Assistant WebSocket is closed.'));
+    }
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new HomeAssistantError(`WebSocket command '${type}' timed out.`));
+      }, this.config.timeoutSeconds * 1000);
+      this.pending.set(id, { resolve, reject, timer });
+      this.transport.send(JSON.stringify({ id, type, ...payload }));
+    });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.transport.close();
+    this.rejectAllPending(new HomeAssistantError('Home Assistant WebSocket closed.'));
+  }
+
+  private authenticate(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new HomeAssistantError('Home Assistant WebSocket auth timed out.')),
+        this.config.timeoutSeconds * 1000,
+      );
+      this.authResolve = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      this.authReject = (err: Error) => {
+        clearTimeout(timer);
+        reject(err);
+      };
+    });
+  }
+
+  private handleMessage(raw: string): void {
+    let msg: any;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return; // ignore non-JSON frames
+    }
+    switch (msg?.type) {
+      case 'auth_required':
+        this.transport.send(JSON.stringify({ type: 'auth', access_token: this.config.haToken }));
+        return;
+      case 'auth_ok':
+        this.authResolve?.();
+        this.authResolve = null;
+        this.authReject = null;
+        return;
+      case 'auth_invalid':
+        this.authReject?.(
+          new HomeAssistantError(
+            typeof msg.message === 'string' ? msg.message : 'Home Assistant rejected the token.',
+          ),
+        );
+        this.authResolve = null;
+        this.authReject = null;
+        return;
+      case 'result': {
+        const p = this.pending.get(msg.id);
+        if (!p) return;
+        this.pending.delete(msg.id);
+        clearTimeout(p.timer);
+        if (msg.success) {
+          p.resolve(msg.result);
+        } else {
+          const message =
+            msg.error && typeof msg.error.message === 'string'
+              ? msg.error.message
+              : 'Home Assistant WebSocket command failed.';
+          p.reject(new HomeAssistantError(message));
+        }
+        return;
+      }
+      default:
+        return; // events/pings: not used by the single-shot command flow
+    }
+  }
+
+  private handleClose(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.authReject?.(new HomeAssistantError('Home Assistant WebSocket closed before auth.'));
+    this.rejectAllPending(new HomeAssistantError('Home Assistant WebSocket closed.'));
+  }
+
+  private rejectAllPending(err: Error): void {
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+}

--- a/plugins/claude-code-homeassistant-hermit/src/policy.ts
+++ b/plugins/claude-code-homeassistant-hermit/src/policy.ts
@@ -29,7 +29,7 @@ export const SENSITIVE_KEYWORDS = new Set([
   'access',
 ]);
 
-export const SAFE_RELOAD_DOMAINS = new Set(['automation', 'script']);
+export const SAFE_RELOAD_DOMAINS = new Set(['automation', 'script', 'scene']);
 
 export const Severity = {
   BLOCK: 'block',
@@ -102,6 +102,45 @@ function loadSafetyMode(root: string): string {
 /** Read ha_safety_mode from .claude-code-hermit/config.json. Fail-closed: returns 'strict'. */
 export function safetyMode(root?: string | null): string {
   return loadSafetyMode(resolve(root ?? process.cwd()));
+}
+
+export interface MutationGate {
+  allowed: boolean;
+  requiresConfirm: boolean;
+  mode: string;
+  reason: string;
+}
+
+/**
+ * Gate for structural WebSocket mutations (helpers, areas, entity/device
+ * registries). Reads are never gated — only call this for writes.
+ *
+ *   strict (default): blocked — surface the work as a proposal.
+ *   ask: allowed only with operator confirmation. The CLI is non-interactive,
+ *        so the caller passes `confirmed` (the `--confirm` flag) after the main
+ *        session has prompted the operator; without it the gate asks for it.
+ */
+export function gateStructuralMutation(root?: string | null, confirmed = false): MutationGate {
+  const mode = safetyMode(root);
+  if (mode === 'strict') {
+    return {
+      allowed: false,
+      requiresConfirm: false,
+      mode,
+      reason:
+        'Blocked under strict ha_safety_mode — surface this as a proposal for the operator to approve.',
+    };
+  }
+  if (confirmed) {
+    return { allowed: true, requiresConfirm: false, mode, reason: 'Approved via --confirm.' };
+  }
+  return {
+    allowed: false,
+    requiresConfirm: true,
+    mode,
+    reason:
+      'Requires operator confirmation under ask ha_safety_mode — re-run with --confirm once the operator approves.',
+  };
 }
 
 export interface PolicyDecision {

--- a/plugins/claude-code-homeassistant-hermit/src/structure.ts
+++ b/plugins/claude-code-homeassistant-hermit/src/structure.ts
@@ -1,0 +1,224 @@
+// Structural HA management over WebSocket — the supporting structure REST cannot
+// reach: helpers, areas, entity/device registries. Wraps a WS command client and
+// writes an audit report for each mutation (mirroring apply.ts's remove report).
+//
+// The safety gate (ha_safety_mode) is applied by the CLI *before* a connection is
+// opened, so this module assumes the gate has already passed — it only validates
+// inputs and executes. Read functions return WsReadResult; mutations return
+// WsMutationResult. Validation problems (unknown helper type, bad JSON) come back
+// as ok:false results; only transport/HA failures throw HomeAssistantError, which
+// the CLI's per-command catch already handles.
+
+import { currentSessionId, slugify, standardMetadata, writeMarkdownArtifact } from './artifacts';
+import { HomeAssistantError } from './ha-api';
+
+/** Minimal WS surface (HomeAssistantWsClient satisfies it; tests inject a fake). */
+export interface WsCommandClient {
+  command(type: string, payload?: Record<string, unknown>): Promise<any>;
+  close(): void;
+}
+
+export const HELPER_TYPES = [
+  'input_boolean',
+  'input_number',
+  'input_text',
+  'input_select',
+  'input_datetime',
+  'timer',
+  'counter',
+  'schedule',
+] as const;
+export type HelperType = (typeof HELPER_TYPES)[number];
+
+export interface WsReadResult {
+  ok: boolean;
+  data: unknown;
+  message: string;
+}
+
+export interface WsMutationResult {
+  ok: boolean;
+  data: unknown;
+  message: string;
+  reportPath: string | null;
+}
+
+function isHelperType(value: string): value is HelperType {
+  return (HELPER_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Execute a (pre-gated) mutation and write its audit report. HA failures are
+ * caught and reported (ok: false) so a report always lands, like removeConfig.
+ */
+async function runMutation(
+  root: string,
+  client: WsCommandClient,
+  label: string,
+  type: string,
+  payload: Record<string, unknown>,
+): Promise<WsMutationResult> {
+  let ok: boolean;
+  let data: unknown = null;
+  let message: string;
+  try {
+    data = await client.command(type, payload);
+    ok = true;
+    message = 'ok';
+  } catch (exc) {
+    if (!(exc instanceof HomeAssistantError)) throw exc;
+    ok = false;
+    message = exc.message;
+  }
+
+  const reportPath = writeMutationReport(root, label, type, payload, ok, message);
+  return { ok, data, message, reportPath };
+}
+
+function writeMutationReport(
+  root: string,
+  label: string,
+  type: string,
+  payload: Record<string, unknown>,
+  ok: boolean,
+  message: string,
+): string {
+  const metadata = standardMetadata('ws-mutation', `WS Mutation Report — ${label}`, {
+    session: currentSessionId(root),
+    tags: ['ha-ws', `ha-${label}`],
+    extra: { ws_type: type, payload, ok, message },
+  });
+  const body = [
+    `# WS Mutation Report for \`${label}\``,
+    '',
+    `- ok: ${ok}`,
+    `- ws_type: ${type}`,
+    `- payload: ${JSON.stringify(payload)}`,
+    '',
+    `Message: ${message}`,
+  ].join('\n');
+  return writeMarkdownArtifact(
+    root,
+    '.claude-code-hermit/raw',
+    `audit-ha-ws-${slugify(label)}`,
+    metadata,
+    body,
+    'audit-ha-ws-latest.md',
+  );
+}
+
+// --- Helpers -------------------------------------------------------------
+
+export async function listHelpers(client: WsCommandClient, type?: string): Promise<WsReadResult> {
+  if (type !== undefined && !isHelperType(type)) {
+    return { ok: false, data: null, message: unknownHelperType(type) };
+  }
+  const types = type ? [type as HelperType] : [...HELPER_TYPES];
+  // Fan out concurrently — the WS client correlates responses by id, so all
+  // list commands can be in flight at once (≈1×RTT instead of 8×).
+  const results = await Promise.all(
+    types.map((t) => client.command(`${t}/list`).then((r) => [t, r] as const)),
+  );
+  return { ok: true, data: Object.fromEntries(results), message: 'ok' };
+}
+
+export async function createHelper(
+  root: string,
+  client: WsCommandClient,
+  type: string,
+  json: string,
+): Promise<WsMutationResult> {
+  if (!isHelperType(type)) return invalidPayload(unknownHelperType(type));
+  let payload: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(json);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return invalidPayload('helper JSON must be a JSON object');
+    }
+    payload = parsed as Record<string, unknown>;
+  } catch {
+    return invalidPayload('helper JSON is not valid JSON');
+  }
+  return runMutation(root, client, `create-${type}`, `${type}/create`, payload);
+}
+
+export async function deleteHelper(
+  root: string,
+  client: WsCommandClient,
+  type: string,
+  id: string,
+): Promise<WsMutationResult> {
+  if (!isHelperType(type)) return invalidPayload(unknownHelperType(type));
+  return runMutation(root, client, `delete-${type}`, `${type}/delete`, { [`${type}_id`]: id });
+}
+
+// --- Areas ---------------------------------------------------------------
+
+export async function listAreas(client: WsCommandClient): Promise<WsReadResult> {
+  return { ok: true, data: await client.command('config/area_registry/list'), message: 'ok' };
+}
+
+export async function createArea(
+  root: string,
+  client: WsCommandClient,
+  name: string,
+): Promise<WsMutationResult> {
+  return runMutation(root, client, 'create-area', 'config/area_registry/create', { name });
+}
+
+export async function deleteArea(
+  root: string,
+  client: WsCommandClient,
+  areaId: string,
+): Promise<WsMutationResult> {
+  return runMutation(root, client, 'delete-area', 'config/area_registry/delete', { area_id: areaId });
+}
+
+// --- Entity registry -----------------------------------------------------
+
+export async function listEntities(client: WsCommandClient): Promise<WsReadResult> {
+  return { ok: true, data: await client.command('config/entity_registry/list'), message: 'ok' };
+}
+
+/** Generic entity_registry/update: rename, set area, or enable/disable. */
+export async function updateEntity(
+  root: string,
+  client: WsCommandClient,
+  entityId: string,
+  fields: Record<string, unknown>,
+  label: string,
+): Promise<WsMutationResult> {
+  return runMutation(root, client, label, 'config/entity_registry/update', {
+    entity_id: entityId,
+    ...fields,
+  });
+}
+
+// --- Device registry -----------------------------------------------------
+
+export async function listDevices(client: WsCommandClient): Promise<WsReadResult> {
+  return { ok: true, data: await client.command('config/device_registry/list'), message: 'ok' };
+}
+
+export async function updateDevice(
+  root: string,
+  client: WsCommandClient,
+  deviceId: string,
+  fields: Record<string, unknown>,
+  label: string,
+): Promise<WsMutationResult> {
+  return runMutation(root, client, label, 'config/device_registry/update', {
+    device_id: deviceId,
+    ...fields,
+  });
+}
+
+// --- shared error shapes -------------------------------------------------
+
+function unknownHelperType(type: string): string {
+  return `Unknown helper type '${type}'. Choose from: ${HELPER_TYPES.join(', ')}.`;
+}
+
+function invalidPayload(message: string): WsMutationResult {
+  return { ok: false, data: null, message, reportPath: null };
+}

--- a/plugins/claude-code-homeassistant-hermit/src/structure.ts
+++ b/plugins/claude-code-homeassistant-hermit/src/structure.ts
@@ -49,7 +49,9 @@ function isHelperType(value: string): value is HelperType {
 
 /**
  * Execute a (pre-gated) mutation and write its audit report. HA failures are
- * caught and reported (ok: false) so a report always lands, like removeConfig.
+ * caught and reported (ok: false) so a report lands for them too, like
+ * removeConfig; a report-write failure degrades to reportPath: null rather
+ * than escaping.
  */
 async function runMutation(
   root: string,
@@ -71,7 +73,15 @@ async function runMutation(
     message = exc.message;
   }
 
-  const reportPath = writeMutationReport(root, label, type, payload, ok, message);
+  // Never let a report-write failure (disk full, permissions) escape as a
+  // non-HomeAssistantError and crash the CLI past its per-command catch — the
+  // mutation already landed; report a null path instead.
+  let reportPath: string | null = null;
+  try {
+    reportPath = writeMutationReport(root, label, type, payload, ok, message);
+  } catch {
+    // intentionally empty: mutation already landed, reportPath stays null
+  }
   return { ok, data, message, reportPath };
 }
 
@@ -115,11 +125,21 @@ export async function listHelpers(client: WsCommandClient, type?: string): Promi
   }
   const types = type ? [type as HelperType] : [...HELPER_TYPES];
   // Fan out concurrently — the WS client correlates responses by id, so all
-  // list commands can be in flight at once (≈1×RTT instead of 8×).
-  const results = await Promise.all(
-    types.map((t) => client.command(`${t}/list`).then((r) => [t, r] as const)),
+  // list commands can be in flight at once (≈1×RTT instead of 8×). Use
+  // allSettled so one unavailable integration (e.g. `schedule` on a host
+  // without default_config) doesn't discard the other helper lists.
+  const settled = await Promise.all(
+    types.map((t) =>
+      client
+        .command(`${t}/list`)
+        .then((r) => ({ t, r, err: null as string | null }))
+        .catch((exc) => ({ t, r: null, err: exc instanceof HomeAssistantError ? exc.message : String(exc) })),
+    ),
   );
-  return { ok: true, data: Object.fromEntries(results), message: 'ok' };
+  const data = Object.fromEntries(settled.filter((s) => s.err === null).map((s) => [s.t, s.r]));
+  const unavailable = settled.filter((s) => s.err !== null).map((s) => s.t);
+  const message = unavailable.length ? `ok; unavailable: ${unavailable.join(', ')}` : 'ok';
+  return { ok: true, data, message };
 }
 
 export async function createHelper(

--- a/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
@@ -60,7 +60,7 @@ MCP tool IDs follow `mcp__homeassistant__*`. If you registered the HA MCP Server
 ```
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha refresh-context [--incremental]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha simulate <artifact>
-${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <artifact> [--reload automation|script]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha validate-apply <artifact> [--reload automation|script|scene]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha policy-check <entity_id_or_yaml>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha audit-automations
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha audit-scripts
@@ -73,6 +73,20 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha get-script-config <id>
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha integration-health
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha fetch-history [--window-days N] [--entities <glob> …] [--include-transitions]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha probe <path>
+# WebSocket structural commands (helpers/areas/registries); writes gated by ha_safety_mode (strict→proposal, ask→--confirm)
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-helpers [--type <helper_type>]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha create-helper <type> <json> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-helper <type> <id> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-areas
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha create-area <name> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha delete-area <id> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-entities --registry
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha rename-entity <entity_id> --name <name> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha set-entity-area <entity_id> --area <area_id> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha set-entity-enabled <entity_id> --enabled true|false [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha list-devices
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha set-device-area <device_id> --area <area_id> [--confirm]
+${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab ha rename-device <device_id> --name <name> [--confirm]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab boot status [--probe]
 ${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab boot store --language <locale> --url <url> [--token <token>]
 ```

--- a/plugins/claude-code-homeassistant-hermit/tests/apply.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/apply.test.ts
@@ -49,6 +49,13 @@ alias: Safe script
 sequence:
   - delay: "00:00:01"`;
 
+const SCENE_YAML = `id: my_scene
+name: Movie Night
+entities:
+  light.living_room:
+    state: "on"
+    brightness: 80`;
+
 const safeRoot = () => makeHaRoot();
 
 /** post handler that pops a queue; entries may be values or thrown errors. */
@@ -171,6 +178,27 @@ test('pushes script config via rest', async () => {
     '/api/config/script/config/my_script',
     { id: 'my_script', alias: 'Safe script', sequence: [{ delay: '00:00:01' }] },
   ]);
+});
+
+test('pushes scene config via rest', async () => {
+  const root = safeRoot();
+  const artifact = writeArtifact(root, SCENE_YAML);
+  const client = fakeClient({
+    post: () => ({ result: 'ok' }),
+    get: () => ({ id: 'my_scene', name: 'Movie Night' }),
+  });
+
+  const result = await validateAndApply(root, client, artifact, 'scene');
+
+  expect(result.ok).toBe(true);
+  expect(result.creationAttempted).toBe(true);
+  expect(result.creationOk).toBe(true);
+  expect(client.calls.post).toContainEqual([
+    '/api/config/scene/config/my_scene',
+    { id: 'my_scene', name: 'Movie Night', entities: { 'light.living_room': { state: 'on', brightness: 80 } } },
+  ]);
+  // reload service call uses the scene domain
+  expect(client.calls.post).toContainEqual(['/api/services/scene/reload', {}]);
 });
 
 test('id extracted from yaml id field', async () => {
@@ -321,6 +349,16 @@ test('remove script ok', async () => {
 
   expect(result.ok).toBe(true);
   expect(client.calls.delete).toEqual(['/api/config/script/config/my_script']);
+});
+
+test('remove scene ok', async () => {
+  const root = safeRoot();
+  const client = fakeClient({ del: () => ({ result: 'ok' }) });
+
+  const result = await removeConfig(root, client, 'scene', 'my_scene');
+
+  expect(result.ok).toBe(true);
+  expect(client.calls.delete).toEqual(['/api/config/scene/config/my_scene']);
 });
 
 test('remove returns 400 with resource not found', async () => {

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-structure.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-structure.test.ts
@@ -1,0 +1,236 @@
+// Tests for the WebSocket structural CLI commands (helpers, areas, registries)
+// and the safety gate, driven through main() with an injected fake WS client.
+
+import { afterEach, expect, test } from 'bun:test';
+
+import { main } from '../src/cli';
+import { AppConfig } from '../src/config';
+import { HomeAssistantError } from '../src/ha-api';
+import { clearPolicyCaches } from '../src/policy';
+import { captureOutput, cleanupTmp, makeHaConfig, tmpPath } from './helpers';
+
+afterEach(() => {
+  cleanupTmp();
+  clearPolicyCaches();
+});
+
+/** A config whose root carries the given ha_safety_mode (omit ⇒ strict default). */
+function cfg(mode?: string): AppConfig {
+  const root = mode ? makeHaConfig(mode) : tmpPath();
+  return new AppConfig(root, 'http://ha.local:8123', null, null, 'tok', 5, 0);
+}
+
+interface FakeWs {
+  calls: Array<{ type: string; payload: Record<string, unknown> }>;
+  closed: boolean;
+  command(type: string, payload?: Record<string, unknown>): Promise<any>;
+  close(): void;
+}
+
+function fakeWs(handler?: (type: string, payload: Record<string, unknown>) => any): FakeWs {
+  return {
+    calls: [],
+    closed: false,
+    async command(type: string, payload: Record<string, unknown> = {}) {
+      this.calls.push({ type, payload });
+      return handler ? handler(type, payload) : { result: 'ok' };
+    },
+    close() {
+      this.closed = true;
+    },
+  };
+}
+
+function runCli(argv: string[], ws: FakeWs, config: AppConfig) {
+  return captureOutput(() =>
+    main(argv, { loadConfig: () => config, createWsClient: async () => ws }),
+  );
+}
+
+// --- reads ---------------------------------------------------------------
+
+test('list-areas reads via WS and closes', async () => {
+  const ws = fakeWs(() => [{ area_id: 'a1', name: 'Office' }]);
+  const { code, out } = await runCli(['ha', 'list-areas'], ws, cfg());
+  expect(code).toBe(0);
+  const parsed = JSON.parse(out);
+  expect(parsed.ok).toBe(true);
+  expect(parsed.data).toEqual([{ area_id: 'a1', name: 'Office' }]);
+  expect(ws.calls).toEqual([{ type: 'config/area_registry/list', payload: {} }]);
+  expect(ws.closed).toBe(true);
+});
+
+test('list-helpers fans out across all 8 types', async () => {
+  const ws = fakeWs(() => []);
+  const { code, out } = await runCli(['ha', 'list-helpers'], ws, cfg());
+  expect(code).toBe(0);
+  const parsed = JSON.parse(out);
+  expect(Object.keys(parsed.data).sort()).toEqual(
+    ['counter', 'input_boolean', 'input_datetime', 'input_number', 'input_select', 'input_text', 'schedule', 'timer'].sort(),
+  );
+  expect(ws.calls.length).toBe(8);
+});
+
+test('list-helpers --type scopes to one', async () => {
+  const ws = fakeWs(() => []);
+  const { code } = await runCli(['ha', 'list-helpers', '--type', 'input_boolean'], ws, cfg());
+  expect(code).toBe(0);
+  expect(ws.calls).toEqual([{ type: 'input_boolean/list', payload: {} }]);
+});
+
+test('list-entities requires --registry', async () => {
+  const ws = fakeWs();
+  const { code, out } = await runCli(['ha', 'list-entities'], ws, cfg());
+  expect(code).toBe(1);
+  expect(JSON.parse(out).message).toContain('--registry');
+  expect(ws.calls.length).toBe(0);
+});
+
+test('list-entities --registry reads entity registry', async () => {
+  const ws = fakeWs(() => [{ entity_id: 'light.x' }]);
+  const { code } = await runCli(['ha', 'list-entities', '--registry'], ws, cfg());
+  expect(code).toBe(0);
+  expect(ws.calls).toEqual([{ type: 'config/entity_registry/list', payload: {} }]);
+});
+
+// --- gate ----------------------------------------------------------------
+
+test('mutation blocked under strict, no WS command sent', async () => {
+  const ws = fakeWs();
+  const { code, out } = await runCli(['ha', 'create-area', 'Office'], ws, cfg('strict'));
+  expect(code).toBe(1);
+  const parsed = JSON.parse(out);
+  expect(parsed.blocked).toBe(true);
+  expect(parsed.requires_confirm).toBe(false);
+  expect(parsed.message).toContain('proposal');
+  expect(ws.calls.length).toBe(0);
+});
+
+test('mutation under ask needs --confirm', async () => {
+  const ws = fakeWs();
+  const { code, out } = await runCli(['ha', 'create-area', 'Office'], ws, cfg('ask'));
+  expect(code).toBe(1);
+  const parsed = JSON.parse(out);
+  expect(parsed.blocked).toBe(true);
+  expect(parsed.requires_confirm).toBe(true);
+  expect(ws.calls.length).toBe(0);
+});
+
+test('mutation under ask with --confirm runs', async () => {
+  const ws = fakeWs(() => ({ area_id: 'a9' }));
+  const { code, out } = await runCli(['ha', 'create-area', 'Office', '--confirm'], ws, cfg('ask'));
+  expect(code).toBe(0);
+  const parsed = JSON.parse(out);
+  expect(parsed.ok).toBe(true);
+  expect(parsed.blocked).toBe(false);
+  expect(parsed.report_path).toBeTruthy();
+  expect(ws.calls).toEqual([{ type: 'config/area_registry/create', payload: { name: 'Office' } }]);
+});
+
+// --- helpers create/delete ----------------------------------------------
+
+test('create-helper rejects unknown type', async () => {
+  const ws = fakeWs();
+  const { code, out } = await runCli(
+    ['ha', 'create-helper', 'input_bogus', '{}', '--confirm'],
+    ws,
+    cfg('ask'),
+  );
+  expect(code).toBe(1);
+  expect(JSON.parse(out).message).toContain('Unknown helper type');
+  expect(ws.calls.length).toBe(0);
+});
+
+test('create-helper rejects invalid JSON', async () => {
+  const ws = fakeWs();
+  const { code, out } = await runCli(
+    ['ha', 'create-helper', 'input_boolean', 'not-json', '--confirm'],
+    ws,
+    cfg('ask'),
+  );
+  expect(code).toBe(1);
+  expect(JSON.parse(out).message).toContain('valid JSON');
+  expect(ws.calls.length).toBe(0);
+});
+
+test('create-helper sends type/create with parsed payload', async () => {
+  const ws = fakeWs(() => ({ id: 'h1' }));
+  const { code } = await runCli(
+    ['ha', 'create-helper', 'input_boolean', '{"name":"Guests"}', '--confirm'],
+    ws,
+    cfg('ask'),
+  );
+  expect(code).toBe(0);
+  expect(ws.calls).toEqual([{ type: 'input_boolean/create', payload: { name: 'Guests' } }]);
+});
+
+test('delete-helper sends type/delete with id key', async () => {
+  const ws = fakeWs();
+  const { code } = await runCli(['ha', 'delete-helper', 'timer', 't1', '--confirm'], ws, cfg('ask'));
+  expect(code).toBe(0);
+  expect(ws.calls).toEqual([{ type: 'timer/delete', payload: { timer_id: 't1' } }]);
+});
+
+// --- registry writes -----------------------------------------------------
+
+test('rename-entity requires --name', async () => {
+  const ws = fakeWs();
+  const { code, out } = await runCli(['ha', 'rename-entity', 'light.x', '--confirm'], ws, cfg('ask'));
+  expect(code).toBe(1);
+  expect(JSON.parse(out).message).toContain('--name');
+  expect(ws.calls.length).toBe(0);
+});
+
+test('rename-entity updates the entity registry', async () => {
+  const ws = fakeWs(() => ({ entity_entry: {} }));
+  const { code } = await runCli(
+    ['ha', 'rename-entity', 'light.x', '--name', 'Lamp', '--confirm'],
+    ws,
+    cfg('ask'),
+  );
+  expect(code).toBe(0);
+  expect(ws.calls).toEqual([
+    { type: 'config/entity_registry/update', payload: { entity_id: 'light.x', name: 'Lamp' } },
+  ]);
+});
+
+test('set-entity-enabled false maps to disabled_by user', async () => {
+  const ws = fakeWs();
+  const { code } = await runCli(
+    ['ha', 'set-entity-enabled', 'light.x', '--enabled', 'false', '--confirm'],
+    ws,
+    cfg('ask'),
+  );
+  expect(code).toBe(0);
+  expect(ws.calls[0]).toEqual({
+    type: 'config/entity_registry/update',
+    payload: { entity_id: 'light.x', disabled_by: 'user' },
+  });
+});
+
+test('set-device-area updates the device registry', async () => {
+  const ws = fakeWs();
+  const { code } = await runCli(
+    ['ha', 'set-device-area', 'dev1', '--area', 'a1', '--confirm'],
+    ws,
+    cfg('ask'),
+  );
+  expect(code).toBe(0);
+  expect(ws.calls).toEqual([
+    { type: 'config/device_registry/update', payload: { device_id: 'dev1', area_id: 'a1' } },
+  ]);
+});
+
+// --- HA failure surfaces verbatim ---------------------------------------
+
+test('WS command failure surfaces HA message and writes report', async () => {
+  const ws = fakeWs(() => {
+    throw new HomeAssistantError('Area name already exists.');
+  });
+  const { code, out } = await runCli(['ha', 'create-area', 'Office', '--confirm'], ws, cfg('ask'));
+  expect(code).toBe(1);
+  const parsed = JSON.parse(out);
+  expect(parsed.ok).toBe(false);
+  expect(parsed.message).toBe('Area name already exists.');
+  expect(parsed.report_path).toBeTruthy();
+});

--- a/plugins/claude-code-homeassistant-hermit/tests/ha-ws.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/ha-ws.test.ts
@@ -1,0 +1,166 @@
+// Tests for src/ha-ws.ts — the WebSocket client. No real sockets: a fake
+// WsTransport scripts the server side via an onSend reactor + manual emit/close.
+
+import { expect, test } from 'bun:test';
+
+import { AppConfig } from '../src/config';
+import { HomeAssistantError } from '../src/ha-api';
+import { HomeAssistantWsClient, httpToWs, type WsTransport } from '../src/ha-ws';
+
+function config(timeoutSeconds = 5): AppConfig {
+  return new AppConfig('/tmp', 'http://ha.local:8123', null, null, 'tok', timeoutSeconds, 0);
+}
+
+interface ServerApi {
+  emit(obj: unknown): void;
+  emitRaw(raw: string): void;
+  triggerClose(): void;
+  sent: any[];
+}
+
+/**
+ * Fake transport. `onSend(msg, api)` reacts to each client frame. The server
+ * initiates the handshake by emitting `auth_required` on a macrotask, so it
+ * lands after create() registers its message listener (matching real HA, which
+ * sends auth_required right after the socket opens).
+ */
+function fakeFactory(onSend: (msg: any, api: ServerApi) => void) {
+  const sent: any[] = [];
+  let messageCb: (data: string) => void = () => {};
+  let closeCb: () => void = () => {};
+  const api: ServerApi = {
+    emit: (obj) => messageCb(JSON.stringify(obj)),
+    emitRaw: (raw) => messageCb(raw),
+    triggerClose: () => closeCb(),
+    sent,
+  };
+  const transport: WsTransport = {
+    send: (data) => {
+      const msg = JSON.parse(data);
+      sent.push(msg);
+      onSend(msg, api);
+    },
+    onMessage: (cb) => {
+      messageCb = cb;
+    },
+    onClose: (cb) => {
+      closeCb = cb;
+    },
+    close: () => {},
+  };
+  return {
+    factory: async () => {
+      setTimeout(() => api.emit({ type: 'auth_required', ha_version: 'test' }), 0);
+      return transport;
+    },
+    api,
+  };
+}
+
+// happy-path server: ack auth, echo commands as successful results.
+const echoServer = (msg: any, api: ServerApi) => {
+  if (msg.type === 'auth') {
+    api.emit({ type: 'auth_ok', ha_version: 'test' });
+  } else {
+    api.emit({ id: msg.id, type: 'result', success: true, result: { echoed: msg.type } });
+  }
+};
+
+test('httpToWs maps scheme and appends endpoint', () => {
+  expect(httpToWs('http://ha.local:8123')).toBe('ws://ha.local:8123/api/websocket');
+  expect(httpToWs('https://x.ui.nabu.casa/')).toBe('wss://x.ui.nabu.casa/api/websocket');
+});
+
+test('create completes auth handshake and sends token', async () => {
+  const { factory, api } = fakeFactory(echoServer);
+  const client = await HomeAssistantWsClient.create(config(), factory);
+  expect(api.sent).toContainEqual({ type: 'auth', access_token: 'tok' });
+  client.close();
+});
+
+test('command resolves with result payload', async () => {
+  const { factory } = fakeFactory(echoServer);
+  const client = await HomeAssistantWsClient.create(config(), factory);
+  const result = await client.command('config/area_registry/list');
+  expect(result).toEqual({ echoed: 'config/area_registry/list' });
+  client.close();
+});
+
+test('command sends id-correlated frame with payload merged', async () => {
+  const { factory, api } = fakeFactory(echoServer);
+  const client = await HomeAssistantWsClient.create(config(), factory);
+  await client.command('config/area_registry/create', { name: 'Office' });
+  const cmd = api.sent.find((m) => m.type === 'config/area_registry/create');
+  expect(cmd).toMatchObject({ type: 'config/area_registry/create', name: 'Office' });
+  expect(typeof cmd.id).toBe('number');
+  client.close();
+});
+
+test('auth_invalid rejects create with HA message', async () => {
+  const { factory } = fakeFactory((msg, api) => {
+    if (msg.type === 'auth') api.emit({ type: 'auth_invalid', message: 'Invalid token.' });
+  });
+  await expect(HomeAssistantWsClient.create(config(), factory)).rejects.toThrow('Invalid token.');
+});
+
+test('command failure surfaces HA error message verbatim', async () => {
+  const { factory } = fakeFactory((msg, api) => {
+    if (msg.type === 'auth') api.emit({ type: 'auth_ok' });
+    else api.emit({ id: msg.id, type: 'result', success: false, error: { code: 'not_found', message: 'Area not found.' } });
+  });
+  const client = await HomeAssistantWsClient.create(config(), factory);
+  await expect(client.command('config/area_registry/delete', { area_id: 'x' })).rejects.toThrow(
+    'Area not found.',
+  );
+  client.close();
+});
+
+test('interleaved results route to the correct command by id', async () => {
+  // Server defers both results, then answers in reverse order.
+  const queue: Array<{ id: number; type: string }> = [];
+  const { factory, api } = fakeFactory((msg) => {
+    if (msg.type === 'auth') api.emit({ type: 'auth_ok' });
+    else queue.push({ id: msg.id, type: msg.type });
+  });
+  const client = await HomeAssistantWsClient.create(config(), factory);
+  const pA = client.command('cmd_a');
+  const pB = client.command('cmd_b');
+  // answer B first, then A
+  const b = queue.find((q) => q.type === 'cmd_b')!;
+  const a = queue.find((q) => q.type === 'cmd_a')!;
+  api.emit({ id: b.id, type: 'result', success: true, result: 'B' });
+  api.emit({ id: a.id, type: 'result', success: true, result: 'A' });
+  expect(await pA).toBe('A');
+  expect(await pB).toBe('B');
+  client.close();
+});
+
+test('command times out when no result arrives', async () => {
+  const { factory } = fakeFactory((msg, api) => {
+    if (msg.type === 'auth') api.emit({ type: 'auth_ok' });
+    // never answers commands
+  });
+  const client = await HomeAssistantWsClient.create(config(0.05), factory);
+  await expect(client.command('cmd_never')).rejects.toThrow('timed out');
+  client.close();
+});
+
+test('early close rejects pending commands', async () => {
+  const { factory, api } = fakeFactory((msg) => {
+    if (msg.type === 'auth') api.emit({ type: 'auth_ok' });
+    // hold commands open
+  });
+  const client = await HomeAssistantWsClient.create(config(), factory);
+  const pending = client.command('cmd_held');
+  api.triggerClose();
+  await expect(pending).rejects.toThrow('closed');
+});
+
+test('non-JSON frames are ignored, not fatal', async () => {
+  const { factory, api } = fakeFactory(echoServer);
+  const client = await HomeAssistantWsClient.create(config(), factory);
+  api.emitRaw('not json at all');
+  const result = await client.command('cmd_after_garbage');
+  expect(result).toEqual({ echoed: 'cmd_after_garbage' });
+  client.close();
+});

--- a/plugins/claude-code-homeassistant-hermit/tests/policy.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/policy.test.ts
@@ -24,6 +24,7 @@ import {
   classifyEntity,
   clearPolicyCaches,
   evaluateReferences,
+  gateStructuralMutation,
   isSensitiveEntity,
   safetyMode,
 } from '../src/policy';
@@ -142,6 +143,24 @@ test('safety mode invalid value defaults to strict', () => {
 test('safety mode permissive no longer valid', () => {
   // `permissive` was removed in favour of two-tier strict/ask. Falls back to strict.
   expect(safetyMode(makeHaConfig('permissive'))).toBe('strict');
+});
+
+test('gate blocks structural mutation under strict (default)', () => {
+  const gate = gateStructuralMutation(tmpPath());
+  expect(gate.allowed).toBe(false);
+  expect(gate.requiresConfirm).toBe(false);
+  expect(gate.mode).toBe('strict');
+  expect(gate.reason).toContain('proposal');
+});
+
+test('gate under ask requires confirmation', () => {
+  const root = makeHaConfig('ask');
+  const unconfirmed = gateStructuralMutation(root, false);
+  expect(unconfirmed.allowed).toBe(false);
+  expect(unconfirmed.requiresConfirm).toBe(true);
+  const confirmed = gateStructuralMutation(root, true);
+  expect(confirmed.allowed).toBe(true);
+  expect(confirmed.requiresConfirm).toBe(false);
 });
 
 test('classify strict blocks sensitive', () => {


### PR DESCRIPTION
## Summary

The `ha-agent-lab` CLI was REST-only and could only manage two config domains (automations, scripts). This adds **scenes** over the existing REST config path, plus a **WebSocket client** that unlocks the structure Home Assistant exposes only over `wss://…/api/websocket`: helpers, areas, and entity/device registries. All structural mutations are gated through the existing `ha_safety_mode` safety policy.

Closes #466.

## Changes

- **Phase A — scenes (REST):** `scene` added to `CONFIG_DOMAINS`, `SAFE_RELOAD_DOMAINS`, and the `validate-apply --reload` choices. Reuses the whole existing apply/simulate/report path (`/api/config/scene/config/{id}` + `scene.reload`).
- **Phase B — `src/ha-ws.ts`:** single-shot WebSocket client (zero new deps — Bun's global `WebSocket`), reusing the REST client's URL selection and token. Auth handshake, id-correlated commands, timeouts, injectable transport seam for tests.
- **Phases C+D — `src/structure.ts` + 13 CLI commands:** helpers (`list/create/delete-helper`, 8 types), areas (`list/create/delete-area`), entity registry (`list-entities --registry`, `rename-entity`, `set-entity-area`, `set-entity-enabled`), device registry (`list-devices`, `set-device-area`, `rename-device`).
- **Safety:** `gateStructuralMutation` in `policy.ts` — reads always allowed; under `strict` (default) writes are blocked and surfaced as a proposal; under `ask` writes require `--confirm` (the gate runs before any socket is opened). Every mutation writes an `audit-ha-ws-*` report.
- **Docs:** `CLAUDE.md` (CLI list + WebSocket gotchas), `CLAUDE-APPEND.md`, `CHANGELOG.md` `[Unreleased]`. No `required_core_version` bump (no core dependency).

## Test plan

- `bunx tsc --noEmit` — clean.
- `bun test` — **511 pass / 0 fail** (49 new across `apply`, `policy`, `ha-ws`, `cli-structure`). The 4 `gate-fuzz` property tests only flake under the default 5s timeout on a loaded box (they spawn the hook as a subprocess thousands of times); they pass at `--timeout 30000`, and the golden `gate-corpus` gate test passes regardless.
- **Still needs a live HA instance before merge** (no HA connection from the dev session): (1) `ha probe /api/config/scene/config/<id>` to confirm the scene REST endpoint; (2) confirm the exact WS command `type`/field shapes for registries/helpers — the docs index only documents the auth/result envelope. Both are flagged in `CLAUDE.md`'s WebSocket subsection.