### PR TITLE
fix: operator-facing doc pointers no longer dangle downstream

### DIFF
--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -9,6 +9,9 @@ on:
       # Cross-plugin invariants in hooks.contract.test.ts walk every plugin's
       # manifest and the marketplace, so those paths must trigger this suite too.
       - 'plugins/*/.claude-plugin/**'
+      # operator-doc-refs.test.ts walks every plugin's state-templates for bare
+      # docs/ refs, so a sibling plugin's state-template edit must run this suite.
+      - 'plugins/*/state-templates/**'
       - '.claude-plugin/marketplace.json'
       - '.github/workflows/test-hooks.yml'
       - 'package.json'
@@ -21,6 +24,9 @@ on:
       # Cross-plugin invariants in hooks.contract.test.ts walk every plugin's
       # manifest and the marketplace, so those paths must trigger this suite too.
       - 'plugins/*/.claude-plugin/**'
+      # operator-doc-refs.test.ts walks every plugin's state-templates for bare
+      # docs/ refs, so a sibling plugin's state-template edit must run this suite.
+      - 'plugins/*/state-templates/**'
       - '.claude-plugin/marketplace.json'
       - '.github/workflows/test-hooks.yml'
       - 'package.json'

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **operator doc pointers no longer dangle** — CLAUDE-APPEND, the SessionStart storage-drift line, and the docker-compose template stopped naming plugin-root docs by a bare `docs/…` path (unresolvable from the operator's project cwd, where the plugin's `docs/` doesn't exist); the artifact-refresh skill refs now use `${CLAUDE_PLUGIN_ROOT}/docs/`. New `operator-doc-refs` test fails the build on any bare `docs/…` ref in a state-template or SessionStart injection.
+
 ## [1.2.17] - 2026-07-05
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -435,7 +435,7 @@ function checkStaleRuntime(config: Json, sessionName: string): void {
 /** Acquire exclusive lifecycle lock. Exits on contention. */
 function acquireLifecycleLock(): void {
   if (process.platform === 'win32') {
-    console.log('[hermit] Always-on mode requires Linux, macOS, or WSL2. See docs/faq.md.');
+    console.log('[hermit] Always-on mode requires Linux, macOS, or WSL2. See https://github.com/gtapps/claude-code-hermit/blob/main/plugins/claude-code-hermit/docs/faq.md.');
     process.exit(1);
   }
   fs.mkdirSync(STATE_DIR, { recursive: true });

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -324,7 +324,7 @@ function main(source: string | null) {
       if (hits.length > 0) {
         const lines = hits.slice(0, 5).map(h => `- ${h}`).join('\n');
         const suffix = hits.length > 5 ? `\n(${hits.length - 5} more)` : '';
-        const body = `${hits.length} path${hits.length !== 1 ? 's' : ''} invisible to session injection and archival:\n${lines}${suffix}\nMove files into .claude-code-hermit/raw/ or compiled/ (flat). See docs/plugin-hermit-storage.md.`;
+        const body = `${hits.length} path${hits.length !== 1 ? 's' : ''} invisible to session injection and archival:\n${lines}${suffix}\nMove files into .claude-code-hermit/raw/ or compiled/ (flat).`;
         emit('Storage Drift', body.slice(0, BUDGETS.storageDrift));
       }
     } catch {}

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -54,7 +54,7 @@ For dispatching modes: invoke `claude-code-hermit:skill-eval-runner` pointed at 
 
 ### --morning (routine mode)
 
-**Delivery:** Write the full composed brief text (before any push-fallback single-line condensing) to `.claude-code-hermit/state/last-brief.json` as `{"kind":"morning","text":"<brief text>","generated_at":"<now, ISO>"}`, so the dashboard's "latest brief" section can pick it up. Then refresh the dashboard per docs/artifacts.md; if it returns a URL, append a final line `📎 <url>`. Then deliver the brief to the operator (see Always-On Delivery Rule above).
+**Delivery:** Write the full composed brief text (before any push-fallback single-line condensing) to `.claude-code-hermit/state/last-brief.json` as `{"kind":"morning","text":"<brief text>","generated_at":"<now, ISO>"}`, so the dashboard's "latest brief" section can pick it up. Then refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md`; if it returns a URL, append a final line `📎 <url>`. Then deliver the brief to the operator (see Always-On Delivery Rule above).
 
 Emphasize forward-looking content. Compose from runner JSON (see Dispatch above) and live main-session data:
 - **Cost context:** use `runner.cost_context.yesterday`
@@ -75,7 +75,7 @@ After composing the morning brief, check `state/micro-proposals.json → pending
 
 ### --evening (routine mode)
 
-**Delivery:** Write the full composed brief text (before any push-fallback single-line condensing) to `.claude-code-hermit/state/last-brief.json` as `{"kind":"evening","text":"<brief text>","generated_at":"<now, ISO>"}`, so the dashboard's "latest brief" section can pick it up. Then refresh the dashboard per docs/artifacts.md; if it returns a URL, append a final line `📎 <url>`. Then deliver the brief to the operator (see Always-On Delivery Rule above).
+**Delivery:** Write the full composed brief text (before any push-fallback single-line condensing) to `.claude-code-hermit/state/last-brief.json` as `{"kind":"evening","text":"<brief text>","generated_at":"<now, ISO>"}`, so the dashboard's "latest brief" section can pick it up. Then refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md`; if it returns a URL, append a final line `📎 <url>`. Then deliver the brief to the operator (see Always-On Delivery Rule above).
 
 Emphasize backward-looking content. Compose from runner JSON (see Dispatch above) and live main-session data:
 - **Sessions today:** use `runner.sessions_today`; also note any progress in the current SHELL.md progress log (read SHELL.md in main **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**).

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -53,7 +53,7 @@ All timestamps in frontmatter and Operator Decision text use ISO 8601 with timez
 
 ## Dashboard Refresh
 
-Every flow below (accept, defer, dismiss, resolve) changes a proposal's status. After its final "Respond" step, refresh the dashboard and the proposals page (`config.artifacts.proposals`) per docs/artifacts.md — both silently, no URL re-post (unlike `proposal-create`'s initial announcement, these status-change confirmations don't carry a deep link).
+Every flow below (accept, defer, dismiss, resolve) changes a proposal's status. After its final "Respond" step, refresh the dashboard and the proposals page (`config.artifacts.proposals`) per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md` — both silently, no URL re-post (unlike `proposal-create`'s initial announcement, these status-change confirmations don't carry a deep link).
 
 ## Accept Flow
 

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -104,7 +104,7 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts \
    ```
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/generate-summary.ts .claude-code-hermit/state/
    ```
-6. Refresh the dashboard per docs/artifacts.md (silently — no URL re-post; the proposal queue changed). Also refresh the proposals page (`config.artifacts.proposals`) per the same doc. Unlike the dashboard, when the proposals page returns a URL, surface a deep link for whatever flow announces this proposal to the operator to append to its message: `📎 <url>#prop-nnn ("PROP-NNN: <title>")` (lowercased `PROP-NNN` prefix as the anchor; include the section name in text since fragment auto-scroll in the artifact viewer is unconfirmed).
+6. Refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md` (silently — no URL re-post; the proposal queue changed). Also refresh the proposals page (`config.artifacts.proposals`) per the same doc. Unlike the dashboard, when the proposals page returns a URL, surface a deep link for whatever flow announces this proposal to the operator to append to its message: `📎 <url>#prop-nnn ("PROP-NNN: <title>")` (lowercased `PROP-NNN` prefix as the anchor; include the section name in text since fragment auto-scroll in the artifact viewer is unconfirmed).
 
 ## Do NOT Create Proposals For
 

--- a/plugins/claude-code-hermit/skills/weekly-review/SKILL.md
+++ b/plugins/claude-code-hermit/skills/weekly-review/SKILL.md
@@ -71,8 +71,8 @@ Generates the weekly review for the current ISO week.
    - If the current-week file is missing (script failed): skip the evolution block entirely.
 
 6. Channel-send the combined weekly summary:
-   - Refresh the dashboard per docs/artifacts.md; if it returns a URL, note it for the message below.
-   - Publish the weekly-review artifact (`config.artifacts.weekly_review`) per docs/artifacts.md; if it returns a URL, note it for the message below too.
+   - Refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md`; if it returns a URL, note it for the message below.
+   - Publish the weekly-review artifact (`config.artifacts.weekly_review`) per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md`; if it returns a URL, note it for the message below too.
    - Compose the message: one-line review headline (session count, cost, self-directed rate from frontmatter) followed by the evolution block from step 5, plus the `Topic pages:` findings from step 3 when present, plus a final line listing whichever of the dashboard/weekly-review URLs were returned (e.g. `📎 <dashboard url> · 📎 <weekly-review url>` — omit either half that wasn't returned).
    - Resolve the outbound channel:
      ```

--- a/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
@@ -32,7 +32,7 @@ Full eligibility rules, resolution order, and the per-branch matrix: `/claude-co
 
 ## Artifact Pages
 
-Dashboard/proposals/weekly-review, gated by `config.artifacts.*` (default on). On-demand publish needs no gate. Protocol: `docs/artifacts.md`.
+Dashboard/proposals/weekly-review, gated by `config.artifacts.*` (default on). On-demand publish needs no gate. Refresh runs inside the publish skills, not from here.
 
 ## Knowledge Discipline
 
@@ -40,7 +40,7 @@ Auto-memory handles all learning; `compiled/` is for durable domain outputs, not
 
 - Domain inputs → `raw/<type>-<slug>-<date>.md`; one-off outputs → `compiled/<type>-<slug>-<date>.md`; evolving subjects → `compiled/topic-<slug>.md` updated in place. All require frontmatter (`title`, `type`, `created`, `tags`).
 - **`type` in frontmatter is the discriminator — never a folder.** No subdirectories inside `raw/`/`compiled/`, no new top-level dirs inside `.claude-code-hermit/`. Artifacts outside `raw/`/`compiled/` are invisible to injection and retention.
-- Naming, retention, `foundational`-tag semantics, and the session-start catalog: `docs/plugin-hermit-storage.md` + `knowledge-schema.md`.
+- Naming and retention are enforced by the storage scripts; `.claude-code-hermit/knowledge-schema.md` defines what this hermit produces.
 
 ## Rules
 
@@ -53,5 +53,5 @@ Auto-memory handles all learning; `compiled/` is for durable domain outputs, not
 - **OPERATOR.md:** Never edit autonomously. If you notice stale or contradictory context, draft the minimal change, show a diff, and apply only after the operator confirms. In always-on mode, flag it via channel instead — the operator edits directly.
 - **Proposals mandatory:** Every improvement goes through `/proposal-create` → operator accepts → implement. Trivial fixes (typos, one-liners) exempt. **Never hand-write `proposals/PROP-*.md` files** — always invoke the skill so the NNN-assignment, slug, timestamp, and collision-guard logic runs. Manually-assigned ids reuse NNNs across parallel sessions and produce short-form ids that violate the canonical `PROP-NNN-<slug>-HHMMSS` schema.
 - **Tasks:** Use `TaskCreate`/`TaskUpdate` for multi-step work. `tasks-snapshot.md` is auto-generated — don't edit.
-- **Artifact frontmatter:** Any `.md` file you create outside `.claude-code-hermit/` must include YAML frontmatter with at least `title` (string) and `created` (ISO 8601 with timezone). If inside a hermit session, add `session: S-NNN`. Optionally add `proposal`, `source` (`session` | `interactive` | `routine` | `manual`), and `tags` (array of strings). Full conventions: `docs/frontmatter-contract.md`.
+- **Artifact frontmatter:** Any `.md` file you create outside `.claude-code-hermit/` must include YAML frontmatter with at least `title` (string) and `created` (ISO 8601 with timezone). If inside a hermit session, add `session: S-NNN`. Optionally add `proposal`, `source` (`session` | `interactive` | `routine` | `manual`), and `tags` (array of strings).
 - **Tag discipline:** Add `tags` to every session report, proposal, and artifact you create. Before tagging, scan the last 5 session reports and proposals for the existing vocabulary and reuse — introduce new tags only when nothing fits. Keep tags lowercase and hyphenated (1–2 per document).

--- a/plugins/claude-code-hermit/state-templates/docker/docker-compose.hermit.yml.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-compose.hermit.yml.template
@@ -29,7 +29,7 @@ services:
       - GH_TOKEN=${HERMIT_GH_TOKEN:-}
 {{AUTH_ENV_LINE}}{{CHANNEL_ENV_LINES}}
 {{NETWORK_MODE_LINE}}
-    # Defense in depth — see docs/security.md#container-hardening for rationale and override path.
+    # Defense in depth — rationale and override path: run /claude-code-hermit:docker-security.
     cap_drop:
       - ALL
     # Load-bearing: blocks setuid escalation even from a planted binary in a compromised plugin.

--- a/plugins/claude-code-hermit/tests/operator-doc-refs.test.ts
+++ b/plugins/claude-code-hermit/tests/operator-doc-refs.test.ts
@@ -59,8 +59,14 @@ describe('operator surfaces have no bare docs/ refs', () => {
     });
   }
 
-  test('scripts/startup-context.ts emits no bare docs/ ref', () => {
-    const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'scripts', 'startup-context.ts'), 'utf8');
-    expect(bareRefs(src)).toEqual([]);
-  });
+  // Scripts that print doc pointers to the operator's terminal from their
+  // project cwd, where a bare `docs/foo.md` dangles. Listed explicitly (not a
+  // blanket scripts/ walk) so code-comment refs in helper libs don't trip the
+  // guard — only strings the operator actually sees are in scope.
+  for (const script of ['startup-context.ts', 'hermit-start.ts']) {
+    test(`scripts/${script} emits no bare docs/ ref`, () => {
+      const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'scripts', script), 'utf8');
+      expect(bareRefs(src)).toEqual([]);
+    });
+  }
 });

