### PR TITLE
fix(claude-code-hermit): update wrappers now upgrade sibling hermits

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **`hermit-docker update` / `hermit-update`: domain (sibling) hermits now update, not just core** — the per-plugin loop moved pins straight from the local marketplace cache, which is never refreshed after first boot (auto-update is off by default for third-party/local marketplaces), so siblings silently resolved as "already up to date." Both wrappers now run `claude plugin marketplace update <name>` before the loop and process core first so `^core`-dependent siblings re-resolve cleanly. A plugin left `unchanged` with a live CLI error (e.g. `dependency-version-unsatisfied`) is now reported as `blocked` with the reason, instead of silently looking up to date, in both the terminal summary and `update-history.jsonl`.
+
+### Upgrade Instructions
+- Existing hermits run a stale on-disk copy of `bin/hermit-docker` and `bin/hermit-update` — `hermit-evolve`'s Step 5b bin-wrapper refresh replaces both from the current template, so a normal `/claude-code-hermit:hermit-evolve` picks up this fix. Until that runs, `hermit-docker update` / `hermit-update` on an un-evolved hermit keeps the old core-only behavior.
+
 ## [1.2.15] - 2026-07-03
 
 ### Removed

--- a/plugins/claude-code-hermit/docs/troubleshooting.md
+++ b/plugins/claude-code-hermit/docs/troubleshooting.md
@@ -138,7 +138,7 @@ Common causes:
 - Check plugin version: `cat .claude-plugin/plugin.json | grep version` (or check the installed plugin path).
 - Check config version: `cat .claude-code-hermit/config.json | grep _hermit_versions`.
 - If both match, there's genuinely nothing to upgrade. New features may have landed as skill changes (no config migration needed).
-- If the plugin was updated but the marketplace cache is stale: `claude plugin marketplace add gtapps/claude-code-hermit` to force refresh, then reinstall.
+- If the plugin was updated but the marketplace cache is stale: `claude plugin marketplace add gtapps/claude-code-hermit` to force refresh, then reinstall. `hermit-docker update` / `hermit-update` refresh the catalog automatically before moving pins, so this manual step is mainly for driving `plugin update` by hand.
 
 ## Docker Container Keeps Restarting
 

--- a/plugins/claude-code-hermit/docs/upgrading.md
+++ b/plugins/claude-code-hermit/docs/upgrading.md
@@ -23,13 +23,19 @@ Always-on hermits do this on their own: the session-start upgrade banner trigger
 
 If you'd rather drive it by hand:
 
-**1. Move the plugin pin (durable).** Refreshing the marketplace alone does NOT update the installed version — it only stages it; the pin reverts on the next restart. Use `plugin update` with the full marketplace-qualified id and your install scope (a bare plugin name fails with "not found"):
+**1. Refresh the marketplace catalog first.** `plugin update` moves the pin against whatever version is already in the local cache — it does not git-pull the catalog itself. Auto-refresh is off by default for third-party/local marketplaces like this one, so a new upstream release stays invisible until you refresh:
+
+```bash
+claude plugin marketplace update claude-code-hermit
+```
+
+**2. Move the plugin pin (durable).** Refreshing the marketplace alone does NOT update the installed version — it only stages it; the pin reverts on the next restart. Use `plugin update` with the full marketplace-qualified id and your install scope (a bare plugin name fails with "not found"):
 
 ```bash
 claude plugin update claude-code-hermit@claude-code-hermit --scope local
 ```
 
