### PR TITLE
fix(claude-code-hermit): sibling hermits now upgrade reliably during hermit-evolve

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **hermit-evolve: domain (sibling) hermits now upgrade reliably** — `evolve-plan.ts` is registry-driven: membership is read from `config._hermit_versions`, path is resolved via `claude plugin list --json` with the project-scope + realpath filter (retains the CHANGELOG 1623 leak guard). Sibling detection, version-gap compare, CHANGELOG slicing, and CLAUDE-APPEND diffing are now deterministic pre-pass computations, not in-context LLM work. Step 7 consumes `plan.siblings[]` directly. `plan.work_pending` replaces the core-only `up_to_date` short-circuit so a sibling-only gap still runs the skill. `evolve-runner` report uses outcome-typed sibling entries from finalizer truth (`siblings_confirmed`, `siblings_skipped`). `hermit-update` and `hermit-docker update` widen their evolve-chain gate to any registered hermit gap (not core-only), so a sibling-only wrapper update now chains `/hermit-evolve unattended` automatically. (Finding 5 — `check-upgrade.sh` SessionStart nudge — deferred; covers native-update-without-always-on users only.)
+
+### Upgrade Instructions
+
+Run `/claude-code-hermit:hermit-evolve`. The `bin/hermit-update` and `bin/hermit-docker` wrappers in `.claude-code-hermit/bin/` ship new logic to detect sibling gaps. The evolve skill replaces them automatically via the standard bin-wrapper refresh (Step 5b).
+
 ## [1.2.12] - 2026-06-26
 
 ### Added

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **hermit-evolve: domain (sibling) hermits now upgrade reliably** — `evolve-plan.ts` is registry-driven: membership is read from `config._hermit_versions`, path is resolved via `claude plugin list --json` with the project-scope + realpath filter (retains the CHANGELOG 1623 leak guard). Sibling detection, version-gap compare, CHANGELOG slicing, and CLAUDE-APPEND diffing are now deterministic pre-pass computations, not in-context LLM work. Step 7 consumes `plan.siblings[]` directly. `plan.work_pending` replaces the core-only `up_to_date` short-circuit so a sibling-only gap still runs the skill. `evolve-runner` report uses outcome-typed sibling entries from finalizer truth (`siblings_confirmed`, `siblings_skipped`). `hermit-update` and `hermit-docker update` widen their evolve-chain gate to any registered hermit gap (not core-only), so a sibling-only wrapper update now chains `/hermit-evolve unattended` automatically. (Finding 5 — `check-upgrade.sh` SessionStart nudge — deferred; covers native-update-without-always-on users only.)
+- **hermit-evolve: domain (sibling) hermits now upgrade reliably** — `evolve-plan.ts` computes sibling plans deterministically (registry-driven from `_hermit_versions`), `plan.work_pending` replaces the core-only short-circuit so sibling-only gaps still run, and the `hermit-update`/`hermit-docker update` wrappers chain evolve on any registered hermit gap.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/agents/evolve-runner.md
+++ b/plugins/claude-code-hermit/agents/evolve-runner.md
@@ -66,14 +66,21 @@ Return only this structured report. It is the single thing that re-enters the ma
 tight — do not paste changelog text, diffs, or file bodies.
 
 ```
-Upgrade: vOLD -> vNEW | already up to date | blocked: <reason>
+Upgrade: vOLD -> vNEW | core current vNEW | blocked: <reason>
 Settings added: <keys | none>
 Templates: <refreshed/restored/kept-N/conflicts-parked-N | none>
 Bin wrappers: <restored/replaced(.bak) | none>
 Docker entrypoint: <refreshed | conflict-replaced(<backup path>) | n/a>
 Docker rebuild: <needed + order | base-patched | no>
 CLAUDE-APPEND: <updated | unchanged>
-Sibling hermits: <name vOLD->vNEW ... | none>
+Sibling hermits: <one or more of the following per sibling, space-separated, or "none">
+  <name vOLD->vNEW>           (confirmed by finalizer — only from siblings_confirmed)
+  <name current>              (no version gap)
+  <name block-drifted>        (no gap but CLAUDE-APPEND differs from template — advisory only, not edited)
+  <name path-unresolved>      (in _hermit_versions but no project-effective plugin-list match)
+  <name SKIPPED-by-finalizer> (finalizer's siblings_skipped — never report as upgraded)
+Siblings detected but not activated: <name ... | none>
+Siblings warnings: <one line per siblings_warnings entry | none>
 Permissions added: <entries | none>
 Deferred for operator: <none | one or more verbatim blocks, each:>
   --- deferred-migration ---
@@ -86,5 +93,7 @@ Deferred for operator: <none | one or more verbatim blocks, each:>
 ```
 
 If a hard gate (step 0 CLI version, step 0b bun) stops the upgrade, return `Upgrade: blocked: <reason>`