--- a/plugins/claude-code-hermit/tests/operator-doc-refs.test.ts
+++ b/plugins/claude-code-hermit/tests/operator-doc-refs.test.ts
@@ -1,0 +1,66 @@
+// Operator-facing surfaces must not name a plugin-root doc by a bare path.
+//
+// CLAUDE-APPEND blocks are cat'd verbatim into a downstream operator's
+// CLAUDE.md, and SessionStart injections are emitted into operator context —
+// both read from the operator's project cwd, where a bare `docs/foo.md`
+// resolves to `<operator-project>/docs/foo.md` and does not exist (the docs
+// live only under the plugin root). This guard fails on any such bare ref so
+// the class of bug can't creep back in. Allowed forms all resolve:
+//   ${CLAUDE_PLUGIN_ROOT}/docs/...   (skill-execution context, installed mode)
+//   https://.../docs/...             (absolute URL)
+//   ../../docs/...                    (markdown relative link)
+//
+// Usage: bun test tests/operator-doc-refs.test.ts   (from the plugin root)
+
+import { describe, test, expect } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { PLUGIN_ROOT, MONOREPO_ROOT } from './helpers/run';
+
+// A bare doc ref: `docs/<name>.md` NOT preceded by `/` (URL or ${...}/docs or
+// ../docs), `.` (relative), a word char, `:`, or `}`. The name class allows
+// upper/lower/digits/-/_ so uppercase doc names (docs/GIT-SAFETY.md) are caught
+// too. Global so we can report every hit, not just the first.
+const BARE_DOCS = /(?<![./\w:}])docs\/[A-Za-z0-9_-]+\.md/g;
+
+function bareRefs(text: string): string[] {
+  return [...text.matchAll(BARE_DOCS)].map(m => m[0]);
+}
+
+// Walk plugins/*/state-templates for *.md and *.template — the surfaces cat'd
+// or rendered into the operator's project (CLAUDE.md blocks, docker compose).
+// Siblings are guaranteed present in the monorepo.
+function stateTemplateSurfaces(): string[] {
+  const out: string[] = [];
+  const pluginsDir = path.join(MONOREPO_ROOT, 'plugins');
+  for (const plugin of fs.readdirSync(pluginsDir)) {
+    const root = path.join(pluginsDir, plugin, 'state-templates');
+    if (!fs.existsSync(root)) continue;
+    const stack = [root];
+    while (stack.length) {
+      const dir = stack.pop()!;
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) stack.push(full);
+        else if (entry.name.endsWith('.md') || entry.name.endsWith('.template')) out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+describe('operator surfaces have no bare docs/ refs', () => {
+  for (const file of stateTemplateSurfaces()) {
+    const rel = path.relative(MONOREPO_ROOT, file);
+    test(rel, () => {
+      const hits = bareRefs(fs.readFileSync(file, 'utf8'));
+      expect(hits).toEqual([]);
+    });
+  }
+
+  test('scripts/startup-context.ts emits no bare docs/ ref', () => {
+    const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'scripts', 'startup-context.ts'), 'utf8');
+    expect(bareRefs(src)).toEqual([]);
+  });
+});

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Fixed
+- **CLAUDE-APPEND CLI pointer** — dropped the bare `docs/cli-reference.md` pointer (unresolvable from the operator's project cwd); `ha-agent-lab --help` is the resolvable catalog pointer, `src/cli.ts` the source of truth. The doc still ships under the plugin root.
+
 ## [0.4.1] - 2026-07-03
 
 ### Changed

--- a/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-homeassistant-hermit/state-templates/CLAUDE-APPEND.md
@@ -45,7 +45,7 @@ MCP tool IDs follow `mcp__homeassistant__*`. If you registered the HA MCP Server
 
 ### CLI
 
-`${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab <domain> <command>` — full command catalog: run `ha-agent-lab --help` or see `docs/cli-reference.md` in the plugin (`src/cli.ts` is the source of truth). Structural writes (helpers/areas/registries) are gated by `ha_safety_mode` (strict → proposal, ask → `--confirm`).
+`${CLAUDE_PLUGIN_ROOT}/bin/ha-agent-lab <domain> <command>` — full command catalog: run `ha-agent-lab --help` (`src/cli.ts` is the source of truth). Structural writes (helpers/areas/registries) are gated by `ha_safety_mode` (strict → proposal, ask → `--confirm`).
 
 ### Environment
 

--- a/plugins/claude-code-homeassistant-hermit/tests/claude-append-trim.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/claude-append-trim.test.ts
@@ -4,7 +4,7 @@
 // re-paid on every session load and subagent dispatch. The skills/subagents/CLI
 // catalogs that used to live here duplicated content already carried by each
 // SKILL.md/agent description and by `ha-agent-lab --help`, so they were removed
-// in favor of a self-advertise pointer + docs/cli-reference.md. This test keeps
+// in favor of a self-advertise pointer + `ha-agent-lab --help`. This test keeps
 // the catalogs from creeping back and ensures the CLI reference doc exists.
 
 import { expect, test } from 'bun:test';
@@ -25,8 +25,13 @@ test('HA APPEND self-advertises instead of cataloging', () => {
   expect(APPEND.includes('ha-boot')).toBe(true);
 });
 
-test('HA APPEND points to the relocated CLI reference, which exists', () => {
-  expect(APPEND.includes('docs/cli-reference.md')).toBe(true);
+test('HA APPEND points to the resolvable CLI reference, and the doc exists', () => {
+  // The operator's CLAUDE.md must name a pointer that resolves from their
+  // project cwd: `ha-agent-lab --help`. A bare `docs/cli-reference.md` would
+  // resolve to <operator-project>/docs/... and not exist (the doc ships only
+  // under the plugin root, where it remains the written catalog).
+  expect(APPEND.includes('ha-agent-lab --help')).toBe(true);
+  expect(APPEND.includes('docs/cli-reference.md')).toBe(false);
   expect(existsSync(join(PLUGIN_ROOT, 'docs', 'cli-reference.md'))).toBe(true);
 });
 


### PR DESCRIPTION
## Summary
- Operator-facing surfaces (CLAUDE-APPEND blocks, the SessionStart storage-drift line, a docker-compose template comment) named plugin-root docs by bare `docs/…` paths. Those resolve to `<operator-project>/docs/…` from the operator's cwd, where the plugin's `docs/` doesn't exist — a silent dangling reference for every downstream operator. The v1.2.17 `## Artifact Pages` pointer surfaced it, but it was a systemic pattern.
- **Static operator context** (core CLAUDE-APPEND ×3, HA CLAUDE-APPEND, the SessionStart injection, the docker template) is now self-contained: the broken pointer is dropped and the load-bearing fact inlined, or it points to the owning skill. This also fixes a bare `knowledge-schema.md` ref (the file lives at `.claude-code-hermit/knowledge-schema.md`).
- **Artifact-refresh skill prose** (`brief`, `proposal-create`, `proposal-act`, `weekly-review`) now uses `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md`, which resolves in skill-execution context — confirmed by shipped precedent (`heartbeat`, `smoke-test`, `hermit-evolve` already `Read` `${CLAUDE_PLUGIN_ROOT}/…` paths in prose).
- New `operator-doc-refs` test fails the build on any bare `docs/…` ref in a state-template (`.md`/`.template`) or in the SessionStart injection, across all plugins.

## Approach
The fix splits by surface so nothing depends on the unverified question of whether `${CLAUDE_PLUGIN_ROOT}` expands in a plain `Read` / CLAUDE.md prose:
- Plain operator CLAUDE.md prose has no plugin binding → self-contained (drop / inline / point to the skill).
- Skill execution has a plugin binding → `${CLAUDE_PLUGIN_ROOT}/docs/` (known-good, precedent-confirmed).

Seeding docs into operator state was considered and rejected: it still needs a ref rewrite, violates the hermit's own "no new top-level dirs in `.claude-code-hermit/`" rule, and goes stale.

## Verification
- Core: **1884 pass / 0 fail** (`bun test`, `plugins/claude-code-hermit`), including the new `operator-doc-refs` guard and the CLAUDE-APPEND ≤7000 B budget test (rewrites kept under budget).
- HA: **0 fail** (`bun test`, `plugins/claude-code-homeassistant-hermit`); `claude-append-trim` updated to enforce the resolvable pointer (`ha-agent-lab --help`) instead of the broken `docs/cli-reference.md`.
- `grep` for bare `docs/…` refs across all operator surfaces returns nothing.

## Rollout
No release triggered. The corrected core CLAUDE-APPEND reaches existing operators via `hermit-evolve` Step 6 whole-block sync, HA via Step 7 sibling sync — both on the next `/release` + `/plugin update`. `startup-context.ts` ships as code on `/plugin update`.
