### PR TITLE
fix(claude-code-hermit): window routine-cost $/run to fire-tracking start

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Changed
 - **proposal-act/proposal-create/reflect: mechanics prose collapsed to script calls** — operator-facing behavior is unchanged; each dispatch is now one script invocation instead of an inline algorithm, cutting ~2-4K tokens per proposal/reflect turn.
 
+### Fixed
+- **doctor routine-cost: window $/run to the routine's fire-tracking start** — the cumulative `cost-index.json` numerator was divided by a fire-count denominator that only covers the window since `routine-metrics.jsonl` tracking was added (#378), so hermits with lifetime cost predating that feature saw an inflated $/run and false warns on infrequent routines. Cost is now windowed to each routine's earliest tracked fire, falling back to the lifetime total when windowing isn't available.
+
 ### Upgrade Instructions
 
 Run `/claude-code-hermit:hermit-evolve` — it adds the four new `Bash(bun */scripts/*.ts*)` permission entries required for the new scripts to run unattended.

--- a/plugins/claude-code-hermit/docs/routine-authoring.md
+++ b/plugins/claude-code-hermit/docs/routine-authoring.md
@@ -17,8 +17,9 @@ A routine has a cost signature worth fixing when it:
 
 - Runs frequently (daily or more) and shows up as a high-\$/run line — `/claude-code-hermit:hermit-doctor`'s
   `routine-cost` check flags it automatically (a routine whose \$/run exceeds both 3× the peer
-  median and `doctor.routine_cost_floor_usd`), or scan `.claude/cost-log.jsonl` /
-  `/claude-code-hermit:cost-reflect` by hand.
+  median and `doctor.routine_cost_floor_usd`, cost windowed to the routine's earliest tracked
+  fire so pre-tracking lifetime cost isn't divided across only the tracked runs), or scan
+  `.claude/cost-log.jsonl` / `/claude-code-hermit:cost-reflect` by hand.
 - Invokes a broad, `/session-start`-style skill that loads a lot of context (recovery matrices,
   full state reads, conversational framing) to answer one narrow question ("is there anything to
   do?", "did this threshold cross?", "is this file stale?").

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -10,7 +10,7 @@ import { parseDuration } from './lib/time';
 import { globDir, readFrontmatter } from './lib/frontmatter';
 import { validate } from './validate-config';
 import { kStr } from './lib/format';
-import { costIndexPath, readCostIndex, scanAutomatedOpus } from './lib/cost-log';
+import { costIndexPath, readCostIndex, scanAutomatedOpus, scanRoutineCostWindowed } from './lib/cost-log';
 import { costLogPath } from './lib/cc-compat';
 import { PRICING } from './lib/pricing';
 import { getEnabledChannels } from './hermit-start';
@@ -1408,6 +1408,13 @@ function checkRoutineCost() {
     // by_source key) out.
     const FIRE_EVENTS = new Set(['started', 'skipped-waiting', 'skipped-paused']);
     const fireCounts = new Map<string, number>();
+    // Earliest tracked fire `ts` per routine, keyed by cost-index by_source id — routine-metrics.jsonl
+    // tracking (added #378) can postdate part of a routine's lifetime cost-index accumulation, so the
+    // cost-index numerator (all-time cumulative) and this fire-count denominator (tracked-window only)
+    // can silently cover different windows, inflating $/run on hermits that predate the tracking
+    // feature (#573). Windowing the numerator to [earliest tracked fire, now] via
+    // scanRoutineCostWindowed below keeps both sides on the same window.
+    const cutoffBySource = new Map<string, string>();
     try {
       const lines = fs.readFileSync(path.join(stateDir, 'routine-metrics.jsonl'), 'utf-8').split('\n');
       for (const raw of lines) {
@@ -1417,6 +1424,11 @@ function checkRoutineCost() {
           const e = JSON.parse(line);
           if (e && typeof e.routine_id === 'string' && FIRE_EVENTS.has(e.event)) {
             fireCounts.set(e.routine_id, (fireCounts.get(e.routine_id) || 0) + 1);
+            if (typeof e.ts === 'string' && e.ts) {
+              const source = `routine:${e.routine_id}`;
+              const prev = cutoffBySource.get(source);
+              if (!prev || e.ts < prev) cutoffBySource.set(source, e.ts);
+            }
           }
         } catch {}
       }
@@ -1424,12 +1436,17 @@ function checkRoutineCost() {
       // routine-metrics.jsonl absent — fireCounts stays empty, handled as insufficient data below.
     }
 
+    const windowedCost = scanRoutineCostWindowed(costLog, cutoffBySource);
+
     const MIN_RUNS = 3; // avoid divide-by-small-N false positives
     const perRun: Array<{ id: string; costPerRun: number }> = [];
     for (const r of routines) {
       const runs = fireCounts.get(r.id) || 0;
       if (runs < MIN_RUNS) continue;
-      const cost = bySource[`routine:${r.id}`]?.cost;
+      // Prefer the windowed cost (same window as `runs`); fall back to the lifetime cost-index
+      // bucket when windowing isn't available (no valid fire ts, or cost-log.jsonl absent) —
+      // that preserves today's behavior wherever the new data source can't be used.
+      const cost = windowedCost.get(`routine:${r.id}`) ?? bySource[`routine:${r.id}`]?.cost;
       if (typeof cost !== 'number') continue;
       perRun.push({ id: r.id, costPerRun: cost / runs });
     }

--- a/plugins/claude-code-hermit/scripts/lib/cost-log.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cost-log.ts
@@ -296,20 +296,30 @@ function scanAutomatedOpus(costLogFile: string, sinceDateInclusive: string, time
 // tracking can postdate part of a routine's lifetime cost-index accumulation — see #573).
 // `cutoffBySource` maps a by_source key (e.g. "routine:weekly-review") to an ISO-8601 UTC
 // timestamp string ("...Z"); only lines with a matching source AND timestamp >= that cutoff
-// are summed. Plain string comparison is safe here because both sides are UTC "...Z" ISO
-// strings of the same format, which sort lexicographically in time order.
+// are summed. Compared on epoch-ms via Date.parse, NOT lexicographically: the two writers use
+// different sub-second precision (routine-metrics.jsonl cutoffs are whole-second
+// `...T%H:%M:%SZ` from `date -u`, cost-log.jsonl timestamps are millisecond `...SS.mmmZ` from
+// `toISOString()`), and `...SS.mmmZ` sorts lexicographically *before* `...SSZ` because '.'
+// (0x2E) < 'Z' (0x5A) — so a same-second cost entry at the window boundary would be wrongly
+// excluded under string comparison. Epoch-ms comparison keeps both sides on the true instant.
 function scanRoutineCostWindowed(costLogFile: string, cutoffBySource: Map<string, string>): Map<string, number> {
   const totals = new Map<string, number>();
   if (!fs.existsSync(costLogFile) || cutoffBySource.size === 0) return totals;
+  const cutoffMsBySource = new Map<string, number>();
+  for (const [src, cutoff] of cutoffBySource) {
+    const ms = Date.parse(cutoff);
+    if (!Number.isNaN(ms)) cutoffMsBySource.set(src, ms);
+  }
   for (const line of fs.readFileSync(costLogFile, 'utf8').split('\n')) {
     if (!line.trim()) continue;
     try {
       const e = JSON.parse(line);
       const src = e.source;
       if (typeof src !== 'string') continue;
-      const cutoff = cutoffBySource.get(src);
-      if (!cutoff) continue;
-      if (typeof e.timestamp !== 'string' || e.timestamp < cutoff) continue;
+      const cutoffMs = cutoffMsBySource.get(src);
+      if (cutoffMs === undefined || typeof e.timestamp !== 'string') continue;
+      const ts = Date.parse(e.timestamp);
+      if (Number.isNaN(ts) || ts < cutoffMs) continue;
       totals.set(src, (totals.get(src) || 0) + (e.estimated_cost_usd || 0));
     } catch { /* skip corrupt lines — checkCost already surfaces corruption */ }
   }

--- a/plugins/claude-code-hermit/scripts/lib/cost-log.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cost-log.ts
@@ -291,6 +291,31 @@ function scanAutomatedOpus(costLogFile: string, sinceDateInclusive: string, time
   return { count, cost };
 }
 
+// Per-source windowed cost sum, used by doctor-check.ts's routine-cost check to align the
+// cost numerator to the same window as its fire-count denominator (routine-metrics.jsonl
+// tracking can postdate part of a routine's lifetime cost-index accumulation — see #573).
+// `cutoffBySource` maps a by_source key (e.g. "routine:weekly-review") to an ISO-8601 UTC
+// timestamp string ("...Z"); only lines with a matching source AND timestamp >= that cutoff
+// are summed. Plain string comparison is safe here because both sides are UTC "...Z" ISO
+// strings of the same format, which sort lexicographically in time order.
+function scanRoutineCostWindowed(costLogFile: string, cutoffBySource: Map<string, string>): Map<string, number> {
+  const totals = new Map<string, number>();
+  if (!fs.existsSync(costLogFile) || cutoffBySource.size === 0) return totals;
+  for (const line of fs.readFileSync(costLogFile, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const e = JSON.parse(line);
+      const src = e.source;
+      if (typeof src !== 'string') continue;
+      const cutoff = cutoffBySource.get(src);
+      if (!cutoff) continue;
+      if (typeof e.timestamp !== 'string' || e.timestamp < cutoff) continue;
+      totals.set(src, (totals.get(src) || 0) + (e.estimated_cost_usd || 0));
+    } catch { /* skip corrupt lines — checkCost already surfaces corruption */ }
+  }
+  return totals;
+}
+
 // Counts JSONL lines flagged model_unpriced:true (cost-tracker.ts marks a turn this way
 // when the raw model string didn't match any known haiku/sonnet/opus substring — still
 // priced at sonnet rates, but flagged so the drift is auditable). Mirrors scanAutomatedOpus's
@@ -349,4 +374,4 @@ function scanCostLogWarnings(costLogFile: string, sinceDateInclusive: string, ti
   return { opusWake, unpriced };
 }
 
-export { costIndexPath, readCostIndex, computeIndex, updateCostIndex, rebuildCostIndex, scanAutomatedOpus, scanUnpricedModels, scanCostLogWarnings };
+export { costIndexPath, readCostIndex, computeIndex, updateCostIndex, rebuildCostIndex, scanAutomatedOpus, scanUnpricedModels, scanCostLogWarnings, scanRoutineCostWindowed };

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -2349,6 +2349,46 @@ describe('doctor routine-cost check', () => {
     expect(c.status).toBe('warn');
     expect(c.detail).toContain('lonewolf');
   }), 20000);
+
+  test('#573: lifetime cost predating fire tracking is windowed out, not flagged', withTmpdir(async (dir) => {
+    // routine-metrics.jsonl tracking (added #378) can postdate part of a routine's lifetime
+    // cost-index accumulation. `weekly` accrued $97 before tracking existed, plus $3 across its
+    // 3 tracked fires ($1/run) — lifetime cost-index cost is $100, so dividing by only the 3
+    // tracked runs (the old bug) gives ~$33.33/run and falsely flags it. Windowing the numerator
+    // to [earliest tracked fire, now] should exclude the pre-tracking $97 and correctly compute
+    // $1/run, matching peer `other` and producing no warning.
+    writeConfig(dir, { ...BASE_CONFIG, routines: [routine('weekly'), routine('other')] });
+    writeCostIndex(dir, {
+      'routine:weekly': { cost: 100, tokens: 100000 }, // $97 pre-tracking + $3 tracked = $100 lifetime
+      'routine:other': { cost: 3, tokens: 3000 },       // $1.00/run, no pre-tracking history
+    });
+
+    const earliest = new Date(Date.now() - 3600_000).toISOString(); // 1h ago
+    const mid = new Date(Date.now() - 2400_000).toISOString();
+    const late = new Date(Date.now() - 1200_000).toISOString();
+    fs.writeFileSync(path.join(dir, '.claude-code-hermit', 'state', 'routine-metrics.jsonl'), [
+      { ts: earliest, routine_id: 'weekly', event: 'started', delivery: 'cron-create' },
+      { ts: mid, routine_id: 'weekly', event: 'started', delivery: 'cron-create' },
+      { ts: late, routine_id: 'weekly', event: 'started', delivery: 'cron-create' },
+      { ts: new Date().toISOString(), routine_id: 'other', event: 'started', delivery: 'cron-create' },
+      { ts: new Date().toISOString(), routine_id: 'other', event: 'started', delivery: 'cron-create' },
+      { ts: new Date().toISOString(), routine_id: 'other', event: 'started', delivery: 'cron-create' },
+    ].map(e => JSON.stringify(e)).join('\n') + '\n');
+
+    const preTracking = new Date(Date.now() - 7200_000).toISOString(); // 2h ago, before `earliest`
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.claude', 'cost-log.jsonl'), [
+      { timestamp: preTracking, source: 'routine:weekly', estimated_cost_usd: 97 },
+      { timestamp: earliest, source: 'routine:weekly', estimated_cost_usd: 1 },
+      { timestamp: mid, source: 'routine:weekly', estimated_cost_usd: 1 },
+      { timestamp: late, source: 'routine:weekly', estimated_cost_usd: 1 },
+    ].map(e => JSON.stringify(e)).join('\n') + '\n');
+
+    const report = await runDoctorCheck(dir);
+    const c = routineCostCheck(report);
+    expect(c.status).toBe('ok');
+    expect(c.detail).not.toContain('weekly');
+  }), 20000);
 });
 
 describe('doctor channel-liveness check', () => {

--- a/plugins/claude-code-hermit/tests/cost-log.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-log.test.ts
@@ -194,6 +194,19 @@ describe('scanRoutineCostWindowed — #573 fire-tracking window alignment', () =
     expect(result.has('routine:other')).toBe(false);
   }));
 
