### PR TITLE
fix(claude-code-hermit): stop cost-tracker source bleed on oversized turns

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **cost-tracker: fall back to `other` source when a turn's boundary falls outside the 512KB scan window** — prevents a large turn (e.g. a plugin upgrade run) from inheriting a stale or self-echoed routine marker and tripping a false `hermit-doctor` routine-cost warn.
+
 ### Changed
 - **hooks: shared stdin/profile helper (`lib/hook-input.ts`)** — unifies stdin draining and `AGENT_HOOK_PROFILE` parsing across the four PreToolUse gates (`pause-gate`, `ask-gate`, `enforce-deny-patterns`, `cache-edit-guard`).
 - **hooks: PreToolUse stdin cap raised 64KB → 1MB** — fewer legitimate large payloads hit the cap. The default-allow gates (`enforce-deny-patterns`, `cache-edit-guard`) still fail open above the cap, so this narrows rather than closes the oversize gap for them.

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -74,17 +74,21 @@ function detectModel(modelStr: string | undefined): string {
 // assistant steps (which each carry their own usage) so a multi-step heartbeat/routine
 // turn still reaches its marker, while stopping before the prior turn's prompt so an
 // earlier routine's marker can't bleed into a later turn's source.
-function scanTriggerMarkers(lines: string[], billedIndex: number): string {
+// `boundaryFound` is true only when the loop actually hit that triggering prompt; false
+// means the walk ran off the start of `lines` without finding it — the caller uses this
+// to detect when `lines` (e.g. a truncated tail window) doesn't cover the real turn start.
+function scanTriggerMarkers(lines: string[], billedIndex: number): { text: string; boundaryFound: boolean } {
   const parts: string[] = [];
+  let boundaryFound = false;
   for (let j = billedIndex - 1; j >= 0; j--) {
     try {
       const prev = JSON.parse(lines[j]);
       parts.push(entryText(prev));
       // Reached this turn's triggering prompt — include it, then stop.
-      if (prev.type === 'user' && !isToolResult(prev)) break;
+      if (prev.type === 'user' && !isToolResult(prev)) { boundaryFound = true; break; }
     } catch {}
   }
-  return parts.join(' ');
+  return { text: parts.join(' '), boundaryFound };
 }
 
 // Classify a turn's trigger source from the scanned text of its entries.
@@ -97,6 +101,8 @@ function scanTriggerMarkers(lines: string[], billedIndex: number): string {
 // Limitation: scanning covers the whole turn (prompt + tool_results), so a turn that
 // merely surfaces a marker string in tool output (e.g. grepping these very sources)
 // can be misclassified. Accepted — the markers are stable and this is rare in practice.
+// (When the scan's turn boundary itself falls outside the tail window, the caller in
+// readLastTurnUsage() skips this function entirely and forces 'other' — see there.)
 function classifySource(triggerText: string): string {
   if (!triggerText) return 'other';
   if (triggerText.includes('HEARTBEAT_EVALUATE') ||
@@ -160,7 +166,10 @@ function collectSubagentUsage(lines: string[], billedIndex: number): Array<{
   return out;
 }
 
-// Limitation: a turn spanning more than TAIL_BYTES is summed from buffer start, not the real boundary — same bleed as scanTriggerMarkers.
+// Limitation: a turn spanning more than TAIL_BYTES is summed from buffer start, not the real
+// boundary — token counts still over-count in this case (deliberately: discarding real token
+// data would be worse than a bounded over-count). Source attribution no longer shares this
+// bleed — see the boundaryFound guard in readLastTurnUsage().
 function sumTurnUsage(lines: string[], billedIndex: number): {
   inputTokens: number; cacheWriteTokens: number; cacheReadTokens: number;
   outputTokens: number; model: string; apiCalls: number; maxPromptTokens: number;
@@ -231,8 +240,13 @@ function readLastTurnUsage(transcriptPath: string): Json {
           } catch {}
         }
 
-        const triggerText = scanTriggerMarkers(lines, i);
-        const source = classifySource(triggerText);
+        const { text: triggerText, boundaryFound } = scanTriggerMarkers(lines, i);
+        // A truncated tail (readFrom > 0) whose turn boundary fell outside the window
+        // can't be trusted — the scan may have picked up a stale marker from an earlier,
+        // unrelated turn still in the window, or one echoed in this turn's own tool
+        // output. Attribute to 'other' rather than risk misattributing a large turn
+        // (e.g. a plugin upgrade run) to an unrelated routine/heartbeat/channel source.
+        const source = (!boundaryFound && readFrom > 0) ? 'other' : classifySource(triggerText);
         const subagents = collectSubagentUsage(lines, i);
         return { ...summed, hadHumanTurn, source, subagents };
       } catch {}

--- a/plugins/claude-code-hermit/scripts/subagent-cost.ts
+++ b/plugins/claude-code-hermit/scripts/subagent-cost.ts
@@ -115,9 +115,12 @@ process.stdin.on('end', () => {
     const totalTokens = inputTokens + cacheWriteTokens + cacheReadTokens + outputTokens;
     if (totalTokens === 0) { process.exit(0); return; }
 
-    // Source attribution from the launch entry's turn (best-effort, falls back to 'other')
+    // Source attribution from the launch entry's turn (best-effort, falls back to 'other').
+    // findAsyncLaunch reads the whole parent transcript (no tail window), so a missed
+    // boundary here just means the launch is in the genuine first turn — no truncation
+    // guard needed like cost-tracker.ts's tail-windowed scan.
     let source = 'other';
-    try { source = classifySource(scanTriggerMarkers(launch.lines, launch.index)); } catch {}
+    try { source = classifySource(scanTriggerMarkers(launch.lines, launch.index).text); } catch {}
 
     const model = detectModel(rawModel);
     const estimatedCost = Math.round(

--- a/plugins/claude-code-hermit/tests/cost-tracker.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-tracker.test.ts
@@ -279,6 +279,58 @@ describe('cost-tracker subagent with no resolvedModel', () => {
   });
 });
 
+// Regression for #572: a turn whose real triggering prompt falls outside the 512KB
+// tail window must not inherit a stale/echoed marker still inside that window.
+describe('cost-tracker: oversized turn with boundary outside the tail window', () => {
+  let dir: string;
+  let logPath: string;
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-cost-tracker-oversized-'));
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+    logPath = path.join(dir, '.claude', 'cost-log.jsonl');
+    const stateDir = path.join(dir, '.claude-code-hermit', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'runtime.json'), JSON.stringify({ session_id: 'test-session', session_state: 'active' }));
+
+    // The REAL trigger for this turn — a plain operator prompt, no routine marker.
+    // Followed by >512KB of filler tool_use/tool_result pairs so this line falls
+    // before the tail window's read-from offset. One filler entry near the end
+    // (inside the window) echoes a stale routine marker in its tool_result content
+    // — simulating a leftover `log-routine-event.sh doctor started` string from an
+    // unrelated earlier fire, or output surfaced by this very turn's own tooling.
+    const transcriptLines: string[] = [
+      triggerPrompt('Investigate the failing upgrade run and apply the fix.'),
+    ];
+    const filler = 'x'.repeat(2000);
+    for (let i = 0; i < 300; i++) {
+      transcriptLines.push(JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', id: `t${i}`, name: 'Bash', input: {} }] } }));
+      transcriptLines.push(JSON.stringify({ type: 'user', message: { content: [{ tool_use_id: `t${i}`, type: 'tool_result', content: filler }] } }));
+    }
+    // Stale marker, planted a few entries before the end — well within the 512KB tail.
+    transcriptLines.push(JSON.stringify({ type: 'user', message: { content: [{ tool_use_id: 'stale', type: 'tool_result', content: 'log-routine-event.sh doctor started' }] } }));
+    transcriptLines.push(assistantEntry('claude-sonnet-4-6', 5000, 2000));
+
+    const transcriptPath = path.join(dir, 'transcript.jsonl');
+    const content = transcriptLines.join('\n') + '\n';
+    expect(Buffer.byteLength(content, 'utf-8')).toBeGreaterThan(524288); // sanity: exceeds TAIL_BYTES
+    fs.writeFileSync(transcriptPath, content);
+
+    const stdin = JSON.stringify({ session_id: 'test-session', transcript_path: transcriptPath });
+    await runScript('cost-tracker.ts', { stdin, cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+  });
+
+  afterAll(() => {
+    if (dir) fs.rmSync(dir, { recursive: true });
+  });
+
+  test('cost-tracker: logs source as "other", not the stale in-window marker', () => {
+    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    const entry = JSON.parse(lines[0]);
+    expect(entry.source).toBe('other');
+  });
+});
+
 // max_prompt_tokens is the real context-size signal watchdog's hygiene thresholds
 // key on (a multi-call turn's summed input_tokens is a multiple of its actual
 // context, not the context itself) — the largest single API call in the turn.

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -2661,7 +2661,7 @@ describe('cost-tracker classifySource / scanTriggerMarkers', () => {
       JSON.stringify({ type: 'user', message: { content: [{ tool_use_id: 't1', type: 'tool_result', content: 'ok' }] } }),
       JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 50 } } }),
     ];
-    expect(scanTriggerMarkers(lines, 3)).toContain('[hermit-routine:daily]');
+    expect(scanTriggerMarkers(lines, 3).text).toContain('[hermit-routine:daily]');
   });
 
   // scanTriggerMarkers: turn-boundary stops at prior billed assistant
