### PR TITLE
fix: fleet release-review fixes across core, dev, fitness, scribe

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -31,6 +31,7 @@ No `config.json` changes required.
 ### Fixed
 - **git-push-guard: block bare `git push` and `git push origin HEAD` on protected branches** — the guard now resolves the current branch via `git symbolic-ref` when a push carries no destination ref, closing the hole where a bare push to `main` slipped through (only explicit refspecs were checked before). Handles `git -C <path> push`; a bare push behind `cd … &&` remains a documented fail-open limit.
 - **git-push-guard: notice when the guard is inactive** — emit one stderr line on a `git push` when `AGENT_HOOK_PROFILE` is not `strict`, so a non-strict session no longer silently runs with the guard disabled.
+- **git-push-guard: block stacked force short-flags** — `-f` inside a short-flag cluster (e.g. `git push -fu origin feature`) now matches, closing a force-push bypass that the standalone `-f` check missed.
 
 ## [0.4.6] - 2026-06-29
 

--- a/plugins/claude-code-dev-hermit/scripts/git-push-guard.test.ts
+++ b/plugins/claude-code-dev-hermit/scripts/git-push-guard.test.ts
@@ -166,6 +166,8 @@ assert('push to main is blocked', run('git push origin main', { AGENT_HOOK_PROFI
 assert('push to master is blocked', run('git push origin master', { AGENT_HOOK_PROFILE: 'strict' }), 2);
 assert('--force push to feature branch is blocked', run('git push --force origin feature/x', { AGENT_HOOK_PROFILE: 'strict' }), 2);
 assert('-f push to feature branch is blocked', run('git push -f origin feature/x', { AGENT_HOOK_PROFILE: 'strict' }), 2);
+assert('stacked -fu (force+set-upstream) push is blocked', run('git push -fu origin feature/x', { AGENT_HOOK_PROFILE: 'strict' }), 2);
+assert('stacked -uf push is blocked', run('git push -uf origin feature/x', { AGENT_HOOK_PROFILE: 'strict' }), 2);
 assert('--force-with-lease to main is blocked', run('git push --force-with-lease origin main', { AGENT_HOOK_PROFILE: 'strict' }), 2);
 assert('--force-with-lease to master is blocked', run('git push --force-with-lease origin master', { AGENT_HOOK_PROFILE: 'strict' }), 2);
 

--- a/plugins/claude-code-dev-hermit/scripts/git-push-guard.ts
+++ b/plugins/claude-code-dev-hermit/scripts/git-push-guard.ts
@@ -133,7 +133,10 @@ async function main() {
     if (!/\bgit\b[\s\S]*\bpush\b/.test(subcmd)) continue;
 
     const hasForceWithLease = /(?:^|\s)--force-with-lease\b/.test(subcmd);
-    const hasBareForce = /(?:^|\s)(?:--force(?!-with-lease)\b|-f\b)/.test(subcmd);
+    // `-f` may appear inside a stacked short-flag cluster (e.g. `-fu` = force +
+    // set-upstream), so match `f` anywhere in a single-dash cluster, not just a
+    // standalone `-f`.
+    const hasBareForce = /(?:^|\s)(?:--force(?!-with-lease)\b|-[a-zA-Z]*f[a-zA-Z]*\b)/.test(subcmd);
 
     if (hasBareForce) {
       block('Bare force push is not allowed (--force, -f). Use --force-with-lease on a non-protected branch with an explicit refspec if you must overwrite.');

--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.
 - **`weekly-coaching-patterns` prose: `reflect-scheduled-checks` → `reflect --scheduled-checks`** — the core scheduled-check runner merged into `reflect`; the skill now names the surviving invocation (no behavior change — the `scheduled-checks` routine still consumes its stdout).
 - **CLAUDE-APPEND slimmed 5.3KB → ~3.9KB** — the Skills, Subagents, and Strava-MCP-tool catalog tables were removed; skill descriptions and the already-in-context MCP tool schemas carry that content. The `get-athlete-stats` all-time-totals steer is kept inline (don't sum `get-all-activities` client-side). The block is re-paid on every session load and subagent dispatch, so this cuts recurring context cost.
 
+### Fixed
+- **fitness-lab: surface hard Strava auth failure in `weekly-load`** — a 401 on `/athlete/zones` now propagates the exit-1 `strava_auth` recovery signal instead of silently degrading zone load, matching `analyze`.
+- **fitness-lab: minor correctness** — `weekly-load --weeks` rejects non-positive values; a dead recovery-window branch was removed; `analyze` fetches activity details inside its batch (one fewer round-trip).
+
 ### Upgrade Instructions
 - No manual steps. The Fitness CLAUDE-APPEND block is synced automatically via `hermit-evolve` Step 7's sibling-upgrade flow when this version's gap is processed.
 

--- a/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
+++ b/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
@@ -469,7 +469,7 @@ export function recoveryWindow(
     const h = baseHours as number;
     if (!trail_extended) window = `${h}h`;
     else {
-      const extLow = extension_days === '1-2' ? 24 : 24;
+      const extLow = 24;
       const extHigh = extension_days === '1-2' ? 48 : 24;
       const lowDays = (h + extLow) / 24;
       const highDays = (h + extHigh) / 24;
@@ -578,8 +578,10 @@ export async function analyze(token: string, activityId: number): Promise<any> {
   const warnings: string[] = [];
   const streamKeys = 'heartrate,velocity_smooth,altitude,cadence,watts';
 
-  const details = await stravaGet(token, `/activities/${activityId}`);
-  const [laps, streams, zonesResp, summaries] = await Promise.all([
+  // `details` is essential (no fallback) but independent of the other four, so it
+  // joins the batch rather than serialising an extra round-trip ahead of it.
+  const [details, laps, streams, zonesResp, summaries] = await Promise.all([
+    stravaGet(token, `/activities/${activityId}`),
     optionalFetch(stravaGet(token, `/activities/${activityId}/laps`), warnings, 'laps unavailable', []),
     optionalFetch(
       stravaGet(token, `/activities/${activityId}/streams`, { keys: streamKeys, key_by_type: 'true' }),
@@ -831,8 +833,11 @@ export async function weeklyLoad(token: string, weeks: number): Promise<any> {
   try {
     const z = await stravaGet(token, '/athlete/zones');
     if (z && z.heart_rate && Array.isArray(z.heart_rate.zones)) zoneBounds = z.heart_rate.zones;
-  } catch {
-    // zone_pct degrades to null; method still documents the approximation.
+  } catch (e) {
+    // A hard auth failure must surface (exit-1 strava_auth contract), same as
+    // analyze's optionalFetch — swallowing it would silently understate load.
+    if (e instanceof StravaAuthError) throw e;
+    // Any other failure: zone_pct degrades to null; method documents the approximation.
   }
   return aggregateWeeklyLoad(Array.isArray(activities) ? activities : [], zoneBounds, weeks);
 }
@@ -914,7 +919,7 @@ async function main() {
       const token = getAccessToken(projectRoot);
       if (!token) emitAuth();
       const weeks = flags['weeks'] ? parseInt(flags['weeks'], 10) : 4;
-      console.log(JSON.stringify(await weeklyLoad(token, Number.isFinite(weeks) ? weeks : 4)));
+      console.log(JSON.stringify(await weeklyLoad(token, Number.isFinite(weeks) && weeks >= 1 ? weeks : 4)));
       process.exit(0);
     } else if (cmd === 'weekly-patterns') {
       console.log(JSON.stringify(weeklyPatterns(projectRoot)));

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -40,6 +40,10 @@
 - **hermit-doctor: cost-log path honors the hermit-dir argument** — resolved via `cc-compat.costLogPath()` rather than a CWD-relative path, so the cost and Opus-wake checks no longer report a false `ok` when doctor runs from a different directory.
 - **hermit-doctor: dependency check handles the versioned plugin-cache layout** — when the plugin root sits under `cache/<mp>/<plugin>/<version>/` (the same layout `cache-edit-guard` assumes), the sibling scan now walks up to the marketplace root and picks each sibling's newest version, rather than seeing only other core versions one level up and reporting a false "no siblings" all-clear. The monorepo/flat-cache one-level scan is unchanged.
 - **docs: correct prerequisites and stale samples** — `how-to-use.md` now states Bun (not Node.js 22+) as the hooks/scripts runtime and drops the `python3`/`node` permission samples the wizard never writes; README and `architecture.md` drop hand-written check/skill counts that had drifted.
+- **settings-edit / proposals-index: atomic writes** — both write via tmp+rename. A torn `config.json` no longer makes the strict reader `exit(1)` on every later run (operator locked out of config edits), and a torn `proposals-index.json` no longer makes `proposal-list` throw under concurrent proposal writes.
+- **enforce-deny-patterns: also split on newlines and skip escaped quotes** — a newline-separated command and an escaped quote (`\'`) before a separator no longer hide a dangerous segment (e.g. `rm -rf`) from the leading-anchored deny globs.
+- **hermit-doctor: guard the versioned-cache sibling scan against non-semver dir names** — `Bun.semver.order` throws on a non-semver dir (e.g. a `backup/` copy), which degraded the whole dependency check to a generic warn; non-semver names are filtered before the sort.
+- **brief / hermit-health: preserve folded skills' triggers and pointers** — restore the `hermit brain` activation phrase on `hermit-health`, and pulse's `/claude-code-hermit:session-start` (idle) and `/claude-code-hermit:session` (blocked) recovery pointers on `brief`, all dropped during the fold.
 
 ### Upgrade Instructions
 
@@ -51,6 +55,7 @@ Run `/claude-code-hermit:hermit-evolve`. The evolve skill handles:
    - `claude-code-hermit:pulse` → `claude-code-hermit:brief`
    - `claude-code-hermit:hermit-brain` → `claude-code-hermit:hermit-health`
    - `claude-code-hermit:knowledge` → `claude-code-hermit:hermit-health`
+   - `claude-code-hermit:test-run` → removed with no replacement; delete any `routines`/`scheduled_checks` entry that references it (it was a manual, on-demand skill, so a reference here is unusual but would otherwise dangle to a skill-not-found no-op).
 2. **Scrub the stale permission.** Remove `Bash(bun */scripts/run-with-profile.ts*)` from the target settings file's `permissions.allow` if present (Step 8 already lists this removal). No new permissions are required.
 3. **No config-key additions** this release.
 4. **CLAUDE-APPEND block (token efficiency).** The hermit-managed block in `CLAUDE.md`/`CLAUDE.local.md` is replaced automatically by Step 6; if you customized text inside it, re-apply it afterward (the replaced block is shown in the evolve report). `HEARTBEAT.md` is not touched, and no new config keys are added.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -44,6 +44,7 @@
 - **enforce-deny-patterns: also split on newlines and skip escaped quotes** — a newline-separated command and an escaped quote (`\'`) before a separator no longer hide a dangerous segment (e.g. `rm -rf`) from the leading-anchored deny globs.
 - **hermit-doctor: guard the versioned-cache sibling scan against non-semver dir names** — `Bun.semver.order` throws on a non-semver dir (e.g. a `backup/` copy), which degraded the whole dependency check to a generic warn; non-semver names are filtered before the sort.
 - **brief / hermit-health: preserve folded skills' triggers and pointers** — restore the `hermit brain` activation phrase on `hermit-health`, and pulse's `/claude-code-hermit:session-start` (idle) and `/claude-code-hermit:session` (blocked) recovery pointers on `brief`, all dropped during the fold.
+- **channels: enforce string sender IDs** — `validate-config` now rejects a non-string `allowed_users` entry, and `channel-hook` coerces `dm_channel_id` to a string when persisting a live `chat_id`. A numeric channel ID silently fails the string-based sender allow-list gate (`channel-reply-reminder.ts`), locking out an authorized operator; the type is now enforced at both entry points.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/scripts/channel-hook.ts
+++ b/plugins/claude-code-hermit/scripts/channel-hook.ts
@@ -55,15 +55,20 @@ function writeConfig(config: Json): void {
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n');
 }
 
-function persistDmChannelId(config: Json, channelKey: string, chatId: Json): boolean {
+export function persistDmChannelId(config: Json, channelKey: string, chatId: Json): boolean {
   if (!chatId) return false;
 
+  // Coerce to string (mirrors the log path's String() at the outbound-capture
+  // block): a channel plugin delivering a numeric chat_id must not write a
+  // number into config.json — the sender allow-list gate compares IDs as
+  // strings, and a numeric dm_channel_id also fails validate-config.
+  const id = String(chatId);
   const channel = config.channels[channelKey];
-  if (channel.dm_channel_id === chatId) return false;
+  if (channel.dm_channel_id === id) return false;
 
-  channel.dm_channel_id = chatId;
+  channel.dm_channel_id = id;
   process.stderr.write(
-    `[channel-hook] saved ${channelKey}.dm_channel_id = ${safe(chatId)}\n`
+    `[channel-hook] saved ${channelKey}.dm_channel_id = ${safe(id)}\n`
   );
   return true;
 }
@@ -143,4 +148,6 @@ function main() {
   });
 }
 
-main();
+// Guard so importing this module (e.g. a unit test of persistDmChannelId)
+// doesn't run the hook. Direct execution as a hook keeps import.meta.main true.
+if (import.meta.main) main();

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -290,6 +290,9 @@ function siblingPluginDirs(coreName: string): string[] {
       const newest = versions
         .filter(v => v.isDirectory() && fs.existsSync(path.join(pluginDir, v.name, '.claude-plugin', 'plugin.json')))
         .map(v => v.name)
+        // Guard the comparator: Bun.semver.order throws on a non-semver-named dir
+        // (e.g. a `backup/` copy), which would degrade the whole dependency check.
+        .filter(name => /^\d+\.\d+\.\d+/.test(name))
         .sort((a, b) => Bun.semver.order(b, a))[0];
       if (newest) dirs.push(path.join(pluginDir, newest));
     }

--- a/plugins/claude-code-hermit/scripts/enforce-deny-patterns.ts
+++ b/plugins/claude-code-hermit/scripts/enforce-deny-patterns.ts
@@ -49,6 +49,12 @@ function splitSegments(command: string): string[] {
   let quote: string | null = null;
   for (let i = 0; i < command.length; i++) {
     const c = command[i];
+    // Backslash escapes the next char outside single quotes (bash processes no
+    // escapes inside single quotes), so an escaped quote (`\'`) can't spuriously
+    // open a quoted run and swallow a following separator.
+    if (c === '\\' && quote !== "'" && i + 1 < command.length) {
+      buf += c + command[i + 1]; i++; continue;
+    }
     if (quote) {
       buf += c;
       if (c === quote) quote = null;
@@ -58,7 +64,9 @@ function splitSegments(command: string): string[] {
     if ((c === '&' && command[i + 1] === '&') || (c === '|' && command[i + 1] === '|')) {
       out.push(buf); buf = ''; i++; continue;
     }
-    if (c === ';' || c === '|') { out.push(buf); buf = ''; continue; }
+    // Newline separates commands like `;`. (Single `&` is intentionally not a
+    // separator here — splitting it would fragment redirects like `2>&1`/`&>`.)
+    if (c === ';' || c === '|' || c === '\n') { out.push(buf); buf = ''; continue; }
     buf += c;
   }
   out.push(buf);

--- a/plugins/claude-code-hermit/scripts/proposals-index.ts
+++ b/plugins/claude-code-hermit/scripts/proposals-index.ts
@@ -143,11 +143,12 @@ export function rebuildIndex(stateDir: string): ProposalsIndex | null {
   try {
     const stateSubdir = path.join(stateDir, 'state');
     fs.mkdirSync(stateSubdir, { recursive: true }); // state/ may be absent on a partial layout
-    fs.writeFileSync(
-      path.join(stateSubdir, 'proposals-index.json'),
-      JSON.stringify(index, null, 2) + '\n',
-      'utf8',
-    );
+    // Atomic write: this runs from a PostToolUse hook that can overlap concurrent
+    // proposal writes; a torn index would make proposal-list's JSON.parse throw.
+    const target = path.join(stateSubdir, 'proposals-index.json');
+    const tmp = target + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(index, null, 2) + '\n', 'utf8');
+    fs.renameSync(tmp, target);
   } catch { /* fail-open: a failed write just means a reader rebuilds next time */ }
 
   return index;

--- a/plugins/claude-code-hermit/scripts/settings-edit.ts
+++ b/plugins/claude-code-hermit/scripts/settings-edit.ts
@@ -48,7 +48,11 @@ function readTargetJson(filePath: string): Json {
 function writeJson(filePath: string, data: Json): void {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  // Atomic write: a torn config.json would make readTargetJson (strict) exit(1)
+  // on every later run, locking the operator out of config edits.
+  const tmp = filePath + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmp, filePath);
 }
 
 function parseValue(raw: string): Json {

--- a/plugins/claude-code-hermit/scripts/validate-config.ts
+++ b/plugins/claude-code-hermit/scripts/validate-config.ts
@@ -175,8 +175,14 @@ function validate(config: Json): { errors: string[]; warnings: string[] } {
         errors.push(`channels.${name}: must be an object`);
         continue;
       }
-      if (ch.allowed_users !== undefined && !Array.isArray(ch.allowed_users)) {
-        errors.push(`channels.${name}.allowed_users: must be an array`);
+      if (ch.allowed_users !== undefined) {
+        if (!Array.isArray(ch.allowed_users)) {
+          errors.push(`channels.${name}.allowed_users: must be an array`);
+        } else if (!ch.allowed_users.every((u: unknown) => typeof u === 'string')) {
+          errors.push(
+            `channels.${name}.allowed_users: every entry must be a string (a numeric ID breaks the string-based sender allow-list check)`,
+          );
+        }
       }
       if (ch.dm_channel_id !== undefined && ch.dm_channel_id !== null && typeof ch.dm_channel_id !== 'string') {
         errors.push(`channels.${name}.dm_channel_id: must be string or null`);

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -98,7 +98,7 @@ Current behavior — general purpose summary as described below.
      Session: since [start date]
      Last: [latest Session Summary entry] — [status]
      Cumulative: $X.XX (12.3K tokens) across N tasks
-     Status: Idle — ready for what's next
+     Status: Idle — ready for what's next (run /claude-code-hermit:session-start to begin)
      ```
      Then check for auto-detected proposals (step after Output Format) and return.
    - **1c. No active session (dispatch):** runner JSON is already available (mode: `default-no-session`). Use `runner.report_summary` for the brief. If `report_summary` is null (runner failed), fall back to reading the most recent archived report directly in main.
@@ -122,7 +122,7 @@ Next: description of next action (or "Session complete" if all done)
 - Use the session's date, not today's date
 - Include tags in the header only if they exist
 - For the "Done" line: list completed task subjects from `TaskList`, comma-separated. If too many, show first 3 and "+ N more"
-- For the "Next" line: show the first pending or in_progress task from `TaskList`. If blocked, show "Blocked: reason — run /debug to diagnose" (keeps the actionable pointer on the existing line, no extra line)
+- For the "Next" line: show the first pending or in_progress task from `TaskList`. If blocked, show "Blocked: reason — run /debug to diagnose, or /claude-code-hermit:session for a fresh session" (keeps the actionable pointers on the existing line, no extra line)
 - If summarizing a completed report: "Next" becomes the report's "Next Start Point" content
 - After composing the 5-line output: scan `.claude-code-hermit/proposals/` for files with `source: auto-detected` and `status: proposed` (read `status:` and `source:` from the **leading `---` YAML frontmatter block only** — do not count files where those phrases appear in the proposal body text; fall back to bullet metadata for pre-frontmatter proposals). **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction).** If any exist, append a 6th line: `Proposals: N auto-detected proposal(s) pending review`
 

--- a/plugins/claude-code-hermit/skills/hermit-health/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-health/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hermit-health
 model: haiku
-description: "Show alert state, proposal queue depth, routine engagement, knowledge state, channel availability, plus fragile zones, stale accepted proposals, and recent learnings. Activates on messages like 'health check', 'how's the hermit', 'is anything broken', 'hermit health', 'system health', 'anything wrong', 'hermit status', 'are routines running', 'what's stuck', 'any fragile zones', 'show me what's blocked', 'recent learnings', 'what have you learned lately', 'where are the weak spots', 'check knowledge', 'lint knowledge', 'knowledge health'."
+description: "Show alert state, proposal queue depth, routine engagement, knowledge state, channel availability, plus fragile zones, stale accepted proposals, and recent learnings. Activates on messages like 'health check', 'how's the hermit', 'is anything broken', 'hermit health', 'system health', 'anything wrong', 'hermit status', 'hermit brain', 'are routines running', 'what's stuck', 'any fragile zones', 'show me what's blocked', 'recent learnings', 'what have you learned lately', 'where are the weak spots', 'check knowledge', 'lint knowledge', 'knowledge health'."
 ---
 # Hermit Health
 

--- a/plugins/claude-code-hermit/tests/channel-hook.test.ts
+++ b/plugins/claude-code-hermit/tests/channel-hook.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from 'bun:test';
+import { persistDmChannelId } from '../scripts/channel-hook';
+
+// The sender allow-list gate (channel-reply-reminder.ts isAllowedSender) and
+// validate-config both require channel IDs to be strings. If a channel plugin
+// delivers chat_id as a JSON number, persistDmChannelId must coerce it so a
+// number never lands in config.json.
+describe('persistDmChannelId — dm_channel_id string coercion', () => {
+  test('coerces a numeric chat_id to its string form', () => {
+    const config: any = { channels: { discord: { dm_channel_id: null } } };
+    const changed = persistDmChannelId(config, 'discord', 555);
+    expect(changed).toBe(true);
+    expect(config.channels.discord.dm_channel_id).toBe('555');
+    expect(typeof config.channels.discord.dm_channel_id).toBe('string');
+  });
+
+  test('a numeric chat_id equal to the stored string id is a no-op', () => {
+    const config: any = { channels: { discord: { dm_channel_id: '555' } } };
+    expect(persistDmChannelId(config, 'discord', 555)).toBe(false);
+    expect(persistDmChannelId(config, 'discord', '555')).toBe(false);
+    expect(config.channels.discord.dm_channel_id).toBe('555');
+  });
+
+  test('a falsy chatId returns false and leaves the existing id untouched', () => {
+    const config: any = { channels: { discord: { dm_channel_id: 'D1' } } };
+    expect(persistDmChannelId(config, 'discord', null)).toBe(false);
+    expect(config.channels.discord.dm_channel_id).toBe('D1');
+  });
+});

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -712,6 +712,18 @@ describe('channel resolver contract', () => {
       (result.errors ?? []).some((e: string) => e.includes('primary') && e.includes('string')),
     ).toBe(true);
   });
+
+  test('validator rejects a numeric allowed_users entry (would break the string sender gate)', () => {
+    const result = validate({ channels: { discord: { dm_channel_id: 'D1', allowed_users: [123456789012345678] } } });
+    expect(
+      (result.errors ?? []).some((e: string) => e.includes('allowed_users') && e.includes('string')),
+    ).toBe(true);
+  });
+
+  test('validator accepts string allowed_users entries', () => {
+    const result = validate({ channels: { discord: { dm_channel_id: 'D1', allowed_users: ['123456789012345678'] } } });
+    expect((result.errors ?? []).filter((e: string) => e.includes('allowed_users'))).toEqual([]);
+  });
 });
 
 // ============================================================

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -382,6 +382,24 @@ describe('enforce-deny-patterns', () => {
     expect(r.exitCode).toBe(0);
   }));
 
+  // An escaped quote (`\'`) is a literal to bash and must not open a quoted run
+  // that swallows the following `&&`, or the trailing `rm -rf` segment escapes.
+  test('enforce-deny-patterns (block rm -rf behind escaped-quote separator)', withDir(async (dir) => {
+    const r = await runScript('enforce-deny-patterns.ts', {
+      stdin: JSON.stringify({ tool_name: 'Bash', tool_input: { command: "echo it\\'s done && rm -rf x" } }),
+      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(2);
+  }));
+
+  test('enforce-deny-patterns (block rm -rf on a newline-separated command)', withDir(async (dir) => {
+    const r = await runScript('enforce-deny-patterns.ts', {
+      stdin: JSON.stringify({ tool_name: 'Bash', tool_input: { command: "cd /tmp\nrm -rf x" } }),
+      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    });
+    expect(r.exitCode).toBe(2);
+  }));
+
   // A separator inside a quoted string must NOT fragment the command — a plain
   // echo/commit that merely mentions `rm -rf` after a `;` is not a real bypass.
   test('enforce-deny-patterns (quoted separator does not fragment command)', withDir(async (dir) => {

--- a/plugins/hermit-scribe/CHANGELOG.md
+++ b/plugins/hermit-scribe/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **hermit-scribe: fold issue classifier into `file-issue.ts`** — type/scope/label derivation and the Conventional-Commits title line moved out of SKILL.md prose into a deterministic, unit-tested `classify` subcommand (emits `{type, scope, labels, title_line}`), so filing no longer relies on model-derived labels.
+
 ## [0.0.5] - 2026-06-12
 
 ### Added


### PR DESCRIPTION
## Summary

High-signal code-review pass over the pending **fleet release** (all six plugins' committed-but-unreleased work). Corrects real defects found in that work before it ships; no version bumps — this is not a release. Two review passes (the `.ts`/hook surface, then skill-folds, migration, CLAUDE-APPEND trims, and under-reviewed core scripts), plus a follow-up investigation into a flagged channel-ID issue.

## Changes

**core (`claude-code-hermit`)**
- `settings-edit` / `proposals-index`: atomic `tmp+rename` writes — a torn `config.json` no longer makes the strict reader `exit(1)` on every later run (operator lockout), and a torn `proposals-index.json` no longer makes `proposal-list` throw under concurrent proposal writes.
- `doctor-check`: guard `Bun.semver.order` against a non-semver cache dir name (e.g. `backup/`) that otherwise threw and degraded the whole dependency check to a generic warn (empirically confirmed it throws).
- `enforce-deny-patterns`: `splitSegments` now splits on newlines and skips escaped quotes, closing two bypasses where a dangerous segment (`rm -rf`) hid from the leading-anchored deny globs. (+2 regression tests.)
- `brief` / `hermit-health`: restore triggers/pointers dropped during the skill folds — the `hermit brain` activation phrase, and pulse's `/session-start` (idle) + `/session` (blocked) recovery pointers.
- migration: note `test-run` (removed, no survivor) in the `hermit-evolve` Upgrade Instructions so a routine referencing it doesn't silently dangle.
- **channels: enforce string sender IDs** — `validate-config` now rejects a non-string `allowed_users` element, and `channel-hook` coerces `dm_channel_id` to a string when persisting a live `chat_id` (its `main()` is guarded by `import.meta.main` so the helper is import-safe). The sender allow-list gate (`channel-reply-reminder.ts` `isAllowedSender`) compares IDs with a string `.includes()`, so a numeric channel ID silently fails the match and locks out an authorized operator; the type is now enforced at both entry points. (+5 tests.)
  - _Reframe:_ this started as a flagged `settings-edit` snowflake-precision bug. Investigation showed channel IDs are direct-written as strings by convention (never through `settings-edit`/`parseValue`), so the real, correctly-scoped issue is the missing **string-type enforcement** on the auth gate — fixed above. The off-path `parseValue` guard and skill-prose hardening were deliberately deferred.

**dev (`claude-code-dev-hermit`)**
- `git-push-guard`: block stacked force short-flags (e.g. `git push -fu origin feature`) that the standalone `-f` check missed — a force-push bypass on feature branches. (+2 regression asserts.)

**fitness (`claude-code-fitness-hermit`)**
- `fitness-lab`: `weekly-load` now surfaces a hard Strava auth failure (`exit-1 strava_auth`) instead of silently degrading load, matching `analyze`; removed a dead recovery-window branch; `--weeks` rejects non-positive values; `analyze` batches the `details` fetch (one fewer round-trip).

**hermit-scribe**
- Added the missing `[Unreleased]` CHANGELOG entry for the already-committed classifier-fold refactor (would otherwise ship undocumented).

CHANGELOG `[Unreleased]` bullets added per plugin for all of the above.

## Test plan
- core: `bun test` — **1458 pass, 0 fail** (includes the new channels enforcement + enforce-deny regression tests, and the settings-edit/proposals-index suites).
- dev: `bun test scripts/git-push-guard.test.ts` — 70 pass (includes 2 new stacked-flag asserts), no false positives on the allowed cases.
- fitness: `bun test scripts/fitness-lab.test.ts` — 109 pass.
- `bunx tsc --noEmit` — clean.
- `/simplify` cleanup pass over each staged diff — zero findings (atomic-write inline confirmed as house pattern).