-**2. Run the upgrade skill.** Inside Claude Code, in each project that uses the plugin:
+**3. Run the upgrade skill.** Inside Claude Code, in each project that uses the plugin:
 
 ```
 /claude-code-hermit:hermit-evolve
@@ -37,7 +43,7 @@ claude plugin update claude-code-hermit@claude-code-hermit --scope local
 
 This detects the version gap, shows what changed, prompts for new settings, refreshes templates and the Docker entrypoint, and updates the CLAUDE.md session discipline block.
 
-### 3. What if I don't upgrade?
+### 4. What if I don't upgrade?
 
 `hermit-start.ts` merges missing config keys from defaults at runtime. Session start shows a soft nudge: "A hermit upgrade is available."
 

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -90,20 +90,48 @@ _get_plugin_count() {
 }
 
 # Enumerate updatable plugins inside the container as TAB-separated id<TAB>scope<TAB>version
-# rows. The container's claude-config volume is single-tenant, so user-scope entries are
-# safe to include; project/local entries are filtered to this project (projectPath equals
-# the host PROJECT_DIR via the ${PWD}:${PWD} mount). `id` is already <name>@<marketplace>.
+# rows, core first. The container's claude-config volume is single-tenant, so user-scope
+# entries are safe to include; project/local entries are filtered to this project
+# (projectPath equals the host PROJECT_DIR via the ${PWD}:${PWD} mount). `id` is already
+# <name>@<marketplace>. Core-first ordering matters: sibling hermits declare a `^core`
+# dependency, so updating core first lets them re-resolve against the new version instead
+# of hitting a stale-core version block in the same pass.
 _enumerate_plugins() {
   cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
     claude plugin list --json 2>/dev/null \
     | bun -e '
       const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
       const proj = process.argv[1];
+      const rows = [];
       for (const p of (Array.isArray(d) ? d : [])) {
         if (p.enabled !== true || !p.id) continue;
         const inProj = (p.scope === "project" || p.scope === "local") && p.projectPath === proj;
         if (!inProj && p.scope !== "user") continue;
+        rows.push(p);
+      }
+      rows.sort((a, b) => (a.id.startsWith("claude-code-hermit@") ? 0 : 1) - (b.id.startsWith("claude-code-hermit@") ? 0 : 1));
+      for (const p of rows) {
         console.log([p.id, p.scope ?? "", p.version ?? ""].join("\t"));
+      }
+    ' "$PROJECT_DIR" 2>/dev/null || true
+}
+
+# Emits id<TAB>errors for enumerated plugins currently reporting CLI errors (e.g.
+# dependency-version-unsatisfied, no-matching-tag). Read-only annotation — never drives
+# update logic, only explains an "unchanged" result in the summary/history.
+_enumerate_plugin_errors() {
+  cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" \
+    claude plugin list --json 2>/dev/null \
+    | bun -e '
+      const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
+      const proj = process.argv[1];
+      for (const p of (Array.isArray(d) ? d : [])) {
+        if (!p.id) continue;
+        const inProj = (p.scope === "project" || p.scope === "local") && p.projectPath === proj;
+        if (!inProj && p.scope !== "user") continue;
+        if (!Array.isArray(p.errors) || p.errors.length === 0) continue;
+        const errs = p.errors.map(e => typeof e === "string" ? e : (e.code || e.message || JSON.stringify(e))).join(";");
+        console.log([p.id, errs].join("\t"));
       }
     ' "$PROJECT_DIR" 2>/dev/null || true
 }
@@ -269,7 +297,7 @@ case "$CMD" in
           echo "    - $pid ($pscope, v$pver)"
         done
       fi
-      echo "  Apply method: claude plugin update per plugin, then /reload-plugins + hermit-evolve via tmux"
+      echo "  Apply method: refresh marketplaces, then claude plugin update per plugin (core first), then /reload-plugins + hermit-evolve via tmux"
     fi
 
     if [ "$DRY_RUN" = true ]; then
@@ -322,7 +350,29 @@ case "$CMD" in
     PLUGINS_OK_IDS=()
     PLUGINS_FAIL_IDS=()
     PLUGIN_ROWS_AFTER=""
+    PLUGIN_ERRORS_AFTER=""
     if [ "$CC_ONLY" = false ] && [ -n "$PLUGIN_ROWS" ]; then
+      # Refresh each backing marketplace's catalog first. `claude plugin update` moves the
+      # pin against whatever is already in the local cache — it does not git-pull. A
+      # third-party/local marketplace like this one has auto-update off by default, and the
+      # container only registers it on first boot, so without this refresh the cache stays
+      # frozen and every sibling silently resolves as "already up to date".
+      echo "[hermit] Refreshing plugin marketplaces..."
+      MARKETPLACES=$(printf '%s\n' "$PLUGIN_ROWS" | bun -e '
+        const lines = require("fs").readFileSync(0, "utf8").split("\n").filter(Boolean);
+        const seen = new Set();
+        for (const line of lines) {
+          const mp = (line.split("\t")[0] || "").split("@")[1];
+          if (mp) seen.add(mp);
+        }
+        console.log([...seen].join("\n"));
+      ')
+      while IFS= read -r mp; do
+        [ -z "$mp" ] && continue
+        cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" claude plugin marketplace update "$mp" 2>/dev/null || \
+          echo "[hermit] Warning: could not refresh marketplace $mp — updates may resolve against a stale catalog" >&2
+      done <<< "$MARKETPLACES"
+
       while IFS=$'\t' read -r pid pscope pver; do
         [ -z "$pid" ] && continue
         echo "[hermit] Updating $pid (scope $pscope)..."
@@ -339,6 +389,7 @@ case "$CMD" in
       # Re-read pinned versions NOW — the pin moves at CLI-update time, before reload, so
       # this read is reliable (reading after /reload-plugins risks list/session view lag).
       PLUGIN_ROWS_AFTER=$(_enumerate_plugins)
+      PLUGIN_ERRORS_AFTER=$(_enumerate_plugin_errors)
 
       # Apply in the running session — tmux send-keys on a pane that hasn't reached the
       # REPL yet goes to bash, not the skill queue, so wait for the prompt box first.
@@ -423,9 +474,9 @@ case "$CMD" in
     bun - "$UPDATE_MODE" "$CC_BEFORE" "$CC_AFTER" \
           "$PLUGIN_ROWS" "$PLUGIN_ROWS_AFTER" "$FAIL_IDS_JSON" \
           "$PLUGINS_COUNT_BEFORE" "$PLUGINS_COUNT_AFTER" "$LOG_FILE" \
-          "$RELOAD_PLUGINS_SENT" "$EVOLVE_SENT" <<'JSEOF' || \
+          "$RELOAD_PLUGINS_SENT" "$EVOLVE_SENT" "$PLUGIN_ERRORS_AFTER" <<'JSEOF' || \
       echo "[hermit] Warning: could not write update log" >&2
-const [mode, ccBefore, ccAfter, beforeTsv, afterTsv, failJson, pbCount, paCount, logFile, reloadSent, evolveSent] = process.argv.slice(2);
+const [mode, ccBefore, ccAfter, beforeTsv, afterTsv, failJson, pbCount, paCount, logFile, reloadSent, evolveSent, errorsTsv] = process.argv.slice(2);
 const parseRows = (tsv) => {
   const m = new Map();
   for (const line of (tsv || '').split('\n')) {
@@ -435,15 +486,32 @@ const parseRows = (tsv) => {
   }
   return m;
 };
+const parseErrors = (tsv) => {
+  const m = new Map();
+  for (const line of (tsv || '').split('\n')) {
+    if (!line.trim()) continue;
+    const [id, errors] = line.split('\t');
+    if (id) m.set(id, errors || '');
+  }
+  return m;
+};
 const before = parseRows(beforeTsv);
 const after = parseRows(afterTsv);
+const errors = parseErrors(errorsTsv);
 const failed = new Set(JSON.parse(failJson));
 const plugins = [];
 for (const [id, { scope, version }] of before) {
   const a = after.get(id);
   const afterVer = a ? a.version : version;
-  const status = failed.has(id) ? 'failed' : (afterVer !== version ? 'updated' : 'unchanged');
-  plugins.push({ id, scope, before: version, after: afterVer, status });
+  const err = errors.get(id);
+  const unchanged = afterVer === version;
+  let status;
+  if (failed.has(id)) status = 'failed';
+  else if (!unchanged) status = 'updated';
+  else status = err ? 'blocked' : 'unchanged';
+  const entry = { id, scope, before: version, after: afterVer, status };
+  if (err) entry.error = err;
+  plugins.push(entry);
 }
 const entry = {
   ts: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
@@ -466,13 +534,18 @@ JSEOF
       echo "  Plugins:"
       bun -e '
         const parse = (t) => { const m = new Map(); for (const l of (t||"").split("\n")) { if(!l.trim()) continue; const [id,scope,version]=l.split("\t"); if(id) m.set(id,{scope,version}); } return m; };
-        const before = parse(process.argv[1]); const after = parse(process.argv[2]); const failed = new Set(JSON.parse(process.argv[3]));
+        const parseErrors = (t) => { const m = new Map(); for (const l of (t||"").split("\n")) { if(!l.trim()) continue; const [id,errors]=l.split("\t"); if(id) m.set(id,errors||""); } return m; };
+        const before = parse(process.argv[1]); const after = parse(process.argv[2]); const failed = new Set(JSON.parse(process.argv[3])); const errors = parseErrors(process.argv[4]);
         for (const [id,{version}] of before) {
           const a = after.get(id); const av = a ? a.version : version;
-          const tag = failed.has(id) ? " (FAILED — run manually)" : (av !== version ? "" : " (unchanged)");
+          const err = errors.get(id);
+          let tag;
+          if (failed.has(id)) tag = " (FAILED — run manually)";
+          else if (av !== version) tag = "";
+          else tag = err ? ` (blocked — ${err})` : " (unchanged)";
           console.log("    " + id + ": v" + version + " -> v" + av + tag);
         }
-      ' "$PLUGIN_ROWS" "$PLUGIN_ROWS_AFTER" "$FAIL_IDS_JSON" 2>/dev/null || true
+      ' "$PLUGIN_ROWS" "$PLUGIN_ROWS_AFTER" "$FAIL_IDS_JSON" "$PLUGIN_ERRORS_AFTER" 2>/dev/null || true
     fi
     if [ "$CC_ONLY" = false ]; then
       if [ "$RELOAD_PLUGINS_SENT" = true ]; then

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-update
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-update
@@ -64,21 +64,48 @@ const name = config.tmux_session_name ?? 'hermit-{project_name}';
 console.log(name.replaceAll('{project_name}', require('path').basename(process.argv[2])));
 " "$CONFIG" "$PROJECT_DIR" 2>/dev/null || echo "hermit")
 
-# Enumerate plugins. Project/local entries scoped to THIS project move pins; user-scope
-# entries are skipped (moving a shared pin from a project wrapper would hit every project).
-# Emits class-tagged TAB rows: "UPDATE<TAB>id<TAB>scope<TAB>version" or "SKIPUSER<TAB>id<TAB>...".
+# Enumerate plugins, core first. Project/local entries scoped to THIS project move pins;
+# user-scope entries are skipped (moving a shared pin from a project wrapper would hit every
+# project). Emits class-tagged TAB rows: "UPDATE<TAB>id<TAB>scope<TAB>version" or
+# "SKIPUSER<TAB>id<TAB>...". Core-first ordering matters: sibling hermits declare a `^core`
+# dependency, so updating core first lets them re-resolve against the new version instead of
+# hitting a stale-core version block in the same pass.
 _enumerate_host() {
   claude plugin list --json 2>/dev/null \
     | bun -e '
       const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
       const proj = process.argv[1];
+      const rows = [];
       for (const p of (Array.isArray(d) ? d : [])) {
         if (p.enabled !== true || !p.id) continue;
         if ((p.scope === "project" || p.scope === "local") && p.projectPath === proj) {
-          console.log(["UPDATE", p.id, p.scope, p.version ?? ""].join("\t"));
+          rows.push(["UPDATE", p]);
         } else if (p.scope === "user") {
-          console.log(["SKIPUSER", p.id, p.scope, p.version ?? ""].join("\t"));
+          rows.push(["SKIPUSER", p]);
         }
+      }
+      rows.sort((a, b) => (a[1].id.startsWith("claude-code-hermit@") ? 0 : 1) - (b[1].id.startsWith("claude-code-hermit@") ? 0 : 1));
+      for (const [cls, p] of rows) {
+        console.log([cls, p.id, p.scope, p.version ?? ""].join("\t"));
+      }
+    ' "$PROJECT_DIR" 2>/dev/null || true
+}
+
+# Emits id<TAB>errors for enumerated plugins currently reporting CLI errors (e.g.
+# dependency-version-unsatisfied, no-matching-tag). Read-only annotation — never drives
+# update logic, only explains an "unchanged" result in the summary/history.
+_enumerate_host_errors() {
+  claude plugin list --json 2>/dev/null \
+    | bun -e '
+      const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
+      const proj = process.argv[1];
+      for (const p of (Array.isArray(d) ? d : [])) {
+        if (!p.id) continue;
+        const inProj = (p.scope === "project" || p.scope === "local") && p.projectPath === proj;
+        if (!inProj && p.scope !== "user") continue;
+        if (!Array.isArray(p.errors) || p.errors.length === 0) continue;
+        const errs = p.errors.map(e => typeof e === "string" ? e : (e.code || e.message || JSON.stringify(e))).join(";");
+        console.log([p.id, errs].join("\t"));
       }
     ' "$PROJECT_DIR" 2>/dev/null || true
 }
@@ -121,6 +148,26 @@ if [ "$ASSUME_YES" = false ]; then
   case "$ANS" in [yY]|[yY][eE][sS]) ;; *) echo "[hermit] Aborted."; exit 0 ;; esac
 fi
 
+# Refresh each backing marketplace's catalog first. `claude plugin update` moves the pin
+# against whatever is already in the local cache — it does not git-pull. A third-party/local
+# marketplace like this one has auto-update off by default, so without this refresh the
+# cache stays frozen and every sibling silently resolves as "already up to date".
+echo "[hermit] Refreshing plugin marketplaces..."
+MARKETPLACES=$(printf '%s\n' "$UPDATE_ROWS" | bun -e '
+  const lines = require("fs").readFileSync(0, "utf8").split("\n").filter(Boolean);
+  const seen = new Set();
+  for (const line of lines) {
+    const mp = (line.split("\t")[1] || "").split("@")[1];
+    if (mp) seen.add(mp);
+  }
+  console.log([...seen].join("\n"));
+')
+while IFS= read -r mp; do
+  [ -z "$mp" ] && continue
+  claude plugin marketplace update "$mp" 2>/dev/null || \
+    echo "[hermit] Warning: could not refresh marketplace $mp — updates may resolve against a stale catalog" >&2
+done <<< "$MARKETPLACES"
+
 PLUGINS_OK_IDS=()
 PLUGINS_FAIL_IDS=()
 while IFS=$'\t' read -r _cls pid pscope pver; do
@@ -138,6 +185,7 @@ done <<< "$UPDATE_ROWS"
 # Re-read pins now (pin moves at CLI-update time, before any reload).
 ROWS_AFTER=$(_enumerate_host)
 UPDATE_ROWS_AFTER=$(printf '%s\n' "$ROWS_AFTER" | grep '^UPDATE	' || true)
+PLUGIN_ERRORS_AFTER=$(_enumerate_host_errors)
 
 # --- Apply in the running tmux session if one exists (host tmux, no docker exec). ---
 RELOAD_PLUGINS_SENT=false
@@ -228,9 +276,9 @@ fi
 BEFORE_TSV=$(printf '%s\n' "$UPDATE_ROWS" | cut -f2-)
 AFTER_TSV=$(printf '%s\n' "$UPDATE_ROWS_AFTER" | cut -f2-)
 bun - "$BEFORE_TSV" "$AFTER_TSV" "$FAIL_IDS_JSON" "$LOG_FILE" \
-      "$RELOAD_PLUGINS_SENT" "$EVOLVE_SENT" <<'JSEOF' || \
+      "$RELOAD_PLUGINS_SENT" "$EVOLVE_SENT" "$PLUGIN_ERRORS_AFTER" <<'JSEOF' || \
   echo "[hermit] Warning: could not write update log" >&2
-const [beforeTsv, afterTsv, failJson, logFile, reloadSent, evolveSent] = process.argv.slice(2);
+const [beforeTsv, afterTsv, failJson, logFile, reloadSent, evolveSent, errorsTsv] = process.argv.slice(2);
 const parseRows = (tsv) => {
   const m = new Map();
   for (const line of (tsv || '').split('\n')) {
@@ -240,15 +288,32 @@ const parseRows = (tsv) => {
   }
   return m;
 };
+const parseErrors = (tsv) => {
+  const m = new Map();
+  for (const line of (tsv || '').split('\n')) {
+    if (!line.trim()) continue;
+    const [id, errors] = line.split('\t');
+    if (id) m.set(id, errors || '');
+  }
+  return m;
+};
 const before = parseRows(beforeTsv);
 const after = parseRows(afterTsv);
+const errors = parseErrors(errorsTsv);
 const failed = new Set(JSON.parse(failJson));
 const plugins = [];
 for (const [id, { scope, version }] of before) {
   const a = after.get(id);
   const afterVer = a ? a.version : version;
-  const status = failed.has(id) ? 'failed' : (afterVer !== version ? 'updated' : 'unchanged');
-  plugins.push({ id, scope, before: version, after: afterVer, status });
+  const err = errors.get(id);
+  const unchanged = afterVer === version;
+  let status;
+  if (failed.has(id)) status = 'failed';
+  else if (!unchanged) status = 'updated';
+  else status = err ? 'blocked' : 'unchanged';
+  const entry = { id, scope, before: version, after: afterVer, status };
+  if (err) entry.error = err;
+  plugins.push(entry);
 }
 const entry = {
   ts: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
@@ -267,13 +332,18 @@ if [ -n "$UPDATE_ROWS" ]; then
   echo "  Plugins:"
   bun -e '
     const parse = (t) => { const m = new Map(); for (const l of (t||"").split("\n")) { if(!l.trim()) continue; const [id,scope,version]=l.split("\t"); if(id) m.set(id,{scope,version}); } return m; };
-    const before = parse(process.argv[1]); const after = parse(process.argv[2]); const failed = new Set(JSON.parse(process.argv[3]));
+    const parseErrors = (t) => { const m = new Map(); for (const l of (t||"").split("\n")) { if(!l.trim()) continue; const [id,errors]=l.split("\t"); if(id) m.set(id,errors||""); } return m; };
+    const before = parse(process.argv[1]); const after = parse(process.argv[2]); const failed = new Set(JSON.parse(process.argv[3])); const errors = parseErrors(process.argv[4]);
     for (const [id,{version}] of before) {
       const a = after.get(id); const av = a ? a.version : version;
-      const tag = failed.has(id) ? " (FAILED — run manually)" : (av !== version ? "" : " (unchanged)");
+      const err = errors.get(id);
+      let tag;
+      if (failed.has(id)) tag = " (FAILED — run manually)";
+      else if (av !== version) tag = "";
+      else tag = err ? ` (blocked — ${err})` : " (unchanged)";
       console.log("    " + id + ": v" + version + " -> v" + av + tag);
     }
-  ' "$BEFORE_TSV" "$AFTER_TSV" "$FAIL_IDS_JSON" 2>/dev/null || true
+  ' "$BEFORE_TSV" "$AFTER_TSV" "$FAIL_IDS_JSON" "$PLUGIN_ERRORS_AFTER" 2>/dev/null || true
 fi
 if [ "$EVOLVE_SENT" = true ]; then
   echo "  hermit-evolve auto-started (unattended) — hermit config is upgrading."

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -157,14 +157,33 @@ describe('static file checks', () => {
     }
   });
 
-  test('hermit-docker update moves the pin, not the marketplace', () => {
+  test('hermit-docker update refreshes marketplaces (core first), then moves the pin', () => {
     const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'state-templates', 'bin', 'hermit-docker'), 'utf8');
-    // The whole point of the fix: durable `plugin update` per plugin with explicit scope...
+    // Durable `plugin update` per plugin with explicit scope...
     expect(src).toContain('claude plugin update');
     expect(src).toContain('--scope');
     expect(src).toContain('hermit-evolve unattended');
-    // ...and NOT the old ephemeral marketplace-refresh loop.
-    expect(src).not.toContain('claude plugin marketplace update');
+    // ...preceded by a marketplace refresh — `plugin update` only moves the pin against
+    // whatever is already in the local cache, it does not git-pull the catalog itself.
+    const marketplaceIdx = src.indexOf('claude plugin marketplace update');
+    const updateLoopIdx = src.indexOf('claude plugin update "$pid"');
+    expect(marketplaceIdx).toBeGreaterThan(-1);
+    expect(updateLoopIdx).toBeGreaterThan(-1);
+    expect(marketplaceIdx).toBeLessThan(updateLoopIdx);
+    // Core-first ordering so `^core`-dependent siblings re-resolve against the new core.
+    expect(src).toContain('.sort((a, b) =>');
+  });
+
+  test('hermit-update refreshes marketplaces (core first), then moves the pin', () => {
+    const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'state-templates', 'bin', 'hermit-update'), 'utf8');
+    expect(src).toContain('claude plugin update');
+    expect(src).toContain('--scope');
+    const marketplaceIdx = src.indexOf('claude plugin marketplace update');
+    const updateLoopIdx = src.indexOf('claude plugin update "$pid"');
+    expect(marketplaceIdx).toBeGreaterThan(-1);
+    expect(updateLoopIdx).toBeGreaterThan(-1);
+    expect(marketplaceIdx).toBeLessThan(updateLoopIdx);
+    expect(src).toContain('.sort((a, b) =>');
   });
 });
 
@@ -191,18 +210,20 @@ describe('hermit-update host path', () => {
     fs.mkdirSync(stub, { recursive: true });
     const listFile = path.join(stub, 'list.json');
     const recFile = path.join(stub, 'rec.txt');
+    const mpRecFile = path.join(stub, 'mp-rec.txt');
     write(listFile, opts.listJson(proj));
     write(path.join(stub, 'claude'),
       `#!/usr/bin/env bash\n` +
       `if [ "$1" = "plugin" ] && [ "$2" = "list" ]; then cat "${listFile}"; exit 0; fi\n` +
       `if [ "$1" = "plugin" ] && [ "$2" = "update" ]; then echo "$@" >> "${recFile}"; exit 0; fi\n` +
