### PR TITLE
refactor(core): extract docker template rendering to scripts (Phase D2)

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -8,7 +8,13 @@
 - **scripts/run-with-profile.ts** — vestigial hook wrapper; no hook invoked it, and profile-gated hooks already self-gate on `AGENT_HOOK_PROFILE`.
 - **docs/skills.md** — hand-maintained skill listing that had drifted out of date; the plugin `CLAUDE.md` is the canonical skill list.
 
+### Added
+- **scripts: `render-docker-templates.ts`, `render-security-overlay.ts`, `lib/render-template.ts`** — the deterministic Docker template rendering (placeholder substitution, subnet collision-detection) extracted from the docker skills into fail-loud, tested scripts. `lib/render-template.ts` is the shared `{{PLACEHOLDER}}` engine; it writes nothing if any placeholder survives.
+- **state-templates/docker/security/verify-security.sh** — the `/docker-security` Step 8 live-posture verification heredoc, extracted verbatim into a static file the skill streams via `exec -T hermit sh -s < verify-security.sh`.
+
 ### Changed
+- **docker-setup / docker-security skills delegate rendering** — Steps that hand-substituted `{{...}}` (docker-setup Step 4/7b.6; docker-security subnet detection + overlay/nftables/dnsmasq render) now call the render scripts; the conversational prompts, gates, and operational steps stay in the skills. Rendered output is functionally equivalent to the prior prose substitution — no operator-visible change (the rendered `Dockerfile.hermit` / compose files are not manifest-hashed, so no `hermit-evolve` drift fires).
+- **nftables.conf.template comment** — removed brace-wrapping from the `LAN_ALLOWLIST_RULES` / `DNSMASQ_UID` references in the header comment so the render engine doesn't substitute documentation prose (comment-only; no rendered-output change).
 - **brief absorbs pulse** — the no-flag path now serves live session status (per-session cost from `sessions/.status.json`, active-alert pointer) and gains pulse's `status`/`progress`/`what are you working on` triggers. Preserves pulse's blocked-session `/debug` hint and idle cumulative-cost source (`cost-summary.md`).
 - **hermit-health absorbs hermit-brain and the knowledge lint** — health now reports fragile zones, stale accepted proposals, and recent learnings alongside infra (runner-free), and runs `knowledge-lint.ts` on demand under the `check knowledge`/`lint knowledge` triggers. Runs on `model: haiku` (restoring the tier the absorbed `knowledge` skill used) — the report is mechanical aggregation, so the cheaper model holds for the `check knowledge` path.
 - **session-close gains `--scheduled`** — the midnight close-now/queue/noop decision formerly in `daily-auto-close`; the `daily-auto-close` routine now invokes `/claude-code-hermit:session-close --scheduled` (routine `id` unchanged).

--- a/plugins/claude-code-hermit/scripts/lib/render-template.ts
+++ b/plugins/claude-code-hermit/scripts/lib/render-template.ts
@@ -1,0 +1,23 @@
+// Shared {{PLACEHOLDER}} substitution engine for the docker render scripts.
+//
+// renderTemplate replaces every `{{NAME}}` occurrence with the supplied value,
+// then fails loud if any `{{...}}` token survives — a missing var means the
+// caller forgot to derive a placeholder, and shipping a half-rendered
+// Dockerfile / compose / nftables file is worse than writing nothing. Callers
+// render + validate every file in memory BEFORE touching disk so a throw here
+// leaves nothing partially written.
+
+export function renderTemplate(text: string, vars: Record<string, string>): string {
+  let out = text;
+  for (const [key, value] of Object.entries(vars)) {
+    out = out.replaceAll(`{{${key}}}`, value);
+  }
+  // Real placeholders are UPPER_SNAKE (`{{PACKAGES_BLOCK}}`). Templates also
+  // carry literal `{{...}}` in documentation prose — those are not placeholders
+  // and must not trip the guard.
+  const leftover = out.match(/\{\{[A-Z][A-Z0-9_]*\}\}/);
+  if (leftover) {
+    throw new Error(`renderTemplate: unsubstituted placeholder ${leftover[0]}`);
+  }
+  return out;
+}

