### PR TITLE
docs(laravel-forge-hermit): clarify server-log key format is hyphenated

### DIFF
--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Fixed
+- **forge-logs: server-log key format** — nginx log keys are hyphenated (`nginx-error`, `nginx-access`); underscored variants return a 404.
+
 ## [0.0.3] - 2026-06-24
 
 ### Fixed

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -191,7 +191,7 @@ if ($cmd === '' || $cmd === '--help' || $cmd === 'help') {
       sites <server>              List sites on a server
       site <server> <site>        Show site detail
       logs <server> <site>        Show latest deployment log for a site
-      server-log <server> <key>   Read a server log by key
+      server-log <server> <key>   Read a server log by key (keys are hyphenated: nginx-error, nginx-access)
       deploy-history <server> <site>          List recent deployments
       deploy-log <server> <site> <deploy-id>  Fetch a specific deployment log
       deploy-status <server-id> <site-id> <deploy-id>  Print a deployment's status (raw IDs)

--- a/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
@@ -31,7 +31,7 @@ Use `deploy-history` first to find the deployment ID.
 php ${CLAUDE_PLUGIN_ROOT}/php/forge.php server-log <server> <key>
 ```
 
-Common keys: `php`, `nginx`, `mysql`, `cron`, `daemon`. Key list depends on the server's installed services.
+Common keys: `php`, `mysql`, `cron`, `daemon`, `nginx-error`, `nginx-access`. Nginx keys are hyphenated; `nginx_error` (underscored) returns a 404. Key list depends on the server's installed services.
 
 ---
 


### PR DESCRIPTION
## Summary

Live Forge API testing confirmed that nginx server log keys must be hyphenated (`nginx-error`, `nginx-access`). Underscored variants (`nginx_error`) return a 404 NotFoundException. The docs listed the bare `nginx` key (which also fails) and made no mention of the hyphen convention.

## Changes

- `php/forge.php` help text — added `(keys are hyphenated: nginx-error, nginx-access)` to the `server-log` description
- `skills/forge-logs/SKILL.md` — replaced bare `nginx` in common-keys list with `nginx-error`, `nginx-access`; added nginx-specific hyphen warning; `nginx_error` (underscored) returns a 404
- `CHANGELOG.md` — added `[Unreleased]` section with the fix entry

## Test plan

- `php forge.php --help` shows the updated `server-log` description (requires SDK installed via hatch)
- Read `SKILL.md` line 34: nginx examples are hyphenated, underscore warning is present
- `CHANGELOG.md` opens with `## [Unreleased]` above `## [0.0.3]`