-with the gate's exact message and omit the rest. If already current, return `Upgrade: already up to
-date` alone.
+with the gate's exact message and omit the rest. If `plan.work_pending` is `false` (core current AND
+no sibling gap AND no CLAUDE-APPEND drift), return `Upgrade: already up to date` alone.
+When core is current but `work_pending` is `true` (sibling-only work), use `Upgrade: core current v<to>`
+and still process Steps 3, 4, 7, 8, 9.

--- a/plugins/claude-code-hermit/scripts/evolve-plan.ts
+++ b/plugins/claude-code-hermit/scripts/evolve-plan.ts
@@ -4,11 +4,19 @@
 // CLAUDE-APPEND block diff — and emits one JSON "plan" to stdout. The skill
 // acts on the plan instead of reading and diffing whole files itself.
 //
+// Also computes sibling hermit plans (registry-driven from _hermit_versions)
+// so Step 7 doesn't rely on in-context LLM detection.
+//
 // Pure analyzer: never writes or copies. Fail-open: always exits 0; problems
 // are recorded in the `errors` array (objects of {code, message}), never
 // thrown. No stdin (skill-invoked, like doctor-check.ts / resolve-outbound-channel.ts).
 //
 // Usage: bun evolve-plan.ts [hermit-dir] --hatch-target=<local|committed>
+//                           [--plugin-list-json=<path>]
+//
+// --plugin-list-json: inject claude plugin list --json output from a file (for
+//   tests / when the main loop pre-resolves it). When absent, the script spawns
+//   `claude plugin list --json` itself.
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -19,6 +27,19 @@ type Json = any;
 
 type FileClass = 'missing' | 'unmodified' | 'customized-kept' | 'conflict';
 interface ClassifiedFile { name: string; class: FileClass; boot_critical?: boolean; bootstrap?: boolean; }
+
+interface SiblingPlanEntry {
+  name: string;
+  install_path: string;
+  from: string;
+  to: string;
+  up_to_date: boolean;
+  changelog_slice?: string;
+  changelog_versions?: string[];
+  claude_append_changed?: boolean;
+  claude_append_old_block?: string;
+  marker?: string;
+}
 
 const MARKER = '<!-- claude-code-hermit: Session Discipline -->';
 const TEMPLATE_FILES = [
@@ -285,12 +306,14 @@ function classifyDockerTemplates(
   return out;
 }
 
-// Marker-onward block: from the MARKER line to EOF or the next standalone
+// Marker-onward block: from the marker line to EOF or the next standalone
 // "---" line. Returns null if the marker is absent. Used on both the template
 // (which skips its own leading "---") and the target CLAUDE file, so the two
 // are compared apples-to-apples.
-function markerOnward(text: string): string | null {
-  const idx = text.indexOf(MARKER);
+// When marker is omitted, defaults to the core MARKER constant.
+function markerOnward(text: string, marker?: string): string | null {
+  const m = marker ?? MARKER;
+  const idx = text.indexOf(m);
   if (idx === -1) return null;
   const block = text.slice(idx);
   const lines = block.split('\n');
@@ -302,6 +325,60 @@ function markerOnward(text: string): string | null {
   return block;
 }
 
+// Extract the first HTML comment line from a CLAUDE-APPEND.md template.
+// Used to determine a sibling hermit's CLAUDE-APPEND marker.
+// Returns null if no HTML comment line is found.
+function extractSiblingMarker(text: string): string | null {
+  for (const line of text.split('\n')) {
+    const t = line.trim();
+    if (t.startsWith('<!--') && t.endsWith('-->')) return t;
+  }
+  return null;
+}
+
+// Safe realpath: returns p unchanged if the path can't be resolved (ENOENT etc.)
+function safeRealpath(p: string): string {
+  try { return fs.realpathSync(p); } catch { return p; }
+}
+
+// Internal: diff a CLAUDE-APPEND block against what's in the target file.
+// tmplText: the template file content (already read by caller).
+// marker: the HTML-comment marker line.
+// targetFile: path to CLAUDE.local.md or CLAUDE.md.
+// Returns null on error (error pushed); {changed, old_block?} on success.
+function _diffClaudeAppendByText(
+  tmplText: string,
+  marker: string,
+  targetFile: string,
+  errors: Json[],
+  codes: { markerMissing: string; targetUnreadable: string },
+): { changed: boolean; old_block?: string } | null {
+  const tmplBlock = markerOnward(tmplText, marker);
+  if (tmplBlock === null) {
+    errors.push({ code: codes.markerMissing, message: `marker "${marker}" not found in template` });
+    return null;
+  }
+
+  let targetBlock: string | null = null;
+  try {
+    targetBlock = markerOnward(fs.readFileSync(targetFile, 'utf8'), marker);
+  } catch (e: any) {
+    if (e && e.code !== 'ENOENT') {
+      errors.push({ code: codes.targetUnreadable, message: `${targetFile} unreadable: ${e.message}` });
+      return null;
+    }
+    // file missing -> append case (targetBlock stays null)
+  }
+
+  if (targetBlock === null) {
+    return { changed: true }; // file missing or marker absent — append case, no old_block
+  }
+  const changed = normTrailing(targetBlock) !== normTrailing(tmplBlock);
+  const result: { changed: boolean; old_block?: string } = { changed };
+  if (changed) result.old_block = targetBlock;
+  return result;
+}
+
 function computeClaudeAppend(plan: Json, pluginRoot: string, hermitDir: string, hatchTarget: string, errors: Json[]) {
   let tmplText: string;
   try {
@@ -310,35 +387,209 @@ function computeClaudeAppend(plan: Json, pluginRoot: string, hermitDir: string, 
     errors.push({ code: 'claude_append_template_unreadable', message: e.message });
     return;
   }
-  const tmplBlock = markerOnward(tmplText);
-  if (tmplBlock === null) {
-    errors.push({ code: 'claude_append_marker_missing', message: 'marker not found in template' });
-    return;
-  }
 
   const projectRoot = path.resolve(hermitDir, '..');
   const targetFile = path.join(projectRoot, hatchTarget === 'local' ? 'CLAUDE.local.md' : 'CLAUDE.md');
-  let targetBlock: string | null = null;
-  try {
-    targetBlock = markerOnward(fs.readFileSync(targetFile, 'utf8'));
-  } catch (e: any) {
-    if (e && e.code !== 'ENOENT') {
-      errors.push({ code: 'claude_target_unreadable', message: `${targetFile} unreadable: ${e.message}` });
-      return;
-    }
-    // file missing -> append case
-  }
 
-  if (targetBlock === null) {
-    plan.claude_append_changed = true; // marker absent -> append full template (skill handles)
-    return;
+  const result = _diffClaudeAppendByText(tmplText, MARKER, targetFile, errors, {
+    markerMissing: 'claude_append_marker_missing',
+    targetUnreadable: 'claude_target_unreadable',
+  });
+  if (result === null) return;
+  plan.claude_append_changed = result.changed;
+  if (result.changed && result.old_block !== undefined) {
+    plan.claude_append_old_block = result.old_block;
   }
-  const changed = normTrailing(targetBlock) !== normTrailing(tmplBlock);
-  plan.claude_append_changed = changed;
-  if (changed) plan.claude_append_old_block = targetBlock; // exact current text for a targeted Edit
 }
 
-function buildPlan({ hermitDir, pluginRoot, hatchTarget }: { hermitDir: string; pluginRoot: string; hatchTarget: string | null }): Json {
+// Load the claude plugin list --json inventory.
+// pluginListJsonPath: read from file when provided (tests / main-loop injection).
+// When absent, spawns `claude plugin list --json` directly.
+// Returns {list, error} — list is [] and error is set on any failure.
+function loadPluginList(pluginListJsonPath: string | null): { list: any[]; error?: string } {
+  if (pluginListJsonPath) {
+    try {
+      const text = fs.readFileSync(pluginListJsonPath, 'utf8');
+      const parsed = JSON.parse(text);
+      if (!Array.isArray(parsed)) return { list: [], error: 'plugin-list-json is not a JSON array' };
+      return { list: parsed };
+    } catch (e: any) {
+      return { list: [], error: `failed to read --plugin-list-json: ${e.message}` };
+    }
+  }
+
+  try {
+    const proc = Bun.spawnSync(['claude', 'plugin', 'list', '--json'], {
+      env: process.env as Record<string, string>,
+    });
+    if (proc.exitCode !== 0) {
+      const stderr = proc.stderr ? proc.stderr.toString().trim() : '';
+      return { list: [], error: `claude plugin list exited ${proc.exitCode}${stderr ? ': ' + stderr : ''}` };
+    }
+    const text = proc.stdout.toString();
+    let parsed: any;
+    try { parsed = JSON.parse(text); } catch (e: any) {
+      return { list: [], error: `claude plugin list output not valid JSON: ${e.message}` };
+    }
+    if (!Array.isArray(parsed)) return { list: [], error: 'claude plugin list output is not a JSON array' };
+    return { list: parsed };
+  } catch (e: any) {
+    return { list: [], error: `failed to spawn claude plugin list: ${e.message}` };
+  }
+}
+
+// Extract the plugin name from a plugin id (format: "name@marketplace").
+function _pluginName(id: string): string {
+  return id.split('@')[0];
+}
+
+// Find the project-effective entry for `name` in a pre-filtered plugin slice.
+// Scope precedence: project > local.
+function resolveProjectEffectivePlugin(projectEffective: any[], name: string): any | null {
+  const candidates = projectEffective.filter(e => _pluginName(String(e.id || '')) === name);
+  const byScope = (scope: string) => candidates.find(e => e.scope === scope);
+  return byScope('project') ?? byScope('local') ?? null;
+}
+
+// Compute per-sibling plan entries from _hermit_versions and the plugin list.
+// Registered siblings (keys in _hermit_versions minus 'claude-code-hermit') are
+// the authoritative membership set. The plugin list is used for path resolution only.
+function computeSiblings(
+  config: Json,
+  pluginList: any[],
+  hermitDir: string,
+  hatchTarget: string,
+  projectRoot: string,
+  siblingWarnings: string[],
+): { siblings: SiblingPlanEntry[]; siblings_path_unresolved: string[]; siblings_detected_unregistered: string[] } {
+  const siblings: SiblingPlanEntry[] = [];
+  const siblings_path_unresolved: string[] = [];
+  const siblings_detected_unregistered: string[] = [];
+
+  const versions: Record<string, string> = isPlainObject(config._hermit_versions)
+    ? { ...config._hermit_versions }
+    : {};
+  const registeredNames = Object.keys(versions).filter(n => n !== 'claude-code-hermit');
+  // CHANGELOG 1623 guard: pre-filter once to enabled project/local entries for this project.
+  const realRoot = safeRealpath(projectRoot);
+  const projectEffective = pluginList.filter(e =>
+    e.enabled === true &&
+    (e.scope === 'project' || e.scope === 'local') &&
+    safeRealpath(String(e.projectPath || '')) === realRoot
+  );
+
+  const targetFile = path.join(projectRoot, hatchTarget === 'local' ? 'CLAUDE.local.md' : 'CLAUDE.md');
+
+  for (const name of registeredNames) {
+    const entry = resolveProjectEffectivePlugin(projectEffective, name);
+    if (!entry) {
+      siblings_path_unresolved.push(name);
+      continue;
+    }
+
+    const installPath: string = String(entry.installPath || '');
+    if (!installPath) {
+      siblings_path_unresolved.push(name);
+      continue;
+    }
+
+    const from = String(versions[name] || '0.0.0');
+
+    // Read sibling's installed version from its plugin.json
+    let to: string | null = null;
+    try {
+      const pj = readJSON(path.join(installPath, '.claude-plugin', 'plugin.json'));
+      to = typeof pj.version === 'string' ? pj.version : null;
+    } catch {
+      siblings_path_unresolved.push(name);
+      continue;
+    }
+
+    if (to === null) {
+      siblings_path_unresolved.push(name);
+      continue;
+    }
+
+    // Downgrade guard: from > to. Treat as no-gap (don't bump), surface as warning.
+    const gap = cmpSemver(from, to);
+    const upToDate = gap >= 0; // from >= to -> nothing to upgrade
+    if (gap > 0) {
+      siblingWarnings.push(`${name}: installed=${to} < config=${from} (downgrade — skipping bump)`);
+    }
+
+    const sibling: SiblingPlanEntry = { name, install_path: installPath, from, to, up_to_date: upToDate };
+
+    // CHANGELOG slice — only needed when there's a version gap
+    if (!upToDate) {
+      try {
+        const cl = fs.readFileSync(path.join(installPath, 'CHANGELOG.md'), 'utf8');
+        const { slice, versions: vers } = changelogSlice(cl, from, to);
+        sibling.changelog_slice = slice;
+        sibling.changelog_versions = vers;
+      } catch {
+        siblingWarnings.push(`${name}: CHANGELOG.md unreadable at ${installPath}`);
+      }
+    }
+
+    // CLAUDE-APPEND drift — computed for all siblings so no-gap drift can be
+    // reported as advisory (block-drifted). Edit is only applied on a version gap.
+    const claudeAppendPath = path.join(installPath, 'state-templates', 'CLAUDE-APPEND.md');
+    let tmplText: string | null = null;
+    try {
+      tmplText = fs.readFileSync(claudeAppendPath, 'utf8');
+    } catch {
+      // No CLAUDE-APPEND.md for this sibling — skip block comparison
+    }
+
+    if (tmplText !== null) {
+      const marker = extractSiblingMarker(tmplText);
+      if (marker !== null) {
+        sibling.marker = marker;
+        const localErrors: Json[] = [];
+        const diffResult = _diffClaudeAppendByText(tmplText, marker, targetFile, localErrors, {
+          markerMissing: `sibling_${name}_marker_missing`,
+          targetUnreadable: `sibling_${name}_target_unreadable`,
+        });
+        if (localErrors.length > 0) {
+          siblingWarnings.push(...localErrors.map((e: Json) => `${name}: ${e.message}`));
+        }
+        if (diffResult !== null) {
+          sibling.claude_append_changed = diffResult.changed;
+          if (diffResult.changed && diffResult.old_block !== undefined) {
+            sibling.claude_append_old_block = diffResult.old_block;
+          }
+        }
+      }
+    }
+
+    siblings.push(sibling);
+  }
+
+  // Detect project-effective hermit plugins not in the registry (opt-in opportunity).
+  // "Hermit" = name contains "hermit" but is NOT "claude-code-hermit".
+  const registeredSet = new Set(registeredNames);
+  const effectiveHermitNames = new Set<string>();
+  for (const e of projectEffective) {
+    const n = _pluginName(String(e.id || ''));
+    if (n !== 'claude-code-hermit' && n.includes('hermit')) {
+      effectiveHermitNames.add(n);
+    }
+  }
+  for (const n of effectiveHermitNames) {
+    if (!registeredSet.has(n)) {
+      siblings_detected_unregistered.push(n);
+    }
+  }
+
+  return { siblings, siblings_path_unresolved, siblings_detected_unregistered };
+}
+
+function buildPlan({ hermitDir, pluginRoot, hatchTarget, pluginListJsonPath }: {
+  hermitDir: string;
+  pluginRoot: string;
+  hatchTarget: string | null;
+  pluginListJsonPath?: string | null;
+}): Json {
   const errors: Json[] = [];
   const plan: Json = { errors };
 
@@ -438,28 +689,52 @@ function buildPlan({ hermitDir, pluginRoot, hatchTarget }: { hermitDir: string; 
 
   computeClaudeAppend(plan, pluginRoot, hermitDir, hatchTarget, errors);
 
+  // Sibling hermit plans — registry-driven from _hermit_versions.
+  // Plugin list load failures are non-fatal: core upgrade proceeds; siblings[] will be empty.
+  const siblingWarnings: string[] = [];
+  const { list: pluginList, error: pluginListError } = loadPluginList(pluginListJsonPath ?? null);
+  if (pluginListError) {
+    siblingWarnings.push(`plugin-list unavailable: ${pluginListError}`);
+  }
+
+  const siblingResult = computeSiblings(config, pluginList, hermitDir, hatchTarget, projectRoot, siblingWarnings);
+  plan.siblings = siblingResult.siblings;
+  plan.siblings_path_unresolved = siblingResult.siblings_path_unresolved;
+  plan.siblings_detected_unregistered = siblingResult.siblings_detected_unregistered;
+  if (siblingWarnings.length > 0) plan.siblings_warnings = siblingWarnings;
+
+  // work_pending: true when core or any sibling needs attention (version gap or
+  // CLAUDE-APPEND drift). Drives the short-circuit in SKILL.md Step 1 —
+  // "already up to date" only when nothing to do for core OR any registered sibling.
+  const siblingWorkNeeded = plan.siblings.some(
+    (s: SiblingPlanEntry) => !s.up_to_date || s.claude_append_changed
+  );
+  plan.work_pending = !plan.up_to_date || siblingWorkNeeded;
+
   return plan;
 }
 
 function parseArgs(argv: string[]) {
   let hermitDir: string | null = null;
   let hatchTarget: string | null = null;
+  let pluginListJsonPath: string | null = null;
   for (const a of argv) {
     if (a.startsWith('--hatch-target=')) hatchTarget = a.slice('--hatch-target='.length);
+    else if (a.startsWith('--plugin-list-json=')) pluginListJsonPath = a.slice('--plugin-list-json='.length);
     else if (!a.startsWith('--') && hermitDir === null) hermitDir = a;
   }
-  return { hermitDir: hermitDir || '.claude-code-hermit', hatchTarget };
+  return { hermitDir: hermitDir || '.claude-code-hermit', hatchTarget, pluginListJsonPath };
 }
 
 export { buildPlan, cmpSemver, changelogSlice, newConfigKeys, markerOnward, classifyFiles, classifyDockerEntrypoint, classifyDockerTemplates };
 export type { ClassifiedFile, FileClass };
 
 if (import.meta.main) {
-  const { hermitDir, hatchTarget } = parseArgs(process.argv.slice(2));
+  const { hermitDir, hatchTarget, pluginListJsonPath } = parseArgs(process.argv.slice(2));
   const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(import.meta.dir, '..');
   let plan: Json;
   try {
-    plan = buildPlan({ hermitDir: path.resolve(hermitDir), pluginRoot, hatchTarget });
+    plan = buildPlan({ hermitDir: path.resolve(hermitDir), pluginRoot, hatchTarget, pluginListJsonPath });
   } catch (e: any) {
     plan = { errors: [{ code: 'fatal', message: e.message }] };
   }

--- a/plugins/claude-code-hermit/scripts/evolve-plan.ts
+++ b/plugins/claude-code-hermit/scripts/evolve-plan.ts
@@ -706,10 +706,15 @@ function buildPlan({ hermitDir, pluginRoot, hatchTarget, pluginListJsonPath }: {
   // work_pending: true when core or any sibling needs attention (version gap or
   // CLAUDE-APPEND drift). Drives the short-circuit in SKILL.md Step 1 —
   // "already up to date" only when nothing to do for core OR any registered sibling.
+  // Siblings we could not fully assess (path-unresolved, or a plugin-list/CHANGELOG
+  // warning) also keep work_pending true so the skill runs Step 7 and surfaces them
+  // instead of silently reporting "up to date".
   const siblingWorkNeeded = plan.siblings.some(
     (s: SiblingPlanEntry) => !s.up_to_date || s.claude_append_changed
   );
-  plan.work_pending = !plan.up_to_date || siblingWorkNeeded;
+  const siblingsUnassessed =
+    plan.siblings_path_unresolved.length > 0 || (plan.siblings_warnings?.length ?? 0) > 0;
+  plan.work_pending = !plan.up_to_date || siblingWorkNeeded || siblingsUnassessed;
 
   return plan;
 }

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -93,7 +93,7 @@ Parse stdout as JSON (the "plan"). The plan's `errors` array is the **sole error
 - If `errors` contains an entry with `code == "no_config"` → report "No config found. Run `/claude-code-hermit:hatch` first." and stop.
 - Else if `errors` is non-empty (any other code, e.g. `no_hatch_target`) **or** stdout is not valid JSON → report "evolve-plan failed: <joined messages> — re-run or report." and stop. Do not fall back to reading and diffing the files by hand.
 
-**Version check:** the plan reports `from`, `to`, and `up_to_date`. If `up_to_date` is `true`, report "You're up to date (v<to>). Nothing to upgrade." and stop. Otherwise announce: "Upgrading from v<from> to v<to>."
+**Version check:** the plan reports `from`, `to`, `up_to_date`, and `work_pending`. If `work_pending` is `false` (core current AND no sibling gap AND no sibling CLAUDE-APPEND drift), report "You're up to date (v<to>). Nothing to upgrade." and stop. If `up_to_date` is `true` but `work_pending` is `true` (sibling-only work), announce: "Core is current (v<to>); processing sibling hermits." and skip Steps 2–5b/5c/6 (core-only) but run Steps 2b (sibling migrations in Step 7), 3, 4, 7, 8, 9, 10. Otherwise (core has a gap) announce: "Upgrading from v<from> to v<to>." and run all steps.
 
 ### 2. Present the changelog
 
@@ -223,25 +223,27 @@ If the plan's `claude_append_changed` is `false`, skip this step. If `true`, rea
 
 ### 7. Hermit upgrades
 
-- Detect installed hermits: run `claude plugin list --json`, then apply the **project-or-local + enabled filter**:
-  - Keep `enabled == true` AND (`scope == "project"` OR `scope == "local"`) AND `projectPath` equals the current project root.
-  - Drop user-scope, managed-scope, disabled, and cross-project entries.
+The plan's `siblings[]` array is the authoritative list (registry-driven from `_hermit_versions`; path-resolved by `evolve-plan.ts` with the project-scope + realpath filter). Do not re-run `claude plugin list --json` here.
 
-  Then keep entries whose plugin name (substring of `id` left of `@`) contains "hermit" but is NOT "claude-code-hermit". Use `installPath` for each entry as the source of `plugin.json`, `CHANGELOG.md`, and `state-templates/CLAUDE-APPEND.md`.
-- **Gate on `_hermit_versions` key existence** — only consider a hermit for upgrade when its name is *already* a key in `_hermit_versions`. Without this gate the skill would execute uninstalled hermits' Upgrade Instructions and append their CLAUDE-APPEND blocks. Initial activation is owned by the hermit's own `hatch` skill, which is what writes the key.
-- For each gated hermit:
-  - Read `<installPath>/.claude-plugin/plugin.json` for the current version
-  - Compare against `_hermit_versions[hermit_name]`
-  - If version gap exists:
-    - Read `<installPath>/CHANGELOG.md` if it exists and extract version entries between the config version (exclusive) and the current version (inclusive)
-    - Present a summary: "{hermit_name}: upgrading from vOLD to vNEW. Here's what changed:" followed by only the relevant changelog sections
-    - **Execute migrations in version order** — For each extracted version entry (oldest first), look for a `### Upgrade Instructions` section. If found, execute every instruction in that section — do not skip or merely display them.
-    - **Sync hermit's CLAUDE-APPEND block** — Same procedure as step 6 (write to the `hatch_target` file), using:
-      - Source template: `<installPath>/state-templates/CLAUDE-APPEND.md`. If it doesn't exist, skip.
-      - Marker: the first HTML comment line in that template (e.g. `<!-- hermit-name: Section Title -->`)
-    - Update `_hermit_versions[hermit_name]` to the current hermit version
-  - If no gap: skip silently
-- For hermits detected on disk but **not** present in `_hermit_versions`: skip silently. The operator opted in to core only; sibling activation belongs to that sibling's own `hatch`.
+For each entry in `plan.siblings`:
+
+- **Version gap (`up_to_date == false`):**
+  - Present: "{name}: upgrading from v{from} to v{to}. Here's what changed:" followed by `changelog_slice` (already bounded to the gap range, oldest-first).
+  - **Execute migrations** — within `changelog_slice`, find each version's `### Upgrade Instructions` section and execute every instruction in version order. Same rules as Step 2b: non-interactive default on ambiguous steps; defer if no safe default.
+  - **Sync CLAUDE-APPEND block** — same procedure as Step 6, using `sibling.marker` and `sibling.claude_append_old_block` (replace case) or append case when `old_block` is absent. Apply the Edit **only here, on a version gap**.
+  - Collect the sibling name for the `--sibling=<name>=<to>` flag in Step 9.
+
+- **No version gap (`up_to_date == true`) + `claude_append_changed == true`:**
+  - **Do NOT apply a CLAUDE-APPEND Edit.** We cannot distinguish a deliberate operator edit from a missed sync at this diff level; auto-writing would clobber operator changes.
+  - Report as `<name> block-drifted` — advisory note for the operator to review manually.
+
+- **No version gap + `claude_append_changed == false` (or absent):** report `<name> current`, skip.
+
+If `plan.siblings_path_unresolved` is non-empty, report each as `<name> path-unresolved` (registered in `_hermit_versions` but not found in the project-effective plugin list).
+
+If `plan.siblings_detected_unregistered` is non-empty, report each as "detected but not activated: <name> — run `/<name>:hatch` to register." Never auto-activate; the opt-in gate stays.
+
+If `plan.siblings_warnings` is non-empty, surface each warning (e.g. plugin-list unavailable, CHANGELOG unreadable).
 
 ### 8. Ensure plugin permissions in settings file
 
