### PR TITLE
fix(hermit-routines): quiet success-path load log

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **hermit-routines: quiet success-path load log** — a clean `load` run now logs registration counts only; the full per-ID CronCreate list is reserved for runs with at least one failure. Cuts a recurring ~21-ID dump from SHELL.md on every session start and daily `heartbeat-restart` re-arm. (#533)
+
 ## [1.2.18] - 2026-07-05
 
 ### Added

--- a/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
@@ -35,7 +35,7 @@ Called automatically by `hermit-start.ts` on always-on launches. Can also be cal
    - `prompt`: the resolved prompt string
 
    **Per-routine error isolation:** if `CronCreate` throws for one routine (bad cron expression, hit the 50-task session limit, etc.), record the failure and continue with the next routine. Do not abort the loop — one bad config entry must not prevent unrelated routines from registering.
-5. Log one line summarizing outcomes: `Routines registered: <id1>, <id2> (<N> ok, <M> failed[, <K> tz-shifted, <W> tz-warned])`. If any failed, list each failed id with the error on its own line. If any warned, list each warned id with the WARN reason on its own line.
+5. Log one line summarizing outcomes. If `M == 0` (no failures), log counts only — no per-ID list: `Routines registered: <N> ok, 0 failed[, <K> tz-shifted, <W> tz-warned]`. If `M > 0`, log the full per-ID form: `Routines registered: <id1>, <id2> (<N> ok, <M> failed[, <K> tz-shifted, <W> tz-warned])`, then list each failed id with the error on its own line. Regardless of `M`, if any warned, list each warned id with the WARN reason on its own line.
 
 #### Prompt templates
 


### PR DESCRIPTION
## Summary
A clean `hermit-routines load` run enumerates every registered routine's CronCreate ID in its summary log line, even when nothing failed. Since `load` runs at every session start and is re-triggered daily by `heartbeat-restart`, this dumps a long, mostly-redundant ~21-ID list into SHELL.md on every clean run — and SHELL.md is read in full at every session start.

## Changes
- `hermit-routines/SKILL.md` step 5: log counts only (`Routines registered: <N> ok, 0 failed[, ...]`) on a clean run; reserve the full per-ID enumeration (plus failed-id/error lines) for runs with at least one failure. Warned IDs are still listed regardless of failure count, since a WARN is a debug signal worth surfacing even on an otherwise-clean run.
- `CHANGELOG.md`: added `[Unreleased]` entry.

## Test plan
- `bun test` in `plugins/claude-code-hermit/` — 1914 pass, 0 fail (unaffected, as expected: no test asserts this skill-text format).
- Manual read of the edited step 5 for internal consistency (clean-run branch has no `<id...>` tokens, failure branch retains them, warned-id line unchanged).

Closes #533