### PR TITLE
feat: remove static maxTurns caps from growing-workload agents; fail-closed gate guards

### DIFF
--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **strava-data-cruncher: removed `maxTurns` cap** — the agent already self-limits via an internal 30-API-call governor; the turn cap was redundant and risked silently truncating analysis on long activity histories.
+
 ## [0.0.10] - 2026-06-24
 
 ### Fixed

--- a/plugins/claude-code-fitness-hermit/agents/strava-data-cruncher.md
+++ b/plugins/claude-code-fitness-hermit/agents/strava-data-cruncher.md
@@ -2,7 +2,6 @@
 name: strava-data-cruncher
 description: Lightweight Haiku subagent for bulk Strava data aggregation — weekly load, zone distribution, efficiency trends. Returns compact structured output; no coaching judgment. Use when you need multi-week trend tables, zone distribution over time, or bulk activity metrics.
 model: haiku
-maxTurns: 10
 tools:
   - mcp__strava__check-strava-connection
   - mcp__strava__get-all-activities

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **proposal-triage, reflection-judge, skill-eval-runner: removed `maxTurns` cap** — fixed caps caused turn-exhaustion failures on mature deployments where proposals, sessions, and memory accumulate over time; any static number eventually becomes too small. Empirically confirmed: omitting the cap gives generous harness-default headroom rather than a trap.
+
+### Fixed
+- **proposal-triage, reflection-judge: gates now fail closed on missing verdict** — a no-verdict result (cap hit, error, or malformed output) previously failed open, letting candidates bypass dedup/suppression. All callers (`proposal-create`, `reflect`, `reflect-scheduled-checks`) now fail closed and append a `gate-failed` row to `state/proposal-metrics.jsonl` plus a Progress Log note. The candidate re-surfaces on the next reflect cycle.
+
 ## [1.2.12] - 2026-06-26
 
 ### Added

--- a/plugins/claude-code-hermit/agents/proposal-triage.md
+++ b/plugins/claude-code-hermit/agents/proposal-triage.md
@@ -3,7 +3,6 @@ name: proposal-triage
 description: "Pre-creation gate for proposals — deduplicates, cross-references sessions/OPERATOR.md/compiled, and applies the three-condition rule. Returns CREATE | SUPPRESS — <code>: <reason> (\"<excerpt>\") | DUPLICATE:<id> — <reason>, plus additive metadata lines. Call before proposal-create and before queuing micro-proposals in reflect."
 model: haiku
 effort: low
-maxTurns: 14
 tools:
   - Read
   - Write

--- a/plugins/claude-code-hermit/agents/reflection-judge.md
+++ b/plugins/claude-code-hermit/agents/reflection-judge.md
@@ -3,7 +3,6 @@ name: reflection-judge
 description: Post-processes reflect candidates — validates that cross-session evidence citations actually exist in S-NNN-REPORT.md before proposals or micro-approvals are queued. Returns ACCEPT | DOWNGRADE:<new-tier> | SUPPRESS per observation.
 model: sonnet
 effort: medium
-maxTurns: 8
 tools:
   - Read
   - Write

--- a/plugins/claude-code-hermit/agents/skill-eval-runner.md
+++ b/plugins/claude-code-hermit/agents/skill-eval-runner.md
@@ -2,7 +2,6 @@
 name: skill-eval-runner
 description: Generic isolated-context runner — executes the analysis spec named in its dispatch and returns the structured output that spec defines. Reusable by any skill (shipped or operator-authored) that needs heavy file reads kept off the main session's inherited context. The calling skill applies any side effects the spec defers to it.
 effort: medium
-maxTurns: 20
 ---
 You are a generic, isolated-context analysis runner. Your dispatch names an instruction file (a `reference.md` or equivalent spec) and the inputs to use. Read that file and do exactly what it specifies — perform the reads and computations it lists, and return exactly the output it defines, nothing more (no extra prose unless the spec asks for it).
 

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -45,6 +45,13 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
 - `CREATE` — proceed with the steps below
 - `DUPLICATE:<PROP-ID> — <reason>`: stop, report to the caller: "Proposal already exists as <PROP-ID>"
 - `SUPPRESS — <code>: <reason>`: stop, report the suppression reason to the caller
+- **Unrecognized line 1** (agent errored, returned malformed/empty output, or was terminated before emitting a verdict): fail closed — do not create the proposal; skip the triage-verdict append above. Append:
+  ```bash
+  bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
+    .claude-code-hermit/state/proposal-metrics.jsonl \
+    '{"ts":"<now ISO>","type":"gate-failed","agent":"proposal-triage","title":"<title>"}'
+  ```
+  Note `gate-failed: proposal-triage — <title>` in the SHELL.md Progress Log. The candidate re-surfaces on the next reflect cycle.
 
 ## How to Create
 