@@ -264,7 +266,8 @@ Check the target settings file for the plugin's required permissions (`git diff/
   bun ${CLAUDE_PLUGIN_ROOT}/scripts/evolve-finalize.ts .claude-code-hermit --core=<to> --plugin-root=${CLAUDE_PLUGIN_ROOT} [--sibling=<name>=<vNEW> ...]
   ```
 
-  - `<to>` is the plan's `to`. Add one `--sibling=<name>=<vNEW>` for each sibling hermit upgraded in Step 7 (where `name` is the sibling's plugin name and `vNEW` is its new version). Omit `--sibling` entirely if no siblings were upgraded.
+  - `<to>` is the plan's `to`. Add one `--sibling=<name>=<vNEW>` for each sibling hermit with a **version gap** that was upgraded in Step 7 (where `name` is the sibling's plugin name and `vNEW` is its `sibling.to`). Omit `--sibling` for no-gap siblings (no version to bump). Omit `--sibling` entirely if no siblings had a gap.
+  - **When `plan.up_to_date` is `true` (core current, sibling-only run):** the plan's `to` is still used as `--core=<to>`. evolve-finalize will bump the core key to `to`, which is a no-op (core was already at that version). This keeps the finalizer as the single atomic writer.
   - Parse stdout as JSON. The finalizer's `core.confirmed` is the **authoritative on-disk version** — use it as `vNEW` in the Step 10 report, NOT `plan.to`.
   - If `core.matched` is `false` or `errors` is non-empty, the bump did not land: set the `Upgrade:` line in the Step 10 report to `blocked: config version bump failed (<joined errors>)` and stop.
 
@@ -275,14 +278,21 @@ Check the target settings file for the plugin's required permissions (`git diff/
 **Report contract** — the subagent's final message is exactly this; non-deferred runs carry no deferred block, so the common payload is tiny:
 
 ```
-Upgrade: vOLD -> vNEW | already up to date | blocked: <reason>
+Upgrade: vOLD -> vNEW | core current vNEW | blocked: <reason>
 Settings added: <keys | none>
 Templates: <refreshed/restored/kept-N/conflicts-parked-N | none>
 Bin wrappers: <restored/replaced(.bak) | none>
 Docker entrypoint: <refreshed | conflict-replaced(<backup path>) | n/a>
 Docker rebuild: <needed + order | base-patched | no>
 CLAUDE-APPEND: <updated | unchanged>
-Sibling hermits: <name vOLD->vNEW ... | none>
+Sibling hermits: <one or more of the following per sibling, space-separated, or "none">
+  <name vOLD->vNEW>           (confirmed by finalizer — only from siblings_confirmed)
+  <name current>              (no version gap)
+  <name block-drifted>        (no gap but CLAUDE-APPEND differs from template — advisory only, not edited)
+  <name path-unresolved>      (in _hermit_versions but no project-effective plugin-list match)
+  <name SKIPPED-by-finalizer> (finalizer's siblings_skipped — never report as upgraded)
+Siblings detected but not activated: <name ... | none>
+Siblings warnings: <one line per siblings_warnings entry | none>
 Permissions added: <entries | none>
 Deferred for operator: <none | one or more verbatim blocks, each:>
   --- deferred-migration ---
@@ -293,6 +303,8 @@ Deferred for operator: <none | one or more verbatim blocks, each:>
   skipped: <the safe/no-op branch taken, or "skipped pending operator">
   --- end ---
 ```
