### PR TITLE
fix(claude-code-hermit): route hermit-settings "default" to the none sentinel

### DIFF
--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -164,7 +164,7 @@ Ask: "Claude model to use?
   haiku  → claude-haiku-4-5-20251001
   none   → use Claude Code default (inherit from user config)
 [current: <value or 'default'>]"
-Run `settings-edit ... set model <value>` ("none"/"default"/"clear" → null).
+Run `settings-edit ... set model <value>`. To clear (operator says "none", "default", or "clear" → inherit Claude Code default), pass the `none` sentinel: `settings-edit ... set model none` (the script maps `none`/`clear` → null; do NOT pass the literal word `default`, which would be stored as a string).
 Note: "Model changes take effect on next `hermit-start` run."
 
 **If argument is "brief":**
@@ -180,7 +180,7 @@ Ask: "Boot skill to invoke on always-on launch? This runs after heartbeat/routin
   <skill>  — any namespaced skill (e.g. `/claude-code-foo-hermit:foo-boot`)
   none     — clear (falls back to `/claude-code-hermit:session`)
 [current: <value or 'default'>]"
-Run `settings-edit ... set boot_skill <value>` ("none"/"default"/"clear" → null). The domain boot skill is responsible for calling `/claude-code-hermit:session-start` itself — this setting just controls the single bootstrap command `hermit-start.ts` fires into the REPL.
+Run `settings-edit ... set boot_skill <value>`. To clear (operator says "none", "default", or "clear" → fall back to `/claude-code-hermit:session`), pass the `none` sentinel: `settings-edit ... set boot_skill none` (the script maps `none`/`clear` → null; do NOT pass the literal word `default`, which would be stored as a string). The domain boot skill is responsible for calling `/claude-code-hermit:session-start` itself — this setting just controls the single bootstrap command `hermit-start.ts` fires into the REPL.
 Note: "Boot skill changes take effect on next `hermit-start` run."
 
 **If argument is "permissions":**

--- a/plugins/claude-code-hermit/tests/settings-edit.test.ts
+++ b/plugins/claude-code-hermit/tests/settings-edit.test.ts
@@ -121,6 +121,14 @@ describe('settings-edit.ts CLI', () => {
     expect(readConfig(file).sign_off).toBeNull();
   });
 
+  test('set writes the literal string "default" (not null) — for permission_mode', async () => {
+    const dir = freshDir();
+    const file = seedConfig(dir, { permission_mode: 'auto' });
+    await runScript('settings-edit.ts', { args: [file, 'set', 'permission_mode', 'default'] });
+    // "default" is a real Claude Code permission_mode enum value, distinct from null.
+    expect(readConfig(file).permission_mode).toBe('default');
+  });
+
   test('set creates nested parents when absent', async () => {
     const dir = freshDir();
     const file = seedConfig(dir, { agent_name: 'Atlas' });


### PR DESCRIPTION
## Summary

Fixes a latent bug from #501 (Phase B script extraction). The `model` and `boot_skill` branches of `hermit-settings` annotate `set <field> <value>` with `(none/default/clear → null)`, but `settings-edit.ts`'s `parseValue` only maps `none`/`clear` to null. Passing the literal word `default` — as the annotation invited — fails `JSON.parse` and is stored as the **string** `"default"`, which `hermit-start` then feeds to `--model default` (invalid model id) or invokes as the `/default` boot skill instead of inheriting the Claude Code default.

## Why the fix is at the skill layer, not the script

The script can't context-freely map `"default" → null`: `permission_mode` also routes through `settings-edit`, and `"default"` is a **legitimate** Claude Code enum value there (`hermit-start.ts:623` explicitly recognizes it, distinct from the "unknown" warning path). A blanket `'default' → null` in `parseValue` would wrongly null out `permission_mode default`.

So `settings-edit.ts` stays untouched. Instead the `model`/`boot_skill` branches now instruct passing the script's existing `none` sentinel when the operator says none/default/clear, and explicitly warn against passing the literal `default`.

## Changes

- **`skills/hermit-settings/SKILL.md`** — `model` and `boot_skill` clear-to-null instructions route the operator's "default" through `set <field> none` (the `none`/`clear` → null sentinel the script already handles).
- **`tests/settings-edit.test.ts`** — regression test asserting `set permission_mode default` still writes the string `"default"`, not null.

No `settings-edit.ts` change and no CHANGELOG entry — the buggy routing is unreleased (added in #501, no release cut), same precedent as Phase A/B.

## Test plan

- **core** `bun test` — **1379 pass, 0 fail**.
- `bunx tsc --noEmit` clean.
