### PR TITLE
fix(claude-code-hermit): operator slash commands refresh last-operator-action.json

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **record-operator-action: operator-typed slash commands now refresh `last-operator-action.json`** — the blanket bare-`/` drop keyed on a `<command-message>` wrapper that never reaches the hook's stdin, so slash-driven sessions looked idle to AUTO_CLOSE and watchdog hygiene; only hermit's own tmux-injected commands are filtered now (#574).
 - **cost-tracker: fall back to `other` source when a turn's boundary falls outside the 512KB scan window** — prevents a large turn (e.g. a plugin upgrade run) from inheriting a stale or self-echoed routine marker and tripping a false `hermit-doctor` routine-cost warn.
 
 ### Changed

--- a/plugins/claude-code-hermit/scripts/record-operator-action.ts
+++ b/plugins/claude-code-hermit/scripts/record-operator-action.ts
@@ -14,10 +14,10 @@ process.stdout.on('error', () => {});
 //
 // Filtered prompts (not operator activity):
 //   [hermit-routine:…   — cron-delivered routine prompts (hermit-routines/SKILL.md:43-54)
-//   /<anything> (bare, no <command-message>) — /loop re-fires, cron injections,
-//                          programmatic slash invocations
 //   <channel…           — unauthorized DMs arrive here before channel-responder's allowlist
 //                          check; recording them would let bot traffic suppress AUTO_CLOSE
+//   hermit's own tmux-injected slash commands — see INJECTED_EXACT below. Every
+//   other bare `/…` prompt counts as operator activity (see isRoutinePrompt).
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -35,20 +35,33 @@ function write() {
   } catch { /* fail-open */ }
 }
 
+// Hermit-injected slash prompts — tmux send-keys from hermit-watchdog.ts and
+// hermit-stop.ts arrive at this hook as bare text, byte-identical to operator
+// typing. A live probe (2026-07-10, CC v2.1.206) showed operator-typed slash
+// commands ALSO arrive bare (no <command-message> wrapper reaches stdin), so
+// there is no stdin-visible signal to key on: drop exactly our own known
+// injections and count every other prompt as operator activity. Missing the
+// operator is the destructive direction (mid-session /clear, AUTO_CLOSE);
+// counting a stray programmatic prompt only delays cleanup.
+// tests/auto-close.test.ts syncs this list against the actual sendKeys call
+// sites — extend it when adding a new injection.
+const INJECTED_EXACT = new Set([
+  '/claude-code-hermit:heartbeat run',
+  '/claude-code-hermit:heartbeat start',
+  '/claude-code-hermit:heartbeat stop',
+  '/claude-code-hermit:hermit-routines load',
+  '/claude-code-hermit:session-close --shutdown',
+]);
+
 function isRoutinePrompt(prompt: string): boolean {
   if (prompt.startsWith('[hermit-routine:')) return true;
-  const t = prompt.trimStart();
+  const t = prompt.trim();
   if (t.startsWith('<channel')) return true;
-  // /loop re-fires and other programmatic slash injections arrive as bare strings.
-  // NOTE: operator-typed slash commands ALSO arrive as bare text with no
-  // <command-message> wrapper (live-probed 2026-07-10, CC v2.1.206 — the wrapper
-  // only exists in the stored transcript, added later by CC's prompt-expansion
-  // pipeline; see the skill-capture note below). This hook cannot distinguish an
-  // operator slash-command turn from a programmatic one at this boundary, so it
-  // drops both — a genuine operator `/…` turn does NOT refresh
-  // last-operator-action.json. Known limitation, not fixed here: narrowing the
-  // filter would alter AUTO_CLOSE gating.
-  if (t.startsWith('/') && !prompt.includes('<command-message>')) return true;
+  if (INJECTED_EXACT.has(t)) return true;
+  // Watchdog hygiene injections (hermit-watchdog.ts:421,620,754). Native
+  // commands may never reach this hook at all; dropping them is safe either
+  // way — typing /clear or /compact ends a context, it doesn't signal presence.
+  if (t === '/clear' || t.startsWith('/compact')) return true;
   return false;
 }
 

