### PR TITLE
chore: make the test gates real (pipeline integrity)

### DIFF
--- a/.claude/agents/release-auditor.md
+++ b/.claude/agents/release-auditor.md
@@ -82,17 +82,20 @@ Abort with: `Plugin 'plugins/<slug>/' not found. Available: <comma-separated slu
 
 ### 7. Dependency version triad
 
-For domain plugins, the three core-version fields (`required_core_version`, `requires["claude-code-hermit"]`, `dependencies[].version` for `claude-code-hermit`) must reference the same base SemVer. Operators may differ (`>=` for the runtime check in `doctor-check.js`, `^` for the resolver) — but the underlying version number must match. CLAUDE.md requires all three be updated together; this check enforces it.
+For domain plugins, the three core-version fields (`required_core_version`, `requires["claude-code-hermit"]`, `dependencies[].version` for `claude-code-hermit`) must reference the same base SemVer. Operators may differ (`>=` for the runtime check in `doctor-check.ts`, `^` for the resolver) — but the underlying version number must match. CLAUDE.md requires all three be updated together; this check enforces it.
 
 - **Skip silently** if `<slug> == "claude-code-hermit"` (core has no self-dependency).
-- Read all three values in one `jq` call:
+- The three values live in two files: `required_core_version` and `requires` are in `hermit-meta.json`; `dependencies` is in `plugin.json`. Read them with two `jq` calls:
   ```bash