--- a/plugins/claude-code-hermit/skills/reflect-scheduled-checks/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect-scheduled-checks/SKILL.md
@@ -83,8 +83,22 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
 
 - Triage `CREATE` → classify tier. Tier 1/2: queue micro-approval (§ Micro-approval queuing). Tier 3: call `/claude-code-hermit:proposal-create` directly.
 - Triage `SUPPRESS` or `DUPLICATE` → drop silently; note in SHELL.md Progress Log.
+- **Unrecognized triage line 1** (agent errored, returned malformed/empty output, or was terminated before emitting a verdict): fail closed — skip the triage-verdict append. Append:
+  ```bash
+  bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
+    .claude-code-hermit/state/proposal-metrics.jsonl \
+    '{"ts":"<now ISO>","type":"gate-failed","agent":"proposal-triage","title":"<title>"}'
+  ```
+  Note `gate-failed: proposal-triage — <title>` in the SHELL.md Progress Log. The candidate re-surfaces on the next scheduled-checks run.
 
 On SUPPRESS from reflection-judge → drop silently.
+On **unrecognized verdict from reflection-judge** (malformed/empty output): fail closed — treat as SUPPRESS. Append:
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
+  .claude-code-hermit/state/proposal-metrics.jsonl \
+  '{"ts":"<now ISO>","type":"gate-failed","agent":"reflection-judge","title":"<title>"}'
+```
+Note `gate-failed: reflection-judge — <title>` in the SHELL.md Progress Log. The candidate re-surfaces on the next scheduled-checks run.
 
 **`empty`:**
 

--- a/plugins/claude-code-hermit/skills/reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/reflect/SKILL.md
@@ -22,7 +22,7 @@ If `$ARGUMENTS` contains `--quick` (invoked as `/claude-code-hermit:reflect --qu
   HERMIT_METRICS_JSON
   ```
   so the signal survives session archival and can graduate by recurrence (§ Outcomes). **Exception:** a `current-session` candidate with `Evidence Origin: external-content` (see § Proposal Tier Classification) is **not** deferred — send it to the judge and let the Tier-3 escalation route it to `proposal-create`.
-- For each candidate that passes the evidence integrity rule, run `claude-code-hermit:proposal-triage`. Collect candidates where triage returned CREATE, then make a single `claude-code-hermit:reflection-judge` call for those candidates (see § Evidence Validation for input/output format). Route each ACCEPT/DOWNGRADE verdict through the standard Outcomes path (micro-approval queue for Tier 1/2, `/claude-code-hermit:proposal-create` for Tier 3).
+- For each candidate that passes the evidence integrity rule, run `claude-code-hermit:proposal-triage`. Collect candidates where triage returned CREATE, then make a single `claude-code-hermit:reflection-judge` call for those candidates (see § Evidence Validation for input/output format). Route each ACCEPT/DOWNGRADE verdict through the standard Outcomes path (micro-approval queue for Tier 1/2, `/claude-code-hermit:proposal-create` for Tier 3). An unrecognized triage or judge verdict (empty/malformed output) is treated as a SUPPRESS — drop the candidate and apply the gate-failed metric and Progress Log note (see § Proposal triage gate and § Evidence Validation for the append commands).
 - Append one Progress Log line: `[HH:MM] reflect (quick, post-routine) — N candidates; verdicts: accept=A downgrade=D suppress=S; outcomes: <list or "none">`. When suppress>0, append the same `; suppressed: [<slug>: <code>, ...]` suffix the scheduled path uses (see § Progress Log Entry) so quick-run suppressions reach the weekly digest.
 - **Do not call `update-reflection-state.ts`** — quick runs are event-driven, not cadence ticks. Mutating `last_run_at` would suppress the next scheduled reflect. Consequence: judge verdicts from quick runs do not accumulate into the Component Health counters (`judge_accept` / `judge_suppress`); on daemons with frequent `reflect_after` use, those counters will under-represent total judge activity. This is intentional — cadence preservation wins.
 - Then stop. Do not continue to the scheduled-reflect steps below.
@@ -281,6 +281,13 @@ The judge returns one verdict line per candidate, matched by `<title>`. Apply th
 - **ACCEPT** or **ACCEPT (<source>)** — proceed with the candidate at its original tier
 - **DOWNGRADE:<new-tier>** or **DOWNGRADE:<new-tier> (<source>)** — proceed at the revised tier. When the reason contains `quarantine: external origin`, the revised tier is 3 regardless of apparent reversibility — route to `proposal-create` and pass `Evidence Origin: external-content` through so proposal-create can write the operator-visible provenance line in the PROP body. reflect does not write the PROP body itself.
 - **SUPPRESS** — if suppressed with code `no-sessions`, note the candidate in SHELL.md Findings for future revisit. Otherwise drop silently.
+- **Unrecognized line** for a candidate (agent errored, returned malformed/empty output, or was terminated mid-batch): fail closed — treat as SUPPRESS. Append:
+  ```bash
+  bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
+    .claude-code-hermit/state/proposal-metrics.jsonl \
+    '{"ts":"<now ISO>","type":"gate-failed","agent":"reflection-judge","title":"<title>"}'
+  ```
+  Note `gate-failed: reflection-judge — <title>` in the SHELL.md Progress Log. The candidate re-surfaces on the next reflect cycle.
 
 Only act on ACCEPT and DOWNGRADE verdicts. `proposal-triage` (the gate in § Proposal Tier Classification) is single-candidate — invoke it per-candidate, not as a batch.
 
@@ -345,6 +352,13 @@ Evidence: <one-paragraph evidence summary>
 - `CREATE` — proceed
 - `DUPLICATE:<PROP-ID>` — link to existing proposal in SHELL.md Findings instead, do not create
 - `SUPPRESS` — drop silently
+- **Unrecognized line 1** (agent errored, returned malformed/empty output, or was terminated before emitting a verdict): fail closed — do not create or queue the candidate; skip the triage-verdict append. Append:
+  ```bash
+  bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
+    .claude-code-hermit/state/proposal-metrics.jsonl \
+    '{"ts":"<now ISO>","type":"gate-failed","agent":"proposal-triage","title":"<title>"}'
+  ```
+  Note `gate-failed: proposal-triage — <title>` in the SHELL.md Progress Log. The candidate re-surfaces on the next reflect cycle.
 
 Parse line 1 as the verdict. Lines 2+ are additive metadata (`closest_prop`, `aligned`, `operator_excerpt`, `overlap_compiled`, `prior_discussion`, `failed_condition`) — read for context if useful, but do not treat as part of the verdict for branching.
 

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Changed
+- **ha-pattern-analyst: removed `maxTurns` cap** — workload grows with accumulated entity inventory and historical snapshots; a fixed cap silently truncates analysis on mature deployments.
+
 ## [0.3.0] - 2026-06-26
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/agents/ha-pattern-analyst.md
+++ b/plugins/claude-code-homeassistant-hermit/agents/ha-pattern-analyst.md
@@ -3,7 +3,6 @@ name: ha-pattern-analyst
 description: Analyzes HA history artifacts and entity data to identify patterns, anomalies, and automation opportunities. Cheap and fast — read-only.
 model: haiku
 effort: low
-maxTurns: 15
 tools:
   - Read
   - Bash


### PR DESCRIPTION
## Summary

Static `maxTurns` caps on `proposal-triage`, `reflection-judge`, and `skill-eval-runner` caused turn-exhaustion failures on mature hermit deployments — these agents' workloads grow with accumulated proposals, sessions, and memory, so any fixed number eventually becomes too small. Empirically confirmed: omitting the cap gives generous harness-default headroom (probe ran 40+ turns uncapped) rather than collapsing to a low default.

Also removes caps from `strava-data-cruncher` (redundant — internal 30-API-call governor already bounds it) and `ha-pattern-analyst` (grows with snapshot history).

The second part fixes the underlying correctness gap: all callers of `proposal-triage` and `reflection-judge` previously failed **open** on a missing verdict — a cap hit, error, or malformed response would silently let the candidate bypass the dedup/suppression gate. All callers now fail **closed** and log a `gate-failed` metric row + Progress Log note.

## Changes

**5 cap removals (3 plugins):**
- `plugins/claude-code-hermit/agents/proposal-triage.md` — removed `maxTurns: 14`
- `plugins/claude-code-hermit/agents/reflection-judge.md` — removed `maxTurns: 8`
- `plugins/claude-code-hermit/agents/skill-eval-runner.md` — removed `maxTurns: 20`
- `plugins/claude-code-fitness-hermit/agents/strava-data-cruncher.md` — removed `maxTurns: 10`
- `plugins/claude-code-homeassistant-hermit/agents/ha-pattern-analyst.md` — removed `maxTurns: 15`

**Fail-closed guard added to all triage/judge callers:**
- `skills/proposal-create/SKILL.md` — unrecognized triage verdict → fail closed + gate-failed metric
- `skills/reflect/SKILL.md` — same for triage gate section, Evidence Validation (judge), and quick-run path
- `skills/reflect-scheduled-checks/SKILL.md` — same for both triage and judge dispatch points

**Kept (no change):** `session-mgr` (12), `evolve-runner` (50), `quality-gate-judge` (5), `hermit-config-validator` (5), `ha-automation-builder` (30), `ha-safety-reviewer` (10), `issue-sanitizer` (2) — bounded-task or no-tool agents where the cap is safe and meaningful.

## Test plan

- `bun test` in `plugins/claude-code-hermit` — 1240/1240 pass
- `bash tests/run-all.sh` in `plugins/claude-code-fitness-hermit` — 44/44 pass
- `bun test` in `plugins/claude-code-homeassistant-hermit` — 553/553 pass (1 pre-existing todo)
- Static check: `grep -rn "maxTurns" plugins/*/agents/` confirms only the 7 "keep" agents remain capped
- Static check: `grep -n "gate-failed"` confirms the guard token appears at all 4 insertion points across the 3 skill files