### PR TITLE
feat(drift,forge): config.storage_drift.ignore allowlist for runtime dirs

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## [Unreleased]
 
 ### Added
+- **config: `storage_drift.ignore`** — allowlist of top-level `.claude-code-hermit/` dirs exempt from storage-drift alerts. Domain plugins register hermit-owned runtime trees (Composer vendor installs, SDK caches) so the drift check never false-flags them as stray archive content. See `docs/plugin-hermit-storage.md`.
 - **session-close: Completed-vs-Artifacts closeout check** — a quality-check item flags when `## Completed` claims a deliverable a skill persists to `compiled/` but it's absent from `## Artifacts`, catching silently-dropped outputs at close instead of in a later session. Report template now labels `## Completed` as narrative. (#465)
 
 ### Changed
 - **judge subagents: state terse-output rationale explicitly** — `proposal-triage`, `reflection-judge`, and `quality-gate-judge` now say their final message lands verbatim in the caller's long-lived context and re-read from cache each turn, so reasoning belongs in thinking, not the response (#468).
 
 ### Fixed
+- **drift: storage-drift no longer false-flags allowlisted runtime dirs** — `findStorageDrift` reads `config.storage_drift.ignore` and skips declared dirs in both the session-start Storage Drift block and the reflect observations ledger. Fail-open: absent or invalid config defaults to no exemptions.
 - **heartbeat/alert-state: atomic writes + corrupt-file quarantine** — `heartbeat-precheck.ts` and `update-alert-state.ts` write `alert-state.json` via temp+rename and quarantine an unparseable existing file to `alert-state.json.corrupt-<ts>` instead of reinitializing skill-owned `alerts`/`self_eval` to empty. Reads split the file read from the JSON parse (shared `scripts/lib/alert-state.ts`), so a transient read error (EACCES/EMFILE/EIO) on a healthy file is never mistaken for corruption and never quarantined or reset. Stops silent loss of accumulated alert/self-eval telemetry on an interrupted or partial write (#463).
 - **hermit-settings: reconcile the heartbeat monitor on change** — after writing a `heartbeat` change, auto-runs `/heartbeat start` (if enabled) or `/heartbeat stop` (if disabled) so the live Monitor's cadence and `config.json` can't silently desync. (#452)
 - **routines: suppress duplicate `fired` metric** — heartbeat-restart's self-re-arm (`hermit-routines load` at its own prompt tail) could log a second `fired` with no intervening `started` (#464); `log-routine-event.sh` now skips a `fired` that immediately follows another `fired` for the same routine.

--- a/plugins/claude-code-hermit/docs/plugin-hermit-storage.md
+++ b/plugins/claude-code-hermit/docs/plugin-hermit-storage.md
@@ -5,11 +5,31 @@ Plugin hermits must store all domain artifacts in exactly two directories:
 - `.claude-code-hermit/raw/` — ephemeral inputs (fetched content, snapshots, logs, API dumps).
 - `.claude-code-hermit/compiled/` — durable outputs (briefings, digests, assessments, audit results).
 
-Everything else is infra managed by the base hermit (`state/`, `sessions/`, `proposals/`, `templates/`, operator-curated docs). Plugins don't add new directories.
+Everything else is infra managed by the base hermit (`state/`, `sessions/`, `proposals/`, `templates/`, operator-curated docs). Domain plugins must not add top-level directories for knowledge artifacts — the one exception is a hermit-owned runtime directory declared in `config.storage_drift.ignore` (see below).
 
 ## Why these two and nothing else
 
 The `compiled/` directory is scanned at session start to inject foundational context. `scripts/archive-raw.ts` and the weekly review run retention against `raw/`, covering both dated `.md` and `.json` artifacts. Fixed-name `-latest.*` aliases are never archived. Anything outside these two paths is invisible to both mechanisms — your audits won't surface at session start, and your snapshots will never be archived.
+
+## Runtime dirs (`storage_drift.ignore`)
+
+Some domain plugins install a hermit-owned runtime tree that is **not** a knowledge artifact — for example, `laravel-forge-hermit` puts a Composer vendor tree at `.claude-code-hermit/forge-runtime/`. These dirs should not live in `raw/` or `compiled/` (they're not archivable content), but they're also legitimate, so the storage-drift check must not flag them.
+
+Declare such dirs in `config.json`:
+
+```json
+"storage_drift": {
+  "ignore": ["forge-runtime"]
+}
+```
+
+When a domain plugin calls hatch, its Step 8 (config.json rewrite) appends its runtime dir name to `storage_drift.ignore` idempotently. The drift check (`scripts/lib/drift.ts`) reads this list at runtime and skips declared dirs — in both the session-start Storage Drift block and the reflect observations ledger.
+
+Rules for a compliant runtime dir:
+- One per domain plugin (keep it scoped).
+- Hermit-owned only — not the application's own `vendor/` or `node_modules/`.
+- Never write archivable knowledge content into it; use `raw/` or `compiled/` for that.
+- Register it in `storage_drift.ignore` during hatch — never rely on it being silently ignored.
 
 This mirrors the Karpathy raw-vs-compiled split: raw is the immutable ground truth, compiled is the LLM-maintained derivative. The filesystem layout is fixed; the `type` field in frontmatter is what differentiates work products within each directory.
 
@@ -76,6 +96,7 @@ If a hermit produces many artifacts of the same type (per-room audits, per-accou
 | `audits/` (repo root) | ❌ | completely outside hermit state |
 | `reports/` (repo root) | ❌ | same — outside hermit state |
 | `memory/` (inside `.claude-code-hermit/`) | ❌ | base hermit infra — plugins don't add top-level dirs |
+| `.claude-code-hermit/forge-runtime/` (with `storage_drift.ignore: ["forge-runtime"]`) | ✅ | hermit-owned runtime dir, registered in config, not a knowledge artifact |
 
 ## Declare your types in knowledge-schema.md
 

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -102,6 +102,9 @@ const DEFAULT_CONFIG: Json = {
   reflection: {
     graduation_min_sessions: 1,
   },
+  storage_drift: {
+    ignore: [],
+  },
   post_close_clear: true,
 };
 

--- a/plugins/claude-code-hermit/scripts/lib/drift.ts
+++ b/plugins/claude-code-hermit/scripts/lib/drift.ts
@@ -9,6 +9,17 @@ import { parseSchema } from '../knowledge-lint';
 export function findStorageDrift(hermitDir: string): string[] {
   const KNOWN_DIRS = new Set(['raw', 'compiled', 'sessions', 'proposals', 'state', 'templates',
     'memory', 'bin', 'docker']);
+
+  // Fail-open: any parse error → no exemptions applied.
+  let ignoreDirs = new Set<string>();
+  try {
+    const cfg = JSON.parse(fs.readFileSync(path.join(hermitDir, 'config.json'), 'utf-8'));
+    const listed = cfg?.storage_drift?.ignore;
+    if (Array.isArray(listed)) {
+      ignoreDirs = new Set(listed.filter((d: unknown) => typeof d === 'string'));
+    }
+  } catch {}
+
   const hits: string[] = [];
 
   function countEntries(dir: string): number {
@@ -19,7 +30,7 @@ export function findStorageDrift(hermitDir: string): string[] {
   try {
     for (const entry of fs.readdirSync(hermitDir, { withFileTypes: true })) {
       if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-      if (!KNOWN_DIRS.has(entry.name)) {
+      if (!KNOWN_DIRS.has(entry.name) && !ignoreDirs.has(entry.name)) {
         const n = countEntries(path.join(hermitDir, entry.name));
         hits.push(`.claude-code-hermit/${entry.name}/ (${n} file${n !== 1 ? 's' : ''})`);
       }

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -346,7 +346,7 @@ For routines — if Yes: use the config defaults (`active_hours.start = 08:00`, 
 
 **Re-initialization merge**: read the existing `.claude-code-hermit/config.json`, then overlay only the fields the wizard asked about. Never strip unknown keys (operators may have added custom fields). Don't re-default fields the operator didn't touch this run.
 
-**Template-only fields** (the wizard never asks about these — they come straight from `config.json.template` and the operator can tune them via `/hermit-settings` later): `model`, `auto_session`, `always_on`, `chrome`, `monitors`, `compact`, `heartbeat`, `knowledge`, `env`, `quality_gate`, `watchdog`, `reflection`, `post_close_clear`. The Quick branch and Advanced wizard both leave these at template defaults.
+**Template-only fields** (the wizard never asks about these — they come straight from `config.json.template` and the operator can tune them via `/hermit-settings` later): `model`, `auto_session`, `always_on`, `chrome`, `monitors`, `compact`, `heartbeat`, `knowledge`, `env`, `quality_gate`, `watchdog`, `reflection`, `storage_drift`, `post_close_clear`. The Quick branch and Advanced wizard both leave these at template defaults.
 
 If channels were configured in Phase 5, populate each channel's entry in the `channels` object using a **relative path** (relative to the project root):
 

--- a/plugins/claude-code-hermit/state-templates/config.json.template
+++ b/plugins/claude-code-hermit/state-templates/config.json.template
@@ -73,5 +73,8 @@
   "reflection": {
     "graduation_min_sessions": 1
   },
+  "storage_drift": {
+    "ignore": []
+  },
   "post_close_clear": true
 }

--- a/plugins/claude-code-hermit/tests/storage-drift.test.ts
+++ b/plugins/claude-code-hermit/tests/storage-drift.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { findStorageDrift } from '../scripts/lib/drift';
+
+function mkHermitDir(base: string, config?: object): string {
+  const hermitDir = path.join(base, '.claude-code-hermit');
+  fs.mkdirSync(hermitDir, { recursive: true });
+  if (config !== undefined) {
+    fs.writeFileSync(path.join(hermitDir, 'config.json'), JSON.stringify(config), 'utf-8');
+  }
+  return hermitDir;
+}
+
+function mkDir(hermitDir: string, name: string): void {
+  fs.mkdirSync(path.join(hermitDir, name), { recursive: true });
+  // Put one file inside so countEntries returns > 0.
+  fs.writeFileSync(path.join(hermitDir, name, 'placeholder'), '', 'utf-8');
+}
+
+let tmp: string;
+
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-drift-'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('findStorageDrift — allowlist', () => {
+  it('does NOT flag a dir listed in storage_drift.ignore', () => {
+    const base = path.join(tmp, 'test-exempt');
+    fs.mkdirSync(base);
+    const hermitDir = mkHermitDir(base, { storage_drift: { ignore: ['forge-runtime'] } });
+    mkDir(hermitDir, 'forge-runtime');
+
+    const hits = findStorageDrift(hermitDir);
+    expect(hits.every(h => !h.includes('forge-runtime'))).toBe(true);
+  });
+
+  it('still flags an unknown dir NOT in the ignore list', () => {
+    const base = path.join(tmp, 'test-garbage');
+    fs.mkdirSync(base);
+    const hermitDir = mkHermitDir(base, { storage_drift: { ignore: ['forge-runtime'] } });
+    mkDir(hermitDir, 'garbage');
+
+    const hits = findStorageDrift(hermitDir);
+    expect(hits.some(h => h.includes('garbage'))).toBe(true);
+  });
+
+  it('exempts multiple dirs in the ignore list', () => {
+    const base = path.join(tmp, 'test-multi');
+    fs.mkdirSync(base);
+    const hermitDir = mkHermitDir(base, { storage_drift: { ignore: ['foo-runtime', 'bar-runtime'] } });
+    mkDir(hermitDir, 'foo-runtime');
+    mkDir(hermitDir, 'bar-runtime');
+
+    const hits = findStorageDrift(hermitDir);
+    expect(hits.every(h => !h.includes('foo-runtime') && !h.includes('bar-runtime'))).toBe(true);
+  });
+});
+
+describe('findStorageDrift — fail-open', () => {
+  it('still flags drift when config.json is missing', () => {
+    const base = path.join(tmp, 'test-no-config');
+    fs.mkdirSync(base);
+    const hermitDir = mkHermitDir(base);
+    mkDir(hermitDir, 'garbage');
+
+    const hits = findStorageDrift(hermitDir);
+    expect(hits.some(h => h.includes('garbage'))).toBe(true);
+  });
+
+  it('still flags drift when config.json is invalid JSON', () => {
+    const base = path.join(tmp, 'test-bad-config');
+    fs.mkdirSync(base);
+    const hermitDir = mkHermitDir(base);
+    fs.writeFileSync(path.join(hermitDir, 'config.json'), 'NOT JSON', 'utf-8');
+    mkDir(hermitDir, 'garbage');
+
+    const hits = findStorageDrift(hermitDir);
+    expect(hits.some(h => h.includes('garbage'))).toBe(true);
+  });
+
+  it('still flags drift when storage_drift.ignore is not an array', () => {
+    const base = path.join(tmp, 'test-bad-ignore');
+    fs.mkdirSync(base);
+    const hermitDir = mkHermitDir(base, { storage_drift: { ignore: 'forge-runtime' } });
+    mkDir(hermitDir, 'garbage');
+
+    const hits = findStorageDrift(hermitDir);
+    expect(hits.some(h => h.includes('garbage'))).toBe(true);
+  });
+});

--- a/plugins/laravel-forge-hermit/.claude-plugin/hermit-meta.json
+++ b/plugins/laravel-forge-hermit/.claude-plugin/hermit-meta.json
@@ -1,4 +1,4 @@
 {
-  "required_core_version": ">=1.2.11",
-  "requires": { "claude-code-hermit": ">=1.2.11" }
+  "required_core_version": ">=1.2.12",
+  "requires": { "claude-code-hermit": ">=1.2.12" }
 }

--- a/plugins/laravel-forge-hermit/.claude-plugin/plugin.json
+++ b/plugins/laravel-forge-hermit/.claude-plugin/plugin.json
@@ -20,7 +20,7 @@
   "dependencies": [
     {
       "name": "claude-code-hermit",
-      "version": "^1.2.11"
+      "version": "^1.2.12"
     }
   ]
 }

--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Fixed
 - **hatch: register `forge-runtime` in `storage_drift.ignore`** — Step 8 now idempotently adds `"forge-runtime"` to `config.storage_drift.ignore`, so the core storage-drift check never false-flags the Composer vendor tree as stray archive content. Requires `claude-code-hermit` ≥1.2.12.
+- **forge-logs: server-log key format** — nginx log keys are hyphenated (`nginx-error`, `nginx-access`); underscored variants return a 404.
 
 ### Upgrade Instructions
 
 Read `.claude-code-hermit/config.json`. Check `storage_drift.ignore`: if the key is absent or not an array, add `"storage_drift": {"ignore": ["forge-runtime"]}` at the top level. If it is already an array but does not contain `"forge-runtime"`, append it. Write the updated file.
-- **forge-logs: server-log key format** — nginx log keys are hyphenated (`nginx-error`, `nginx-access`); underscored variants return a 404.
 
 ## [0.0.3] - 2026-06-24
 

--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Fixed
+- **hatch: register `forge-runtime` in `storage_drift.ignore`** — Step 8 now idempotently adds `"forge-runtime"` to `config.storage_drift.ignore`, so the core storage-drift check never false-flags the Composer vendor tree as stray archive content. Requires `claude-code-hermit` ≥1.2.12.
+
+### Upgrade Instructions
+
+Read `.claude-code-hermit/config.json`. Check `storage_drift.ignore`: if the key is absent or not an array, add `"storage_drift": {"ignore": ["forge-runtime"]}` at the top level. If it is already an array but does not contain `"forge-runtime"`, append it. Write the updated file.
+
 ## [0.0.3] - 2026-06-24
 
 ### Fixed

--- a/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/hatch/SKILL.md
@@ -172,6 +172,8 @@ Use the `config.json` content loaded in Step 1.
 
 If present: skip (do not clobber).
 
+**Register runtime dir**: ensure `config.storage_drift` exists and `config.storage_drift.ignore` is an array that includes `"forge-runtime"`. If the key is absent, add `"storage_drift": {"ignore": ["forge-runtime"]}`. If the array exists but does not include `"forge-runtime"`, append it. Skip if already present.
+
 Write the updated `config.json` via Write tool (full file replacement for valid JSON).
 
 ---

--- a/plugins/laravel-forge-hermit/tests/run-all.sh
+++ b/plugins/laravel-forge-hermit/tests/run-all.sh
@@ -8,6 +8,8 @@ echo "=== laravel-forge-hermit test suite ==="
 
 EXIT=0
 
+composer install --no-dev --no-interaction --quiet --working-dir=php
+
 echo ""
 echo "--- PHP tests (php/tests/run.php) ---"
 if ! php php/tests/run.php; then


### PR DESCRIPTION
## Summary

Adds a `storage_drift.ignore` config allowlist so domain plugins can register hermit-owned runtime directories (like `laravel-forge-hermit`'s Composer vendor tree at `.claude-code-hermit/forge-runtime/`) without triggering false-positive storage-drift alerts at every session start and reflect run.

## Changes

**`claude-code-hermit` (core)**
- `scripts/lib/drift.ts` — `findStorageDrift` reads `config.storage_drift.ignore` (fail-open: missing/invalid config = no exemptions) and skips declared dirs in the top-level scan. Both the session-start Storage Drift block and the reflect observations ledger use this function, so one change fixes both surfaces.
- `state-templates/config.json.template` + `scripts/hermit-start.ts` (`DEFAULT_CONFIG`) — carry the new `storage_drift: { ignore: [] }` key so new hermits get it from hatch and the existing config-contract test stays green.
- `skills/hatch/SKILL.md` — adds `storage_drift` to the template-only fields list (required by `tests/template-skill-sync.test.ts`).
- `docs/plugin-hermit-storage.md` — documents the allowlist, reconciles the "plugins don't add new directories" clause, adds a compliant-path table row for `forge-runtime/`.
- `tests/storage-drift.test.ts` (new) — 6 unit tests covering: exempt dir not flagged, unlisted dir still flagged, multiple exemptions, missing config, invalid JSON, non-array ignore value.

**`laravel-forge-hermit`**
- `skills/hatch/SKILL.md` Step 8 — idempotently appends `"forge-runtime"` to `config.storage_drift.ignore` on every hatch run.
- `.claude-plugin/hermit-meta.json` + `plugin.json` — bumps `required_core_version` to `>=1.2.12` so `doctor-check` warns operators still on old core.
- `CHANGELOG.md` — `[Unreleased]` entry + Upgrade Instructions for `hermit-evolve` to backfill existing deployments.
- `tests/run-all.sh` — drops the `autoload.php` existence guard (TOCTOU); `composer install --quiet` is idempotent and self-checks the lock file.

## Test plan

- `cd plugins/claude-code-hermit && bun test` — 1240 pass, 0 fail (includes new `storage-drift.test.ts` 6/6 and `template-skill-sync.test.ts` 45/45).
- `cd plugins/laravel-forge-hermit && bash tests/run-all.sh` — 73 pass, 0 fail (31 PHP + 42 bun); `run-all.sh` now auto-installs vendor if missing.

## Release dependency

Core ships the allowlist reader; forge ships the writer. Forge's hatch write is inert on old core (unknown key is ignored), so partial upgrades are safe. Full fix lands once an operator is on both `claude-code-hermit >=1.2.12` and the next `laravel-forge-hermit` release. Ordering via `/fleet-release` when ready.