### PR TITLE
docs(claude-code-hermit): add Owner's Guide and plain trust page

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **cost attribution: inbound-channel turns get their own `by_source` bucket** — `classifySource` now recognizes the `<channel source="...">` transcript envelope and tags the turn `channel:<name>` (e.g. `channel:discord`) instead of collapsing into the catch-all `other` bucket. Redaction collapses `channel:*` the same way it already does `routine:*`.
+- **docs: Owner's Guide and plain trust page** — new `docs/owners-guide.md` (talk, approve, pause, spend, who to call) and `docs/what-your-assistant-can-do.md`, both written for the non-developer owner. `channel-setup` now sends a short plain-language welcome pointing at the guide the first time a channel is newly paired.
 
 ### Fixed
 - **session-cost: per-session `cost_usd` no longer reads `0.00` for real work** — cost-log rows carry the shared transcript UUID, never the logical `S-NNN`, so the old exact-id match never hit; `session-cost.ts` now sums the arc window `[opened_at, closed_at]`. `cost-tracker.ts` re-stamps `opened_at` per arc keyed on the transcript id (so a crash/restart's stale window can't over-count the next session) and stamps `closed_at` on the idle transition (so a close running after idle still recovers the window instead of falling back to the always-zero exact-id match).

--- a/plugins/claude-code-hermit/docs/how-to-use.md
+++ b/plugins/claude-code-hermit/docs/how-to-use.md
@@ -87,6 +87,8 @@ Hermit isn't just a work engine. During any session, you can ask it to reflect a
 
 You're always in control. Hermit suggests. You decide.
 
