### PR TITLE
fix(laravel-forge-hermit): auto-resolve PHP-FPM log key, clean 404 handling

### DIFF
--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Fixed
+- **forge-logs: `server-log <server> php` auto-resolves the PHP-FPM log key** — the key is dot-version notation matching the server's installed PHP (`php-8.3`), not the literal `php`. Passing `php` now looks up the server's `php_version` and translates it automatically.
+- **forge-logs: server-log 404s no longer crash** — a missing log key now prints a readable message (wrong key, or the service has no Forge-tracked log path) instead of an uncaught exception.
+
+### Files affected
+
+| File | Change |
+|------|--------|
+| `php/forge-lib.php` | Add `phpLogKey()` translation helper |
+| `php/forge.php` | `server-log`: auto-resolve `php` key, catch `NotFoundException` |
+| `skills/forge-logs/SKILL.md` | Document PHP-FPM key format and custom-provider 404s |
+
 ## [0.0.5] - 2026-07-03
 
 ### Changed

--- a/plugins/laravel-forge-hermit/php/forge-lib.php
+++ b/plugins/laravel-forge-hermit/php/forge-lib.php
@@ -74,6 +74,18 @@ function matchServer(array $servers, string $query): array {
     }));
 }
 
+// ---------------------------------------------------------------------------
+// Translate a server's raw `php_version` (e.g. "php83") into the log key
+// Forge expects for its PHP-FPM log (e.g. "php-8.3"). Returns null if the
+// input doesn't match the expected `php<major><minor+>` shape.
+// ---------------------------------------------------------------------------
+function phpLogKey(string $phpVersion): ?string {
+    if (!preg_match('/^php(\d)(\d+)$/', $phpVersion, $m)) {
+        return null;
+    }
+    return "php-{$m[1]}.{$m[2]}";
+}
+
 function matchSite(array $sites, string $query): array {
     if (is_numeric($query)) {
         return array_values(array_filter($sites, fn($s) => (string)$s->id === $query));

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -39,6 +39,7 @@ if (file_exists($prodAutoload)) {
 }
 
 use Laravel\Forge\Forge;
+use Laravel\Forge\Exceptions\NotFoundException;
 
 // ---------------------------------------------------------------------------
 // .env loader (project root only; getenv() takes precedence)
@@ -191,7 +192,7 @@ if ($cmd === '' || $cmd === '--help' || $cmd === 'help') {
       sites <server>              List sites on a server
       site <server> <site>        Show site detail
       logs <server> <site>        Show latest deployment log for a site
-      server-log <server> <key>   Read a server log by key (keys are hyphenated: nginx-error, nginx-access)
+      server-log <server> <key>   Read a server log by key (keys are hyphenated: nginx-error, nginx-access; 'php' auto-resolves to php-<major>.<minor>)
       deploy-history <server> <site>          List recent deployments
       deploy-log <server> <site> <deploy-id>  Fetch a specific deployment log
       deploy-status <server-id> <site-id> <deploy-id>  Print a deployment's status (raw IDs)
@@ -368,7 +369,22 @@ if ($cmd === 'logs') {
 if ($cmd === 'server-log') {
     check(isset($positional[1]), "Usage: forge.php server-log <server> <key>");
     $server = resolveServer($forge, $org, $positional[0]);
-    $log    = $forge->serverLog($org, $server->id, $positional[1]);
+    $key    = $positional[1];
+
+    if ($key === 'php') {
+        $detail   = $forge->server($org, $server->id);
+        $resolved = phpLogKey($detail->phpVersion ?? '');
+        if ($resolved !== null) {
+            $key = $resolved;
+        }
+    }
+
+    try {
+        $log = $forge->serverLog($org, $server->id, $key);
+    } catch (NotFoundException $e) {
+        fwrite(STDERR, "No log found for key '$key' on server {$server->name}. Either this key is wrong, or Forge doesn't track a log path for this service (common on servers with a custom, non-Forge-provisioned install of it). Check the server's installed services.\n");
+        exit(1);
+    }
     echo $log . "\n";
     exit(0);
 }

--- a/plugins/laravel-forge-hermit/php/tests/run.php
+++ b/plugins/laravel-forge-hermit/php/tests/run.php
@@ -85,6 +85,16 @@ $result = matchServer($servers, 'nonexistent');
 check(count($result) === 0, 'no match returns empty');
 
 // ---------------------------------------------------------------------------
+// Tests: phpLogKey
+// ---------------------------------------------------------------------------
+echo "\nphpLogKey:\n";
+check(phpLogKey('php83') === 'php-8.3', "php83 -> php-8.3");
+check(phpLogKey('php74') === 'php-7.4', "php74 -> php-7.4");
+check(phpLogKey('php810') === 'php-8.10', "php810 -> php-8.10 (multi-digit minor)");
+check(phpLogKey('nonsense') === null, "non-matching input returns null");
+check(phpLogKey('') === null, "empty input returns null");
+
+// ---------------------------------------------------------------------------
 // Tests: matchSite
 // ---------------------------------------------------------------------------
 echo "\nmatchSite:\n";

--- a/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
@@ -31,7 +31,7 @@ Use `deploy-history` first to find the deployment ID.
 php ${CLAUDE_PLUGIN_ROOT}/php/forge.php server-log <server> <key>
 ```
 
-Common keys: `php`, `mysql`, `cron`, `daemon`, `nginx-error`, `nginx-access`. Nginx keys are hyphenated; `nginx_error` (underscored) returns a 404. Key list depends on the server's installed services.
+Common keys: `php`, `mysql`, `cron`, `daemon`, `nginx-error`, `nginx-access`. Nginx keys are hyphenated; `nginx_error` (underscored) returns a 404. The PHP-FPM log key is dot-version notation matching the server's installed PHP (`php-8.3`, not `php`) — passing the literal `php` key auto-resolves it against the server's `php_version`. `mysql`/`cron`/`daemon` may 404 outright on servers with a custom, non-Forge-provisioned install of that service (no Forge-tracked log path) — a 404 there isn't necessarily a wrong key. Key list depends on the server's installed services.
 
 ---
 


### PR DESCRIPTION
## Summary
`server-log <server> php` never matched the Forge API's actual log key naming (dot-version, e.g. `php-8.3`), forcing trial-and-error during live incident response. Separately, a 404 on any `server-log` key crashed with an uncaught exception instead of a readable message, making service-not-tracked 404s indistinguishable from a wrong key.

## Changes
- `php/forge-lib.php`: add `phpLogKey()` — translates a server's raw `php_version` (`php83`) into the Forge log key format (`php-8.3`).
- `php/forge.php`: `server-log <server> php` now fetches the server's authoritative `php_version` (single-server detail GET, not the possibly-abbreviated list response) and auto-resolves the key; any `NotFoundException` from `serverLog()` is now caught and surfaced as a readable message instead of an uncaught stack trace.
- `skills/forge-logs/SKILL.md` + `--help` text: document the PHP-FPM key format and that `mysql`/`cron`/`daemon` may legitimately 404 on servers with a custom, non-Forge-provisioned install of that service.
- `php/tests/run.php`: unit tests for `phpLogKey()`.

Closes #564

## Test plan
- `php php/tests/run.php` — 36/36 passed (includes 5 new `phpLogKey()` cases: standard version, single/multi-digit minor, non-matching input, empty input).
- `bun test` — 42/42 passed (skill structure/frontmatter checks).
- `php -l` on both changed PHP files — no syntax errors.
- Live 404-vs-200 Forge behavior not verified here (no Forge-connected test environment in this repo) — the pure translation helper is unit-tested; the live half rests on the reporter's original incident.