--- a/plugins/claude-code-hermit/tests/auto-close.test.ts
+++ b/plugins/claude-code-hermit/tests/auto-close.test.ts
@@ -267,14 +267,42 @@ describe('last-operator-action.json signal', () => {
     expect(fs.existsSync(lastOp(dir))).toBe(true);
   }));
 
-  // g. hook smoke: bare loop re-fire → file NOT written
-  test('hook smoke: bare /claude-code-hermit:heartbeat run → file NOT written', withTmp(async (dir) => {
-    await recordHook(dir, '{"prompt":"/claude-code-hermit:heartbeat run"}');
+  // g. hook smoke: exact hermit-injected commands (watchdog re-arm + shutdown) → file NOT written
+  for (const injected of [
+    '/claude-code-hermit:heartbeat run',
+    '/claude-code-hermit:heartbeat start',
+    '/claude-code-hermit:heartbeat stop',
+    '/claude-code-hermit:hermit-routines load',
+    '/claude-code-hermit:session-close --shutdown',
+  ]) {
+    test(`hook smoke: injected "${injected}" → file NOT written`, withTmp(async (dir) => {
+      await recordHook(dir, JSON.stringify({ prompt: injected }));
+      expect(fs.existsSync(lastOp(dir))).toBe(false);
+    }));
+  }
+
+  // g3. hook smoke: injected command with trailing whitespace/newline still matches
+  test('hook smoke: injected command with trailing whitespace → file NOT written', withTmp(async (dir) => {
+    await recordHook(dir, JSON.stringify({ prompt: '/claude-code-hermit:heartbeat run\n' }));
     expect(fs.existsSync(lastOp(dir))).toBe(false);
   }));
 
-  // h. hook smoke: operator-typed /heartbeat run (with command-message wrapper) → file IS written
-  test('hook smoke: operator-typed /heartbeat run (command-message wrapper) → file IS written', withTmp(async (dir) => {
+  // g4. hook smoke: watchdog hygiene commands (/clear, /compact ...) → file NOT written
+  test('hook smoke: bare /clear (watchdog hygiene) → file NOT written', withTmp(async (dir) => {
+    await recordHook(dir, '{"prompt":"/clear"}');
+    expect(fs.existsSync(lastOp(dir))).toBe(false);
+  }));
+
+  test('hook smoke: bare /compact ... (watchdog hygiene) → file NOT written', withTmp(async (dir) => {
+    await recordHook(dir, JSON.stringify({
+      prompt: '/compact focus on unfinished work, pending operator items, and in-flight decisions',
+    }));
+    expect(fs.existsSync(lastOp(dir))).toBe(false);
+  }));
+
+  // h. hook smoke: legacy wrapped shape (never actually reaches stdin per the
+  // 2026-07-10 probe, but must not regress to dropped if some future CC version emits it)
+  test('hook smoke: legacy <command-message> wrapped shape → file IS written', withTmp(async (dir) => {
     await recordHook(dir, JSON.stringify({
       prompt: '<command-message>heartbeat run</command-message>\n<command-name>/claude-code-hermit:heartbeat run</command-name>',
     }));
@@ -287,24 +315,40 @@ describe('last-operator-action.json signal', () => {
     expect(fs.existsSync(lastOp(dir))).toBe(false);
   }));
 
-  // j. hook smoke: bare /loop re-fire of /brief → file NOT written
-  test('hook smoke: bare /claude-code-hermit:brief (loop re-fire) → file NOT written', withTmp(async (dir) => {
+  // j. hook smoke: operator-typed bare /brief → file IS written (#574 repro — this is the
+  // shape a real operator slash-command turn actually arrives as; no <command-message>
+  // wrapper reaches this hook's stdin)
+  test('hook smoke: operator-typed bare /claude-code-hermit:brief → file IS written', withTmp(async (dir) => {
     await recordHook(dir, '{"prompt":"/claude-code-hermit:brief"}');
-    expect(fs.existsSync(lastOp(dir))).toBe(false);
+    expect(fs.existsSync(lastOp(dir))).toBe(true);
   }));
 
-  // k. hook smoke: operator-typed /brief (command-message wrapper) → file IS written
-  test('hook smoke: operator-typed /brief (command-message wrapper) → file IS written', withTmp(async (dir) => {
+  // k. hook smoke: legacy wrapped /brief shape → still written
+  test('hook smoke: legacy <command-message> wrapped /brief shape → file IS written', withTmp(async (dir) => {
     await recordHook(dir, JSON.stringify({
       prompt: '<command-message>claude-code-hermit:brief</command-message>\n<command-name>/claude-code-hermit:brief</command-name>',
     }));
     expect(fs.existsSync(lastOp(dir))).toBe(true);
   }));
 
-  // l. hook smoke: bare arbitrary slash command (any future loop re-fire) → file NOT written
-  test('hook smoke: bare /some-future-plugin:some-cmd → file NOT written', withTmp(async (dir) => {
+  // l. hook smoke: bare arbitrary namespaced slash command → file IS written (not on the
+  // hermit-injected drop-list, so it counts as operator activity — see #574)
+  test('hook smoke: bare /some-future-plugin:some-cmd → file IS written', withTmp(async (dir) => {
     await recordHook(dir, '{"prompt":"/some-future-plugin:some-cmd --flag"}');
-    expect(fs.existsSync(lastOp(dir))).toBe(false);
+    expect(fs.existsSync(lastOp(dir))).toBe(true);
+  }));
+
+  // l2. hook smoke: un-namespaced operator command (e.g. a personal/project skill) → file IS written
+  test('hook smoke: bare /tackle-issue 574 (un-namespaced) → file IS written', withTmp(async (dir) => {
+    await recordHook(dir, '{"prompt":"/tackle-issue 574"}');
+    expect(fs.existsSync(lastOp(dir))).toBe(true);
+  }));
+
+  // l3. hook smoke: single-step always-on boot skill (hermit-start.ts argv bootstrap) →
+  // file IS written (accepted delta: this is indistinguishable from operator-typed /session)
+  test('hook smoke: bare /claude-code-hermit:session (boot_skill) → file IS written', withTmp(async (dir) => {
+    await recordHook(dir, '{"prompt":"/claude-code-hermit:session"}');
+    expect(fs.existsSync(lastOp(dir))).toBe(true);
   }));
 
   // m. SessionStart (no payload) + absent file → file IS written (cold-start seed)
@@ -332,6 +376,45 @@ describe('last-operator-action.json signal', () => {
     await recordHook(dir, '', ['--force']);
     expect(fs.readFileSync(lastOp(dir), 'utf-8')).not.toContain('2026-05-20T09:00:00');
   }));
+});
+
+// -------------------------------------------------------
+// injection-sync drift guard: every slash literal hermit-watchdog.ts /
+// hermit-stop.ts inject via tmux send-keys must be dropped by
+// record-operator-action.ts's isRoutinePrompt. Prevents a future injection
+// from silently refreshing the operator clock it should not touch.
+// -------------------------------------------------------
+
+describe('record-operator-action: hermit-injected commands stay in sync', () => {
+  function extractSendKeysLiterals(file: string): string[] {
+    const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'scripts', file), 'utf-8');
+    const literals: string[] = [];
+    for (const line of src.split('\n')) {
+      if (!line.includes('sendKeys(') && !line.includes("'send-keys'")) continue;
+      for (const m of line.matchAll(/'(\/[^']*)'/g)) literals.push(m[1]);
+    }
+    return literals;
+  }
+
+  const literals = [
+    ...extractSendKeysLiterals('hermit-watchdog.ts'),
+    ...extractSendKeysLiterals('hermit-stop.ts'),
+  ];
+
+  test('sweep finds a non-trivial number of injected slash literals', () => {
+    expect(literals.length).toBeGreaterThanOrEqual(5);
+  });
+
+  for (const literal of [...new Set(literals)]) {
+    test(`injected literal "${literal}" is dropped by record-operator-action.ts`, withTmp(async (dir) => {
+      const r = await runScript('record-operator-action.ts', {
+        stdin: JSON.stringify({ prompt: literal }),
+        cwd: dir,
+      });
+      expect(r.exitCode).toBe(0);
+      expect(fs.existsSync(hermit(dir, 'state', 'last-operator-action.json'))).toBe(false);
+    }));
+  }
 });
 
 // -------------------------------------------------------

--- a/plugins/claude-code-hermit/tests/auto-close.test.ts
+++ b/plugins/claude-code-hermit/tests/auto-close.test.ts
@@ -390,8 +390,8 @@ describe('record-operator-action: hermit-injected commands stay in sync', () => 
     const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'scripts', file), 'utf-8');
     const literals: string[] = [];
     for (const line of src.split('\n')) {
-      if (!line.includes('sendKeys(') && !line.includes("'send-keys'")) continue;
-      for (const m of line.matchAll(/'(\/[^']*)'/g)) literals.push(m[1]);
+      if (!line.includes('sendKeys(') && !line.includes('send-keys')) continue;
+      for (const m of line.matchAll(/(['"])(\/[^'"]*)\1/g)) literals.push(m[2]);
     }
     return literals;
   }


### PR DESCRIPTION
## Summary
Operator-typed slash commands (e.g. `/claude-code-hermit:brief`) arrive at the `UserPromptSubmit` hook as bare text with no `<command-message>` wrapper — a live probe (PR #571) proved the wrapper only exists in stored transcripts, added later by CC's prompt-expansion pipeline, and never reaches the hook's stdin. `record-operator-action.ts`'s blanket "drop any bare `/…`" filter therefore also dropped genuine operator slash turns, so `state/last-operator-action.json` never refreshed on a slash-driven session. Since that file gates AUTO_CLOSE (midnight pending-close drain, 12h inactivity) and the watchdog's operator-recency backoff before `/clear`/`/compact`, a session driven entirely via slash commands could be auto-closed or have its context cleared out from under the operator.

Closes #574.

## Changes
- `scripts/record-operator-action.ts` — replaced the blanket bare-slash drop with an exact `INJECTED_EXACT` set of hermit's own tmux-injected commands (`heartbeat run/start/stop`, `hermit-routines load`, `session-close --shutdown`) plus a `/clear` / `/compact` prefix check for watchdog hygiene injections. Every other bare `/…` prompt now counts as operator activity.
- `tests/auto-close.test.ts` — flipped/extended the hook-smoke cases for the new behavior (operator-typed bare slash commands now write; hermit-injected commands still don't), and added a drift-guard test that scrapes every `sendKeys`/`send-keys` slash literal out of `hermit-watchdog.ts` and `hermit-stop.ts` and asserts each one is still dropped — so a future injection added without updating the filter fails CI instead of silently refreshing the operator clock.
- `CHANGELOG.md` — `[Unreleased]` Fixed entry.

## Test plan
- `bun test` (from `plugins/claude-code-hermit/`) — 2296 pass, 0 fail.
- `bunx tsc --noEmit` (from repo root) — clean.
- Live tmux probe (`claude --plugin-dir`, Haiku 4.5, hatched scratch project): typing `/claude-code-hermit:brief` now writes `last-operator-action.json` (the issue's repro, now passing); a hermit-injected `/claude-code-hermit:heartbeat run` left the file's stale timestamp untouched.
- `/simplify` cleanup pass (3 parallel reviewers: reuse, quality, efficiency) — one duplicate test case merged; no other findings.