--- a/plugins/claude-code-hermit/scripts/render-docker-templates.ts
+++ b/plugins/claude-code-hermit/scripts/render-docker-templates.ts
@@ -138,10 +138,13 @@ if (import.meta.main) {
     try {
       const inputs = JSON.parse(raw) as Inputs;
 
-      // Render + validate everything before any write.
+      // Render + validate everything before any write. pluginVersion() reads +
+      // parses plugin.json; resolve it here too so a missing/corrupt manifest
+      // throws BEFORE any file is written (honours the "nothing written" contract).
       const { dockerfile, compose } = render(inputs);
       const entrypointSrc = path.join(TEMPLATES_DIR, 'docker-entrypoint.hermit.sh.template');
       if (!fs.existsSync(entrypointSrc)) throw new Error(`missing entrypoint template: ${entrypointSrc}`);
+      const version = pluginVersion();
 
       const dockerfilePath = path.join(projectRoot, 'Dockerfile.hermit');
       const composePath = path.join(projectRoot, 'docker-compose.hermit.yml');
@@ -152,7 +155,7 @@ if (import.meta.main) {
       fs.copyFileSync(entrypointSrc, entrypointPath);
 
       const manifestSeed = {
-        pluginVersion: pluginVersion(),
+        pluginVersion: version,
         entries: [
           { key: 'docker/docker-entrypoint.hermit.sh', file: entrypointPath },
           {

--- a/plugins/claude-code-hermit/scripts/render-docker-templates.ts
+++ b/plugins/claude-code-hermit/scripts/render-docker-templates.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+/**
+ * Renders the base Docker scaffolding for /docker-setup Step 7b.6.
+ *
+ * The skill owns every DECISION (auth, channels, packages, networking, plugin
+ * resolution) and hands this script the resolved SEMANTIC inputs on stdin; the
+ * script derives the `{{PLACEHOLDER}}` strings, renders `Dockerfile.hermit` and
+ * `docker-compose.hermit.yml` from the upstream templates, and copies the
+ * entrypoint verbatim (it has no placeholders — the session name is resolved
+ * from config.json at container startup, so it must be `cp`-copied, never
+ * regenerated). All rendering + validation happens in memory; nothing is
+ * written unless every file passes the fail-loud placeholder check.
+ *
+ * Usage: bun render-docker-templates.ts <project-root>
+ *   stdin JSON:
+ *     {
+ *       "packages": ["libsqlite3-dev", ...],
+ *       "auth": "oauth-token" | "api-key",
+ *       "channels": {
+ *         "envLines":    ["DISCORD_STATE_DIR=${PWD}/.claude.local/channels/discord", ...],
+ *         "volumeLines": ["${PWD}/.claude.local/channels/discord:/home/claude/.claude/channels/discord", ...]
+ *       },
+ *       "agentHookProfile": "strict",
+ *       "tmuxSessionName": "hermit-myproject",
+ *       "networkMode": "bridge" | "host",
+ *       "gitIdentityMount": true
+ *     }
+ *   channels.envLines / volumeLines carry the line BODY (the text after
+ *   `      - `); this script owns the compose indentation.
+ *
+ * Prints JSON to stdout:
+ *   { "written": ["/abs/Dockerfile.hermit", "/abs/docker-compose.hermit.yml"],
+ *     "entrypointCopied": true,
+ *     "manifestSeed": { "pluginVersion": "...", "entries": [...] } }
+ * The skill pipes `manifestSeed` straight into manifest-seed.ts — this script
+ * does NOT hash anything itself (one writer per file).
+ *
+ * Exit 0 on success. Any validation failure / unsubstituted placeholder →
+ * exit 1 with nothing written.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { renderTemplate } from './lib/render-template';
+
+const PLUGIN_ROOT = path.resolve(import.meta.dir, '..');
+const TEMPLATES_DIR = path.join(PLUGIN_ROOT, 'state-templates', 'docker');
+
+const ENV_INDENT = '      - ';
+
+interface Channels {
+  envLines?: string[];
+  volumeLines?: string[];
+}
+interface Inputs {
+  packages?: string[];
+  auth: 'oauth-token' | 'api-key';
+  channels?: Channels;
+  agentHookProfile: string;
+  tmuxSessionName: string;
+  networkMode: 'bridge' | 'host';
+  gitIdentityMount: boolean;
+}
+
+function packagesBlock(packages: string[]): string {
+  if (packages.length === 0) return '';
+  return [
+    '# Project-specific packages (from config.json docker.packages)',
+    '# To modify: /hermit-settings docker, then rebuild',
+    'RUN apt-get update && apt-get install -y --no-install-recommends \\',
+    `      ${packages.join(' ')} && \\`,
+    '    rm -rf /var/lib/apt/lists/*',
+  ].join('\n');
+}
+
+function indentedLines(bodies: string[]): string {
+  return bodies.map((b) => ENV_INDENT + b).join('\n');
+}
+
+/** Build every rendered file in memory. Throws on any unsubstituted placeholder. */
+export function render(inputs: Inputs): { dockerfile: string; compose: string } {
+  const packages = inputs.packages ?? [];
+  const channels = inputs.channels ?? {};
+  const envLines = channels.envLines ?? [];
+  const volumeLines = channels.volumeLines ?? [];
+
+  const dockerfileTemplate = fs.readFileSync(
+    path.join(TEMPLATES_DIR, 'Dockerfile.hermit.template'), 'utf8');
+  let composeTemplate = fs.readFileSync(
+    path.join(TEMPLATES_DIR, 'docker-compose.hermit.yml.template'), 'utf8');
+
+  // Git identity has no placeholder in the template — it is a fixed bind-mount
+  // line the skill removes when the host has no ~/.gitconfig.
+  if (!inputs.gitIdentityMount) {
+    composeTemplate = composeTemplate.replace(
+      '      - ${HOME}/.gitconfig:/home/claude/.gitconfig:ro\n', '');
+  }
+
+  const dockerfile = renderTemplate(dockerfileTemplate, {
+    PACKAGES_BLOCK: packagesBlock(packages),
+  });
+
+  // AUTH_ENV_LINE carries a trailing newline (api-key) so CHANNEL_ENV_LINES,
+  // which shares the same template line, starts on a fresh line.
+  const authEnvLine = inputs.auth === 'api-key'
+    ? '      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}\n'
+    : '';
+  const networkModeLine = inputs.networkMode === 'host'
+    ? '    # WARNING: host networking exposes all host-local services to the container.\n    network_mode: host'
+    : '';
+
+  const compose = renderTemplate(composeTemplate, {
+    AUTH_ENV_LINE: authEnvLine,
+    CHANNEL_ENV_LINES: indentedLines(envLines),
+    CHANNEL_VOLUME_LINES: indentedLines(volumeLines),
+    AGENT_HOOK_PROFILE: inputs.agentHookProfile,
+    TMUX_SESSION_NAME: inputs.tmuxSessionName,
+    NETWORK_MODE_LINE: networkModeLine,
+  });
+
+  return { dockerfile, compose };
+}
+
+function pluginVersion(): string {
+  const pj = JSON.parse(
+    fs.readFileSync(path.join(PLUGIN_ROOT, '.claude-plugin', 'plugin.json'), 'utf8'));
+  return String(pj.version);
+}
+
+if (import.meta.main) {
+  const projectRoot = path.resolve(process.argv[2] || process.cwd());
+
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (c) => { raw += c; });
+  process.stdin.on('error', () => {});
+  process.stdin.on('end', () => {
+    try {
+      const inputs = JSON.parse(raw) as Inputs;
+
+      // Render + validate everything before any write.
+      const { dockerfile, compose } = render(inputs);
+      const entrypointSrc = path.join(TEMPLATES_DIR, 'docker-entrypoint.hermit.sh.template');
+      if (!fs.existsSync(entrypointSrc)) throw new Error(`missing entrypoint template: ${entrypointSrc}`);
+
+      const dockerfilePath = path.join(projectRoot, 'Dockerfile.hermit');
+      const composePath = path.join(projectRoot, 'docker-compose.hermit.yml');
+      const entrypointPath = path.join(projectRoot, 'docker-entrypoint.hermit.sh');
+
+      fs.writeFileSync(dockerfilePath, dockerfile);
+      fs.writeFileSync(composePath, compose);
+      fs.copyFileSync(entrypointSrc, entrypointPath);
+
+      const manifestSeed = {
+        pluginVersion: pluginVersion(),
+        entries: [
+          { key: 'docker/docker-entrypoint.hermit.sh', file: entrypointPath },
+          {
+            key: 'docker/docker-compose.hermit.yml.template',
+            file: path.join(TEMPLATES_DIR, 'docker-compose.hermit.yml.template'),
+          },
+          {
+            key: 'docker/Dockerfile.hermit.template',
+            file: path.join(TEMPLATES_DIR, 'Dockerfile.hermit.template'),
+          },
+        ],
+      };
+
+      console.log(JSON.stringify({
+        written: [dockerfilePath, composePath],
+        entrypointCopied: true,
+        manifestSeed,
+      }));
+      process.exit(0);
+    } catch (e: any) {
+      console.error(`render-docker-templates: ${e.message}`);
+      process.exit(1);
+    }
+  });
+}

--- a/plugins/claude-code-hermit/scripts/render-security-overlay.ts
+++ b/plugins/claude-code-hermit/scripts/render-security-overlay.ts
@@ -76,10 +76,14 @@ export interface Chosen {
   netguardIp: string;
 }
 
+// derive is only ever called with a /24 (CANDIDATES are /24; validateCandidate
+// enforces /24). Normalize to the network address so an operator-supplied CIDR
+// with host bits set (e.g. 192.168.5.10/24) renders as 192.168.5.0/24: Docker
+// rejects a subnet whose address has host bits ("it should be 192.168.5.0/24").
 function derive(subnet: string): Chosen {
-  const base = subnet.split('/')[0];
-  const o = base.split('.');
-  return { subnet, gateway: `${o[0]}.${o[1]}.${o[2]}.1`, netguardIp: `${o[0]}.${o[1]}.${o[2]}.2` };
+  const o = subnet.split('/')[0].split('.');
+  const base = `${o[0]}.${o[1]}.${o[2]}`;
+  return { subnet: `${base}.0/24`, gateway: `${base}.1`, netguardIp: `${base}.2` };
 }
 
 export interface PickResult {
@@ -117,6 +121,16 @@ export function validateCandidate(candidate: string, occupied: string[]): PickRe
   return { chosen: derive(candidate.trim()), allCandidatesCollide: false, occupied };
 }
 
+/**
+ * Extract the parseable IPv4 subnets from a `docker network inspect` subnet
+ * field (space-separated when a network is dual-stack). Drops IPv6 / unparseable
+ * entries but keeps the IPv4 range (dropping the whole net on an unparseable
+ * IPv6 half would hide its real IPv4 range from the overlap check).
+ */
+export function ipv4SubnetsFromInspect(subnetField: string): string[] {
+  return (subnetField ?? '').trim().split(/\s+/).filter((s) => cidrToRange(s) !== null);
+}
+
 // ---------------------------------------------------------------------------
 // Impure docker enumeration (mirrors docker-preflight's spawnSync + timeouts).
 // ---------------------------------------------------------------------------
@@ -149,16 +163,17 @@ export function gatherOccupied(projectRoot: string): string[] {
   for (const net of nets) {
     try {
       const insp = spawnSync('docker', ['network', 'inspect', net,
-        '--format', '{{range .IPAM.Config}}{{.Subnet}}{{end}}|||{{json .Labels}}'],
+        '--format', '{{range .IPAM.Config}}{{.Subnet}} {{end}}|||{{json .Labels}}'],
         { timeout: 5000, encoding: 'utf8' });
       if (insp.status !== 0 || !insp.stdout) continue;
       const [subnetPart, labelsPart] = insp.stdout.trim().split('|||');
-      if (!subnetPart || !cidrToRange(subnetPart)) continue; // skip non-IPv4 nets
+      const subnets = ipv4SubnetsFromInspect(subnetPart);
+      if (subnets.length === 0) continue; // no IPv4 subnet on this net
       let labels: any = {};
       try { labels = JSON.parse(labelsPart || '{}') || {}; } catch {}
       if (labels['com.docker.compose.project'] === projectName
         && labels['com.docker.compose.network'] === 'hermit-net') continue;
-      occupied.push(subnetPart);
+      occupied.push(...subnets);
     } catch { /* skip this network */ }
   }
   return occupied;

--- a/plugins/claude-code-hermit/scripts/render-security-overlay.ts
+++ b/plugins/claude-code-hermit/scripts/render-security-overlay.ts
@@ -1,0 +1,400 @@
+#!/usr/bin/env bun
+/**
+ * Deterministic rendering for /docker-security. Two subcommands:
+ *
+ *   pick-subnet <project-root> [--candidate <cidr>]
+ *     Enumerates occupied Docker subnets, excludes this project's own
+ *     hermit-net, and walks the 8 fixed /24 candidates for the first that does
+ *     not overlap. With --candidate, validates an operator-supplied /24 (prefix
+ *     + collision) so the AskUserQuestion retry loop is one cheap call. Always
+ *     exits 0 — the caller inspects fields, not the exit code (probe pattern).
+ *     Output: { chosen: {subnet, gateway, netguardIp} | null,
+ *               allCandidatesCollide: bool, occupied: [...] }
+ *
+ *   render <project-root>
+ *     Renders docker-compose.security.yml + nftables.conf + dnsmasq.allowlist
+ *     from operator selections on stdin. All three render in memory and pass the
+ *     fail-loud placeholder check before anything is written; any failure →
+ *     exit 1, nothing written. Output: { written: [...] }.
+ *     stdin JSON:
+ *       {
+ *         "network": { "subnet": "172.28.0.0/24", "gateway": "172.28.0.1", "netguardIp": "172.28.0.2" },
+ *         "toggles": {
+ *           "lan":       { "enabled": true, "dnsMode": "log-only" | "enforce" },
+ *           "resources": { "enabled": true, "memLimit": "4g", "memswapLimit": "4g", "cpus": 2.0, "sysctlsEnabled": true },
+ *           "audit":     { "enabled": true }
+ *         },
+ *         "publishPorts": [ { "target": 3000, "published": "3000", "protocol": "tcp", "host_ip": "0.0.0.0", "mode": "ingress" } ],
+ *         "lanAllowlist": ["192.168.1.50", ...],
+ *         "fleetDomains": ["api.strava.com", ...],
+ *         "additionalDomains": ["example.org", ...]
+ *       }
+ *     network is required only when toggles.lan.enabled.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { renderTemplate } from './lib/render-template';
+
+const PLUGIN_ROOT = path.resolve(import.meta.dir, '..');
+const SECURITY_DIR = path.join(PLUGIN_ROOT, 'state-templates', 'docker', 'security');
+
+const DNSMASQ_UID = '100'; // Alpine dnsmasq's static UID — see docker-security SKILL step 6a.
+
+const CANDIDATES = [
+  '172.28.0.0/24', '172.29.0.0/24', '172.30.0.0/24', '172.31.0.0/24',
+  '10.244.0.0/24', '10.245.0.0/24', '10.246.0.0/24', '10.247.0.0/24',
+];
+
+// ---------------------------------------------------------------------------
+// Pure subnet-overlap logic (exported — tests exercise it without docker).
+// ---------------------------------------------------------------------------
+
+export type Range = [number, number];
+
+export function cidrToRange(cidr: string): Range | null {
+  const m = String(cidr).trim().match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})$/);
+  if (!m) return null;
+  const octets = [m[1], m[2], m[3], m[4]].map(Number);
+  if (octets.some((o) => o > 255)) return null;
+  const prefix = Number(m[5]);
+  if (prefix > 32) return null;
+  const ip = octets[0] * 2 ** 24 + octets[1] * 2 ** 16 + octets[2] * 2 ** 8 + octets[3];
+  const size = 2 ** (32 - prefix);
+  const network = Math.floor(ip / size) * size;
+  return [network, network + size - 1];
+}
+
+export function overlaps(a: Range, b: Range): boolean {
+  return a[0] <= b[1] && b[0] <= a[1];
+}
+
+export interface Chosen {
+  subnet: string;
+  gateway: string;
+  netguardIp: string;
+}
+
+function derive(subnet: string): Chosen {
+  const base = subnet.split('/')[0];
+  const o = base.split('.');
+  return { subnet, gateway: `${o[0]}.${o[1]}.${o[2]}.1`, netguardIp: `${o[0]}.${o[1]}.${o[2]}.2` };
+}
+
+export interface PickResult {
+  chosen: Chosen | null;
+  allCandidatesCollide: boolean;
+  occupied: string[];
+}
+
+/** Walk `candidates`, return the first that overlaps no occupied subnet. */
+export function pickSubnet(candidates: string[], occupied: string[]): PickResult {
+  const occRanges = occupied
+    .map(cidrToRange)
+    .filter((r): r is Range => r !== null);
+  for (const cand of candidates) {
+    const cr = cidrToRange(cand);
+    if (!cr) continue;
+    if (!occRanges.some((o) => overlaps(cr, o))) {
+      return { chosen: derive(cand), allCandidatesCollide: false, occupied };
+    }
+  }
+  return { chosen: null, allCandidatesCollide: true, occupied };
+}
+
+/** Validate an operator-supplied /24 against the occupied set. */
+export function validateCandidate(candidate: string, occupied: string[]): PickResult {
+  const cr = cidrToRange(candidate);
+  const isSlash24 = /\/24$/.test(String(candidate).trim());
+  if (!cr || !isSlash24) {
+    return { chosen: null, allCandidatesCollide: true, occupied };
+  }
+  const occRanges = occupied.map(cidrToRange).filter((r): r is Range => r !== null);
+  if (occRanges.some((o) => overlaps(cr, o))) {
+    return { chosen: null, allCandidatesCollide: true, occupied };
+  }
+  return { chosen: derive(candidate.trim()), allCandidatesCollide: false, occupied };
+}
+
+// ---------------------------------------------------------------------------
+// Impure docker enumeration (mirrors docker-preflight's spawnSync + timeouts).
+// ---------------------------------------------------------------------------
+
+function ownProjectName(projectRoot: string): string {
+  try {
+    const r = spawnSync('docker', ['compose', '-f', 'docker-compose.hermit.yml', 'config', '--format', 'json'],
+      { cwd: projectRoot, timeout: 10000, encoding: 'utf8' });
+    if (r.status === 0 && r.stdout) {
+      const j = JSON.parse(r.stdout);
+      if (j && typeof j.name === 'string' && j.name) return j.name;
+    }
+  } catch {}
+  return path.basename(projectRoot);
+}
+
+/** Enumerate occupied IPv4 subnets, excluding this project's own hermit-net. */
+export function gatherOccupied(projectRoot: string): string[] {
+  const occupied: string[] = [];
+  let nets: string[];
+  try {
+    const ls = spawnSync('docker', ['network', 'ls', '--format', '{{.Name}}'],
+      { timeout: 10000, encoding: 'utf8' });
+    if (ls.status !== 0 || !ls.stdout) return occupied;
+    nets = ls.stdout.split('\n').map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return occupied;
+  }
+  const projectName = ownProjectName(projectRoot);
+  for (const net of nets) {
+    try {
+      const insp = spawnSync('docker', ['network', 'inspect', net,
+        '--format', '{{range .IPAM.Config}}{{.Subnet}}{{end}}|||{{json .Labels}}'],
+        { timeout: 5000, encoding: 'utf8' });
+      if (insp.status !== 0 || !insp.stdout) continue;
+      const [subnetPart, labelsPart] = insp.stdout.trim().split('|||');
+      if (!subnetPart || !cidrToRange(subnetPart)) continue; // skip non-IPv4 nets
+      let labels: any = {};
+      try { labels = JSON.parse(labelsPart || '{}') || {}; } catch {}
+      if (labels['com.docker.compose.project'] === projectName
+        && labels['com.docker.compose.network'] === 'hermit-net') continue;
+      occupied.push(subnetPart);
+    } catch { /* skip this network */ }
+  }
+  return occupied;
+}
+
+// ---------------------------------------------------------------------------
+// Overlay / nftables / dnsmasq rendering (pure — exported for tests).
+// ---------------------------------------------------------------------------
+
+interface Port {
+  target: number | string;
+  published: number | string;
+  host_ip?: string;
+  protocol?: string;
+  mode?: string;
+}
+interface Toggles {
+  lan?: { enabled?: boolean; dnsMode?: 'log-only' | 'enforce' };
+  resources?: { enabled?: boolean; memLimit?: string; memswapLimit?: string; cpus?: number | string; sysctlsEnabled?: boolean };
+  audit?: { enabled?: boolean };
+}
+export interface RenderInput {
+  network?: Chosen;
+  toggles: Toggles;
+  publishPorts?: Port[];
+  lanAllowlist?: string[];
+  fleetDomains?: string[];
+  additionalDomains?: string[];
+}
+
+const SYSCTLS_ITEMS = [
+  'net.ipv4.conf.all.accept_redirects=0',
+  'net.ipv4.conf.all.send_redirects=0',
+  'net.ipv4.conf.all.accept_source_route=0',
+  'net.ipv4.conf.default.accept_redirects=0',
+];
+
+function sysctlsBlock(keyIndent: string): string {
+  const item = keyIndent + '  ';
+  return `${keyIndent}sysctls:\n` + SYSCTLS_ITEMS.map((s) => `${item}- ${s}`).join('\n');
+}
+
+function portsBlock(ports: Port[], keyIndent: string): string {
+  const item = keyIndent + '  ';
+  const field = item + '  ';
+  const lines = [`${keyIndent}ports:`];
+  for (const p of ports) {
+    lines.push(`${item}- target: ${p.target}`);
+    lines.push(`${field}published: "${p.published}"`);
+    if (p.host_ip && p.host_ip !== '0.0.0.0') lines.push(`${field}host_ip: ${p.host_ip}`);
+    lines.push(`${field}protocol: ${p.protocol ?? 'tcp'}`);
+    if (p.mode && p.mode !== 'ingress') lines.push(`${field}mode: ${p.mode}`);
+  }
+  return lines.join('\n');
+}
+
+function netguardService(net: Chosen, dnsMode: string, sysctls: string, ports: string): string {
+  const dnsLogOnly = dnsMode === 'log-only' ? '1' : '0';
+  const lines = [
+    '  hermit-netguard:',
+    '    build:',
+    '      context: ./.claude-code-hermit/docker',
+    '      dockerfile: Dockerfile.hermit-netguard',
+    "    # NET_BIND_SERVICE: dnsmasq retains it post-bind-drop. SETUID+SETGID:",
+    "    # drops to UID/GID 100 (Alpine's `dnsmasq` user).",
+    '    cap_add: [NET_ADMIN, NET_BIND_SERVICE, SETUID, SETGID]',
+    '    cap_drop: [ALL]',
+    '    security_opt:',
+    '      - no-new-privileges:true',
+    '    pids_limit: 256',
+    '    networks:',
+    '      hermit-net:',
+    `        ipv4_address: ${net.netguardIp}`,
+    '    volumes:',
+    '      - ./.claude-code-hermit/docker/nftables.conf:/etc/nftables.conf:ro',
+    '      - ./.claude-code-hermit/docker/dnsmasq.allowlist:/etc/dnsmasq.allowlist:ro',
+    '    environment:',
+    `      - DNS_LOG_ONLY=${dnsLogOnly}`,
+    '    restart: unless-stopped',
+  ];
+  if (sysctls) lines.push(sysctls);
+  if (ports) lines.push(ports);
+  lines.push(
+    '    healthcheck:',
+    `      test: ["CMD-SHELL", "nft list ruleset | grep -q 'table inet firewall' && (! [ -f /etc/dnsmasq.allowlist ] || pgrep dnsmasq)"]`,
+    '      interval: 10s',
+    '      timeout: 5s',
+    '      retries: 3',
+    '      start_period: 5s',
+  );
+  return lines.join('\n');
+}
+
+export function renderOverlay(input: RenderInput): string {
+  const template = fs.readFileSync(path.join(SECURITY_DIR, 'docker-compose.security.yml.template'), 'utf8');
+  const lanOn = input.toggles.lan?.enabled === true;
+  const resOn = input.toggles.resources?.enabled === true;
+  const auditOn = input.toggles.audit?.enabled === true;
+  const sysctlsOn = resOn && input.toggles.resources?.sysctlsEnabled === true;
+  const ports = input.publishPorts ?? [];
+
+  if (lanOn && !input.network) throw new Error('render: toggles.lan.enabled requires network {subnet,gateway,netguardIp}');
+
+  const networksBlock = lanOn
+    ? [
+        'networks:',
+        '  hermit-net:',
+        '    driver: bridge',
+        '    ipam:',
+        '      config:',
+        `        - subnet: ${input.network!.subnet}`,
+        `          gateway: ${input.network!.gateway}`,
+      ].join('\n')
+    : '';
+
+  const netguardSysctls = lanOn && sysctlsOn ? sysctlsBlock('    ') : '';
+  const netguardPorts = lanOn && ports.length > 0 ? portsBlock(ports, '    ') : '';
+  const netguardBlock = lanOn
+    ? netguardService(input.network!, input.toggles.lan?.dnsMode ?? 'log-only', netguardSysctls, netguardPorts)
+    : '';
+
+  const hermitNetworkMode = lanOn
+    ? [
+        '    network_mode: "service:hermit-netguard"',
+        '    depends_on:',
+        '      hermit-netguard:',
+        '        condition: service_healthy',
+      ].join('\n')
+    : '';
+
+  const resourceBounds = resOn
+    ? [
+        `    mem_limit: ${input.toggles.resources?.memLimit ?? '4g'}`,
+        `    memswap_limit: ${input.toggles.resources?.memswapLimit ?? '4g'}`,
+        `    cpus: ${input.toggles.resources?.cpus ?? 2.0}`,
+      ].join('\n')
+    : '';
+
+  const hermitSysctls = sysctlsOn && !lanOn ? sysctlsBlock('    ') : '';
+  const auditEnv = auditOn
+    ? ['    environment:', '      - HERMIT_PLUGIN_INSTALL_AUDIT=1'].join('\n')
+    : '';
+
+  return renderTemplate(template, {
+    NETWORKS_BLOCK: networksBlock,
+    HERMIT_NETGUARD_SERVICE: netguardBlock,
+    HERMIT_NETWORK_MODE: hermitNetworkMode,
+    HERMIT_RESOURCE_BOUNDS: resourceBounds,
+    HERMIT_SYSCTLS_ON_HERMIT: hermitSysctls,
+    HERMIT_AUDIT_ENV: auditEnv,
+  });
+}
+
+export function renderNftables(lanAllowlist: string[]): string {
+  const template = fs.readFileSync(path.join(SECURITY_DIR, 'nftables.conf.template'), 'utf8');
+  // The template line is `        {{LAN_ALLOWLIST_RULES}}` (8 leading spaces).
+  // Leave the first entry unindented (the template supplies its indent); prefix
+  // every subsequent entry with the same 8 spaces so they align.
+  const rules = lanAllowlist
+    .map((e, i) => (i === 0 ? '' : '        ') + `ip daddr ${e} accept`)
+    .join('\n');
+  return renderTemplate(template, {
+    LAN_ALLOWLIST_RULES: rules,
+    DNSMASQ_UID,
+  });
+}
+
+export function renderDnsmasq(fleetDomains: string[], additionalDomains: string[]): string {
+  const template = fs.readFileSync(path.join(SECURITY_DIR, 'dnsmasq.allowlist.template'), 'utf8');
+  const toServers = (domains: string[]) => domains.map((d) => `server=/${d}/1.1.1.1`).join('\n');
+  return renderTemplate(template, {
+    FLEET_DOMAINS: toServers(fleetDomains),
+    ADDITIONAL_DOMAINS: toServers(additionalDomains),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function runPickSubnet(projectRoot: string, candidate: string | null): void {
+  const occupied = gatherOccupied(projectRoot);
+  const result = candidate ? validateCandidate(candidate, occupied) : pickSubnet(CANDIDATES, occupied);
+  console.log(JSON.stringify(result));
+  process.exit(0);
+}
+
+function runRender(projectRoot: string, raw: string): void {
+  const input = JSON.parse(raw) as RenderInput;
+  // Render + validate all three in memory before any write.
+  const overlay = renderOverlay(input);
+  const nftables = renderNftables(input.lanAllowlist ?? []);
+  const dnsmasq = renderDnsmasq(input.fleetDomains ?? [], input.additionalDomains ?? []);
+
+  const lanOn = input.toggles.lan?.enabled === true;
+  const overlayPath = path.join(projectRoot, 'docker-compose.security.yml');
+  const written: string[] = [overlayPath];
+  fs.writeFileSync(overlayPath, overlay);
+
+  if (lanOn) {
+    const dockerDir = path.join(projectRoot, '.claude-code-hermit', 'docker');
+    fs.mkdirSync(dockerDir, { recursive: true });
+    const nftPath = path.join(dockerDir, 'nftables.conf');
+    const allowPath = path.join(dockerDir, 'dnsmasq.allowlist');
+    fs.writeFileSync(nftPath, nftables);
+    fs.writeFileSync(allowPath, dnsmasq);
+    written.push(nftPath, allowPath);
+  }
+
+  console.log(JSON.stringify({ written }));
+  process.exit(0);
+}
+
+if (import.meta.main) {
+  const sub = process.argv[2];
+  const projectRoot = path.resolve(process.argv[3] || process.cwd());
+
+  if (sub === 'pick-subnet') {
+    const ci = process.argv.indexOf('--candidate');
+    const candidate = ci >= 0 ? process.argv[ci + 1] ?? null : null;
+    runPickSubnet(projectRoot, candidate);
+  } else if (sub === 'render') {
+    let raw = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => { raw += c; });
+    process.stdin.on('error', () => {});
+    process.stdin.on('end', () => {
+      try {
+        runRender(projectRoot, raw.trim());
+      } catch (e: any) {
+        console.error(`render-security-overlay: ${e.message}`);
+        process.exit(1);
+      }
+    });
+  } else {
+    console.error('usage: render-security-overlay.ts <pick-subnet|render> <project-root> [...]');
+    process.exit(1);
+  }
+}

--- a/plugins/claude-code-hermit/skills/docker-security/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-security/SKILL.md
@@ -253,42 +253,22 @@ If `persisted_publish_ports` is empty: proceed directly to deletion without the 
 
 **Subnet auto-detection (only if LAN containment is enabled):**
 
-Run the following to enumerate occupied subnets across **all** Docker networks (not filtered to bridge — overlap is address-space-based):
+Run `pick-subnet` — it enumerates occupied Docker subnets, excludes this project's own `hermit-net`, integer-range-checks overlap, walks the 8 fixed /24 candidates, and always exits 0 (probe pattern):
 
 ```bash
-timeout 10s docker network ls --format '{{.Name}}' 2>/dev/null | while read net; do
-  timeout 5s docker network inspect "$net" \
-    --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}|||{{json .Labels}}' 2>/dev/null
-done
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/render-security-overlay.ts pick-subnet <PROJECT_ROOT>
 ```
 
-Parse each output line into a subnet string and a Labels JSON object. Skip lines without IPv4 subnets.
+It prints `{ "chosen": { "subnet", "gateway", "netguardIp" } | null, "allCandidatesCollide": bool, "occupied": [...] }`.
 
-**Exclude** networks belonging to this project's own `hermit-net` from the collision list. Identify these by labels:
-- `com.docker.compose.project == <our project name>` AND `com.docker.compose.network == "hermit-net"`
+- If `chosen` is non-null, use it.
+- If `allCandidatesCollide` is true, `AskUserQuestion` (header: `"Custom subnet"`) with an Other field for an IPv4 /24 CIDR. Validate each answer with one cheap re-run:
+  ```bash
+  bun ${CLAUDE_PLUGIN_ROOT}/scripts/render-security-overlay.ts pick-subnet <PROJECT_ROOT> --candidate <cidr>
+  ```
+  `chosen: null` means still colliding or not a /24 — re-prompt. `chosen` set means accepted.
 
-Derive `<our project name>` from `timeout 10s docker compose -f docker-compose.hermit.yml config --format json 2>/dev/null | bun -e 'console.log(JSON.parse(require("fs").readFileSync(0,"utf8")).name ?? "")'` — fall back to `basename "$PROJECT_DIR"` if the command fails.
-
-Check subnet overlap with a `bun -e` snippet (convert each /24 candidate and occupied CIDR to an integer range and compare). Walk candidate /24 subnets in order: `172.28.0.0/24`, `172.29.0.0/24`, `172.30.0.0/24`, `172.31.0.0/24`, `10.244.0.0/24`, `10.245.0.0/24`, `10.246.0.0/24`, `10.247.0.0/24`. Pick the first that doesn't overlap any occupied subnet. Treat parse failures as "subnet unknown, skip."
-
-If all candidates collide, `AskUserQuestion` (header: `"Custom subnet"`) with Other field accepting an IPv4 /24 CIDR (reject if prefix != 24; re-prompt on invalid or still-colliding).
-
-Compute `chosen_gateway = <base>.0.1`, `chosen_netguard_ip = <base>.0.2`. Persist to `docker.security.network`:
-
-```json
-{
-  "enabled": true,
-  "dns_mode": "log-only" | "enforce",
-  "subnet": "172.28.0.0/24",
-  "gateway": "172.28.0.1",
-  "netguard_ip": "172.28.0.2",
-  "lan_allowlist": [...],
-  "additional_domains": [...],
-  "publish_ports": [...]
-}
-```
-
-If LAN containment is not enabled, omit `subnet`, `gateway`, `netguard_ip` from the `docker.security.network` object.
+Persist the chosen values to `docker.security.network` (`subnet`, `gateway`, `netguard_ip` from `chosen`), alongside `enabled`, `dns_mode`, `lan_allowlist`, `additional_domains`, `publish_ports`. If LAN containment is not enabled, omit `subnet`, `gateway`, `netguard_ip`.
 
 If at least one toggle is enabled, render the overlay. Otherwise (all-off): handled in the all-off branch above.
 
@@ -298,109 +278,40 @@ Render `100` directly into `nftables.conf` as the dnsmasq UID — no probe step.
 
 After the netguard files are rendered (step 6c), the wizard runs an explicit `--no-cache` build of `hermit-netguard` to prevent stale Docker cache artifacts from surviving a hermit upgrade. Do not rely on `hermit-docker up` to trigger a rebuild.
 
-#### 6b. Write the overlay
+#### 6b. Render the overlay + nftables + dnsmasq
 
-Render `docker-compose.security.yml` from `state-templates/docker/security/docker-compose.security.yml.template` by substituting the placeholder blocks. The template has placeholders:
+`render-security-overlay.ts render` derives every `{{PLACEHOLDER}}` (networks block, netguard service with cap_add/healthcheck, `DNS_LOG_ONLY` from `dns_mode`, per-toggle hermit blocks, sysctls placement, ports, LAN rules at the chain-body indent, `DNSMASQ_UID=100`, `server=` domain lines) and fails loud (exit 1, nothing written) if any survives. It writes `docker-compose.security.yml` to the project root, and — only when LAN containment is on — `nftables.conf` + `dnsmasq.allowlist` into `.claude-code-hermit/docker/`. Pipe the resolved selections:
 
-- `{{NETWORKS_BLOCK}}` — empty unless Prompt 1 enabled. When enabled, substitute `chosen_subnet` and `chosen_gateway` from the subnet auto-detection step above:
-  ```yaml
-  networks:
-    hermit-net:
-      driver: bridge
-      ipam:
-        config:
-          - subnet: <chosen_subnet>
-            gateway: <chosen_gateway>
-  ```
-- `{{HERMIT_NETGUARD_SERVICE}}` — empty unless Prompt 1 enabled. When enabled, substitute `chosen_netguard_ip` and `dns_log_only`. Also render `{{NETGUARD_PORTS_BLOCK}}` (see below):
-  ```yaml
-    hermit-netguard:
-      build:
-        context: ./.claude-code-hermit/docker
-        dockerfile: Dockerfile.hermit-netguard
-      # NET_BIND_SERVICE: dnsmasq retains it post-bind-drop. SETUID+SETGID:
-      # drops to UID/GID 100 (Alpine's `dnsmasq` user).
-      cap_add: [NET_ADMIN, NET_BIND_SERVICE, SETUID, SETGID]
-      cap_drop: [ALL]
-      security_opt:
-        - no-new-privileges:true
-      pids_limit: 256
-      networks:
-        hermit-net:
-          ipv4_address: <chosen_netguard_ip>
-      volumes:
-        - ./.claude-code-hermit/docker/nftables.conf:/etc/nftables.conf:ro
-        - ./.claude-code-hermit/docker/dnsmasq.allowlist:/etc/dnsmasq.allowlist:ro
-      environment:
-        - DNS_LOG_ONLY=<dns_log_only>
-      restart: unless-stopped
-      {{NETGUARD_SYSCTLS}}
-      {{NETGUARD_PORTS_BLOCK}}
-      healthcheck:
-        test: ["CMD-SHELL", "nft list ruleset | grep -q 'table inet firewall' && (! [ -f /etc/dnsmasq.allowlist ] || pgrep dnsmasq)"]
-        interval: 10s
-        timeout: 5s
-        retries: 3
-        start_period: 5s
-  ```
-  Where `<dns_log_only>` = `"1"` if `dns_mode == "log-only"` else `"0"`. `{{NETGUARD_SYSCTLS}}` is the sysctls block from below if Prompt 2 enabled AND Prompt 1 enabled (sysctls live on netguard, the netns owner).
-
-  **`{{NETGUARD_PORTS_BLOCK}}`** — empty unless `persisted_publish_ports` is non-empty AND Prompt 1 is enabled. When non-empty, render as long-form YAML using the parsed port objects (`target`, `published`, `host_ip`, `protocol`, `mode`). Omit `host_ip` if `"0.0.0.0"` (Compose default). Omit `mode` if `"ingress"` (Compose default for non-swarm). Example for two ports:
-  ```yaml
-      ports:
-        - target: 3000
-          published: "3000"
-          protocol: tcp
-        - target: 8080
-          published: "8080"
-          protocol: tcp
-  ```
-  If the ports were detected via grep fallback (`detected_hermit_ports_unparsed=true`) and no parsed shape is available, leave `{{NETGUARD_PORTS_BLOCK}}` empty and tell the operator: "Could not parse port shapes from the compose config — manually add your `ports:` block to `hermit-netguard` in the rendered overlay and delete it from the base file."
-- `{{HERMIT_NETWORK_MODE}}` — empty unless Prompt 1 enabled. When enabled:
-  ```yaml
-      network_mode: "service:hermit-netguard"
-      depends_on:
-        hermit-netguard:
-          condition: service_healthy
-  ```
-- `{{HERMIT_RESOURCE_BOUNDS}}` — empty unless Prompt 2 enabled. When enabled:
-  ```yaml
-      mem_limit: 4g
-      memswap_limit: 4g
-      cpus: 2.0
-  ```
-  (Custom values substituted if operator provided them.)
-- `{{HERMIT_SYSCTLS_ON_HERMIT}}` — sysctls block from below ONLY if Prompt 2 enabled, `sysctls_enabled` is true, AND Prompt 1 is OFF. (When Prompt 1 is on, sysctls go on netguard via `{{NETGUARD_SYSCTLS}}`.)
-- `{{HERMIT_AUDIT_ENV}}` — empty unless Prompt 3 enabled. When enabled:
-  ```yaml
-      environment:
-        - HERMIT_PLUGIN_INSTALL_AUDIT=1
-  ```
-
-The shared sysctls block (used in either `{{NETGUARD_SYSCTLS}}` or `{{HERMIT_SYSCTLS_ON_HERMIT}}`):
-
-```yaml
-      sysctls:
-        - net.ipv4.conf.all.accept_redirects=0
-        - net.ipv4.conf.all.send_redirects=0
-        - net.ipv4.conf.all.accept_source_route=0
-        - net.ipv4.conf.default.accept_redirects=0
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/render-security-overlay.ts render <PROJECT_ROOT> <<'HERMIT_SEC_JSON'
+{
+  "network": { "subnet": "...", "gateway": "...", "netguardIp": "..." },
+  "toggles": {
+    "lan":       { "enabled": true, "dnsMode": "log-only" | "enforce" },
+    "resources": { "enabled": true, "memLimit": "4g", "memswapLimit": "4g", "cpus": 2.0, "sysctlsEnabled": true },
+    "audit":     { "enabled": true }
+  },
+  "publishPorts": [ { "target": 3000, "published": "3000", "protocol": "tcp", "host_ip": "0.0.0.0", "mode": "ingress" } ],
+  "lanAllowlist": [...],
+  "fleetDomains": [...],
+  "additionalDomains": [...]
+}
+HERMIT_SEC_JSON
 ```
 
-#### 6c. Write Dockerfile + entrypoint + nftables + dnsmasq files (only if Prompt 1 enabled)
+Notes:
+- `network` is required only when `toggles.lan.enabled`. The script places sysctls on netguard when LAN is on, on hermit when LAN is off (Prompt 2 only). `host_ip: "0.0.0.0"` and `mode: "ingress"` (Compose defaults) are omitted from rendered port entries.
+- If base ports were detected via the grep fallback (`detected_hermit_ports_unparsed=true`) with no parsed shape, pass `publishPorts: []` and tell the operator: "Could not parse port shapes from the compose config — manually add your `ports:` block to `hermit-netguard` in the rendered overlay and delete it from the base file."
+- The script prints `{ "written": [...] }`.
 
-Copy from `state-templates/docker/security/` into `.claude-code-hermit/docker/`:
+#### 6c. Copy the netguard Dockerfile + entrypoint (only if Prompt 1 enabled)
+
+`render` (6b) already wrote `nftables.conf` + `dnsmasq.allowlist`. Copy the two static netguard files from `state-templates/docker/security/` into `.claude-code-hermit/docker/`:
 
 - `Dockerfile.hermit-netguard.template` → `Dockerfile.hermit-netguard`
 - `netguard-entrypoint.sh.template` → `netguard-entrypoint.sh` (chmod +x)
-- `nftables.conf.template` → `nftables.conf`, substituting:
-  - `{{LAN_ALLOWLIST_RULES}}` → for each entry in `lan_allowlist`, render `        ip daddr <entry> accept` (8-space indent matching the chain body). Empty string if no entries.
-  - `{{DNSMASQ_UID}}` → the literal string `100` (Alpine dnsmasq's static UID — see step 6a).
-- `dnsmasq.allowlist.template` → `dnsmasq.allowlist`, substituting:
-  - `{{FLEET_DOMAINS}}` → for each fleet domain, render `server=/<domain>/1.1.1.1` with a comment line above grouping by source plugin. Empty string if no entries.
-  - `{{ADDITIONAL_DOMAINS}}` → for each operator-added domain, render `server=/<domain>/1.1.1.1`. Empty string if no entries.
 
-After all files are copied, force a fresh netguard image build:
+After both are copied, force a fresh netguard image build:
 
 ```bash
 timeout 180s docker compose -f docker-compose.hermit.yml -f docker-compose.security.yml build --no-cache hermit-netguard
@@ -449,83 +360,11 @@ If operator chose to restart now AND container was running before this skill (an
    Then stop.
 ### 8. Verify
 
-Run the verification block via `docker exec hermit sh -c '...'`. The hermit base image has `bun`, `jq`, `curl`, and glibc (`getent`) — no `python3`, `nc`, or `nslookup`. Use bun and getent.
+Stream the static verification script into the live container. It is placeholder-free (hardcoded probe values) and uses only tools the hermit base image ships — `bun`, `jq`, `curl`, glibc `getent` (no `python3`, `nc`, or `nslookup`):
 
 ```bash
 docker compose -f docker-compose.hermit.yml -f docker-compose.security.yml \
-  exec -T hermit sh -s <<'VERIFY_EOF'
-set +e
-echo "=== Baseline (v1.0.26 — should always be on) ==="
-grep -E '^Cap(Eff|Bnd)' /proc/self/status
-grep NoNewPrivs /proc/self/status
-echo "pids.max: $(cat /sys/fs/cgroup/pids.max)"
-
-echo
-echo "=== LAN containment ==="
-bun -e '
-const s = require("net").connect({ host: "192.168.1.1", port: 22, timeout: 2000 });
-s.on("connect", () => { console.error("connected"); process.exit(0); });
-s.on("timeout", () => { console.error("timed out"); process.exit(1); });
-s.on("error", (e) => {
-  console.error(e.code === "ECONNREFUSED" ? "refused"
-    : e.code === "ENETUNREACH" || e.code === "EHOSTUNREACH" ? "Network is unreachable"
-    : String(e));
-  process.exit(1);
-});
-' 2>&1 \
-  | grep -qE 'timed out|refused|Network is unreachable' \
-  && echo "  LAN-block:    OK (192.168.1.1:22 unreachable)" \
-  || echo "  LAN-block:    NOT BLOCKED (compromised hermit could reach LAN)"
-
-echo
-echo "=== DNS policy ==="
-getent hosts api.anthropic.com >/dev/null \
-  && echo "  DNS-allow:    OK (api.anthropic.com resolves)" \
-  || echo "  DNS-allow:    FAIL (allowlisted domain does not resolve)"
-_dns_err=$(mktemp)
-trap 'rm -f "$_dns_err"' EXIT
-timeout 2s bun -e 'require("dns").lookup("example.com", (e) => { if (e) { console.error(e.code === "ENOTFOUND" ? "Name or service not known" : String(e)); process.exit(1); } console.log("resolved"); });' >/dev/null 2>"$_dns_err"
-dns_rc=$?
-if [ $dns_rc -eq 124 ]; then
-  echo "  DNS-block:    FAIL — query timed out (likely DNS leak; no-resolv missing or upstream unreachable)"
-elif grep -qE 'Name or service not known|nodename nor servname' "$_dns_err"; then
-  echo "  DNS-block:    OK (example.com NXDOMAIN — policy applies)"
-else
-  echo "  DNS-block:    FAIL — example.com resolved or unexpected error"
-fi
-bun -e '
-const sock = require("dgram").createSocket("udp4");
-// Hand-crafted DNS query for example.com type A. Using Buffer.from(hex) avoids
-// escape-processing pitfalls when this SKILL travels through model -> shell -> bun.
-// Layout: header(12B: id=1234 flags=0100 qdcount=1 the rest 0) + qname(7example3com0) + qtype 0001 + qclass 0001
-const q = Buffer.from("123401000001000000000000076578616d706c6503636f6d0000010001", "hex");
-const timer = setTimeout(() => { console.log("no-response (timeout)"); sock.close(); }, 2000);
-sock.on("message", (resp) => {
-  clearTimeout(timer);
-  const rcode = resp[3] & 0x0f;
-  console.log(rcode === 3 ? "NXDOMAIN" : "rcode=" + rcode);
-  sock.close();
-});
-sock.on("error", (e) => { clearTimeout(timer); console.log("no-response (" + e + ")"); sock.close(); });
-sock.send(q, 53, "8.8.8.8");
-' | grep -q NXDOMAIN \
-  && echo "  DNS-redirect: OK (port-53 redirected even with explicit upstream)" \
-  || echo "  DNS-redirect: NOT ENFORCED (or in log-only mode — expected)"
-
-echo
-echo "=== Resource bounds + sysctls ==="
-echo "  memory.max:   $(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo 'unset')"
-[ -r /proc/sys/net/ipv4/conf/all/accept_redirects ] \
-  && [ "$(cat /proc/sys/net/ipv4/conf/all/accept_redirects)" = "0" ] \
-  && echo "  sysctls:      OK (ICMP redirects disabled)" \
-  || echo "  sysctls:      not active (host mode, or Prompt 2 off)"
-
-echo
-echo "=== Audit log ==="
-test -f "${AGENT_DIR:-/home/claude/project/.claude-code-hermit}/state/plugin-installs.jsonl" \
-  && echo "  Audit log:    OK ($(wc -l < ${AGENT_DIR:-/home/claude/project/.claude-code-hermit}/state/plugin-installs.jsonl) entries)" \
-  || echo "  Audit log:    not yet written (no plugin installs since last boot)"
-VERIFY_EOF
+  exec -T hermit sh -s < "${CLAUDE_PLUGIN_ROOT}/state-templates/docker/security/verify-security.sh"
 ```
 
 Surface the output to the operator. Suggest: "Run `/claude-code-hermit:hermit-doctor` to also verify the docker-security check shows green."

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -323,8 +323,10 @@ The script prints `{ "written": [...], "entrypointCopied": true, "manifestSeed":
 
 **Record the template baselines in the manifest** (arms the `hermit-evolve` drift signals) by piping `report.manifestSeed` — emitted with absolute paths and the current plugin version — straight into `manifest-seed.ts`. **Do not hand-compute the hashes.**
 
+Pipe **only the value of the `manifestSeed` field** (the `{ "pluginVersion", "entries" }` object): NOT the whole render stdout envelope. `manifest-seed.ts` expects a top-level `{pluginVersion, entries}`; handing it the full `{written, entrypointCopied, manifestSeed}` object seeds no baselines (the drift signals silently never arm).
+
 ```bash
-echo '<report.manifestSeed>' | bun ${CLAUDE_PLUGIN_ROOT}/scripts/manifest-seed.ts <PROJECT_ROOT>/.claude-code-hermit
+echo '<the manifestSeed object only: {"pluginVersion":...,"entries":[...]}>' | bun ${CLAUDE_PLUGIN_ROOT}/scripts/manifest-seed.ts <PROJECT_ROOT>/.claude-code-hermit
 ```
 
 The `manifestSeed` payload deliberately hashes the **on-disk rendered** entrypoint (copied verbatim, so its hash equals the upstream template's — lets `hermit-evolve` Step 5c manage it as a boot-critical file) and the two **upstream** `.template` files (never the rendered output, which differs from upstream forever due to substitution — lets Step 10 report upstream drift without false positives). `manifest-seed.ts` preserves every other manifest key (`templates/`/`bin/` baselines, sibling-hermit keys) and refuses to overwrite a present-but-corrupt manifest.

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -110,45 +110,24 @@ Read `.claude-code-hermit/config.json` and extract:
 - `agent_name`
 - Detect project path from `pwd`
 
-Do NOT set `AGENT_HOOK_PROFILE` in `config.json` `env` — it stays as `standard` (the host default). The strict profile is rendered into the docker-compose environment block in step 4 via `{{AGENT_HOOK_PROFILE}}`.
+Do NOT set `AGENT_HOOK_PROFILE` in `config.json` `env` — it stays as `standard` (the host default). The strict profile is rendered into the docker-compose environment block at Step 7b.6 via the `agentHookProfile` render input.
 
-### 4. Template placeholder reference (rendering deferred to Step 7b.6)
+### 4. Template inputs (rendering deferred to Step 7b.6)
 
-> **Execution moved.** Template rendering is now performed at Step 7b.6 — AFTER plugin resolution (Step 7b) and apt-package union (Step 7b.packages) have finalized `docker.packages`. The placeholder definitions are documented here for reference; the actual `Read` + `Write` calls happen later, with all values resolved.
->
-> Why: `{{PACKAGES_BLOCK}}` substitution depends on `docker.packages`, which isn't finalized until Step 7b.packages. Rendering at Step 4 (the original position) consumed an empty/pre-resolution package list. Channel placeholders (`{{CHANNEL_ENV_LINES}}`, `{{CHANNEL_VOLUME_LINES}}`) similarly depend on Step 7 channel-token configuration.
+> **Execution moved.** `scripts/render-docker-templates.ts` renders the three base files at Step 7b.6 — AFTER plugin resolution (Step 7b) and apt-package union (Step 7b.packages) have finalized `docker.packages`, and Step 7 has configured channels. Rendering earlier consumed an empty package list. Do NOT read or write template files here; just collect the semantic inputs the render call needs.
 
-The three templates live in `${CLAUDE_SKILL_DIR}/../../state-templates/docker/`. Placeholder substitution rules per file (do NOT read or write here — all file I/O happens at Step 7b.6):
+The render script derives every `{{PLACEHOLDER}}` internally and fails loud (writes nothing) if any survives. Assemble this input object as choices resolve, to be piped on stdin at Step 7b.6:
 
-**Dockerfile.hermit** (from `Dockerfile.hermit.template`):
-- `{{PACKAGES_BLOCK}}` — if `docker.packages` is non-empty, replace with:
-  ```
-  # Project-specific packages (from config.json docker.packages)
-  # To modify: /hermit-settings docker, then rebuild
-  RUN apt-get update && apt-get install -y --no-install-recommends \
-        <space-separated packages> && \
-      rm -rf /var/lib/apt/lists/*
-  ```
-  If empty, remove the `{{PACKAGES_BLOCK}}` line entirely. The block is placed after the npm install layer so changing project packages doesn't bust the npm cache.
-
-**docker-entrypoint.hermit.sh** (from `docker-entrypoint.hermit.sh.template`):
-- No placeholder substitution needed — the entrypoint resolves the tmux session name from
-  `config.json` at runtime. Copy verbatim; the resulting file is correct without any edits.
-
-**docker-compose.hermit.yml** (from `docker-compose.hermit.yml.template`):
-- `{{AUTH_ENV_LINE}}` — If apikey: `      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}\n`. If oauth: empty string (remove the line entirely — OAuth credentials live in `.credentials.json` inside the named volume, written by `claude /login`).
-- `{{CHANNEL_ENV_LINES}}` — for each enabled channel, derive the `*_STATE_DIR` value from `channels.<name>.state_dir` in config.json and add an indented environment line:
-  - `      - DISCORD_STATE_DIR=${PWD}/.claude.local/channels/discord`
-  - `      - TELEGRAM_STATE_DIR=${PWD}/.claude.local/channels/telegram`
-  Remove `{{CHANNEL_ENV_LINES}}` entirely if no channels configured.
-- `{{CHANNEL_VOLUME_LINES}}` — for each configured channel, add an indented volume bind-mount that maps the project-local state dir into the container's `~/.claude/channels/` path. This ensures channel plugin writes stay inside the project tree (no permission prompts with `bypassPermissions`):
-  - `      - ${PWD}/.claude.local/channels/discord:/home/claude/.claude/channels/discord`
-  - `      - ${PWD}/.claude.local/channels/telegram:/home/claude/.claude/channels/telegram`
-  Remove `{{CHANNEL_VOLUME_LINES}}` entirely if no channels configured.
-- `{{AGENT_HOOK_PROFILE}}` — always `strict` for Docker (enforces `always_on` deny patterns inside the container)
-- `{{TMUX_SESSION_NAME}}` — resolved session name
-- `{{NETWORK_MODE_LINE}}` — If `docker.network_mode` is `"host"`: replace with `    # WARNING: host networking exposes all host-local services to the container.\n    network_mode: host`. If `"bridge"` (default): remove the line entirely (bridge is Docker's default — no directive needed).
-- **Git identity:** Use `gitconfigExists` from the Step 1 preflight. If false, remove the `.gitconfig` bind-mount line from the rendered file and add a note in the summary: "No ~/.gitconfig found — git commits inside the container will have no author identity. Create one on the host and re-run docker-setup, or set git config manually inside the container."
+- `packages` — the finalized `docker.packages` array (Step 7b.packages). Empty array → no project-package layer.
+- `auth` — `"api-key"` or `"oauth-token"` (Step 2). OAuth adds no auth env line; credentials live in `.credentials.json` in the named volume, written by `claude /login`.
+- `channels` — `{ envLines: [...], volumeLines: [...] }`, one entry per enabled channel (Step 7). Pass the line **bodies** (the script owns the `      - ` indent):
+  - env body: `<VAR>_STATE_DIR=${PWD}/.claude.local/channels/<plugin>` (VAR = `DISCORD` / `TELEGRAM`)
+  - volume body: `${PWD}/.claude.local/channels/<plugin>:/home/claude/.claude/channels/<plugin>` (keeps channel writes inside the project tree — no permission prompts under `bypassPermissions`)
+  - No channels → both arrays empty.
+- `agentHookProfile` — always `"strict"` for Docker (enforces `always_on` deny patterns inside the container).
+- `tmuxSessionName` — the session name resolved in Step 3.
+- `networkMode` — `docker.network_mode` (`"bridge"` or `"host"`, Step 2).
+- `gitIdentityMount` — the Step 1 preflight `gitconfigExists`. When **false**, the `.gitconfig` bind-mount is dropped and you must add to the summary: "No ~/.gitconfig found — git commits inside the container will have no author identity. Create one on the host and re-run docker-setup, or set git config manually inside the container."
 
 ### 5. Auto-memory seed
 
@@ -324,32 +303,31 @@ After plugin selection is finalized, union the two sources of apt package candid
 
 ### 7b.6. Render templates (deferred from Step 4)
 
-Now that `docker.packages` (Step 7b.packages), `docker.recommended_plugins` (Step 7b), channel state dirs (Step 7), and the auth/network choices (Step 2) are all finalized, perform the template rendering described in Step 4 above. Write the three rendered files to project root:
+Now that `docker.packages` (Step 7b.packages), channel state dirs (Step 7), and the auth/network choices (Step 2) are finalized, render the three base files in **one** call. `render-docker-templates.ts` derives every `{{PLACEHOLDER}}`, renders `Dockerfile.hermit` + `docker-compose.hermit.yml`, `cp`-copies the entrypoint verbatim, and fails loud (exit 1, nothing written) if any placeholder survives. Anchor the argv to the **absolute** `<PROJECT_ROOT>` (Step 1) — cwd can drift after earlier `docker compose` / `tmux` calls. Pipe the Step 4 input object on stdin:
 
-- `Dockerfile.hermit` — substitute `{{PACKAGES_BLOCK}}` with the finalized `docker.packages`.
-- `docker-entrypoint.hermit.sh` — **copy with `cp`, do not regenerate it by hand** (it is a large static file with no placeholders; the session name is resolved from `config.json` at container startup). Run: `cp "${CLAUDE_SKILL_DIR}/../../state-templates/docker/docker-entrypoint.hermit.sh.template" <PROJECT_ROOT>/docker-entrypoint.hermit.sh`. The copied bytes are correct without any edits.
-- `docker-compose.hermit.yml` — substitute `{{AUTH_ENV_LINE}}`, `{{CHANNEL_ENV_LINES}}`, `{{CHANNEL_VOLUME_LINES}}`, `{{AGENT_HOOK_PROFILE}}`, `{{TMUX_SESSION_NAME}}`, `{{NETWORK_MODE_LINE}}`, plus the git-identity bind-mount handling.
-
-Use the placeholder rules from Step 4 verbatim.
-
-**Record docker template baselines in the manifest** (arms the `hermit-evolve` drift signals) via `manifest-seed.ts` — **do not hand-compute the hashes**. Read the current plugin version from `${CLAUDE_SKILL_DIR}/../../.claude-plugin/plugin.json`. Anchor the state-dir argv and the entrypoint file path to the **absolute project root** (verified in Step 1), not a cwd-relative path — cwd can drift after the `docker compose` / `tmux` calls earlier in this skill. Using `<PROJECT_ROOT>` for that absolute path, run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/manifest-seed.ts <PROJECT_ROOT>/.claude-code-hermit` with this JSON on stdin:
-
-```json
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/render-docker-templates.ts <PROJECT_ROOT> <<'HERMIT_RENDER_JSON'
 {
-  "pluginVersion": "<version>",
-  "entries": [
-    { "key": "docker/docker-entrypoint.hermit.sh", "file": "<PROJECT_ROOT>/docker-entrypoint.hermit.sh" },
-    { "key": "docker/docker-compose.hermit.yml.template", "file": "${CLAUDE_PLUGIN_ROOT}/state-templates/docker/docker-compose.hermit.yml.template" },
-    { "key": "docker/Dockerfile.hermit.template", "file": "${CLAUDE_PLUGIN_ROOT}/state-templates/docker/Dockerfile.hermit.template" }
-  ]
+  "packages": [...],
+  "auth": "oauth-token" | "api-key",
+  "channels": { "envLines": [...], "volumeLines": [...] },
+  "agentHookProfile": "strict",
+  "tmuxSessionName": "<resolved>",
+  "networkMode": "bridge" | "host",
+  "gitIdentityMount": true | false
 }
+HERMIT_RENDER_JSON
 ```
 
-The **file each key hashes is deliberate**:
-- `docker/docker-entrypoint.hermit.sh` hashes the **on-disk rendered** entrypoint at the project root — it is copied verbatim, so its hash equals the upstream template's. It is anchored to `<PROJECT_ROOT>` (absolute) so it resolves correctly regardless of the current working directory. This baseline lets `hermit-evolve` Step 5c manage the entrypoint as a boot-critical file (keep operator edits, refresh when upstream moves).
-- The two `.template` keys hash the **upstream templates**, never the rendered output — they render with placeholder substitution, so rendered ≠ upstream forever. This lets `hermit-evolve` Step 10 report upstream drift (`status: changed`) without false positives from substitution.
+The script prints `{ "written": [...], "entrypointCopied": true, "manifestSeed": {...} }`. If `gitIdentityMount` was false, surface the summary note from Step 4.
 
-The script preserves every other manifest key (the `templates/`/`bin/` baselines `hatch` seeded, sibling-hermit keys) and refuses to overwrite a present-but-corrupt manifest.
+**Record the template baselines in the manifest** (arms the `hermit-evolve` drift signals) by piping `report.manifestSeed` — emitted with absolute paths and the current plugin version — straight into `manifest-seed.ts`. **Do not hand-compute the hashes.**
+
+```bash
+echo '<report.manifestSeed>' | bun ${CLAUDE_PLUGIN_ROOT}/scripts/manifest-seed.ts <PROJECT_ROOT>/.claude-code-hermit
+```
+
+The `manifestSeed` payload deliberately hashes the **on-disk rendered** entrypoint (copied verbatim, so its hash equals the upstream template's — lets `hermit-evolve` Step 5c manage it as a boot-critical file) and the two **upstream** `.template` files (never the rendered output, which differs from upstream forever due to substitution — lets Step 10 report upstream drift without false positives). `manifest-seed.ts` preserves every other manifest key (`templates/`/`bin/` baselines, sibling-hermit keys) and refuses to overwrite a present-but-corrupt manifest.
 
 ### 7c. Write Docker settings to config.json
 

--- a/plugins/claude-code-hermit/state-templates/docker/security/nftables.conf.template
+++ b/plugins/claude-code-hermit/state-templates/docker/security/nftables.conf.template
@@ -4,11 +4,11 @@
 # `network_mode: "service:hermit-netguard"`, so every rule here applies
 # to hermit's outbound traffic.
 #
-# {{LAN_ALLOWLIST_RULES}} is rendered at overlay-render time from
+# LAN_ALLOWLIST_RULES is rendered at overlay-render time from
 # docker.security.network.lan_allowlist (merged with fleet-plugin LAN
 # suggestions confirmed by the operator during /docker-security).
 #
-# {{DNSMASQ_UID}} is hardcoded to 100 by the wizard (Alpine's dnsmasq
+# DNSMASQ_UID is hardcoded to 100 by the wizard (Alpine's dnsmasq
 # package's static UID). CRITICAL: this exempts dnsmasq's OWN upstream
 # queries from the port-53 redirect — without it, dnsmasq would receive
 # its own outbound queries in a loop and DNS would stop working.

--- a/plugins/claude-code-hermit/state-templates/docker/security/verify-security.sh
+++ b/plugins/claude-code-hermit/state-templates/docker/security/verify-security.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+# Live security-posture verification for /docker-security Step 8.
+# Placeholder-free by design (hardcoded probe values). The wizard runs it via:
+#   docker compose ... exec -T hermit sh -s < verify-security.sh
+# The hermit base image has bun, jq, curl, and glibc (getent) — no python3,
+# nc, or nslookup — so every probe below uses bun and getent.
+set +e
+echo "=== Baseline (v1.0.26 — should always be on) ==="
+grep -E '^Cap(Eff|Bnd)' /proc/self/status
+grep NoNewPrivs /proc/self/status
+echo "pids.max: $(cat /sys/fs/cgroup/pids.max)"
+
+echo
+echo "=== LAN containment ==="
+bun -e '
+const s = require("net").connect({ host: "192.168.1.1", port: 22, timeout: 2000 });
+s.on("connect", () => { console.error("connected"); process.exit(0); });
+s.on("timeout", () => { console.error("timed out"); process.exit(1); });
+s.on("error", (e) => {
+  console.error(e.code === "ECONNREFUSED" ? "refused"
+    : e.code === "ENETUNREACH" || e.code === "EHOSTUNREACH" ? "Network is unreachable"
+    : String(e));
+  process.exit(1);
+});
+' 2>&1 \
+  | grep -qE 'timed out|refused|Network is unreachable' \
+  && echo "  LAN-block:    OK (192.168.1.1:22 unreachable)" \
+  || echo "  LAN-block:    NOT BLOCKED (compromised hermit could reach LAN)"
+
+echo
+echo "=== DNS policy ==="
+getent hosts api.anthropic.com >/dev/null \
+  && echo "  DNS-allow:    OK (api.anthropic.com resolves)" \
+  || echo "  DNS-allow:    FAIL (allowlisted domain does not resolve)"
+_dns_err=$(mktemp)
+trap 'rm -f "$_dns_err"' EXIT
+timeout 2s bun -e 'require("dns").lookup("example.com", (e) => { if (e) { console.error(e.code === "ENOTFOUND" ? "Name or service not known" : String(e)); process.exit(1); } console.log("resolved"); });' >/dev/null 2>"$_dns_err"
+dns_rc=$?
+if [ $dns_rc -eq 124 ]; then
+  echo "  DNS-block:    FAIL — query timed out (likely DNS leak; no-resolv missing or upstream unreachable)"
+elif grep -qE 'Name or service not known|nodename nor servname' "$_dns_err"; then
+  echo "  DNS-block:    OK (example.com NXDOMAIN — policy applies)"
+else
+  echo "  DNS-block:    FAIL — example.com resolved or unexpected error"
+fi
+bun -e '
+const sock = require("dgram").createSocket("udp4");
+// Hand-crafted DNS query for example.com type A. Using Buffer.from(hex) avoids
+// escape-processing pitfalls when this SKILL travels through model -> shell -> bun.
+// Layout: header(12B: id=1234 flags=0100 qdcount=1 the rest 0) + qname(7example3com0) + qtype 0001 + qclass 0001
+const q = Buffer.from("123401000001000000000000076578616d706c6503636f6d0000010001", "hex");
+const timer = setTimeout(() => { console.log("no-response (timeout)"); sock.close(); }, 2000);
+sock.on("message", (resp) => {
+  clearTimeout(timer);
+  const rcode = resp[3] & 0x0f;
+  console.log(rcode === 3 ? "NXDOMAIN" : "rcode=" + rcode);
+  sock.close();
+});
+sock.on("error", (e) => { clearTimeout(timer); console.log("no-response (" + e + ")"); sock.close(); });
+sock.send(q, 53, "8.8.8.8");
+' | grep -q NXDOMAIN \
+  && echo "  DNS-redirect: OK (port-53 redirected even with explicit upstream)" \
+  || echo "  DNS-redirect: NOT ENFORCED (or in log-only mode — expected)"
+
+echo
+echo "=== Resource bounds + sysctls ==="
+echo "  memory.max:   $(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo 'unset')"
+[ -r /proc/sys/net/ipv4/conf/all/accept_redirects ] \
+  && [ "$(cat /proc/sys/net/ipv4/conf/all/accept_redirects)" = "0" ] \
+  && echo "  sysctls:      OK (ICMP redirects disabled)" \
+  || echo "  sysctls:      not active (host mode, or Prompt 2 off)"
+
+echo
+echo "=== Audit log ==="
+test -f "${AGENT_DIR:-/home/claude/project/.claude-code-hermit}/state/plugin-installs.jsonl" \
+  && echo "  Audit log:    OK ($(wc -l < ${AGENT_DIR:-/home/claude/project/.claude-code-hermit}/state/plugin-installs.jsonl) entries)" \
+  || echo "  Audit log:    not yet written (no plugin installs since last boot)"

--- a/plugins/claude-code-hermit/tests/docker-security-templates.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-security-templates.test.ts
@@ -21,6 +21,10 @@ const entrypoint = read('state-templates', 'docker', 'security', 'netguard-entry
 const skill = read('skills', 'docker-security', 'SKILL.md');
 const allowlist = read('state-templates', 'docker', 'security', 'dnsmasq.allowlist.template');
 const docs = read('docs', 'docker-security.md');
+// Step 8's verification heredoc was extracted verbatim into a static file the
+// skill streams via `exec -T hermit sh -s < verify-security.sh`. The runtime
+// probe assertions moved here with it.
+const verify = read('state-templates', 'docker', 'security', 'verify-security.sh');
 
 // -------------------------------------------------------
 // Entrypoint: no tee-piping, no DNSMASQ_PID=$! capture
@@ -58,27 +62,12 @@ describe('netguard-entrypoint.sh.template', () => {
 // SKILL.md contract assertions
 // -------------------------------------------------------
 describe('docker-security SKILL.md', () => {
-  // cap_add list (exact match — fails loud if any cap is missing,
-  // reordered, or extras are added without test coverage)
-  test('SKILL.md: cap_add list is [NET_ADMIN, NET_BIND_SERVICE, SETUID, SETGID]', () => {
-    expect(skill).toContain('cap_add: [NET_ADMIN, NET_BIND_SERVICE, SETUID, SETGID]');
-  });
-
-  test('SKILL.md: healthcheck has start_period', () => {
-    expect(skill).toContain('start_period:');
-  });
+  // cap_add / start_period moved out of the SKILL into the rendered overlay when
+  // template rendering was extracted to render-security-overlay.ts — those two
+  // assertions now live in tests/render-security-overlay.test.ts.
 
   test("SKILL.md: no 'state:/var/log/netguard' bind mount (regression: rootless)", () => {
     expect(skill).not.toContain('state:/var/log/netguard');
-  });
-
-  // Hardened DNS-block verifier
-  test("SKILL.md: DNS-block check uses 'timeout 2s' (catches timeout vs NXDOMAIN)", () => {
-    expect(skill).toContain('timeout 2s bun -e');
-  });
-
-  test('SKILL.md: DNS-block check classifies timeout explicitly (not just grep-on-stderr)', () => {
-    expect(skill).toContain('query timed out');
   });
 
   // Python retired from the Docker layer (bun migration WP9) — the base image
@@ -88,15 +77,37 @@ describe('docker-security SKILL.md', () => {
     expect(invocations).toEqual([]);
   });
 
-  test('SKILL.md: verification block uses bun for LAN/DNS checks', () => {
-    expect(skill).toContain('require("net").connect');
-    expect(skill).toContain('require("dns").lookup');
-    expect(skill).toContain('require("dgram").createSocket');
-  });
-
-  // --no-cache netguard rebuild
+  // --no-cache netguard rebuild (operational step 6c — stays in the skill)
   test('SKILL.md: step 6c forces --no-cache netguard build (prevents stale image on upgrade)', () => {
     expect(skill).toContain('build --no-cache hermit-netguard');
+  });
+});
+
+// -------------------------------------------------------
+// verify-security.sh: the extracted Step 8 verification heredoc.
+// Assertions retargeted here from the in-SKILL block.
+// -------------------------------------------------------
+describe('verify-security.sh', () => {
+  test('verify: placeholder-free (streamed verbatim, never rendered)', () => {
+    expect(verify).not.toMatch(/\{\{[A-Z][A-Z0-9_]*\}\}/);
+  });
+
+  // Hardened DNS-block verifier
+  test("verify: DNS-block check uses 'timeout 2s' (catches timeout vs NXDOMAIN)", () => {
+    expect(verify).toContain('timeout 2s bun -e');
+  });
+
+  test('verify: DNS-block check classifies timeout explicitly (not just grep-on-stderr)', () => {
+    expect(verify).toContain('query timed out');
+  });
+
+  test('verify: uses bun for LAN/DNS checks (no nc / nslookup invocations)', () => {
+    expect(verify).toContain('require("net").connect');
+    expect(verify).toContain('require("dns").lookup');
+    expect(verify).toContain('require("dgram").createSocket');
+    // python3 appears only in the header note; assert no invocation of it.
+    const py = verify.split('\n').filter((l) => l.includes('python3') && !l.includes('no python3'));
+    expect(py).toEqual([]);
   });
 });
 

--- a/plugins/claude-code-hermit/tests/manifest-seed.test.ts
+++ b/plugins/claude-code-hermit/tests/manifest-seed.test.ts
@@ -170,11 +170,24 @@ describe('manifest-seed: skill-call source-path contract', () => {
     expect(hatch).toContain('state-templates/bin');
   });
 
-  test('docker-setup hashes the upstream .template files for the two substituted keys', () => {
+  test('docker-setup delegates rendering + pipes the emitted manifestSeed', () => {
+    // The upstream-.template-vs-on-disk-entrypoint source-path contract now lives
+    // in render-docker-templates.ts, which emits the manifestSeed payload; it is
+    // asserted behaviorally in tests/render-docker-templates.test.ts. Here we only
+    // check the skill still routes rendering + manifest seeding through the scripts.
     const docker = read('skills/docker-setup/SKILL.md');
+    expect(docker).toContain('render-docker-templates.ts');
     expect(docker).toContain('manifest-seed.ts');
-    expect(docker).toContain('state-templates/docker/docker-compose.hermit.yml.template');
-    expect(docker).toContain('state-templates/docker/Dockerfile.hermit.template');
+  });
+
+  test('render-docker-templates emits upstream .template files for the two substituted keys', () => {
+    const script = read('scripts/render-docker-templates.ts');
+    // Keys ending in .template map to plugin-root upstream templates (never rendered output).
+    expect(script).toContain("'docker/docker-compose.hermit.yml.template'");
+    expect(script).toContain("'docker/Dockerfile.hermit.template'");
+    // The entrypoint key hashes the ON-DISK rendered copy at the project root.
+    expect(script).toContain("'docker/docker-entrypoint.hermit.sh'");
+    expect(script).toContain('entrypointPath');
   });
 
   test('hermit-evolve routes its manifest write through the script', () => {

--- a/plugins/claude-code-hermit/tests/render-docker-templates.test.ts
+++ b/plugins/claude-code-hermit/tests/render-docker-templates.test.ts
@@ -1,0 +1,156 @@
+// End-to-end tests for render-docker-templates.ts — renders the REAL base
+// Docker templates into a tmp dir via the CLI and asserts the property contract
+// (no golden fixtures; the repo style is property assertions).
+//
+// Usage: bun test tests/render-docker-templates.test.ts   (from the plugin root)
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript, PLUGIN_ROOT } from './helpers/run';
+
+const tmpdirs: string[] = [];
+function freshDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-rdt-'));
+  tmpdirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmpdirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+});
+
+const BASE_INPUT = {
+  packages: [] as string[],
+  auth: 'oauth-token' as const,
+  channels: { envLines: [] as string[], volumeLines: [] as string[] },
+  agentHookProfile: 'strict',
+  tmuxSessionName: 'hermit-myproj',
+  networkMode: 'bridge' as const,
+  gitIdentityMount: true,
+};
+
+async function render(dir: string, overrides: Record<string, unknown> = {}) {
+  const input = { ...BASE_INPUT, ...overrides };
+  const r = await runScript('render-docker-templates.ts', { args: [dir], stdin: JSON.stringify(input) });
+  return r;
+}
+
+const dockerfile = (dir: string) => fs.readFileSync(path.join(dir, 'Dockerfile.hermit'), 'utf8');
+const compose = (dir: string) => fs.readFileSync(path.join(dir, 'docker-compose.hermit.yml'), 'utf8');
+
+describe('render-docker-templates.ts', () => {
+  test('renders all three files, exit 0, no {{ }} left', async () => {
+    const dir = freshDir();
+    const r = await render(dir);
+    expect(r.exitCode).toBe(0);
+    expect(dockerfile(dir)).not.toMatch(/\{\{[A-Z][A-Z0-9_]*\}\}/);
+    expect(compose(dir)).not.toMatch(/\{\{[A-Z][A-Z0-9_]*\}\}/);
+    expect(fs.existsSync(path.join(dir, 'docker-entrypoint.hermit.sh'))).toBe(true);
+  });
+
+  test('entrypoint is byte-identical to the template (cp, not regenerate)', async () => {
+    const dir = freshDir();
+    await render(dir);
+    const rendered = fs.readFileSync(path.join(dir, 'docker-entrypoint.hermit.sh'));
+    const template = fs.readFileSync(
+      path.join(PLUGIN_ROOT, 'state-templates', 'docker', 'docker-entrypoint.hermit.sh.template'));
+    expect(rendered.equals(template)).toBe(true);
+  });
+
+  test('packages land in a Dockerfile RUN apt-get block', async () => {
+    const dir = freshDir();
+    await render(dir, { packages: ['libsqlite3-dev', 'ffmpeg'] });
+    const df = dockerfile(dir);
+    expect(df).toContain('# Project-specific packages (from config.json docker.packages)');
+    expect(df).toMatch(/RUN apt-get update && apt-get install -y --no-install-recommends \\\n {6}libsqlite3-dev ffmpeg && \\/);
+  });
+
+  test('empty packages leaves no project-package RUN block', async () => {
+    const dir = freshDir();
+    await render(dir, { packages: [] });
+    expect(dockerfile(dir)).not.toContain('# Project-specific packages');
+  });
+
+  test('network_mode: host is present only for host networking', async () => {
+    const bridgeDir = freshDir();
+    await render(bridgeDir, { networkMode: 'bridge' });
+    expect(compose(bridgeDir)).not.toContain('network_mode: host');
+
+    const hostDir = freshDir();
+    await render(hostDir, { networkMode: 'host' });
+    expect(compose(hostDir)).toContain('network_mode: host');
+  });
+
+  test('api-key auth adds ANTHROPIC_API_KEY env line; oauth does not', async () => {
+    const keyDir = freshDir();
+    await render(keyDir, { auth: 'api-key' });
+    expect(compose(keyDir)).toContain('- ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}');
+
+    const oauthDir = freshDir();
+    await render(oauthDir, { auth: 'oauth-token' });
+    expect(compose(oauthDir)).not.toContain('ANTHROPIC_API_KEY');
+  });
+
+  test('git-identity bind-mount is conditional on gitIdentityMount', async () => {
+    const withDir = freshDir();
+    await render(withDir, { gitIdentityMount: true });
+    expect(compose(withDir)).toContain('- ${HOME}/.gitconfig:/home/claude/.gitconfig:ro');
+
+    const withoutDir = freshDir();
+    await render(withoutDir, { gitIdentityMount: false });
+    expect(compose(withoutDir)).not.toContain('${HOME}/.gitconfig');
+  });
+
+  test('channel volume + env lines render at exact 6-space indent', async () => {
+    const dir = freshDir();
+    await render(dir, {
+      channels: {
+        envLines: ['DISCORD_STATE_DIR=${PWD}/.claude.local/channels/discord'],
+        volumeLines: ['${PWD}/.claude.local/channels/discord:/home/claude/.claude/channels/discord'],
+      },
+    });
+    const c = compose(dir);
+    // Exact-indent assertions — YAML breaks silently on wrong indent.
+    expect(c).toMatch(/^ {6}- \$\{PWD\}\/\.claude\.local\/channels\/discord:\/home\/claude\/\.claude\/channels\/discord$/m);
+    expect(c).toMatch(/^ {6}- DISCORD_STATE_DIR=\$\{PWD\}\/\.claude\.local\/channels\/discord$/m);
+  });
+
+  test('no channels leaves no channel state-dir wiring', async () => {
+    const dir = freshDir();
+    await render(dir, { channels: { envLines: [], volumeLines: [] } });
+    expect(compose(dir)).not.toContain('STATE_DIR');
+  });
+
+  test('manifestSeed payload carries absolute paths and current plugin version', async () => {
+    const dir = freshDir();
+    const r = await render(dir);
+    const out = JSON.parse(r.stdout);
+    expect(out.entrypointCopied).toBe(true);
+    expect(out.written).toHaveLength(2);
+    for (const w of out.written) expect(path.isAbsolute(w)).toBe(true);
+
+    const pj = JSON.parse(fs.readFileSync(path.join(PLUGIN_ROOT, '.claude-plugin', 'plugin.json'), 'utf8'));
+    expect(out.manifestSeed.pluginVersion).toBe(pj.version);
+
+    const byKey = Object.fromEntries(out.manifestSeed.entries.map((e: any) => [e.key, e.file]));
+    for (const file of Object.values(byKey)) expect(path.isAbsolute(file as string)).toBe(true);
+    // Entrypoint hashes the on-disk rendered file at the project root; the two
+    // .template keys hash the upstream templates in the plugin.
+    expect(byKey['docker/docker-entrypoint.hermit.sh']).toBe(path.join(dir, 'docker-entrypoint.hermit.sh'));
+    expect(byKey['docker/Dockerfile.hermit.template']).toContain('state-templates/docker/Dockerfile.hermit.template');
+  });
+
+  test('relative project-root argv is resolved to an absolute path', async () => {
+    const dir = freshDir();
+    const rel = path.relative(process.cwd(), dir);
+    const r = await runScript('render-docker-templates.ts', {
+      args: [rel], stdin: JSON.stringify(BASE_INPUT),
+    });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout);
+    for (const w of out.written) expect(path.isAbsolute(w)).toBe(true);
+  });
+});

--- a/plugins/claude-code-hermit/tests/render-security-overlay.test.ts
+++ b/plugins/claude-code-hermit/tests/render-security-overlay.test.ts
@@ -14,7 +14,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
 import {
-  cidrToRange, overlaps, pickSubnet, validateCandidate,
+  cidrToRange, overlaps, pickSubnet, validateCandidate, ipv4SubnetsFromInspect,
 } from '../scripts/render-security-overlay';
 
 const tmpdirs: string[] = [];
@@ -86,6 +86,23 @@ describe('subnet overlap logic', () => {
   test('validateCandidate rejects a colliding /24', () => {
     const r = validateCandidate('172.17.5.0/24', ['172.17.0.0/16']);
     expect(r.chosen).toBeNull();
+  });
+
+  test('validateCandidate normalizes an operator /24 with host bits to its network address', () => {
+    // Docker rejects a subnet whose address has host bits set; the wizard must
+    // persist/render the canonical network address, not the raw operator input.
+    const r = validateCandidate('192.168.5.10/24', ['172.17.0.0/16']);
+    expect(r.chosen).toEqual({ subnet: '192.168.5.0/24', gateway: '192.168.5.1', netguardIp: '192.168.5.2' });
+  });
+
+  test('ipv4SubnetsFromInspect keeps the IPv4 range of a dual-stack network', () => {
+    // `{{range .IPAM.Config}}{{.Subnet}} {{end}}` space-joins every subnet; a
+    // dual-stack net emits IPv4 + IPv6. The IPv4 half must survive so pickSubnet
+    // can't hand back a /24 that overlaps it.
+    expect(ipv4SubnetsFromInspect('172.20.0.0/16 fc00::/64')).toEqual(['172.20.0.0/16']);
+    expect(ipv4SubnetsFromInspect('172.20.0.0/16 172.21.0.0/16')).toEqual(['172.20.0.0/16', '172.21.0.0/16']);
+    expect(ipv4SubnetsFromInspect('fc00::/64')).toEqual([]); // IPv6-only → nothing occupied
+    expect(ipv4SubnetsFromInspect('')).toEqual([]);
   });
 });
 

--- a/plugins/claude-code-hermit/tests/render-security-overlay.test.ts
+++ b/plugins/claude-code-hermit/tests/render-security-overlay.test.ts
@@ -1,0 +1,220 @@
+// Tests for render-security-overlay.ts.
+//
+// Subnet-overlap logic is exercised in-process (no docker). One subprocess test
+// drives the pick-subnet CLI with docker unreachable to assert graceful
+// degrade. The render subcommand renders the REAL security templates into a tmp
+// dir and asserts the property contract (indentation is load-bearing for the
+// compose overlay merge; no golden fixtures).
+//
+// Usage: bun test tests/render-security-overlay.test.ts   (from the plugin root)
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript } from './helpers/run';
+import {
+  cidrToRange, overlaps, pickSubnet, validateCandidate,
+} from '../scripts/render-security-overlay';
+
+const tmpdirs: string[] = [];
+function freshDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-rso-'));
+  tmpdirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmpdirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+});
+
+const CANDIDATES = [
+  '172.28.0.0/24', '172.29.0.0/24', '172.30.0.0/24', '172.31.0.0/24',
+  '10.244.0.0/24', '10.245.0.0/24', '10.246.0.0/24', '10.247.0.0/24',
+];
+
+// -------------------------------------------------------
+// Pure subnet-overlap logic (no docker)
+// -------------------------------------------------------
+describe('subnet overlap logic', () => {
+  test('cidrToRange rejects malformed / out-of-range input', () => {
+    expect(cidrToRange('not-a-cidr')).toBeNull();
+    expect(cidrToRange('172.28.0.0')).toBeNull();      // no prefix
+    expect(cidrToRange('999.0.0.0/24')).toBeNull();    // octet > 255
+    expect(cidrToRange('10.0.0.0/33')).toBeNull();     // prefix > 32
+  });
+
+  test('overlaps detects a /24 inside a /16 and disjoint ranges', () => {
+    const inner = cidrToRange('172.17.5.0/24')!;
+    const outer = cidrToRange('172.17.0.0/16')!;
+    expect(overlaps(inner, outer)).toBe(true);
+    expect(overlaps(cidrToRange('10.0.0.0/24')!, cidrToRange('11.0.0.0/24')!)).toBe(false);
+  });
+
+  test('pickSubnet returns the first candidate when nothing is occupied', () => {
+    const r = pickSubnet(CANDIDATES, []);
+    expect(r.chosen).toEqual({ subnet: '172.28.0.0/24', gateway: '172.28.0.1', netguardIp: '172.28.0.2' });
+    expect(r.allCandidatesCollide).toBe(false);
+  });
+
+  test('pickSubnet skips candidates that overlap an occupied subnet', () => {
+    // Occupy the first three /24s via covering /16s.
+    const occupied = ['172.28.0.0/16', '172.29.0.0/16', '172.30.0.0/16'];
+    const r = pickSubnet(CANDIDATES, occupied);
+    expect(r.chosen!.subnet).toBe('172.31.0.0/24');
+  });
+
+  test('pickSubnet reports allCandidatesCollide when every candidate overlaps', () => {
+    const occupied = CANDIDATES.map((c) => c.replace('/24', '/16'));
+    const r = pickSubnet(CANDIDATES, occupied);
+    expect(r.chosen).toBeNull();
+    expect(r.allCandidatesCollide).toBe(true);
+  });
+
+  test('validateCandidate accepts a non-colliding /24 and derives gateway/netguard', () => {
+    const r = validateCandidate('192.168.50.0/24', ['172.17.0.0/16']);
+    expect(r.chosen).toEqual({ subnet: '192.168.50.0/24', gateway: '192.168.50.1', netguardIp: '192.168.50.2' });
+  });
+
+  test('validateCandidate rejects a non-/24 prefix', () => {
+    const r = validateCandidate('192.168.0.0/16', []);
+    expect(r.chosen).toBeNull();
+    expect(r.allCandidatesCollide).toBe(true);
+  });
+
+  test('validateCandidate rejects a colliding /24', () => {
+    const r = validateCandidate('172.17.5.0/24', ['172.17.0.0/16']);
+    expect(r.chosen).toBeNull();
+  });
+});
+
+// -------------------------------------------------------
+// pick-subnet CLI — graceful degrade when docker is unreachable
+// -------------------------------------------------------
+describe('pick-subnet CLI (docker absent)', () => {
+  test('degrades to first candidate, exits 0, occupied empty', async () => {
+    const dir = freshDir();
+    const r = await runScript('render-security-overlay.ts', {
+      args: ['pick-subnet', dir],
+      // PATH at a nonexistent dir → spawnSync('docker') ENOENTs deterministically
+      // (an empty PATH still hits execvp's built-in /bin:/usr/bin fallback).
+      env: { PATH: '/nonexistent-hermit-test' },
+    });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.occupied).toEqual([]);
+    expect(out.chosen.subnet).toBe('172.28.0.0/24');
+  });
+});
+
+// -------------------------------------------------------
+// render subcommand — real templates, property assertions
+// -------------------------------------------------------
+async function renderOverlay(dir: string, input: Record<string, unknown>) {
+  const r = await runScript('render-security-overlay.ts', {
+    args: ['render', dir], stdin: JSON.stringify(input),
+  });
+  expect(r.exitCode).toBe(0);
+  return r;
+}
+
+const overlayPath = (dir: string) => path.join(dir, 'docker-compose.security.yml');
+const nftPath = (dir: string) => path.join(dir, '.claude-code-hermit', 'docker', 'nftables.conf');
+const allowPath = (dir: string) => path.join(dir, '.claude-code-hermit', 'docker', 'dnsmasq.allowlist');
+
+const ALL_ON = {
+  network: { subnet: '172.28.0.0/24', gateway: '172.28.0.1', netguardIp: '172.28.0.2' },
+  toggles: {
+    lan: { enabled: true, dnsMode: 'enforce' },
+    resources: { enabled: true, memLimit: '4g', memswapLimit: '4g', cpus: 2.0, sysctlsEnabled: true },
+    audit: { enabled: true },
+  },
+  publishPorts: [{ target: 3000, published: '3000', protocol: 'tcp', host_ip: '0.0.0.0', mode: 'ingress' }],
+  lanAllowlist: ['192.168.1.50', '10.0.0.5'],
+  fleetDomains: ['api.strava.com'],
+  additionalDomains: ['example.org'],
+};
+
+describe('render subcommand — all toggles on', () => {
+  test('writes all three files with no {{ }} left', async () => {
+    const dir = freshDir();
+    const r = await renderOverlay(dir, ALL_ON);
+    expect(JSON.parse(r.stdout).written).toHaveLength(3);
+    for (const p of [overlayPath(dir), nftPath(dir), allowPath(dir)]) {
+      expect(fs.readFileSync(p, 'utf8')).not.toMatch(/\{\{[A-Z][A-Z0-9_]*\}\}/);
+    }
+  });
+
+  test('hermit and hermit-netguard services align at 2-space indent (merge-critical)', async () => {
+    const dir = freshDir();
+    await renderOverlay(dir, ALL_ON);
+    const overlay = fs.readFileSync(overlayPath(dir), 'utf8');
+    expect(overlay).toMatch(/^ {2}hermit:$/m);
+    expect(overlay).toMatch(/^ {2}hermit-netguard:$/m);
+    // A 4-space service key would silently corrupt the compose merge.
+    expect(overlay).not.toMatch(/^ {4}hermit(-netguard)?:$/m);
+  });
+
+  test('netguard cap_add list and healthcheck start_period render (retargeted from SKILL)', async () => {
+    const dir = freshDir();
+    await renderOverlay(dir, ALL_ON);
+    const overlay = fs.readFileSync(overlayPath(dir), 'utf8');
+    expect(overlay).toContain('cap_add: [NET_ADMIN, NET_BIND_SERVICE, SETUID, SETGID]');
+    expect(overlay).toContain('start_period: 5s');
+  });
+
+  test('DNS enforce mode sets DNS_LOG_ONLY=0', async () => {
+    const dir = freshDir();
+    await renderOverlay(dir, ALL_ON);
+    expect(fs.readFileSync(overlayPath(dir), 'utf8')).toContain('- DNS_LOG_ONLY=0');
+  });
+
+  test('nftables LAN carve-outs render at 8-space chain-body indent, uid=100', async () => {
+    const dir = freshDir();
+    await renderOverlay(dir, ALL_ON);
+    const nft = fs.readFileSync(nftPath(dir), 'utf8');
+    expect(nft).toMatch(/^ {8}ip daddr 192\.168\.1\.50 accept$/m);
+    expect(nft).toMatch(/^ {8}ip daddr 10\.0\.0\.5 accept$/m);
+    expect(nft).toContain('meta skuid != 100 ');
+    // The doc-comment reference must not have been mangled into a rule line.
+    expect(nft).not.toMatch(/accept is rendered at overlay/);
+  });
+
+  test('dnsmasq renders fleet + additional domains as server= lines', async () => {
+    const dir = freshDir();
+    await renderOverlay(dir, ALL_ON);
+    const allow = fs.readFileSync(allowPath(dir), 'utf8');
+    expect(allow).toContain('server=/api.strava.com/1.1.1.1');
+    expect(allow).toContain('server=/example.org/1.1.1.1');
+  });
+});
+
+describe('render subcommand — partial toggles', () => {
+  test('resources-only (no LAN) writes only the overlay, sysctls on hermit', async () => {
+    const dir = freshDir();
+    const r = await renderOverlay(dir, {
+      toggles: {
+        lan: { enabled: false },
+        resources: { enabled: true, sysctlsEnabled: true },
+        audit: { enabled: false },
+      },
+    });
+    expect(JSON.parse(r.stdout).written).toHaveLength(1);
+    expect(fs.existsSync(nftPath(dir))).toBe(false);
+    const overlay = fs.readFileSync(overlayPath(dir), 'utf8');
+    expect(overlay).not.toContain('hermit-netguard:');
+    expect(overlay).toContain('sysctls:');
+    expect(overlay).toContain('mem_limit:');
+  });
+
+  test('log-only DNS mode sets DNS_LOG_ONLY=1', async () => {
+    const dir = freshDir();
+    await renderOverlay(dir, {
+      network: { subnet: '172.28.0.0/24', gateway: '172.28.0.1', netguardIp: '172.28.0.2' },
+      toggles: { lan: { enabled: true, dnsMode: 'log-only' }, resources: { enabled: false }, audit: { enabled: false } },
+      lanAllowlist: [], fleetDomains: [], additionalDomains: [],
+    });
+    expect(fs.readFileSync(overlayPath(dir), 'utf8')).toContain('- DNS_LOG_ONLY=1');
+  });
+});

--- a/plugins/claude-code-hermit/tests/render-template.test.ts
+++ b/plugins/claude-code-hermit/tests/render-template.test.ts
@@ -1,0 +1,36 @@
+// Unit tests for the shared {{PLACEHOLDER}} substitution engine.
+//
+// Usage: bun test tests/render-template.test.ts   (from the plugin root)
+
+import { describe, test, expect } from 'bun:test';
+import { renderTemplate } from '../scripts/lib/render-template';
+
+describe('renderTemplate', () => {
+  test('substitutes a single placeholder', () => {
+    expect(renderTemplate('hello {{NAME}}', { NAME: 'world' })).toBe('hello world');
+  });
+
+  test('substitutes every occurrence of a placeholder', () => {
+    expect(renderTemplate('{{X}}-{{X}}', { X: 'a' })).toBe('a-a');
+  });
+
+  test('empty-string value collapses the placeholder', () => {
+    expect(renderTemplate('a{{GAP}}b', { GAP: '' })).toBe('ab');
+  });
+
+  test('multi-line values are inserted verbatim', () => {
+    expect(renderTemplate('[{{BLOCK}}]', { BLOCK: 'l1\nl2' })).toBe('[l1\nl2]');
+  });
+
+  test('throws when an UPPER_SNAKE placeholder is left unsubstituted', () => {
+    expect(() => renderTemplate('{{FOO}} {{BAR}}', { FOO: 'x' })).toThrow(/BAR/);
+  });
+
+  test('does not throw on literal {{...}} documentation prose (not a placeholder)', () => {
+    expect(renderTemplate('marked {{...}} here', {})).toBe('marked {{...}} here');
+  });
+
+  test('does not treat lowercase {{tokens}} as placeholders', () => {
+    expect(renderTemplate('{{lower}}', {})).toBe('{{lower}}');
+  });
+});


### PR DESCRIPTION
## Summary

Phase D2 of the architecture-placement audit (the docker half of the biggest item): the two docker skills hand-substituted `{{PLACEHOLDER}}` values into compose/Dockerfile/nftables/dnsmasq templates and did subnet collision-detection as a prose algorithm every run. This extracts that deterministic rendering into fail-loud, tested scripts. **Stacked on #505 (Phase D1)** — final PR in the A→D series; base auto-retargets as the stack merges. Rendered output is functionally equivalent to the prior prose substitution: **no operator-visible change.**

## What moved to code

- `scripts/lib/render-template.ts` — shared `renderTemplate(text, vars)`: `{{NAME}}` substitution, then throws if any placeholder survives (writes nothing on failure).
- `scripts/render-docker-templates.ts <project-root>` — stdin semantic-inputs JSON → renders `Dockerfile.hermit` + `docker-compose.hermit.yml`, `cp`-copies the entrypoint verbatim, emits the `manifest-seed` payload for the skill to pipe on (keeps one writer per file — the hashing stays a separate call).
- `scripts/render-security-overlay.ts` — `pick-subnet` (shells docker network inspect, integer-range overlap, candidate walk → `{chosen|null, allCandidatesCollide, occupied}`, always exit 0) + `render` (stdin JSON → the 3 security files).
- `state-templates/docker/security/verify-security.sh` — the `/docker-security` Step 8 verification heredoc, extracted verbatim (confirmed placeholder-free) and streamed via `exec -T hermit sh -s < verify-security.sh`.

The conversational surface stays in the skills: auth/plugin/deployment prompts, security toggles, gates, restart flow. docker-setup's Step 7b plugin resolution (which Phase B pointed at `resolve-siblings.ts`) is untouched.

## Verification

- Full core `bun test` — **1401 pass, 0 fail** (47 files). New: `render-template.test.ts`, `render-docker-templates.test.ts`, `render-security-overlay.test.ts`.
- Property assertions (repo style, no full-file goldens): rendered templates have no surviving `{{`, packages land in the Dockerfile RUN block, `network_mode:` present/absent per input, git-identity mount conditional, entrypoint byte-identical to template, manifestSeed paths absolute, YAML at 2-space / nftables chain body at 8-space, docker-absent `pick-subnet` degrades to the first candidate.
- **Test retargeting (the tricky part):** `docker-security-templates.test.ts` previously matched the verification block *inside* the skill; those assertions now target `verify-security.sh` (+ a placeholder-free assertion). `manifest-seed.test.ts`'s docker-setup source-path contract now targets the render script. Both retargeted in this change so CI stays green.
- `nftables.conf.template`: header-comment references to `LAN_ALLOWLIST_RULES`/`DNSMASQ_UID` de-braced so the engine doesn't substitute documentation prose — **comment-only, verified no rule/rendered-output change.**
- `bunx tsc --noEmit` clean. A plumbing-only cleanup pass applied one DRY fix (reuse `TEMPLATES_DIR`); re-tested green.

## Note

Rendered `Dockerfile.hermit` / compose files are not manifest-hashed, so no `hermit-evolve` drift fires from this change; no Upgrade Instructions needed.