+  test('includes a same-second boundary entry despite ms-vs-second precision mismatch', withTmpdir((dir) => {
+    // routine-metrics.jsonl cutoffs are whole-second (`date -u +...SZ`); cost-log timestamps
+    // carry milliseconds (`toISOString()`). `...SS.mmmZ` sorts lexicographically *before*
+    // `...SSZ` ('.' < 'Z'), so a same-second boundary entry would be wrongly dropped under
+    // string comparison. The earliest tracked fire's cost lands in exactly this window.
+    const logPath = writeLog(dir, [
+      { timestamp: '2026-07-01T00:00:00.500Z', source: 'routine:weekly', estimated_cost_usd: 5 }, // same second as cutoff
+      { timestamp: '2026-06-30T23:59:59.999Z', source: 'routine:weekly', estimated_cost_usd: 9 }, // prior second, excluded
+    ]);
+    const result = scanRoutineCostWindowed(logPath, new Map([['routine:weekly', '2026-07-01T00:00:00Z']]));
+    expect(result.get('routine:weekly')).toBe(5);
+  }));
+
   test('returns an empty map on an absent log file or empty cutoff map', () => {
     expect(scanRoutineCostWindowed('/nonexistent/path/cost-log.jsonl', new Map([['routine:a', '2026-01-01T00:00:00Z']])).size).toBe(0);
     expect(scanRoutineCostWindowed('/nonexistent/path/cost-log.jsonl', new Map()).size).toBe(0);

--- a/plugins/claude-code-hermit/tests/cost-log.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-log.test.ts
@@ -8,7 +8,7 @@ import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { updateCostIndex, readCostIndex, computeIndex, scanUnpricedModels } from '../scripts/lib/cost-log';
+import { updateCostIndex, readCostIndex, computeIndex, scanUnpricedModels, scanRoutineCostWindowed } from '../scripts/lib/cost-log';
 
 function withTmpdir(fn: (dir: string) => void) {
   return () => {
@@ -178,5 +178,24 @@ describe('scanUnpricedModels', () => {
   test('returns zero on an absent log file', () => {
     const result = scanUnpricedModels('/nonexistent/path/cost-log.jsonl', '2026-01-01');
     expect(result).toEqual({ count: 0, cost: 0 });
+  });
+});
+
+describe('scanRoutineCostWindowed — #573 fire-tracking window alignment', () => {
+  test('sums only lines at/after each source\'s cutoff, excluding earlier lines and other sources', withTmpdir((dir) => {
+    const logPath = writeLog(dir, [
+      { timestamp: '2026-06-01T00:00:00Z', source: 'routine:weekly', estimated_cost_usd: 97 }, // pre-cutoff, excluded
+      { timestamp: '2026-07-01T00:00:00Z', source: 'routine:weekly', estimated_cost_usd: 1 },   // at cutoff, included
+      { timestamp: '2026-07-05T00:00:00Z', source: 'routine:weekly', estimated_cost_usd: 2 },   // after cutoff, included
+      { timestamp: '2026-07-05T00:00:00Z', source: 'routine:other', estimated_cost_usd: 50 },   // different source, excluded
+    ]);
+    const result = scanRoutineCostWindowed(logPath, new Map([['routine:weekly', '2026-07-01T00:00:00Z']]));
+    expect(result.get('routine:weekly')).toBe(3);
+    expect(result.has('routine:other')).toBe(false);
+  }));
+
+  test('returns an empty map on an absent log file or empty cutoff map', () => {
+    expect(scanRoutineCostWindowed('/nonexistent/path/cost-log.jsonl', new Map([['routine:a', '2026-01-01T00:00:00Z']])).size).toBe(0);
+    expect(scanRoutineCostWindowed('/nonexistent/path/cost-log.jsonl', new Map()).size).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
The `routine-cost` doctor check divided `cost-index.json`'s lifetime cumulative cost for a routine by a fire count that only covers the window since `routine-metrics.jsonl` tracking was added (#378). On hermits whose routines predate that feature, this inflated `$/run` and produced false `warn`s on infrequent routines (e.g. `weekly-review`).

## Changes
- `scripts/lib/cost-log.ts`: add `scanRoutineCostWindowed`, a per-source windowed cost sum over `cost-log.jsonl` (never pruned/rotated), mirroring the existing `scanAutomatedOpus` scan shape.
- `scripts/doctor-check.ts`: `checkRoutineCost` now tracks each routine's earliest tracked fire timestamp and windows the cost-index numerator to `[earliest tracked fire, now]`, matching the denominator's window. Falls back to the lifetime `cost-index.json` total when windowing data isn't available (no valid fire timestamp, or `cost-log.jsonl` absent), preserving current behavior in that case.
- Tests: a regression case in `contracts.test.ts` reproducing the false positive (lifetime cost with pre-tracking history no longer flags), plus a focused unit test for `scanRoutineCostWindowed` in `cost-log.test.ts`.
- `docs/routine-authoring.md` + `CHANGELOG.md`: updated to describe the windowed computation.

## Test plan
- `bun test` — full core plugin suite: 2252 pass, 0 fail.
- `bunx tsc --noEmit` — clean.

Closes #573