### PR TITLE
docs: recommend staggering routine schedules for warm cache reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ All live-editable with `/hermit-settings` (or just ask the hermit) — no reboot
 
 - **Idle behavior.** `discover` (default) adds a priority-alignment pass against `OPERATOR.md` + cost log; `wait` is passive (tasks/channels only). Either way the daily `reflect` routine still runs — `wait` only silences between-schedule discovery, not the learning loop.
 
-- **Routines.** Each routine takes an optional `model`: run lightweight ones on `haiku` to save cost or heavier ones on `opus` for more reasoning, in an isolated subagent. Omit `model` to keep it inline in the main session context — use that when the routine's value is its chat/transcript output, not just a status line.
+- **Routines.** Each routine takes an optional `model`: run lightweight ones on `haiku` to save cost or heavier ones on `opus` for more reasoning, in an isolated subagent. Omit `model` to keep it inline in the main session context — use that when the routine's value is its chat/transcript output, not just a status line. When several routines fire around the same time, offset them by a minute or two so the later ones reuse the warm prompt cache instead of hitting a cold one (see [Config Reference](plugins/claude-code-hermit/docs/config-reference.md) for the full rule).
 
 - **Quiet & cheap:** `idle_behavior: "wait"` + a longer `heartbeat.every` + `quality_gate.tier: "budget"` (the default). Idle cost is already near-zero; these trim the rest.
 

--- a/plugins/claude-code-hermit/README.md
+++ b/plugins/claude-code-hermit/README.md
@@ -184,7 +184,7 @@ All live-editable with `/hermit-settings` (or just ask the hermit) — no reboot
 
 - **Idle behavior.** `discover` (default) adds a priority-alignment pass against `OPERATOR.md` + cost log; `wait` is passive (tasks/channels only). Either way the daily `reflect` routine still runs — `wait` only silences between-schedule discovery, not the learning loop.
 
-- **Routines.** Each routine takes an optional `model`: run lightweight ones on `haiku` to save cost or heavier ones on `opus` for more reasoning, in an isolated subagent. Omit `model` to keep it inline in the main session context — use that when the routine's value is its chat/transcript output, not just a status line.
+- **Routines.** Each routine takes an optional `model`: run lightweight ones on `haiku` to save cost or heavier ones on `opus` for more reasoning, in an isolated subagent. Omit `model` to keep it inline in the main session context — use that when the routine's value is its chat/transcript output, not just a status line. When several routines fire around the same time, offset them by a minute or two so the later ones reuse the warm prompt cache instead of hitting a cold one (see [Config Reference](docs/config-reference.md) for the full rule).
 
 - **Quiet & cheap:** `idle_behavior: "wait"` + a longer `heartbeat.every` + `quality_gate.tier: "budget"` (the default). Idle cost is already near-zero; these trim the rest.
 


### PR DESCRIPTION
## Summary
The Routines tip in both READMEs (root and plugin) only covered the `model` cost-lever for routines. It didn't mention a second one already documented in `docs/config-reference.md`: offsetting co-scheduled routines by a minute or two keeps each fire inside the prompt-cache TTL window, so later routines reuse warm cache instead of paying a cold cache-write.

## Changes
- `README.md` — appended a sentence to the Routines bullet under "Tips & tuning" recommending staggered routine timing, linking to the full rule in Config Reference.
- `plugins/claude-code-hermit/README.md` — same sentence, mirrored (only the relative link path differs).

No behavior change, no code touched — `docs/config-reference.md`'s existing "Staggering routines" tip already documents the underlying rule in full.

## Test plan
- Diffed both README files to confirm the appended sentence is identical apart from the link path, and no other lines drifted.
- Visual read to confirm the addition fits the bullet's existing voice and doesn't contradict the fuller Config Reference explanation.