+      `if [ "$1" = "plugin" ] && [ "$2" = "marketplace" ] && [ "$3" = "update" ]; then echo "$4" >> "${mpRecFile}"; exit 0; fi\n` +
       `exit 0\n`);
     write(path.join(stub, 'tmux'),
       `#!/usr/bin/env bash\n[ "$1" = "has-session" ] && exit 1\nexit 0\n`);
     fs.chmodSync(path.join(stub, 'claude'), 0o755);
     fs.chmodSync(path.join(stub, 'tmux'), 0o755);
 
-    return { wd, proj, recFile, env: { PATH: `${stub}:${process.env.PATH}` } };
+    return { wd, proj, recFile, mpRecFile, env: { PATH: `${stub}:${process.env.PATH}` } };
   }
 
   const listThreeScopes = (proj: string) => JSON.stringify([
@@ -231,6 +252,10 @@ describe('hermit-update host path', () => {
       expect(entry.mode).toBe('host-plugins');
       expect(Array.isArray(entry.plugins)).toBe(true);
       expect(entry.plugins[0].id).toBe('claude-code-hermit@claude-code-hermit');
+      // marketplace refreshed before the pin move (the bug this fixes: `plugin update`
+      // only moves the pin against whatever is already in the local cache)
+      const mpRec = fs.existsSync(f.mpRecFile) ? fs.readFileSync(f.mpRecFile, 'utf8') : '';
+      expect(mpRec).toContain('claude-code-hermit');
     } finally { f.wd.cleanup(); }
   });
 
@@ -239,6 +264,42 @@ describe('hermit-update host path', () => {
     try {
       await runBash(hermit(f.proj, 'bin', 'hermit-update'), { args: ['--dry-run'], cwd: f.proj, env: f.env });
       expect(fs.existsSync(f.recFile)).toBe(false);
+    } finally { f.wd.cleanup(); }
+  });
+
+  // Regression: siblings (dev-hermit, hermit-scribe, ...) previously never moved past
+  // core because the source list here is intentionally NOT core-first — the wrapper
+  // must reorder it itself.
+  const listMultiSibling = (proj: string) => JSON.stringify([
+    { id: 'hermit-scribe@claude-code-hermit', scope: 'project', enabled: true, version: '0.0.5', projectPath: proj },
+    { id: 'claude-code-dev-hermit@claude-code-hermit', scope: 'project', enabled: true, version: '0.4.6', projectPath: proj },
+    { id: 'claude-code-hermit@claude-code-hermit', scope: 'project', enabled: true, version: '1.2.14', projectPath: proj },
+  ]);
+
+  test('multi-sibling: every hermit updates, core first, all recorded in history', async () => {
+    const f = fixture({ listJson: listMultiSibling });
+    try {
+      await runBash(hermit(f.proj, 'bin', 'hermit-update'), { args: ['--yes'], cwd: f.proj, env: f.env });
+      const rec = fs.existsSync(f.recFile) ? fs.readFileSync(f.recFile, 'utf8').trim().split('\n') : [];
+      // every sibling gets a durable pin move with its own id and scope
+      expect(rec.some(l => l === 'plugin update claude-code-hermit@claude-code-hermit --scope project')).toBe(true);
+      expect(rec.some(l => l === 'plugin update claude-code-dev-hermit@claude-code-hermit --scope project')).toBe(true);
+      expect(rec.some(l => l === 'plugin update hermit-scribe@claude-code-hermit --scope project')).toBe(true);
+      // core is updated before either sibling, regardless of source list order
+      const coreIdx = rec.findIndex(l => l.includes('claude-code-hermit@claude-code-hermit'));
+      const devIdx = rec.findIndex(l => l.includes('claude-code-dev-hermit@claude-code-hermit'));
+      const scribeIdx = rec.findIndex(l => l.includes('hermit-scribe@claude-code-hermit'));
+      expect(coreIdx).toBeGreaterThanOrEqual(0);
+      expect(coreIdx).toBeLessThan(devIdx);
+      expect(coreIdx).toBeLessThan(scribeIdx);
+      // history entry records all three, not just core
+      const hist = fs.readFileSync(hermit(f.proj, 'state', 'update-history.jsonl'), 'utf8').trim();
+      const entry = JSON.parse(hist);
+      expect(entry.plugins.map((p: any) => p.id).sort()).toEqual([
+        'claude-code-dev-hermit@claude-code-hermit',
+        'claude-code-hermit@claude-code-hermit',
+        'hermit-scribe@claude-code-hermit',
+      ]);
     } finally { f.wd.cleanup(); }
   });
 });