@@ -2673,7 +2673,7 @@ describe('cost-tracker classifySource / scanTriggerMarkers', () => {
       JSON.stringify({ type: 'user', message: { content: 'operator message with no marker' } }),
       JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 50 } } }),
     ];
-    expect(scanTriggerMarkers(lines, 3)).not.toContain('[hermit-routine:old-routine]');
+    expect(scanTriggerMarkers(lines, 3).text).not.toContain('[hermit-routine:old-routine]');
   });
 
   // scanTriggerMarkers: reaches the marker past an intermediate tool-calling assistant
@@ -2686,8 +2686,9 @@ describe('cost-tracker classifySource / scanTriggerMarkers', () => {
       JSON.stringify({ type: 'user', message: { content: [{ tool_use_id: 't1', type: 'tool_result', content: 'ok' }] } }),
       JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 50 }, content: [{ type: 'text', text: 'done' }] } }),
     ];
-    const text = scanTriggerMarkers(lines, 3);
+    const { text, boundaryFound } = scanTriggerMarkers(lines, 3);
     expect(text).toContain('[hermit-routine:reflect]');
+    expect(boundaryFound).toBe(true);
     expect(classifySource(text)).toBe('routine:reflect');
   });
 
@@ -2701,8 +2702,32 @@ describe('cost-tracker classifySource / scanTriggerMarkers', () => {
       JSON.stringify({ type: 'user', message: { content: [{ tool_use_id: 't1', type: 'tool_result', content: 'ok' }] } }),
       JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 50 } } }),
     ];
