### PR TITLE
fix(homeassistant-hermit): deliver routine briefs via Operator Notification protocol

### DIFF
--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `claude-code-homeassistant-hermit` / `ha-agent-lab` are documented here.
 
+## [Unreleased]
+
+### Fixed
+- **ha-morning-brief / ha-evening-brief: routine fires now notify the operator** — delivery is keyed on routine invocation / `config.always_on` via the core Operator Notification protocol; previously channel delivery only fired when `session_state` was `waiting`, so routines firing on idle always-on hermits wrote the brief to `compiled/` but never notified (#581)
+
 ## [0.4.2] - 2026-07-06
 
 ### Added

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-evening-brief/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-evening-brief/SKILL.md
@@ -68,6 +68,6 @@ Keep the entire brief under 10 lines. Adapt the greeting and section headers to 
 
 ## Delivery
 
-- If invoked as a routine, or `config.always_on` is `true` in `.claude-code-hermit/config.json`: deliver the composed brief via the Operator Notification protocol in CLAUDE.md (core resolves the channel and falls back to push / SHELL.md logging when no channel is reachable). The terminal is unmonitored in always-on mode — never gate delivery on `session_state`.
+- If invoked as a routine, or `config.always_on` is `true` in `.claude-code-hermit/config.json`: deliver the composed brief via the Operator Notification protocol in CLAUDE.md (core resolves the channel and falls back to push / SHELL.md logging when no channel is reachable). The terminal is unmonitored in always-on mode — never gate delivery on `session_state`. For the push-fallback branch, condense to a single line (≤200 chars, no markdown): lead with the security verdict (open doors, unlocked, open windows) or `secure`, then any anomaly. Example: `House secure, garage door still open — open CC to view`.
 - Otherwise (invoked on demand in an interactive session): output to terminal.
 - Never include secrets, tokens, or internal file paths in the brief.

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-evening-brief/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-evening-brief/SKILL.md
@@ -17,15 +17,6 @@ An end-of-day house check that confirms the house is secure before night. Design
 
 When both `claude-code-hermit` and `claude-code-homeassistant-hermit` are installed and `evening-brief` is enabled, this skill subsumes `/claude-code-hermit:brief --evening` — operators should disable the core `evening` routine to avoid duplicate ~22:30 notifications. For hermits without HA, `/claude-code-hermit:brief --evening` remains the standalone path.
 
-## Delivery Guard
-
-Before doing any work, read `.claude-code-hermit/state/runtime.json` if it exists.
-
-- If `session_state` is `waiting`: the operator is absent. Check `config.json` for a configured notification channel.
-  - Channel present → proceed, notify the operator via the configured channel.
-  - No channel → suppress entirely (log `evening-brief skipped: session_state=waiting, no channel` to SHELL.md Monitoring and exit).
-- Otherwise: proceed normally.
-
 ## Steps
 
 1. **Time & context** — Call `GetDateTime` for current time. Read `.claude-code-hermit/OPERATOR.md` for language preferences.
@@ -77,6 +68,6 @@ Keep the entire brief under 10 lines. Adapt the greeting and section headers to 
 
 ## Delivery
 
-- If invoked as a routine and `session_state` is `waiting` with a channel configured: notify the operator via that channel only.
-- Otherwise: output to terminal.
+- If invoked as a routine, or `config.always_on` is `true` in `.claude-code-hermit/config.json`: deliver the composed brief via the Operator Notification protocol in CLAUDE.md (core resolves the channel and falls back to push / SHELL.md logging when no channel is reachable). The terminal is unmonitored in always-on mode — never gate delivery on `session_state`.
+- Otherwise (invoked on demand in an interactive session): output to terminal.
 - Never include secrets, tokens, or internal file paths in the brief.

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md
@@ -112,6 +112,6 @@ Adapt the greeting and section headers to the operator's configured language. Ke
 
 ## Delivery
 
-- If invoked as a routine, or `config.always_on` is `true` in `.claude-code-hermit/config.json`: deliver the composed brief via the Operator Notification protocol in CLAUDE.md (core resolves the channel and falls back to push / SHELL.md logging when no channel is reachable). The terminal is unmonitored in always-on mode — never gate delivery on `session_state`.
+- If invoked as a routine, or `config.always_on` is `true` in `.claude-code-hermit/config.json`: deliver the composed brief via the Operator Notification protocol in CLAUDE.md (core resolves the channel and falls back to push / SHELL.md logging when no channel is reachable). The terminal is unmonitored in always-on mode — never gate delivery on `session_state`. For the push-fallback branch, condense to a single line (≤200 chars, no markdown): lead with any overnight anomaly or open `Awaiting decision:` count, then energy/cost if flagged. Example: `House OK overnight, 2 awaiting decision, 14kWh — open CC to view`.
 - Otherwise (invoked on demand in an interactive session): output to terminal.
 - Never include secrets, tokens, or internal file paths in the brief.

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md
@@ -17,15 +17,6 @@ A house-focused morning brief that combines live HA state with hermit session co
 
 When both `claude-code-hermit` and `claude-code-homeassistant-hermit` are installed and `morning-brief` is enabled, this skill subsumes `/claude-code-hermit:brief --morning` — operators should disable the core `morning` routine to avoid duplicate notifications. For hermits without HA, `/claude-code-hermit:brief --morning` remains the standalone path.
 
-## Delivery Guard
-
-Before doing any work, read `.claude-code-hermit/state/runtime.json` if it exists.
-
-- If `session_state` is `waiting`: the operator is absent. Check `config.json` for a configured notification channel.
-  - Channel present → proceed, notify the operator via the configured channel.
-  - No channel → suppress entirely (log `morning-brief skipped: session_state=waiting, no channel` to SHELL.md Monitoring and exit).
-- Otherwise: proceed normally.
-
 ## Steps
 
 1. **Time & context** — Call `GetDateTime` for current time. Read `.claude-code-hermit/OPERATOR.md` for priorities and language preferences.
@@ -121,6 +112,6 @@ Adapt the greeting and section headers to the operator's configured language. Ke
 
 ## Delivery
 
-- If invoked as a routine and `session_state` is `waiting` with a channel configured: notify the operator via that channel only.
-- Otherwise: output to terminal.
+- If invoked as a routine, or `config.always_on` is `true` in `.claude-code-hermit/config.json`: deliver the composed brief via the Operator Notification protocol in CLAUDE.md (core resolves the channel and falls back to push / SHELL.md logging when no channel is reachable). The terminal is unmonitored in always-on mode — never gate delivery on `session_state`.
+- Otherwise (invoked on demand in an interactive session): output to terminal.
 - Never include secrets, tokens, or internal file paths in the brief.


### PR DESCRIPTION
## Summary
`ha-morning-brief` and `ha-evening-brief` gated channel delivery on `session_state` being `waiting`. That state actually means "blocked on an operator reply the hermit already asked for," not "operator absent" — the guard's rationale was inverted. A routine fire on an always-on hermit sees `session_state: idle` (the normal resting state; `routine-precheck.ts` already skips non-`run_during_waiting` routines during `waiting`), so the guard's delivery branch never triggered and the brief silently fell through to an unmonitored terminal.

Fixes #581

## Changes
- Removed the `session_state`-gated `Delivery Guard` section from both skills.
- Rewrote `## Delivery` to route through the core Operator Notification protocol whenever invoked as a routine or when `config.always_on` is `true` — matching the pattern already used by core's `brief` skill (`Always-On Delivery Rule`) and the fitness plugin's routine templates. Interactive on-demand invocation still prints to terminal.
- Added a CHANGELOG `[Unreleased]` entry.

## Test plan
- `cd plugins/claude-code-homeassistant-hermit && bun test` — 654 pass, 0 fail (no contract test pinned the old guard text).
- `grep -n "session_state\|Delivery Guard"` on both skill files — no delivery-gating logic remains (one explanatory prose line intentionally states delivery is never gated on `session_state`).