### PR DESCRIPTION
## Summary
`hermit-docker update` and `hermit-update` only ever updated the core `claude-code-hermit` plugin — domain/sibling hermits (dev, home-assistant, fitness, forge, scribe) silently stayed pinned, contradicting what `docs/upgrading.md` promises ("the wrappers above update every installed hermit plugin in one pass").

Root cause is two Claude Code CLI behaviors that both cut the same way: `claude plugin update` only moves the pin against whatever is already in the *local* marketplace cache (it doesn't git-pull), and third-party/local marketplaces like this repo's have auto-update off by default — the container only registers the marketplace once, on first boot. Separately, every sibling declares a `^core` dependency that Claude Code resolves via git tags, so an unsatisfied range disables the dependent rather than upgrading core; core has no dependency, so it always "wins."

## Changes
- `hermit-docker` / `hermit-update`: refresh each backing marketplace's catalog before the per-plugin update loop, and process core first so `^core`-dependent siblings re-resolve cleanly in the same pass.
- Add a read-only errors annotation (`claude plugin list --json`'s `errors` field) so a plugin left `unchanged` because of a live CLI error (e.g. `dependency-version-unsatisfied`) is reported as `blocked` with the reason — in the terminal summary and `update-history.jsonl` — instead of silently looking up to date.
- `tests/scripts.test.ts`: flip the static test that used to assert `marketplace update` was absent (now asserts it's present and ordered before the pin move); add a multi-sibling behavioral fixture proving every hermit updates, core first, all recorded in history.
- `CHANGELOG.md` `[Unreleased]` entry + Upgrade Instructions (existing hermits pick this up via `hermit-evolve`'s Step 5b bin-wrapper refresh); `docs/upgrading.md` and `docs/troubleshooting.md` updated to match the new behavior.

## Test plan
- `bash -n` on both wrapper scripts — syntax valid
- `bunx tsc --noEmit` — clean
- `bun test` (plugins/claude-code-hermit) — 1460 pass, 0 fail, including the new multi-sibling and flipped-ordering tests
- Manually exercised the embedded bun snippets (core-first sort, marketplace extraction, error extraction, status classification) against sample `claude plugin list --json` payloads