-    const text = scanTriggerMarkers(lines, 3);
+    const { text } = scanTriggerMarkers(lines, 3);
     expect(classifySource(text)).toBe('channel:discord');
+  });
+
+  // boundaryFound: false when the scan runs off the start of `lines` without hitting the
+  // triggering user prompt — simulates a truncated tail window whose turn boundary lies
+  // outside the buffer. This is the signal readLastTurnUsage() uses to force 'other'.
+  test('cost-tracker: scanTriggerMarkers boundaryFound is false when the prompt is missing from lines', () => {
+    const lines = [
+      // No triggering user entry at all — everything here is tool-calling/billed assistant
+      // steps, as if the window were truncated before the real turn start.
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 80, output_tokens: 30 }, content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] } }),
+      JSON.stringify({ type: 'user', message: { content: [{ tool_use_id: 't1', type: 'tool_result', content: 'ok' }] } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 50 } } }),
+    ];
+    const { boundaryFound } = scanTriggerMarkers(lines, 2);
+    expect(boundaryFound).toBe(false);
+  });
+
+  test('cost-tracker: scanTriggerMarkers boundaryFound is true when the triggering prompt is present', () => {
+    const lines = [
+      JSON.stringify({ type: 'user', message: { content: '[hermit-routine:daily] fire' } }),
+      JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 50 } } }),
+    ];
+    const { boundaryFound } = scanTriggerMarkers(lines, 1);
+    expect(boundaryFound).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
`cost-tracker.ts` classifies each billed turn's `source` (routine/heartbeat/channel/other) by scanning backward through a 512KB tail slice of the transcript for trigger markers. When a turn's real triggering prompt falls outside that window (an oversized turn, e.g. a plugin upgrade run), the scan ran to buffer start and concatenated whatever was in the window — including a stale marker left over from an earlier, unrelated turn, or one echoed in the big turn's own tool output. That misattributes the turn's cost to the wrong `routine:<id>`/`heartbeat`/`channel:<kind>` bucket, which `hermit-doctor`'s routine-cost check divides by fire count — an inflated numerator trips a false cost-anomaly warning against a routine that wasn't actually the cost driver.

## Changes
- `scanTriggerMarkers` now returns `{ text, boundaryFound }` instead of a bare string — `boundaryFound` is true only when the backward walk actually hit the turn's triggering prompt.
- `readLastTurnUsage` forces `source = 'other'` when the tail window is truncated (`readFrom > 0`) and the boundary wasn't found, instead of trusting whatever marker text happens to be in the window.
- `subagent-cost.ts`'s call site updated to the new return shape — its scan reads the whole parent transcript (no tail window), so it doesn't need the truncation guard.
- Token-sum over-counting for oversized turns is unchanged and intentional (documented pre-existing limitation) — discarding real token data would be worse than a bounded over-count. This fix is scoped to source attribution only.

## Test plan
- `bun test tests/cost-tracker.test.ts tests/scripts.test.ts` — 337 pass, 0 fail, including a new regression test that builds a >512KB transcript whose real trigger falls outside the tail window with a stale `routine:doctor` marker still inside it, asserting the logged `source` is `other` (previously it would have been misattributed).
- `bun test` (full plugin suite) — 2252 pass, 0 fail.
- `bunx tsc --noEmit` from repo root — clean.

Closes #572