-  read -r REQ_CORE REQUIRES DEPS < <(jq -r '[
+  META=plugins/<slug>/.claude-plugin/hermit-meta.json
+  PJ=plugins/<slug>/.claude-plugin/plugin.json
+  read -r REQ_CORE REQUIRES < <(jq -r '[
     (.required_core_version // ""),
-    (.requires["claude-code-hermit"] // ""),
-    (.dependencies[]? | select(.name=="claude-code-hermit") | .version)
-  ] | @tsv' plugins/<slug>/.claude-plugin/plugin.json)
+    (.requires["claude-code-hermit"] // "")
+  ] | @tsv' "$META")
+  DEPS=$(jq -r '.dependencies[]? | select(.name=="claude-code-hermit") | .version' "$PJ")
   ```
+  If `$META` does not exist, FAIL with `dep triad: hermit-meta.json missing for domain plugin '<slug>'`.
 - If any of the three is empty: FAIL with `dep triad: missing field — required_core_version='<v>', requires.claude-code-hermit='<v>', dependencies.claude-code-hermit='<v>'`.
 - Strip leading operator characters character-by-class from each to get the base version (e.g., `^1.0.18` → `1.0.18`). `sed 's/^[<>=^~!]*//'` covers all SemVer range prefixes including `!=`.
 - If the three base versions are not identical: FAIL printing all three values verbatim (operator + version) so the human can see which field drifted.

--- a/.claude/agents/smoke-test-runner.md
+++ b/.claude/agents/smoke-test-runner.md
@@ -34,17 +34,11 @@ Abort with: `Plugin '<slug>' has no tests/ directory — nothing to run.`
 
 Plugins in this monorepo ship one of two test conventions. Detect and dispatch:
 
-- **Bun entrypoint**: if `plugins/<slug>/tests/*.test.ts` files exist with no `run-all.sh`, run `cd plugins/<slug> && bun test` (core hermit convention).
-- **Bash entrypoint**: if `plugins/<slug>/tests/run-all.sh` exists, run it (dev/fitness/scribe convention).
+- **Bash entrypoint**: if `plugins/<slug>/tests/run-all.sh` exists, run it (dev/fitness/scribe/forge convention).
   ```bash
   bash plugins/<slug>/tests/run-all.sh 2>&1
   ```
-
-- **Pytest**: if no `run-all.sh` but `plugins/<slug>/tests/conftest.py` or any `plugins/<slug>/tests/test_*.py` exists, use the plugin's local virtualenv (HA hermit convention).
-  ```bash
-  cd plugins/<slug> && .venv/bin/pytest tests/ -v 2>&1
-  ```
-  If `.venv/bin/pytest` does not exist, abort with: `Plugin '<slug>' uses pytest but .venv/bin/pytest is missing — run plugin's hatch/install first.`
+- **Bun entrypoint**: else if any `plugins/<slug>/tests/*.test.ts` exists, run `cd plugins/<slug> && bun test` (core/HA convention).
 
 - **Neither marker**: report `no recognized test convention` and exit with SKIP.
 

--- a/.claude/skills/bump-core-req/SKILL.md
+++ b/.claude/skills/bump-core-req/SKILL.md
@@ -17,7 +17,7 @@ Update a fleet plugin's minimum core version in all three canonical locations.
 ## Background: why three places?
 
 Per this monorepo's conventions (`CLAUDE.md` → Conventions), the core version requirement lives in:
-1. `plugins/<slug>/.claude-plugin/hermit-meta.json` → `required_core_version` — **authoritative**, read by `doctor-check.js` at runtime to detect incompatible siblings
+1. `plugins/<slug>/.claude-plugin/hermit-meta.json` → `required_core_version` — **authoritative**, read by `doctor-check.ts` at runtime to detect incompatible siblings
 2. `plugins/<slug>/.claude-plugin/hermit-meta.json` → `requires["claude-code-hermit"]` — documentation mirror
 3. `plugins/<slug>/.claude-plugin/plugin.json` → `dependencies[name=claude-code-hermit].version` — native Claude Code resolver field
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -41,16 +41,16 @@ Run before anything else. Abort the release if any step fails.
    Abort on any error other than `Unrecognized keys` — that one means an incomplete hermit-meta.json migration; fix the migration elsewhere, then resume. Background on the migration lives in each plugin's `CONTRIBUTING.md`.
 
 2. **Run test suites for the target plugin.** Detect the convention and dispatch:
-   - If `plugins/<slug>/tests/run-all.sh` exists (bash entrypoint, used by core hermit):
+   - If `plugins/<slug>/tests/run-all.sh` exists (bash entrypoint, used by dev/fitness/scribe/forge):
      ```bash
      bash plugins/<slug>/tests/run-all.sh 2>&1
      ```
-   - Else if `plugins/<slug>/tests/conftest.py` or any `plugins/<slug>/tests/test_*.py` exists (pytest convention, used by HA hermit):
+   - Else if any `plugins/<slug>/tests/*.test.ts` exists (bun entrypoint, used by core/HA):
      ```bash
-     cd plugins/<slug> && .venv/bin/pytest tests/ -v 2>&1
+     cd plugins/<slug> && bun test 2>&1
      ```
-     If `.venv/bin/pytest` is missing, abort the release with: `Plugin uses pytest but plugins/<slug>/.venv/bin/pytest is missing — run plugin's hatch/install first.` Do not silently skip — releases must run the suite.
-   - Else: no recognized test convention → skip this step and note it in the release report.
+   - Else if a `plugins/<slug>/tests/` dir exists but neither marker matched: abort the release with `Plugin '<slug>' has a tests/ dir but no recognized convention (run-all.sh or *.test.ts) — fix the dispatch before releasing.` Do not silently skip.
+   - Else (no `tests/` dir at all): skip this step and note it in the release report.
 
    If any test fails, stop and fix before releasing.
 

--- a/.claude/skills/test-run/SKILL.md
+++ b/.claude/skills/test-run/SKILL.md
@@ -28,16 +28,11 @@ Examples:
 
 Plugins ship one of two test conventions. Detect and dispatch:
 
-- **Bun entrypoint** — if `plugins/<slug>/tests/*.test.ts` exist with no `run-all.sh`: `cd plugins/<slug> && bun test 2>&1` (core hermit convention).
-- **Bash entrypoint** — if `plugins/<slug>/tests/run-all.sh` exists:
+- **Bash entrypoint** — if `plugins/<slug>/tests/run-all.sh` exists (dev/fitness/scribe/forge convention):
   ```bash
   bash plugins/<slug>/tests/run-all.sh 2>&1
   ```
-- **Pytest** — else if `plugins/<slug>/tests/conftest.py` or any `plugins/<slug>/tests/test_*.py` exists:
-  ```bash
-  cd plugins/<slug> && .venv/bin/pytest tests/ -v 2>&1
-  ```
-  If `.venv/bin/pytest` is missing, mark this plugin as `SKIP — venv missing` and continue to the next plugin (don't abort the whole run).
+- **Bun entrypoint** — else if any `plugins/<slug>/tests/*.test.ts` exists (core/HA convention): `cd plugins/<slug> && bun test 2>&1`.
 - **Neither marker** — mark `no tests configured` and continue.
 
 Capture full output. Extract pass/fail counts from each suite's summary line.
@@ -51,7 +46,7 @@ Per-plugin block:
 Hook tests:     X passed, Y failed         (bash convention only)
 Contract tests: X passed, Y failed         (bash convention only)
 Script tests:   X passed, Y failed         (bash convention only)
-Pytest:         X passed, Y failed         (pytest convention only)
+Bun tests:      X passed, Y failed         (bun convention only)
 Plugin result:  PASS / FAIL / SKIP
 ```
 

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -1,18 +1,18 @@
-name: Test Forge
+name: Test Dev Hermit
 
 on:
   push:
     branches: [main]
     paths:
-      - 'plugins/laravel-forge-hermit/**'
-      - '.github/workflows/test-forge.yml'
+      - 'plugins/claude-code-dev-hermit/**'
+      - '.github/workflows/test-dev.yml'
       - 'package.json'
       - 'bun.lock'
       - 'tsconfig.json'
   pull_request:
     paths:
-      - 'plugins/laravel-forge-hermit/**'
-      - '.github/workflows/test-forge.yml'
+      - 'plugins/claude-code-dev-hermit/**'
+      - '.github/workflows/test-dev.yml'
       - 'package.json'
       - 'bun.lock'
       - 'tsconfig.json'
@@ -32,18 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: plugins/laravel-forge-hermit
+        working-directory: plugins/claude-code-dev-hermit
     steps:
       - uses: actions/checkout@v4
-      # Plugin pins php ^8.5 (composer.json platform) — the runner must match.
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.5'
-          extensions: json, curl
-      - name: Install Forge SDK (composer)
-        run: composer install --no-dev --no-interaction --no-progress --working-dir=php
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
-      - name: Run test suite (PHP unit + hook + skill-structure)
+      - name: Run test suite
         run: bash tests/run-all.sh

--- a/.github/workflows/test-fitness.yml
+++ b/.github/workflows/test-fitness.yml
@@ -1,18 +1,18 @@
-name: Test Forge
+name: Test Fitness Hermit
 
 on:
   push:
     branches: [main]
     paths:
-      - 'plugins/laravel-forge-hermit/**'
-      - '.github/workflows/test-forge.yml'
+      - 'plugins/claude-code-fitness-hermit/**'
+      - '.github/workflows/test-fitness.yml'
       - 'package.json'
       - 'bun.lock'
       - 'tsconfig.json'
   pull_request:
     paths:
-      - 'plugins/laravel-forge-hermit/**'
-      - '.github/workflows/test-forge.yml'
+      - 'plugins/claude-code-fitness-hermit/**'
+      - '.github/workflows/test-fitness.yml'
       - 'package.json'
       - 'bun.lock'
       - 'tsconfig.json'
@@ -32,18 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: plugins/laravel-forge-hermit
+        working-directory: plugins/claude-code-fitness-hermit
     steps:
       - uses: actions/checkout@v4
-      # Plugin pins php ^8.5 (composer.json platform) — the runner must match.
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.5'
-          extensions: json, curl
-      - name: Install Forge SDK (composer)
-        run: composer install --no-dev --no-interaction --no-progress --working-dir=php
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
-      - name: Run test suite (PHP unit + hook + skill-structure)
+      - name: Run test suite
         run: bash tests/run-all.sh

--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'plugins/claude-code-hermit/**'
+      # Cross-plugin invariants in hooks.contract.test.ts walk every plugin's
+      # manifest and the marketplace, so those paths must trigger this suite too.
+      - 'plugins/*/.claude-plugin/**'
+      - '.claude-plugin/marketplace.json'
       - '.github/workflows/test-hooks.yml'
       - 'package.json'
       - 'bun.lock'
@@ -12,6 +16,10 @@ on:
   pull_request:
     paths:
       - 'plugins/claude-code-hermit/**'
+      # Cross-plugin invariants in hooks.contract.test.ts walk every plugin's
+      # manifest and the marketplace, so those paths must trigger this suite too.
+      - 'plugins/*/.claude-plugin/**'
+      - '.claude-plugin/marketplace.json'
       - '.github/workflows/test-hooks.yml'
       - 'package.json'
       - 'bun.lock'

--- a/.github/workflows/test-scribe.yml
+++ b/.github/workflows/test-scribe.yml
@@ -1,18 +1,18 @@
-name: Test Forge
+name: Test Scribe Hermit
 
 on:
   push:
     branches: [main]
     paths:
-      - 'plugins/laravel-forge-hermit/**'
-      - '.github/workflows/test-forge.yml'
+      - 'plugins/hermit-scribe/**'
+      - '.github/workflows/test-scribe.yml'
       - 'package.json'
       - 'bun.lock'
       - 'tsconfig.json'
   pull_request:
     paths:
-      - 'plugins/laravel-forge-hermit/**'
-      - '.github/workflows/test-forge.yml'
+      - 'plugins/hermit-scribe/**'
+      - '.github/workflows/test-scribe.yml'
       - 'package.json'
       - 'bun.lock'
       - 'tsconfig.json'
@@ -32,18 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: plugins/laravel-forge-hermit
+        working-directory: plugins/hermit-scribe
     steps:
       - uses: actions/checkout@v4
-      # Plugin pins php ^8.5 (composer.json platform) — the runner must match.
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.5'
-          extensions: json, curl
-      - name: Install Forge SDK (composer)
-        run: composer install --no-dev --no-interaction --no-progress --working-dir=php
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
-      - name: Run test suite (PHP unit + hook + skill-structure)
+      - name: Run test suite
         run: bash tests/run-all.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # claude-code-hermit (monorepo)
 
-This repo is a multi-plugin Claude Code marketplace. Four plugins ship from `plugins/<slug>/`:
-`claude-code-hermit` (core), `claude-code-dev-hermit`, `claude-code-homeassistant-hermit`, `claude-code-fitness-hermit`.
+This repo is a multi-plugin Claude Code marketplace. Six plugins ship from `plugins/<slug>/`:
+`claude-code-hermit` (core), `claude-code-dev-hermit`, `claude-code-homeassistant-hermit`, `claude-code-fitness-hermit`, `hermit-scribe`, `laravel-forge-hermit`.
 Each plugin has its own `CLAUDE.md`, `CHANGELOG.md`, and `tests/` — read those for plugin-specific context.
 
 The top-level `.claude-plugin/marketplace.json` is the only marketplace. The README at the repo root is the canonical hermit pitch.
@@ -11,7 +11,7 @@ Always launch Claude Code from this repo's root, not from inside a plugin dir. A
 ## Conventions
 
 - **Per-plugin paths**: every plugin lives at `plugins/<slug>/`. Tests, scripts, skills, agents, hooks, state-templates, docs, CHANGELOG, CLAUDE.md all live inside that dir.
-- **Tests run from inside the plugin dir**: core is pure `bun test` (auto-discovers `tests/*.test.ts`); HA is pytest (plus `bun test` for the TS tree); dev/fitness/scribe use `bash tests/run-all.sh`. Helpers use CWD-relative paths and break if invoked from repo root.
+- **Tests run from inside the plugin dir**: core and HA are pure `bun test` (auto-discovers `tests/*.test.ts`; HA keeps Python only as a test fixture, nothing shipped runs it); dev/fitness/scribe/forge use `bash tests/run-all.sh` (forge also needs a composer/PHP step). Helpers use CWD-relative paths and break if invoked from repo root.
 - **Tag format**: `<slug>--v<X.Y.Z>` (double-dash, e.g. `claude-code-hermit--v1.0.20`).
 - **Independent versioning**: each plugin's `plugin.json` bumps on its own cadence. Domain plugins declare core compat via `required_core_version: ">=X.Y.Z"` (semver range, not pin).
 - **Dependency fields**: `required_core_version` and `requires` live in `.claude-plugin/hermit-meta.json` (hermit-internal, validator-invisible). `dependencies` is the native Claude Code resolver field in `plugin.json`. `required_core_version` is authoritative — read by `plugins/claude-code-hermit/scripts/doctor-check.ts` from `hermit-meta.json`. `requires` mirrors it for documentation. Update all three when the core version requirement changes. All hermit-internal manifest extensions (`hermit.*`, etc.) belong in hermit-meta.json. When a domain hatch depends on new core terminus behavior (e.g. the domain hatch continuation protocol), bump `required_core_version` to the new core version and follow the protocol doc in `plugins/claude-code-hermit/skills/hatch/SKILL.md`.
@@ -21,7 +21,7 @@ Always launch Claude Code from this repo's root, not from inside a plugin dir. A
 
 - Root-scope edits (CI, root README, `.claude/`, `.claude-plugin/marketplace.json`) skip the CHANGELOG step entirely — they don't ship to operators. `/commit` handles that automatically.
 - Releases still go through `/release <slug>`, which promotes a plugin's `[Unreleased]` section to a real version. `/commit` accumulates those entries during day-to-day work.
-- **Where these skills live**: `/commit`, `/release`, `/release-status`, `/fleet-release`, `/test-run`, `/tackle-issue` are repo-internal skills under `.claude/skills/` — they're not shipped to operators, only used during monorepo dev. Use `/release-status` for a read-only pipeline snapshot before any release session; use `/fleet-release` when multiple plugins change together on one branch (handles dep ordering and `required_core_version` sync automatically).
+- **Where these skills live**: `/commit`, `/release`, `/release-status`, `/fleet-release`, `/bump-core-req`, `/test-run`, `/tackle-issue` are repo-internal skills under `.claude/skills/` — they're not shipped to operators, only used during monorepo dev. Use `/release-status` for a read-only pipeline snapshot before any release session; use `/fleet-release` when multiple plugins change together on one branch (handles dep ordering and `required_core_version` sync automatically).
 - **Changelog style: terse like [Claude Code's CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md).** Each `### Added / Changed / Fixed` bullet is 1–3 lines, `- **component: what changed** — short rationale if non-obvious.` Rationale, debugging context, and design tradeoffs go in the commit message and PR description, not the bullet. The verbose form is reserved for `### Upgrade Instructions`, which `hermit-evolve` reads imperative-step-by-step. The `/commit` and `/release` skills enforce this; the convention lives here for any agent that bypasses them.
 - **`/release` is operator-initiated — don't auto-suggest it.** Don't propose `/release <slug>` or `/fleet-release` in plans, summaries, or "next steps." Wait for an explicit ship/release/version request. `/release-status` is read-only and fine to suggest when checking pipeline state.
 
@@ -43,7 +43,7 @@ Always launch Claude Code from this repo's root, not from inside a plugin dir. A
 - **Docker paths mirror the host** (`${PWD}:${PWD}` mount) — absolute paths are identical inside the container despite the container user being `claude`.
 - **`rm -rf` is blocked** by the `enforce-deny-patterns` hook. Use `rm -r` (no `-f`) for scratch cleanup.
 - **Subtree imports are unsquashed**: `git log --first-parent` for the monorepo-only view; full upstream commits live under each subtree merge.
-- **CI is not path-filtered yet**: every plugin's tests run on every PR. Don't assume a HA-test failure on a core-only PR is your fault.
+- **CI is path-filtered per plugin**: every plugin has a paths-filtered workflow under `.github/workflows/` (`test-hooks` core, `test-ha`, `test-dev`, `test-fitness`, `test-scribe`, `test-forge`), so a PR touching one plugin runs only that plugin's suite. Root-file changes (`package.json`, `bun.lock`, `tsconfig.json`) trigger all of them.
 - **Shell `cd` persists across Bash calls.** Any `cd` in a Bash call leaves CWD pinned for subsequent Bash calls in the session — affects CWD-relative scripts like `heartbeat-precheck.ts .claude-code-hermit` (silently `SKIP|HEARTBEAT.md missing`) and commands like `git add`. Plugin test runners (`bun test` or `bash plugins/<slug>/tests/run-all.sh` run from inside the plugin dir) end inside `plugins/<slug>/`. Use absolute paths or prefix `cd "$(git rev-parse --show-toplevel)" && …` (resolves to the current tree root — the worktree under `claude --worktree`, the main checkout otherwise — never a hardcoded path).
 
 ## Verification

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The `@claude-code-hermit` suffix disambiguates when both a user-scoped and a pro
 For HA-hermit changes:
 
 ```bash
-( cd plugins/claude-code-homeassistant-hermit && pytest tests/ -v )
+( cd plugins/claude-code-homeassistant-hermit && bun test )
 ```
 
 See [Testing](docs/testing.md) for hook test details, fixtures, manual testing, and how to write new tests.
@@ -64,7 +64,7 @@ See [Testing](docs/testing.md) for hook test details, fixtures, manual testing, 
 1. Create a feature branch off `main` (`fix/<N>-<slug>`, `feat/<N>-<slug>`, or `chore/<slug>`)
 2. Run `/release-status` for a read-only pipeline snapshot (flags stale `required_core_version`, shows what's awaiting tag)
 3. Make changes
-4. Run `( cd plugins/claude-code-hermit && bun test )` locally (and the HA pytest suite if HA code changed)
+4. Run `( cd plugins/claude-code-hermit && bun test )` locally (and the HA `bun test` suite if HA code changed)
 5. Add a bullet to the affected plugin's `CHANGELOG.md` under `## [Unreleased]` — the maintainer promotes it to a real version at release time. (If you're using Claude Code with the repo's local skills, `/commit` does this automatically.)
 6. Push — CI runs the same tests
 7. Keep commits focused — one concern per PR
@@ -105,9 +105,9 @@ When releasing core and a domain plugin together, use `/fleet-release` — it up
 
 ## Per-Plugin Test Runner Pattern
 
-Each plugin owns its own test entry point. Examples:
+Each plugin owns its own test entry point. Two conventions ship:
 
-- `plugins/claude-code-hermit/` — pure `bun test` from the plugin dir (auto-discovers `tests/*.test.ts`; no runner script). See [`docs/testing.md`](plugins/claude-code-hermit/docs/testing.md) for fixtures and how to write new tests.
-- `plugins/claude-code-homeassistant-hermit/tests/` — pytest suite; run via `.venv/bin/pytest tests/ -v`.
+- **`bun test`** (core and HA) — run from the plugin dir; auto-discovers `tests/*.test.ts`, no runner script. `plugins/claude-code-hermit/` and `plugins/claude-code-homeassistant-hermit/`. See [`docs/testing.md`](plugins/claude-code-hermit/docs/testing.md) for fixtures and how to write new tests.
+- **`bash tests/run-all.sh`** (dev, fitness, scribe, forge) — a bash entry point that returns non-zero on any failure. Forge's runner also installs the PHP/composer deps its suite needs.
 
-CI runs each plugin's suite from its own directory (paths-filtered so unrelated plugin edits don't trigger every workflow). New plugins should follow the same pattern: a `run-all.sh` (or equivalent entry point) that returns non-zero on any failure, plus a paths-filtered GitHub Actions workflow under `.github/workflows/`.
+CI runs each plugin's suite from its own directory (paths-filtered so unrelated plugin edits don't trigger every workflow). New plugins should follow one of the two conventions above, plus a paths-filtered GitHub Actions workflow under `.github/workflows/`.

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Domain plugins you stack on top of any hermit you've hatched.
 - [**`dev-hermit`**](plugins/claude-code-dev-hermit/README.md) — *For software builders.* Safety layer for code-writing agents: push guard, branch discipline, gated PRs.
 - [**`homeassistant-hermit`**](plugins/claude-code-homeassistant-hermit/README.md) — *For Home Assistant users.* HA skills, safety hook, automation builder, zero-dependency CLI.
 - [**`fitness-hermit`**](plugins/claude-code-fitness-hermit/README.md) — *Fitness focused.* Strava MCP wiring, activity deep-dives, weekly-load routines.
+- [**`laravel-forge-hermit`**](plugins/laravel-forge-hermit/README.md) — *For Laravel Forge operators.* Deploy, logs, and server/site skills over the official Forge PHP SDK.
+- [**`hermit-scribe`**](plugins/hermit-scribe/README.md) — *For maintainers.* Files GitHub issues and comments from proposals via a bot identity.
 
 Many operators run several hermits in parallel — one per domain. Each one is a `/hatch` away. They share nothing but the protocol; their memory, cost history, and routines are independent, and a single Claude subscription covers them all. See [Creating Your Own Hermit](plugins/claude-code-hermit/docs/creating-your-own-hermit.md).
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **contract tests: version-triad and marketplace sync** — the sibling manifest walk in `hooks.contract.test.ts` now also asserts each domain plugin's `plugin.json` `dependencies[claude-code-hermit]` base version matches its `hermit-meta.json` `required_core_version`, and a new test enforces `marketplace.json` ↔ `plugin.json` name/version parity in both directions. Runs under `test-hooks.yml`.
+
 ## [1.2.14] - 2026-07-02
 
 ### Added

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -1254,8 +1254,10 @@ test('marketplace.json and plugin dirs are in sync (name + version, bidirectiona
   const listed = new Set<string>();
 
   for (const entry of marketplace.plugins) {
-    listed.add(entry.name);
-    const pjPath = path.join(pluginsDir, entry.name, '.claude-plugin', 'plugin.json');
+    // The source path is the canonical dir pointer; entry.name need not equal it.
+    const dir = path.basename(entry.source);
+    listed.add(dir);
+    const pjPath = path.join(pluginsDir, dir, '.claude-plugin', 'plugin.json');
     expect({ name: entry.name, hasManifest: fs.existsSync(pjPath) })
       .toEqual({ name: entry.name, hasManifest: true });
     const pj = readJson(pjPath);

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -1212,6 +1212,8 @@ describe('doctor-check', () => {
 // Sibling manifest invariant (live monorepo walk)
 // -------------------------------------------------------
 
+const stripOp = (v: string) => v.replace(/^[<>=^~!]+/, '');
+
 test('sibling manifests: required_core_version vs requires consistency', () => {
   const pluginsDir = path.join(MONOREPO_ROOT, 'plugins');
   for (const slug of fs.readdirSync(pluginsDir)) {
@@ -1225,6 +1227,46 @@ test('sibling manifests: required_core_version vs requires consistency', () => {
       expect({ slug, required_core_version: rcv })
         .toEqual({ slug, required_core_version: req });
     }
+  }
+});
+
+// The version triad spans two files: required_core_version lives in
+// hermit-meta.json, the resolver dependency in plugin.json. The auditor's
+// check 7 enforces this at release time; this pins it in CI so drift reddens.
+test('sibling manifests: hermit-meta required_core_version vs plugin.json dependency base', () => {
+  const pluginsDir = path.join(MONOREPO_ROOT, 'plugins');
+  for (const slug of fs.readdirSync(pluginsDir)) {
+    const metaPath = path.join(pluginsDir, slug, '.claude-plugin', 'hermit-meta.json');
+    if (!fs.existsSync(metaPath)) continue;
+    const rcv = readJson(metaPath).required_core_version;
+    if (!rcv) continue;
+    const pj = readJson(path.join(pluginsDir, slug, '.claude-plugin', 'plugin.json'));
+    const dep = (pj.dependencies ?? []).find((d: { name: string }) => d.name === 'claude-code-hermit');
+    expect({ slug, dependency: dep?.version }).not.toEqual({ slug, dependency: undefined });
+    expect({ slug, base: stripOp(dep.version) }).toEqual({ slug, base: stripOp(rcv) });
+  }
+});
+
+test('marketplace.json and plugin dirs are in sync (name + version, bidirectional)', () => {
+  const root = MONOREPO_ROOT;
+  const pluginsDir = path.join(root, 'plugins');
+  const marketplace = readJson(path.join(root, '.claude-plugin', 'marketplace.json'));
+  const listed = new Set<string>();
+
+  for (const entry of marketplace.plugins) {
+    listed.add(entry.name);
+    const pjPath = path.join(pluginsDir, entry.name, '.claude-plugin', 'plugin.json');
+    expect({ name: entry.name, hasManifest: fs.existsSync(pjPath) })
+      .toEqual({ name: entry.name, hasManifest: true });
+    const pj = readJson(pjPath);
+    expect({ name: entry.name, version: entry.version })
+      .toEqual({ name: pj.name, version: pj.version });
+  }
+
+  for (const slug of fs.readdirSync(pluginsDir)) {
+    if (!fs.existsSync(path.join(pluginsDir, slug, '.claude-plugin', 'plugin.json'))) continue;
+    expect({ slug, listedInMarketplace: listed.has(slug) })
+      .toEqual({ slug, listedInMarketplace: true });
   }
 });
 

--- a/plugins/hermit-scribe/README.md
+++ b/plugins/hermit-scribe/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://code.claude.com/docs/en/plugins"><img src="https://img.shields.io/badge/Claude%20Code-plugin-orange.svg" alt="Claude Code Plugin" /></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.0.3-green.svg" alt="Version 0.0.3" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.0.5-green.svg" alt="Version 0.0.5" /></a>
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
 </p>
 


### PR DESCRIPTION
## Summary

The test gates in this repo don't fire where it matters. `/release` silently **skips** the core and HA suites (its dispatch only recognized `run-all.sh` and pytest; both plugins are pure `bun test`), the release-auditor's version-triad check read `required_core_version`/`requires` from `plugin.json` where they don't live (they're in `hermit-meta.json`) so it **FAILed on every domain-plugin release**, and three plugins (dev, fitness, scribe) had real suites with **zero CI**. This lands the "pipeline integrity" sprint (roadmap pick C1) as five independently-reviewable commits: fix the dispatch, repair the auditor, add the missing CI, machine-enforce the invariants in the existing contract suite, and correct the docs that describe a pipeline that no longer exists.

## Changes

**Enforcement (gates that now fire):**
- `fix(tooling)` — `/release`, `/test-run`, and `smoke-test-runner` now dispatch `bun test` for core/HA; dead pytest paths removed (zero `.py` tests in the repo); `run-all.sh` keeps precedence; `/release` **aborts** instead of skipping when a `tests/` dir exists but no convention matches.
- `fix(tooling)` — release-auditor check 7 reads the triad from `hermit-meta.json` (two jq reads: meta for `required_core_version`/`requires`, `plugin.json` for `dependencies`); stale `doctor-check.js` → `.ts` refs corrected.
- `ci` — new `test-dev.yml` / `test-fitness.yml` / `test-scribe.yml` (cloned from the `test-forge.yml` two-job shape, minus PHP); root-file triggers (`package.json`, `bun.lock`, `tsconfig.json`) aligned across all six workflows.
- `test(claude-code-hermit)` — contract tests now assert each domain plugin's `plugin.json` dependency base matches `hermit-meta.json` `required_core_version`, plus a bidirectional `marketplace.json` ↔ `plugin.json` name/version sync check. Runs under the existing `test-hooks.yml` — no new CI infra.

**Docs truth pass:**
- `docs` — CLAUDE.md/CONTRIBUTING.md/README corrected: six plugins (not four), HA is `bun test` (not pytest), CI is path-filtered per plugin (not "not path-filtered yet"), forge + scribe added to Pre-built Hermits, `bump-core-req` added to the repo-internal skill list, stale scribe version badge fixed.

## Test plan

All six plugin suites + typecheck run locally, all green:
- core `bun test`: **1341 pass, 0 fail** · HA `bun test`: **645 pass, 0 fail**
- dev **12**, fitness **44**, scribe **18**, forge **42** — 0 failures
- `bunx tsc` from repo root: exit 0
- Repaired triad jq verified PASS for all 5 domain plugins (dev/fitness/HA `1.2.13`, scribe `1.2.0`, forge `1.2.12`)
- The two new contract tests execute with real assertions (10 + 18 `expect()` calls — non-vacuous)

The three new workflows self-exercise on this PR (their path filters match their own files).

## Notes
- Deliberately **not** consolidating the six workflows into one matrix, and not migrating dev/fitness/scribe to `bun test` — those are refactors of working code, deferred to a follow-up (roadmap C3) now that CI nets them.
- Source: `roadmap-sprint-pipeline-integrity-2026-07-02` (C1).