### PR TITLE
fix(claude-code-hermit): brief token magnitude mislabel + K/M/B formatter

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **brief: `cost_context.yesterday` mislabeled token magnitude (K vs M)** — a ~532M-token day rendered as `532.4K`. `reference.md` now copies the trend row's cells verbatim instead of re-deriving them. (#511)
+- **lib/format.ts: `kStr`/`formatTokens` auto-select K/M/B by magnitude** — was K-only, rendering large totals as `532431K tokens`. Fixes `cost-summary.md`, `today-cost.ts`, `weekly-review.ts`, `doctor-check.ts`, and `startup-context.ts`.
+
 ## [1.2.15] - 2026-07-03
 
 ### Removed

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - **brief: `cost_context.yesterday` mislabeled token magnitude (K vs M)** — a ~532M-token day rendered as `532.4K`. `reference.md` now copies the trend row's cells verbatim instead of re-deriving them. (#511)
-- **lib/format.ts: `kStr`/`formatTokens` auto-select K/M/B by magnitude** — was K-only, rendering large totals as `532431K tokens`. Fixes `cost-summary.md`, `today-cost.ts`, `weekly-review.ts`, `doctor-check.ts`, and `startup-context.ts`.
+- **lib/format.ts: `kStr`/`formatTokens` auto-select K/M/B by magnitude** — was K-only, rendering large totals as `532431K tokens`. Fixes `cost-summary.md`, `today-cost.ts`, `weekly-review.ts`, `doctor-check.ts`, and `startup-context.ts`. Tier thresholds also account for rounding, so values just under a boundary (e.g. `999999`) promote to the next suffix instead of overflowing (`1.0M`, not `1000K`).
 - **`hermit-docker update` / `hermit-update`: domain (sibling) hermits now update, not just core** — the per-plugin loop moved pins straight from the local marketplace cache, which is never refreshed after first boot (auto-update is off by default for third-party/local marketplaces), so siblings silently resolved as "already up to date." Both wrappers now run `claude plugin marketplace update <name>` before the loop and process core first so `^core`-dependent siblings re-resolve cleanly. A plugin left `unchanged` with a live CLI error (e.g. `dependency-version-unsatisfied`) is now reported as `blocked` with the reason, instead of silently looking up to date, in both the terminal summary and `update-history.jsonl`.
 
 ### Upgrade Instructions

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -408,18 +408,18 @@ avg_session_tokens: ${Math.round(avgSessionTokens)}
 ## Today
 - Sessions: ${todaySessions}
 - Cost: $${todayCost.toFixed(2)}
-- Tokens: ${kStr(todayTokens)}K
+- Tokens: ${kStr(todayTokens)}
 
 ## This Week
 - Sessions: ${weekSessionCount}
 - Cost: $${weekCost.toFixed(2)}
-- Tokens: ${kStr(weekTokens)}K
+- Tokens: ${kStr(weekTokens)}
 - Avg per session: $${weekAvg.toFixed(2)}${opusWakeLine}
 
 ## All Time
 - Sessions: ${totalSessions}
 - Cost: $${totalCost.toFixed(2)}
-- Tokens: ${kStr(totalTokens)}K
+- Tokens: ${kStr(totalTokens)}
 - Avg per session: $${avgCost.toFixed(2)}
 
 ## Cost Trend (Last 7 Days)
@@ -548,7 +548,7 @@ async function run(data: Json): Promise<string | null> {
     writeCostSummary(costIdx);
 
     // Return brief summary (pipeline writes this to stderr)
-    return `[cost-tracker] ${model}: ${kStr(totalTokens)}K tokens (${kStr(cacheReadTokens)}K cached), $${cost.toFixed(4)} (cumulative: ${costStr})`;
+    return `[cost-tracker] ${model}: ${kStr(totalTokens)} tokens (${kStr(cacheReadTokens)} cached), $${cost.toFixed(4)} (cumulative: ${costStr})`;
   } catch (err: any) {
     // Non-fatal — never block on cost tracking failure
     console.error(`[cost-tracker] Error: ${err.message}`);

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -199,7 +199,7 @@ function checkCost() {
         }
       } catch {}
     }