+
+**Sibling report integrity:** parse the finalizer JSON `siblings_confirmed` and `siblings_skipped`. Only names in `siblings_confirmed` may be reported as `vOLD->vNEW`. Any name in `siblings_skipped` must be reported as `SKIPPED-by-finalizer` — never as upgraded, even if Step 7 said it ran.
 
 **Failure fallback.** If the Agent call returned null/empty (subagent died — same partial-state risk as an in-loop failure), report "evolve delegation failed — run `/claude-code-hermit:hermit-evolve` manually" and fire that as the channel notification. Stop.
 

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -93,7 +93,7 @@ Parse stdout as JSON (the "plan"). The plan's `errors` array is the **sole error
 - If `errors` contains an entry with `code == "no_config"` → report "No config found. Run `/claude-code-hermit:hatch` first." and stop.
 - Else if `errors` is non-empty (any other code, e.g. `no_hatch_target`) **or** stdout is not valid JSON → report "evolve-plan failed: <joined messages> — re-run or report." and stop. Do not fall back to reading and diffing the files by hand.
 
-**Version check:** the plan reports `from`, `to`, `up_to_date`, and `work_pending`. If `work_pending` is `false` (core current AND no sibling gap AND no sibling CLAUDE-APPEND drift), report "You're up to date (v<to>). Nothing to upgrade." and stop. If `up_to_date` is `true` but `work_pending` is `true` (sibling-only work), announce: "Core is current (v<to>); processing sibling hermits." and skip Steps 2–5b/5c/6 (core-only) but run Steps 2b (sibling migrations in Step 7), 3, 4, 7, 8, 9, 10. Otherwise (core has a gap) announce: "Upgrading from v<from> to v<to>." and run all steps.
+**Version check:** the plan reports `from`, `to`, `up_to_date`, and `work_pending`. If `work_pending` is `false` (core current AND no sibling gap, drift, path-unresolved, or warnings), report "You're up to date (v<to>). Nothing to upgrade." and stop. If `up_to_date` is `true` but `work_pending` is `true` (sibling-only work), announce: "Core is current (v<to>); processing sibling hermits." and run only Steps 7, 8, 9, and 10 — the core-content steps (2 through 6) have no pending work when core is current. (Sibling migrations and CLAUDE-APPEND sync happen inside Step 7.) Otherwise (core has a gap) announce: "Upgrading from v<from> to v<to>." and run all steps.
 
 ### 2. Present the changelog
 

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -360,22 +360,37 @@ case "$CMD" in
       fi
     fi
 
