### PR TITLE
fix(dev): drop early process.exit from render-append CLI

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **CLAUDE-APPEND: collapse two mode templates into one source** — `CLAUDE-APPEND-SAFETY.md` is deleted; `CLAUDE-APPEND.md` carries mode markers and is rendered per mode by the new `scripts/render-append.ts` (both renderings byte-identical to the pre-collapse files, golden-tested). `/hatch` now captures the render script's stdout instead of picking a file.
+- **CLAUDE-APPEND: collapse two mode templates into one source** — `CLAUDE-APPEND-SAFETY.md` is deleted; `CLAUDE-APPEND.md` carries mode markers and is rendered per mode by the new `scripts/render-append.ts` (both renderings byte-identical to the pre-collapse files, golden-tested). `/hatch` now captures the render script's stdout instead of picking a file. The render CLI writes to stdout and returns without an early `process.exit(0)`, so large renders can't be truncated at the pipe buffer.
 
 ### Files affected
 

--- a/plugins/claude-code-dev-hermit/scripts/render-append.ts
+++ b/plugins/claude-code-dev-hermit/scripts/render-append.ts
@@ -40,6 +40,8 @@ if (import.meta.main) {
     process.stderr.write(`render-append: unknown mode "${mode ?? ''}" (expected: standard|safety)\n`);
     process.exit(1);
   }
+  // No process.exit() here: process.stdout.write() to a pipe is async in Bun,
+  // and exiting before it drains truncates output at the pipe buffer (~64 KB).
+  // Letting the module return exits 0 naturally once stdout has flushed.
   process.stdout.write(render(mode, fs.readFileSync(TEMPLATE, 'utf-8')));
-  process.exit(0);
 }


### PR DESCRIPTION
## Summary

Found during review of #502 (Phase C, single-source CLAUDE-APPEND). The new `scripts/render-append.ts` CLI ended with `process.exit(0)` right after `process.stdout.write(...)`. In Bun, writing to a **pipe** is asynchronous, and `process.exit()` does not wait for the buffer to drain — so a render larger than the ~64 KB pipe buffer would be silently truncated. `/hatch` Step 3 captures this stdout and writes it into the operator's CLAUDE-APPEND block, so a truncated render would corrupt operator-facing config.

The fix drops the redundant `process.exit(0)`: once the module returns, Bun exits 0 naturally after stdout flushes. The `exit(1)` error path (unknown mode, stderr-only) is unaffected and stays.

## Changes

- `scripts/render-append.ts` — remove trailing `process.exit(0)`; add a comment documenting the Bun async-stdout gotcha.
- `CHANGELOG.md` — fold a note into the existing `[Unreleased]` bullet (render-append.ts is new in this same unreleased window, so no separate `Fixed` entry).

## Test plan

- `bash tests/run-all.sh` (dev) — **12/12 pass**, including the golden render tests.
- Empirically verified against Bun: pre-fix pattern (`write` 5 MB then `exit(0)`) truncates to exactly 65536 bytes; post-fix the full payload flushes.
- `render(standard)` / `render(safety)` remain byte-exact against the golden fixtures; unknown mode still exits 1.

> Note: does not currently misbehave in production — the live template renders to ~9.3 KB, under the 64 KB buffer. This is a latent-robustness fix so future template growth can't silently truncate.

https://claude.ai/code/session_018pMPG2sshJeZaAT1FGxq9N