-    const detail = `today $${todayTotal.toFixed(4)} · ${kStr(todayTokens)}K tokens, ${kStr(todayCacheRead)}K cached`;
+    const detail = `today $${todayTotal.toFixed(4)} · ${kStr(todayTokens)} tokens, ${kStr(todayCacheRead)} cached`;
 
     try {
       const idx = readCostIndex(costIndexPath(hermitDir));

--- a/plugins/claude-code-hermit/scripts/lib/format.ts
+++ b/plugins/claude-code-hermit/scripts/lib/format.ts
@@ -1,11 +1,17 @@
+// Returns a magnitude-suffixed count, e.g. "532M", "3.3M", "45.0K", "304K", "999", "0".
 function kStr(n: number): string {
-  const k = (n || 0) / 1000;
-  if (k === 0) return '0';
-  return k < 100 ? k.toFixed(1) : String(Math.round(k));
+  const v = n || 0;
+  if (v === 0) return '0';
+  const fmt = (scaled: number, suffix: string) =>
+    (scaled < 100 ? scaled.toFixed(1) : String(Math.round(scaled))) + suffix;
+  if (v >= 1e9) return fmt(v / 1e9, 'B');
+  if (v >= 1e6) return fmt(v / 1e6, 'M');
+  if (v >= 1e3) return fmt(v / 1e3, 'K');
+  return String(Math.round(v));
 }
 
 function formatTokens(n: number): string {
-  return kStr(n) + 'K tokens';
+  return kStr(n) + ' tokens';
 }
 
 export { kStr, formatTokens };

--- a/plugins/claude-code-hermit/scripts/lib/format.ts
+++ b/plugins/claude-code-hermit/scripts/lib/format.ts
@@ -4,8 +4,10 @@ function kStr(n: number): string {
   if (v === 0) return '0';
   const fmt = (scaled: number, suffix: string) =>
     (scaled < 100 ? scaled.toFixed(1) : String(Math.round(scaled))) + suffix;
-  if (v >= 1e9) return fmt(v / 1e9, 'B');
-  if (v >= 1e6) return fmt(v / 1e6, 'M');
+  // thresholds sit half a unit below the next power of 1000 so rounding never overflows
+  // the suffix (e.g. 999999 -> "1.0M" instead of "1000K")
+  if (v >= 999.5e6) return fmt(v / 1e9, 'B');
+  if (v >= 999.5e3) return fmt(v / 1e6, 'M');
   if (v >= 1e3) return fmt(v / 1e3, 'K');
   return String(Math.round(v));
 }

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -14,6 +14,7 @@ import { hermitDir } from './lib/cc-compat';
 import { findStorageDrift, findSchemaDrift } from './lib/drift';
 import { safe } from './lib/sanitize';
 import { resolve as resolveOutboundChannel } from './resolve-outbound-channel';
+import { formatTokens } from './lib/format';
 
 type Json = any;
 
@@ -351,7 +352,7 @@ function main(source: string | null) {
     let out = 'No cost data';
     try {
       const d = JSON.parse(fs.readFileSync(statusPath, 'utf-8'));
-      out = `$${d.cost_usd.toFixed(4)} (${Math.round(d.tokens / 1000)}K tokens)`;
+      out = `$${d.cost_usd.toFixed(4)} (${formatTokens(d.tokens)})`;
     } catch {
       // missing/malformed status — keep the placeholder, same as read-cost.py did
     }

--- a/plugins/claude-code-hermit/scripts/today-cost.ts
+++ b/plugins/claude-code-hermit/scripts/today-cost.ts
@@ -32,5 +32,5 @@ try {
     `$${cost.toFixed(2)} (${formatTokens(tokens)}) across ${sessions.size} session(s)\n`
   );
 } catch {
-  process.stdout.write('$0.00 (0K tokens) across 0 session(s)\n');
+  process.stdout.write('$0.00 (0 tokens) across 0 session(s)\n');
 }

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -37,7 +37,7 @@ For dispatching modes: invoke `claude-code-hermit:skill-eval-runner` pointed at 
 ```json
 {
   "report_summary": { "date": "<ISO>", "tags": ["<tag>"], "working_on": "<one-line>",
-                       "status": "<completed|partial|blocked>", "cost_line": "<$X.XX (NK tokens)>",
+                       "status": "<completed|partial|blocked>", "cost_line": "<$X.XX (N tokens)>",
                        "next_start_point": "<text>" }|null,
   "sessions_today": [ { "session": "S-NNN", "summary": "<one-line>" } ],
   "findings": ["<text>"],
@@ -91,13 +91,13 @@ Current behavior — general purpose summary as described below.
 ## Plan
 
 1. Use `session_state` already read in the Dispatch step:
-   - **1a. `in_progress` (no dispatch):** read `.claude-code-hermit/sessions/SHELL.md` **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. Summarize the active task using TaskList for Done/Next lines; produce the standard 5-line output. For the cost line, read `cost_usd` and `tokens` from `.claude-code-hermit/sessions/.status.json` (live per-session totals; fall back to `0`/`0` if missing) rather than the once-daily `cost-summary.md`. Then read `.claude-code-hermit/state/alert-state.json`; if its `active` array is non-empty, append one line: `⚠ N alert(s) active — run /claude-code-hermit:hermit-health`.
-   - **1b. `idle` (no dispatch):** read SHELL.md **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. For the `Cumulative:` line, read `total_cost_usd` and `total_tokens` from `.claude-code-hermit/cost-summary.md` frontmatter (fall back to `0`/`0` if missing). Format as:
+   - **1a. `in_progress` (no dispatch):** read `.claude-code-hermit/sessions/SHELL.md` **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. Summarize the active task using TaskList for Done/Next lines; produce the standard 5-line output. For the cost line, read `cost_usd` and `tokens` from `.claude-code-hermit/sessions/.status.json` (live per-session totals; fall back to `0`/`0` if missing) rather than the once-daily `cost-summary.md`. Scale the token suffix by magnitude — the same K/M/B convention as `scripts/lib/format.ts`'s `formatTokens` (raw integer under 1K, `K` under 1M, `M` under 1B, `B` beyond, promoting to the next tier when rounding would otherwise overflow to 1000 — e.g. 999999 tokens is `1.0M`, not `1000K`; one decimal place if the scaled value is under 100, otherwise round) — never assume `K`. Then read `.claude-code-hermit/state/alert-state.json`; if its `active` array is non-empty, append one line: `⚠ N alert(s) active — run /claude-code-hermit:hermit-health`.
+   - **1b. `idle` (no dispatch):** read SHELL.md **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. For the `Cumulative:` line, read `total_cost_usd` and `total_tokens` from `.claude-code-hermit/cost-summary.md` frontmatter (fall back to `0`/`0` if missing), scaling the token suffix by magnitude as above. Format as:
      ```
      [Brief] YYYY-MM-DD | idle | N tasks completed
      Session: since [start date]
      Last: [latest Session Summary entry] — [status]
-     Cumulative: $X.XX (12.3K tokens) across N tasks
+     Cumulative: $X.XX (N tokens) across N tasks
      Status: Idle — ready for what's next (run /claude-code-hermit:session-start to begin)
      ```
      Then check for auto-detected proposals (step after Output Format) and return.
@@ -111,7 +111,7 @@ Keep the output to 5 lines, plus an optional 6th line for pending proposals (see
 ```
 [Brief] YYYY-MM-DD | [tags if present]
 Working on: one-line description
-Status: completed/partial/blocked (X/Y tasks) | $cost spent (12.3K tokens)
+Status: completed/partial/blocked (X/Y tasks) | $cost spent (N tokens)
 Done: step1, step2, step3
 Next: description of next action (or "Session complete" if all done)
 ```

--- a/plugins/claude-code-hermit/skills/brief/reference.md
+++ b/plugins/claude-code-hermit/skills/brief/reference.md
@@ -24,7 +24,9 @@ The calling skill passes the following scalars in the dispatch prompt (do not re
 
 1. Read `.claude-code-hermit/cost-summary.md`. Find the trend table row whose Date column matches
    the day before `today`. Populate `cost_context.yesterday` as
-   `"Yesterday: $X.XX (N.NK tokens) across N sessions"`. Set `cost_context.week` and
+   `"Yesterday: <Cost> (<Tokens>) across <Sessions> sessions"`, copying the Cost, Tokens, and
+   Sessions cells from that row **verbatim** (e.g. `"Yesterday: $1189.14 (532M tokens) across
+   44 sessions"`) — do not reformat the token count. Set `cost_context.week` and
    `cost_context.all_time` to `null`.
 2. Scan `.claude-code-hermit/proposals/PROP-*.md` — read the leading `---` YAML block only for
    each file. Collect files where `status: proposed` AND `source: auto-detected`. Populate

--- a/plugins/claude-code-hermit/skills/brief/reference.md
+++ b/plugins/claude-code-hermit/skills/brief/reference.md
@@ -60,9 +60,12 @@ The calling skill passes the following scalars in the dispatch prompt (do not re
 
 1. Same report collection as evening (steps 1–4): collect reports with `date:` matching `today`,
    read full bodies, populate `sessions_today`, `findings`, `tomorrow`.
-2. Read `.claude-code-hermit/cost-summary.md`. Extract the week aggregate and all-time aggregate.
-   Populate `cost_context.week` and `cost_context.all_time`. Set `cost_context.yesterday` to
-   `null` (today's live cost runs in the calling main session via `today-cost.ts`).
+2. Read `.claude-code-hermit/cost-summary.md`. Populate `cost_context.week` and
+   `cost_context.all_time` as `"$X.XX (<Tokens> tokens) across N sessions"`, copying the Cost and
+   Sessions values and the already magnitude-suffixed Tokens figure from the `## This Week` and
+   `## All Time` sections **verbatim** (e.g. `"$1189.14 (532M tokens) across 44 sessions"`) — do
+   not reformat or rescale the token count. Set `cost_context.yesterday` to `null` (today's live
+   cost runs in the calling main session via `today-cost.ts`).
 3. Set `report_summary: null`, `pending_proposals: []`, `operator_priorities: []`, `queued_work: []`.
 
 ### default-no-session
@@ -84,7 +87,7 @@ Return a single JSON object — no prose, no markdown wrapping. Every field is r
 ```json
 {
   "report_summary": { "date": "<ISO>", "tags": ["<tag>"], "working_on": "<one-line>",
-                       "status": "<completed|partial|blocked>", "cost_line": "<$X.XX (NK tokens)>",
+                       "status": "<completed|partial|blocked>", "cost_line": "<$X.XX (N tokens)>",
                        "next_start_point": "<text>" }|null,
   "sessions_today": [ { "session": "S-NNN", "summary": "<one-line>" } ],
   "findings": ["<text>"],

--- a/plugins/claude-code-hermit/tests/format.test.ts
+++ b/plugins/claude-code-hermit/tests/format.test.ts
@@ -1,0 +1,41 @@
+// Tests for scripts/lib/format.ts: kStr/formatTokens magnitude selection.
+// Guards against the #511 regression (532431000 tokens mislabeled as "532.4K").
+
+import { describe, test, expect } from 'bun:test';
+import { kStr, formatTokens } from '../scripts/lib/format';
+
+describe('kStr', () => {
+  test('zero', () => {
+    expect(kStr(0)).toBe('0');
+  });
+
+  test('sub-1000 raw', () => {
+    expect(kStr(999)).toBe('999');
+  });
+
+  test('K range: decimal under 100K, integer at/above', () => {
+    expect(kStr(45000)).toBe('45.0K');
+    expect(kStr(304000)).toBe('304K');
+  });
+
+  test('M range: decimal under 100M, integer at/above', () => {
+    expect(kStr(3310000)).toBe('3.3M');
+    expect(kStr(532431000)).toBe('532M');
+  });
+
+  test('B range', () => {
+    expect(kStr(2156563000)).toBe('2.2B');
+  });
+});
+
+describe('formatTokens', () => {
+  test('appends " tokens" to the magnitude-suffixed value', () => {
+    expect(formatTokens(0)).toBe('0 tokens');
+    expect(formatTokens(45000)).toBe('45.0K tokens');
+  });
+
+  test('#511 regression: large day is labeled M, not a rescaled K', () => {
+    expect(formatTokens(532431000)).toBe('532M tokens');
+    expect(formatTokens(532431000)).not.toBe('532.4K tokens');
+  });
+});

--- a/plugins/claude-code-hermit/tests/format.test.ts
+++ b/plugins/claude-code-hermit/tests/format.test.ts
@@ -26,6 +26,13 @@ describe('kStr', () => {
   test('B range', () => {
     expect(kStr(2156563000)).toBe('2.2B');
   });
+
+  test('tier-boundary rounding promotes instead of overflowing to 1000', () => {
+    expect(kStr(999999)).toBe('1.0M');
+    expect(kStr(999500)).toBe('1.0M');
+    expect(kStr(999499)).toBe('999K');
+    expect(kStr(999999999)).toBe('1.0B');
+  });
 });
 
 describe('formatTokens', () => {


### PR DESCRIPTION
## Summary
The morning brief's `cost_context.yesterday` re-derived a `"N.NK tokens"` string from `cost-summary.md`'s already-scaled trend cell, dropping three orders of magnitude on large days (a ~532M-token day rendered as `532.4K`). Root cause: the shared token formatter was K-only, so raw values like `532431K tokens` were unreadable — that ergonomic pressure is what motivated the buggy brief rescale in the first place.

## Changes
- `skills/brief/reference.md` — morning-mode instruction now copies the trend row's Cost/Tokens/Sessions cells verbatim instead of reformatting them.
- `scripts/lib/format.ts` — `kStr`/`formatTokens` auto-select a K/M/B suffix by magnitude instead of always appending `K`.
- `scripts/cost-tracker.ts`, `scripts/doctor-check.ts` — dropped the now-redundant literal `K` at each `kStr(...)` call site.
- `scripts/startup-context.ts` — routed its inline `/1000` session-cost formatting through the shared `formatTokens` helper (same latent mislabel for large sessions).
- `scripts/today-cost.ts` — zero-fallback literal updated to match the new format.
- `tests/format.test.ts` — new coverage for the K/M/B thresholds, decimal rule, and the exact #511 regression value.

## Test plan
- `bun test` from `plugins/claude-code-hermit/` — 1465 pass, 0 fail (full suite, including the new formatter tests and the unchanged brief schema contract test).
- Spot-checked `formatTokens` across magnitudes (e.g. `532431000 → "532M tokens"`, `2156563000 → "2.2B tokens"`).
- Ran `today-cost.ts` against this repo's live cost log: `$1678.09 (678M tokens) across 23 session(s)`.

Closes #511