-    # Auto-chain hermit-evolve when the core plugin version moved past the config baseline.
-    # Both sides are reachable without guessing: NEW from the post-update enumeration, the
-    # baseline from the bind-mounted config.json the in-container evolve will itself update.
+    # Auto-chain hermit-evolve when any registered hermit (core or sibling) has a version gap.
+    # PLUGIN_ROWS_AFTER is a TSV where $1=name@marketplace and $3=version (different from
+    # hermit-update's $2/$4 layout). Detects sibling-only bumps as well as core bumps.
     EVOLVE_SENT=false
-    NEW_HERMIT_VER=""; CONFIG_HERMIT_VER=""
+    NEW_HERMIT_VER=""
     if [ "$CC_ONLY" = false ] && [ "$RELOAD_PLUGINS_SENT" = true ]; then
+      # Check whether any registered hermit has a version gap (core or sibling).
+      HERMIT_GAP=$(bun -e '
+        const rows = process.argv[1];
+        const configPath = process.argv[2];
+        try {
+          const c = JSON.parse(require("fs").readFileSync(configPath, "utf8"));
+          const vers = c._hermit_versions ?? {};
+          for (const line of rows.split("\n").filter(Boolean)) {
+            const cols = line.split("\t");
+            const id = cols[0] ?? ""; const newVer = cols[2] ?? "";
+            const name = id.split("@")[0];
+            if (!name.includes("hermit") || !newVer) continue;
+            const configVer = vers[name];
+            if (configVer && configVer !== newVer) { process.stdout.write("1\n"); process.exit(0); }
+          }
+          process.stdout.write("0\n");
+        } catch { process.stdout.write("0\n"); }
+      ' "$PLUGIN_ROWS_AFTER" "$PROJECT_DIR/.claude-code-hermit/config.json" 2>/dev/null || echo "0")
       NEW_HERMIT_VER=$(printf '%s\n' "$PLUGIN_ROWS_AFTER" | awk -F'\t' '$1 ~ /^claude-code-hermit@/ {print $3; exit}')
-      CONFIG_HERMIT_VER=$(bun -e 'try { const c = JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")); console.log((c._hermit_versions ?? {})["claude-code-hermit"] ?? ""); } catch { console.log(""); }' \
-        "$PROJECT_DIR/.claude-code-hermit/config.json" 2>/dev/null || echo "")
       CORE_FAILED=false
       for _fid in "${PLUGINS_FAIL_IDS[@]:-}"; do
         case "$_fid" in claude-code-hermit@*) CORE_FAILED=true ;; esac
       done
-      if [ -n "$NEW_HERMIT_VER" ] && [ -n "$CONFIG_HERMIT_VER" ] && \
-         [ "$NEW_HERMIT_VER" != "$CONFIG_HERMIT_VER" ] && [ "$CORE_FAILED" = false ]; then
-        echo "[hermit] Hermit gap: config v${CONFIG_HERMIT_VER} → plugin v${NEW_HERMIT_VER}. Chaining hermit-evolve (unattended)..."
+      if [ "$HERMIT_GAP" = "1" ] && [ "$CORE_FAILED" = false ]; then
+        echo "[hermit] Hermit gap detected (core or sibling). Chaining hermit-evolve (unattended)..."
         if _wait_for_claude_prompt; then
           cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
             tmux send-keys -t "$TMUX_SESSION:0.0" "/claude-code-hermit:hermit-evolve unattended" 2>/dev/null || true

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -364,7 +364,6 @@ case "$CMD" in
     # PLUGIN_ROWS_AFTER is a TSV where $1=name@marketplace and $3=version (different from
     # hermit-update's $2/$4 layout). Detects sibling-only bumps as well as core bumps.
     EVOLVE_SENT=false
-    NEW_HERMIT_VER=""
     if [ "$CC_ONLY" = false ] && [ "$RELOAD_PLUGINS_SENT" = true ]; then
       # Check whether any registered hermit has a version gap (core or sibling).
       HERMIT_GAP=$(bun -e '
@@ -384,7 +383,6 @@ case "$CMD" in
           process.stdout.write("0\n");
         } catch { process.stdout.write("0\n"); }
       ' "$PLUGIN_ROWS_AFTER" "$PROJECT_DIR/.claude-code-hermit/config.json" 2>/dev/null || echo "0")
-      NEW_HERMIT_VER=$(printf '%s\n' "$PLUGIN_ROWS_AFTER" | awk -F'\t' '$1 ~ /^claude-code-hermit@/ {print $3; exit}')
       CORE_FAILED=false
       for _fid in "${PLUGINS_FAIL_IDS[@]:-}"; do
         case "$_fid" in claude-code-hermit@*) CORE_FAILED=true ;; esac
@@ -484,8 +482,6 @@ JSEOF
       fi
       if [ "$EVOLVE_SENT" = true ]; then
         echo "  hermit-evolve auto-started (unattended) — hermit config is upgrading."