+**Handing this off to a non-developer owner?** Give them the [Owner's Guide](owners-guide.md) (talk, approve, pause, spend, who to call) and [What Your Assistant Can and Cannot Do](what-your-assistant-can-do.md) — both written for someone who'll never open a terminal.
+
 ---
 
 ## Tips

--- a/plugins/claude-code-hermit/docs/owners-guide.md
+++ b/plugins/claude-code-hermit/docs/owners-guide.md
@@ -1,0 +1,49 @@
+# Owner's Guide
+
+This page is for the person who owns and uses the assistant day to day — not the developer who set it up. If you were just handed this, here's everything you need.
+
+---
+
+## Talk
+
+Talk to your assistant the way you'd talk to a person. No special commands, no syntax to learn — just say what you need, in your own words, in the same chat you're already using.
+
+It's always listening for your messages. If something you said is unclear, it will ask a quick follow-up question instead of guessing.
+
+---
+
+## Approve
+
+Your assistant does work on its own, but anything significant — an idea, a decision, a change worth your input — comes to you first as a short message describing what it wants to do.
+
+You reply with one of three things:
+
+- **Yes** — go ahead.
+- **Later** — good idea, but not now. It'll wait.
+- **No** — skip it.
+
+That's it. No forms, no IDs to type, no special phrasing. Plain "yes" works.
+
+---
+
+## Pause
+
+You can stop your assistant at any time by saying **"pause"** (or "stop for now") in the chat. This is a real stop — it will not run anything else until you tell it to continue.
+
+Say **"resume"** when you want it to pick back up. Nothing is lost while paused; it just waits.
+
+---
+
+## Spend
+
+Your assistant uses AI services that have a cost, and it keeps track of what it's spending. If a spending limit has been set for it, it will tell you when it's getting close (and, depending on how it's configured, may pause itself automatically once it's reached).
+
+One honest note: if your plan is a flat subscription rather than pay-as-you-go, the dollar figures it reports are *estimates*, not real charges — a useful signal, not a bill.
+
+---
+
+## Who to call
+
+If your assistant goes quiet for longer than usual, or you see a message you don't understand, don't try to fix it yourself. Contact whoever set it up for you and let them know what you saw.
+
+For a plain-language explanation of what your assistant can and can't do on its own, see [What Your Assistant Can and Cannot Do](what-your-assistant-can-do.md).

--- a/plugins/claude-code-hermit/docs/owners-guide.md
+++ b/plugins/claude-code-hermit/docs/owners-guide.md
@@ -28,7 +28,7 @@ That's it. No forms, no IDs to type, no special phrasing. Plain "yes" works.
 
 ## Pause
 
-You can stop your assistant at any time by saying **"pause"** (or "stop for now") in the chat. This is a real stop — it will not run anything else until you tell it to continue.
+You can stop your assistant at any time by saying **"pause"** (or just **"stop"**) in the chat. This is a real stop — it will not run anything else until you tell it to continue.
 
 Say **"resume"** when you want it to pick back up. Nothing is lost while paused; it just waits.
 

--- a/plugins/claude-code-hermit/docs/what-your-assistant-can-do.md
+++ b/plugins/claude-code-hermit/docs/what-your-assistant-can-do.md
@@ -1,0 +1,34 @@
+# What Your Assistant Can and Cannot Do
+
+A plain-language answer to "what is this thing actually allowed to do?" — written for the owner, not the developer. It's derived from the technical [Security](security.md) doc, and it's deliberately honest: it says where the guarantees are real and where they're a strong habit rather than an unbreakable rule.
+
+---
+
+## Always true
+
+These are hard limits — enforced mechanically, not just as good behavior:
+
+- It will never run a command that wipes your whole disk, destroys a drive, or takes down the system it's running on. Those specific dangerous actions are blocked no matter what, regardless of anything it decides in the moment.
+- If it was set up the recommended way (the always-on container setup), it's also blocked from pushing code changes to your team's shared repository without approval first. On other setups this protection may not be switched on — ask whoever installed it if you're unsure which applies to you.
+
+---
+
+## How it normally works
+
+These are the assistant's everyday habits — real, and followed consistently, but not absolute walls:
+
+- Before making a significant or risky change, it shows you a draft and waits for your OK rather than just doing it (see [Approve](owners-guide.md#approve)).
+- It tracks what it spends on AI usage and can warn you or pause itself against a spending limit you set.
+- It generally stays scoped to the project it's working in, rather than roaming freely across your whole computer.
+
+---
+
+## Honest limits
+
+Nobody should be told this is a sealed box, so here's what it isn't:
+
+- By default, it can still read files and reach the internet — those aren't blocked automatically. If your work needs that locked down, ask whoever set this up about the stronger, opt-in network protection.
+- The "shows me a draft first" habit above is just that — a habit the assistant follows, not a guarantee enforced the way the destructive-action blocks are. In an unusual or confusing situation, it could occasionally act without asking first.
+- This isn't a substitute for basic caution. Don't give it access to anything you wouldn't want touched, and keep an eye on what it's doing — especially in the first few weeks.
+
+If your situation needs stronger guarantees than described here — handling sensitive client data, for example — talk to whoever set this up about running it inside a more locked-down environment.

--- a/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
@@ -245,3 +245,28 @@ Channel setup complete!
 ```
 
 If anything was skipped, list the remaining steps.
+
+### 7a. Send owner welcome (once, only when exactly one channel was newly paired)
+
+Run this once, after step 7's summary, across the *whole* run — not per channel inside the steps 2–6 loop.
+
+Skip entirely if no channel selected "Ready to pair" in step 5 this run — an operator re-running setup against an already-paired channel ("Already paired") or one they skipped shouldn't get a repeat welcome.
+
+Also skip, with a note in the summary ("Welcome message skipped — more than one channel was newly paired this run; let the owner know directly"), if *more than one* channel selected "Ready to pair" this run (the "All" path pairing several channels at once). `channel-send.ts` has no per-channel target — it resolves one generic outbound channel (`primary`, else first eligible in config order) — so with several freshly-paired channels there's no reliable way to know which one it would reach.
+
+Otherwise (exactly one channel newly paired), send one short, plain-language welcome so the owner has something the moment the bot can reach them. Not the full guide — a channel message can't hold it, and this is just an orientation pointer:
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/channel-send.ts .claude-code-hermit - <<'HERMIT_WELCOME'
+Hi — I'm connected here now.
+
+A few basics:
+- Talk to me anytime, in plain language.
+- If I have a suggestion or need a decision, I'll ask, and you can just reply yes, later, or no.
+- Say "pause" to stop me and "resume" to continue — pausing really stops me until you say resume.
+- I track what I spend on AI usage and will tell you if it's getting close to any limit that's set.
+- If I ever go quiet, or something's confusing, reach out to whoever set me up for you — they can also give you the full written guide.
+HERMIT_WELCOME
+```
+
+No file paths, slash commands, or internal jargon in this text — it's the owner's first message. If the send fails, note it in the summary above but don't block setup: "Welcome message couldn't be sent (`<error>`) — the channel is paired; let the owner know directly this time."


### PR DESCRIPTION
## Summary
- add Owner's Guide and plain trust page

Two new owner-facing docs for `claude-code-hermit` (core), derived from `docs/security.md` and the everyday-usage audit (`.claude-code-hermit/compiled/audit-business-readiness-2026-07-03.md` §8, language-layer PR #5):

- **`docs/owners-guide.md`** — talk, approve, pause, spend, who to call. Written for the non-developer owner, no slash commands, file paths, or internal IDs.
- **`docs/what-your-assistant-can-do.md`** — a plain-language "always true / how it normally works / honest limits" trust page. Every claim is scoped to what's actually enforced today (e.g. the push-protection claim is scoped to the Docker/always-on deployment, since a plain local `hatch` in minimal mode doesn't apply that deny-pattern bucket).
- `docs/how-to-use.md` links both from the existing "Talk to Your Hermit" section.
- `channel-setup` now sends a short plain-language welcome pointing at the guide the first time a channel is newly paired — skipped (with a note) when more than one channel pairs in the same run, since the send path (`channel-send.ts`) has no per-channel target and could otherwise reach the wrong channel.

## Verification

- Tests: **pass** (80.4s) — full core suite, 2065 tests / 4045 assertions, 0 failures.
- Voice check: grepped both new docs for `PROP-`, `S-NNN`, `MP-`, slash commands, file paths, `cron` — clean.
- Honesty audit: every capability claim in the trust page cross-checked against `docs/security.md` and `skills/hatch/SKILL.md` line references; corrected one overclaim during review (push-guard is Docker/hardened-mode only, not universal).
- Ran a 3-reviewer `/simplify` pass on the diff before committing; applied two real findings (the overclaim above, and a welcome-send scoping fix to avoid misdirecting/duplicating the message across a multi-channel pairing run).