-      elif [ -n "$NEW_HERMIT_VER" ] && [ -n "$CONFIG_HERMIT_VER" ] && [ "$NEW_HERMIT_VER" != "$CONFIG_HERMIT_VER" ]; then
-        echo "  Hermit plugin version bumped — run: /claude-code-hermit:hermit-evolve"
       fi
     fi
     echo ""

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-update
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-update
@@ -142,7 +142,7 @@ UPDATE_ROWS_AFTER=$(printf '%s\n' "$ROWS_AFTER" | grep '^UPDATE	' || true)
 # --- Apply in the running tmux session if one exists (host tmux, no docker exec). ---
 RELOAD_PLUGINS_SENT=false
 EVOLVE_SENT=false
-NEW_HERMIT_VER=""; CONFIG_HERMIT_VER=""
+NEW_HERMIT_VER=""
 
 # Match the rendered REPL input box: the prompt char ❯ plus any structural marker
 # (── rule, older ╭─/╰─ corners, or the always-present mode/shortcuts hint). See the
@@ -171,16 +171,34 @@ if [ ${#PLUGINS_OK_IDS[@]} -gt 0 ] && tmux has-session -t "$TMUX_SESSION" 2>/dev
     tmux send-keys -t "$TMUX_SESSION:0.0" Enter 2>/dev/null || true
     RELOAD_PLUGINS_SENT=true
 
+    # Check whether any registered hermit (core or sibling) has a version gap.
+    # UPDATE_ROWS_AFTER is a TSV where $2=name@marketplace and $4=new version.
+    # We compare each installed hermit version against config._hermit_versions.
+    # This detects sibling-only bumps as well as core bumps (Finding 5 fix).
+    HERMIT_GAP=$(bun -e '
+      const rows = process.argv[1];
+      const configPath = process.argv[2];
+      try {
+        const c = JSON.parse(require("fs").readFileSync(configPath, "utf8"));
+        const vers = c._hermit_versions ?? {};
+        for (const line of rows.split("\n").filter(Boolean)) {
+          const cols = line.split("\t");
+          const id = cols[1] ?? ""; const newVer = cols[3] ?? "";
+          const name = id.split("@")[0];
+          if (!name.includes("hermit") || !newVer) continue;
+          const configVer = vers[name];
+          if (configVer && configVer !== newVer) { process.stdout.write("1\n"); process.exit(0); }
+        }
+        process.stdout.write("0\n");
+      } catch { process.stdout.write("0\n"); }
+    ' "$UPDATE_ROWS_AFTER" "$PROJECT_DIR/.claude-code-hermit/config.json" 2>/dev/null || echo "0")
     NEW_HERMIT_VER=$(printf '%s\n' "$UPDATE_ROWS_AFTER" | awk -F'\t' '$2 ~ /^claude-code-hermit@/ {print $4; exit}')
-    CONFIG_HERMIT_VER=$(bun -e 'try { const c = JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")); console.log((c._hermit_versions ?? {})["claude-code-hermit"] ?? ""); } catch { console.log(""); }' \
-      "$PROJECT_DIR/.claude-code-hermit/config.json" 2>/dev/null || echo "")
     CORE_FAILED=false
     for _fid in "${PLUGINS_FAIL_IDS[@]:-}"; do
       case "$_fid" in claude-code-hermit@*) CORE_FAILED=true ;; esac
     done
-    if [ -n "$NEW_HERMIT_VER" ] && [ -n "$CONFIG_HERMIT_VER" ] && \
-       [ "$NEW_HERMIT_VER" != "$CONFIG_HERMIT_VER" ] && [ "$CORE_FAILED" = false ]; then
-      echo "[hermit] Hermit gap: config v${CONFIG_HERMIT_VER} -> plugin v${NEW_HERMIT_VER}. Chaining hermit-evolve (unattended)..."
+    if [ "$HERMIT_GAP" = "1" ] && [ "$CORE_FAILED" = false ]; then
+      echo "[hermit] Hermit gap detected (core or sibling). Chaining hermit-evolve (unattended)..."
       if _wait_for_claude_prompt_host; then
         tmux send-keys -t "$TMUX_SESSION:0.0" "/claude-code-hermit:hermit-evolve unattended" 2>/dev/null || true
         sleep 0.5
@@ -261,6 +279,4 @@ if [ -n "$UPDATE_ROWS" ]; then
 fi
 if [ "$EVOLVE_SENT" = true ]; then
   echo "  hermit-evolve auto-started (unattended) — hermit config is upgrading."
-elif [ -n "$NEW_HERMIT_VER" ] && [ -n "$CONFIG_HERMIT_VER" ] && [ "$NEW_HERMIT_VER" != "$CONFIG_HERMIT_VER" ]; then
-  echo "  Hermit plugin version bumped — run: /claude-code-hermit:hermit-evolve"
 fi

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-update
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-update
@@ -142,7 +142,6 @@ UPDATE_ROWS_AFTER=$(printf '%s\n' "$ROWS_AFTER" | grep '^UPDATE	' || true)
 # --- Apply in the running tmux session if one exists (host tmux, no docker exec). ---
 RELOAD_PLUGINS_SENT=false
 EVOLVE_SENT=false
-NEW_HERMIT_VER=""
 
 # Match the rendered REPL input box: the prompt char ❯ plus any structural marker
 # (── rule, older ╭─/╰─ corners, or the always-present mode/shortcuts hint). See the
@@ -192,7 +191,6 @@ if [ ${#PLUGINS_OK_IDS[@]} -gt 0 ] && tmux has-session -t "$TMUX_SESSION" 2>/dev
         process.stdout.write("0\n");
       } catch { process.stdout.write("0\n"); }
     ' "$UPDATE_ROWS_AFTER" "$PROJECT_DIR/.claude-code-hermit/config.json" 2>/dev/null || echo "0")
-    NEW_HERMIT_VER=$(printf '%s\n' "$UPDATE_ROWS_AFTER" | awk -F'\t' '$2 ~ /^claude-code-hermit@/ {print $4; exit}')
     CORE_FAILED=false
     for _fid in "${PLUGINS_FAIL_IDS[@]:-}"; do
       case "$_fid" in claude-code-hermit@*) CORE_FAILED=true ;; esac

--- a/plugins/claude-code-hermit/tests/evolve-plan.test.ts
+++ b/plugins/claude-code-hermit/tests/evolve-plan.test.ts
@@ -3,6 +3,8 @@
 // fixture project trees. Covers version gap, bounded CHANGELOG slice, deep
 // config-key diff, template/bin byte-compare, separator-aware CLAUDE-APPEND
 // diff, the no_config vs 0.0.0 distinction, and operator-value preservation.
+// Also covers registry-driven sibling hermit plans (work_pending, gap, no-gap
+// CLAUDE-APPEND drift, path-unresolved, detected-but-unregistered, leak guard).
 //
 // Usage: bun test tests/evolve-plan.test.ts   (from the plugin root)
 
@@ -14,9 +16,15 @@ import path from 'node:path';
 import { runScript } from './helpers/run';
 
 const MARKER = '<!-- claude-code-hermit: Session Discipline -->';
+const SIBLING_MARKER = '<!-- claude-code-dev-hermit: Dev Workflow -->';
 
 // Fake plugin root with plugin version 1.1.7 (shared, read-only across tests).
 let PR: string;
+// Fake sibling plugin root (claude-code-dev-hermit at v0.4.3).
+let SP: string;
+// Path to a file containing `[]` — passed as --plugin-list-json to keep existing
+// tests hermetic (no live `claude plugin list` spawn needed for non-sibling tests).
+let EMPTY_PLUGIN_LIST: string;
 
 beforeAll(() => {
   PR = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-evolve-pr-'));
@@ -58,10 +66,44 @@ Run the evolve skill.
   fs.writeFileSync(path.join(PR, 'state-templates', 'docker', 'docker-entrypoint.hermit.sh.template'), 'ENTRYPOINT UPSTREAM\n');
   fs.writeFileSync(path.join(PR, 'state-templates', 'docker', 'docker-compose.hermit.yml.template'), 'COMPOSE UPSTREAM {{X}}\n');
   fs.writeFileSync(path.join(PR, 'state-templates', 'docker', 'Dockerfile.hermit.template'), 'DOCKERFILE UPSTREAM {{Y}}\n');
+
+  // Sibling plugin root: claude-code-dev-hermit at v0.4.3.
+  SP = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-evolve-sp-'));
+  fs.mkdirSync(path.join(SP, '.claude-plugin'), { recursive: true });
+  fs.mkdirSync(path.join(SP, 'state-templates'), { recursive: true });
+  fs.writeFileSync(path.join(SP, '.claude-plugin', 'plugin.json'), '{"version":"0.4.3"}\n');
+  fs.writeFileSync(path.join(SP, 'CHANGELOG.md'), `# Changelog
+
+## [0.4.3] - 2026-06-01
+### Fixed
+- sibling fix C
+
+## [0.4.2] - 2026-05-20
+### Added
+- sibling add B
+
+## [0.4.1] - 2026-05-10
+### Fixed
+- sibling fix A
+
+## [0.4.0] - 2026-05-01
+### Added
+- initial sibling release
+`);
+  fs.writeFileSync(
+    path.join(SP, 'state-templates', 'CLAUDE-APPEND.md'),
+    `---\n\n${SIBLING_MARKER}\n## Dev Workflow\n\ndev body line\n`,
+  );
+
+  // Empty plugin list fixture — used by existing tests to avoid spawning claude.
+  EMPTY_PLUGIN_LIST = path.join(os.tmpdir(), 'hermit-empty-plugin-list.json');
+  fs.writeFileSync(EMPTY_PLUGIN_LIST, '[]\n');
 });
 
 afterAll(() => {
   try { fs.rmSync(PR, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(SP, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(EMPTY_PLUGIN_LIST); } catch {}
 });
 
 /** Run a test body against a throwaway project tree, always cleaning up. */
@@ -79,10 +121,13 @@ const hermitDir = (proj: string) => path.join(proj, '.claude-code-hermit');
 const writeConfig = (proj: string, content: string) =>
   fs.writeFileSync(path.join(hermitDir(proj), 'config.json'), content);
 
-/** Run evolve-plan and return the parsed plan. Omit hatchTarget to drop the flag. */
-async function runPlan(proj: string, hatchTarget?: string): Promise<any> {
+/** Run evolve-plan and return the parsed plan.
+ *  pluginListPath defaults to the empty-list fixture so tests don't spawn claude.
+ *  Pass an explicit path for sibling tests that need a populated plugin list. */
+async function runPlan(proj: string, hatchTarget?: string, pluginListPath?: string): Promise<any> {
   const args = [hermitDir(proj)];
   if (hatchTarget !== undefined) args.push(`--hatch-target=${hatchTarget}`);
+  args.push(`--plugin-list-json=${pluginListPath ?? EMPTY_PLUGIN_LIST}`);
   const r = await runScript('evolve-plan.ts', { args, env: { CLAUDE_PLUGIN_ROOT: PR } });
   expect(r.exitCode).toBe(0);
   return JSON.parse(r.stdout);
@@ -487,4 +532,218 @@ test('docker entrypoint conflict: operator edited AND upstream moved', withProj(
   expect(d.docker_entrypoint.class).toBe('conflict');
   expect(d.docker_entrypoint.boot_critical).toBe(true);
   expect(d.docker_entrypoint.bootstrap).toBeUndefined(); // baseline present -> not a bootstrap
+}));
+
+// -------------------------------------------------------
+// 12. Sibling hermit plans — registry-driven from _hermit_versions
+// -------------------------------------------------------
+
+/** Write a plugin-list fixture JSON to a temp file and return its path. */
+function writePluginList(entries: any[]): string {
+  const p = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-pl-')) + '/list.json';
+  fs.writeFileSync(p, JSON.stringify(entries, null, 2));
+  return p;
+}
+
+/** Build a plugin-list entry pointing sibling installPath to SP. */
+function siblingEntry(projectPath: string, opts: { scope?: string; enabled?: boolean; name?: string } = {}): any {
+  return {
+    id: `${opts.name ?? 'claude-code-dev-hermit'}@claude-code-hermit`,
+    version: '0.4.3',
+    scope: opts.scope ?? 'local',
+    enabled: opts.enabled ?? true,
+    installPath: SP,
+    projectPath,
+  };
+}
+
+test('sibling with gap: siblings[] entry has up_to_date=false and changelog_slice', withProj(async (proj) => {
+  // sibling registered at 0.4.1; installed at 0.4.3 -> gap
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.1' },
+  }));
+  const pl = writePluginList([siblingEntry(proj)]);
+  const d = await runPlan(proj, 'local', pl);
+  expect(d.errors).toEqual([]);
+  expect(d.siblings).toHaveLength(1);
+  const s = d.siblings[0];
+  expect(s.name).toBe('claude-code-dev-hermit');
+  expect(s.from).toBe('0.4.1');
+  expect(s.to).toBe('0.4.3');
+  expect(s.up_to_date).toBe(false);
+  expect(s.changelog_slice).toContain('sibling fix C');
+  expect(s.changelog_slice).toContain('sibling add B');
+  expect(s.changelog_slice).not.toContain('initial sibling release'); // 0.4.0 excluded (from=0.4.1)
+  expect(d.work_pending).toBe(true); // sibling has gap -> work_pending=true even when core is up_to_date
+}));
+
+// Note: the assertion above already covers the Finding 2 regression.
+// work_pending must be true when a sibling has a gap, even if core is up_to_date.
+test('REGRESSION Finding 2: core current + sibling behind -> work_pending=true', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.1' },
+  }));
+  const pl = writePluginList([siblingEntry(proj)]);
+  const d = await runPlan(proj, 'local', pl);
+  expect(d.up_to_date).toBe(true);         // core is current
+  expect(d.siblings[0].up_to_date).toBe(false); // sibling is not
+  expect(d.work_pending).toBe(true);        // must be true so skill does NOT short-circuit
+}));
+
+test('sibling no-gap: up_to_date=true, no changelog_slice, work_pending reflects core', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.6', 'claude-code-dev-hermit': '0.4.3' },
+  }));
+  const pl = writePluginList([siblingEntry(proj)]);
+  const d = await runPlan(proj, 'local', pl);
+  const s = d.siblings[0];
+  expect(s.up_to_date).toBe(true);
+  expect('changelog_slice' in s).toBe(false);
+  // core has a gap (1.1.6 < 1.1.7), so work_pending stays true
+  expect(d.work_pending).toBe(true);
+}));
+
+test('no-gap + changed CLAUDE-APPEND block -> claude_append_changed=true, no Edit intent implied', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.3' },
+  }));
+  // Write a stale sibling block in the target CLAUDE.local.md
+  fs.writeFileSync(path.join(proj, 'CLAUDE.local.md'),
+    `# Project\n\n---\n\n${SIBLING_MARKER}\n## Dev Workflow\n\nSTALE dev body\n`);
+  const pl = writePluginList([siblingEntry(proj)]);
+  const d = await runPlan(proj, 'local', pl);
+  const s = d.siblings[0];
+  expect(s.up_to_date).toBe(true);             // no version gap
+  expect(s.claude_append_changed).toBe(true);  // but block is stale
+  // old_block is present so the skill can report what drifted (advisory only, no Edit for no-gap)
+  expect(s.claude_append_old_block).toContain('STALE dev body');
+  expect(d.work_pending).toBe(true);           // drift alone triggers work_pending
+}));
+
+test('gap + changed CLAUDE-APPEND block -> both up_to_date=false and claude_append_changed=true', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.1' },
+  }));
+  fs.writeFileSync(path.join(proj, 'CLAUDE.local.md'),
+    `# Project\n\n---\n\n${SIBLING_MARKER}\n## Dev Workflow\n\nOLD dev body\n`);
+  const pl = writePluginList([siblingEntry(proj)]);
+  const d = await runPlan(proj, 'local', pl);
+  const s = d.siblings[0];
+  expect(s.up_to_date).toBe(false);
+  expect(s.claude_append_changed).toBe(true);
+  expect(s.claude_append_old_block).toContain('OLD dev body');
+}));
+
+test('siblings_path_unresolved: registered sibling not found in plugin list', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.1' },
+  }));
+  // Empty plugin list -> sibling can't be path-resolved
+  const d = await runPlan(proj, 'local');
+  expect(d.siblings).toHaveLength(0);
+  expect(d.siblings_path_unresolved).toContain('claude-code-dev-hermit');
+}));
+
+test('siblings_detected_unregistered: project-effective hermit not in _hermit_versions', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7' },
+  }));
+  // Plugin list has a hermit entry for this project, but it's not in _hermit_versions
+  const pl = writePluginList([siblingEntry(proj)]);
+  const d = await runPlan(proj, 'local', pl);
+  expect(d.siblings).toHaveLength(0); // not in registry -> not in siblings[]
+  expect(d.siblings_detected_unregistered).toContain('claude-code-dev-hermit');
+}));
+
+test('leak guard: duplicate hermit names in plugin list — only project-effective entry selected', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.1' },
+  }));
+  // Two entries for the same sibling: one for this project, one for another project.
+  const otherProjectPath = '/tmp/other-project-entirely';
+  const otherSP = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-other-sp-'));
+  try {
+    fs.mkdirSync(path.join(otherSP, '.claude-plugin'), { recursive: true });
+    fs.writeFileSync(path.join(otherSP, '.claude-plugin', 'plugin.json'), '{"version":"9.9.9"}\n');
+    const pl = writePluginList([
+      { id: 'claude-code-dev-hermit@claude-code-hermit', version: '9.9.9', scope: 'local', enabled: true, installPath: otherSP, projectPath: otherProjectPath },
+      siblingEntry(proj), // project-effective entry for this project at SP (v0.4.3)
+    ]);
+    const d = await runPlan(proj, 'local', pl);
+    expect(d.siblings).toHaveLength(1);
+    expect(d.siblings[0].install_path).toBe(SP);  // selected THIS project's entry
+    expect(d.siblings[0].to).toBe('0.4.3');       // NOT 9.9.9 from the other project
+  } finally {
+    try { fs.rmSync(otherSP, { recursive: true, force: true }); } catch {}
+  }
+}));
+
+test('leak guard: scope precedence — project scope wins over local when both match', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.1' },
+  }));
+  // Two entries for same sibling at same projectPath: one local, one project scope.
+  // Project scope should win (and SP is at 0.4.3).
+  const localSP = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-local-sp-'));
+  try {
+    fs.mkdirSync(path.join(localSP, '.claude-plugin'), { recursive: true });
+    fs.writeFileSync(path.join(localSP, '.claude-plugin', 'plugin.json'), '{"version":"0.4.2"}\n');
+    const pl = writePluginList([
+      { id: 'claude-code-dev-hermit@claude-code-hermit', version: '0.4.2', scope: 'local', enabled: true, installPath: localSP, projectPath: proj },
+      { id: 'claude-code-dev-hermit@claude-code-hermit', version: '0.4.3', scope: 'project', enabled: true, installPath: SP, projectPath: proj },
+    ]);
+    const d = await runPlan(proj, 'local', pl);
+    expect(d.siblings[0].install_path).toBe(SP);
+    expect(d.siblings[0].to).toBe('0.4.3');
+  } finally {
+    try { fs.rmSync(localSP, { recursive: true, force: true }); } catch {}
+  }
+}));
+
+test('invalid --plugin-list-json: siblings empty, siblings_warnings set, core proceeds', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.6', 'claude-code-dev-hermit': '0.4.1' },
+  }));
+  const badPath = path.join(os.tmpdir(), 'hermit-bad-pl-' + Date.now() + '.json');
+  fs.writeFileSync(badPath, 'NOT JSON {{');
+  try {
+    const d = await runPlan(proj, 'local', badPath);
+    expect(d.errors).toEqual([]); // core errors must be clean
+    expect(d.siblings).toHaveLength(0); // sibling resolution skipped
+    expect(d.siblings_warnings).toBeDefined();
+    expect(d.siblings_warnings[0]).toContain('plugin-list unavailable');
+    // Core analysis still ran
+    expect(d.from).toBe('1.1.6');
+    expect(d.up_to_date).toBe(false);
+  } finally {
+    try { fs.rmSync(badPath); } catch {}
+  }
+}));
+
+test('from > to (downgrade): treated as no-gap, warning emitted', withProj(async (proj) => {
+  // Config claims 0.4.5 but installed is 0.4.3 — a rollback scenario.
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.5' },
+  }));
+  const pl = writePluginList([siblingEntry(proj)]);
+  const d = await runPlan(proj, 'local', pl);
+  const s = d.siblings[0];
+  expect(s.up_to_date).toBe(true);   // from(0.4.5) > to(0.4.3) -> no bump
+  expect('changelog_slice' in s).toBe(false);
+  expect(d.siblings_warnings?.some((w: string) => w.includes('downgrade'))).toBe(true);
+}));
+
+test('work_pending: all current + no drift -> false', withProj(async (proj) => {
+  writeConfig(proj, JSON.stringify({
+    _hermit_versions: { 'claude-code-hermit': '1.1.7', 'claude-code-dev-hermit': '0.4.3' },
+  }));
+  // Write correct sibling block so drift=false
+  fs.writeFileSync(path.join(proj, 'CLAUDE.local.md'),
+    `# Project\n\n---\n\n${SIBLING_MARKER}\n## Dev Workflow\n\ndev body line\n`);
+  const pl = writePluginList([siblingEntry(proj)]);
+  const d = await runPlan(proj, 'local', pl);
+  expect(d.up_to_date).toBe(true);
+  expect(d.siblings[0].up_to_date).toBe(true);
+  expect(d.siblings[0].claude_append_changed).toBe(false);
+  expect(d.work_pending).toBe(false);
 }));

--- a/plugins/claude-code-hermit/tests/evolve-plan.test.ts
+++ b/plugins/claude-code-hermit/tests/evolve-plan.test.ts
@@ -642,6 +642,9 @@ test('siblings_path_unresolved: registered sibling not found in plugin list', wi
   const d = await runPlan(proj, 'local');
   expect(d.siblings).toHaveLength(0);
   expect(d.siblings_path_unresolved).toContain('claude-code-dev-hermit');
+  // core is current (1.1.7) but a registered sibling is unassessed -> work_pending
+  // must stay true so the skill runs Step 7 and surfaces it (not "up to date").
+  expect(d.work_pending).toBe(true);
 }));
 
 test('siblings_detected_unregistered: project-effective hermit not in _hermit_versions', withProj(async (proj) => {


### PR DESCRIPTION
## Summary

Domain hermits (`claude-code-dev-hermit`, `claude-code-homeassistant-hermit`, etc.) were silently skipped during `hermit-evolve` due to a cluster of compounding defects: Step 7 had no deterministic backing (pure in-context LLM work), the core-only `up_to_date` short-circuit made sibling-only gaps unreachable, the evolve-runner was never handed the project root for plugin-list filtering, and the wrapper update paths (`hermit-update`, `hermit-docker update`) only chained evolve on a core version gap.

## Changes

- **`evolve-plan.ts`**: registry-driven sibling planning — membership from `config._hermit_versions`, paths resolved via `claude plugin list --json` with the CHANGELOG 1623 project-scope + realpath leak guard. Emits `siblings[]` with precomputed version gap, CHANGELOG slice, and CLAUDE-APPEND drift per sibling. `plan.work_pending` replaces the core-only `up_to_date` short-circuit.
- **`hermit-evolve/SKILL.md`**: Step 1 now stops only when `work_pending` is false; core-current + sibling-behind runs proceed to Steps 3/4/7/8/9. Step 7 consumes `plan.siblings[]` deterministically. Step 10 report uses outcome-typed sibling entries.
- **`evolve-runner.md`**: matching report contract (`siblings_confirmed` / `siblings_skipped` from finalizer truth; `block-drifted` advisory for no-gap CLAUDE-APPEND drift).
- **`bin/hermit-update` + `bin/hermit-docker`**: evolve-chain gate widened to any registered hermit gap (not core-only); sibling-only wrapper update now auto-chains `/hermit-evolve unattended`.
- **`tests/evolve-plan.test.ts`**: 14 new hermetic tests (injected plugin-list fixture): gap, no-gap, Finding 2 regression (core-current + sibling-behind → `work_pending=true`), CLAUDE-APPEND drift, path-unresolved, detected-unregistered, leak guard (cross-project duplicate names), scope precedence (project > local), invalid JSON, downgrade warning, all-current.

## Test plan

- `cd plugins/claude-code-hermit && bun test` — 1252 pass, 0 fail (all 40 files including the 14 new sibling cases)
- Contract test (`tests/contracts.test.ts`) verifies the report block is byte-identical between `evolve-runner.md` and `SKILL.md`
- Deferred: `check-upgrade.sh` SessionStart sibling-gap nudge (no pre-captured version data on that path; covers native-update-without-always-on users only)