### PR TITLE
fix(claude-code-fitness-hermit): resolve stale Strava token via MCP server's live refresh

### DIFF
--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **fitness-lab: stop reading a stale `.env` Strava token** — `getAccessToken` now prefers the Strava MCP server's own auto-refreshed token (`~/.config/strava-mcp/config.json`, test seam `STRAVA_MCP_CONFIG`) when present and unexpired, falling back to `.env`'s `STRAVA_ACCESS_TOKEN` otherwise. Previously `fitness-lab.ts` only ever read the one-time `.env` copy, which silently went stale once the MCP server refreshed its own token independently, causing 401s the `strava-health-check` routine didn't catch (it checks the MCP server's live connection, not `.env`).
+
 ## [0.0.13] - 2026-07-06
 
 ### Added

--- a/plugins/claude-code-fitness-hermit/scripts/fitness-lab.test.ts
+++ b/plugins/claude-code-fitness-hermit/scripts/fitness-lab.test.ts
@@ -234,6 +234,9 @@ console.log('\ngetAccessToken (MCP config vs .env fallback):');
   fs.writeFileSync(configPath, 'not json');
   eq('unparseable config → .env fallback', getAccessToken(envProj), 'env-token');
 
+  fs.writeFileSync(configPath, JSON.stringify({ accessToken: 'mcp-token' }));
+  eq('config token without expiresAt → .env fallback', getAccessToken(envProj), 'env-token');
+
   const noEnvProj = fs.mkdtempSync(path.join(os.tmpdir(), 'fitness-lab-noenv-'));
   process.env.STRAVA_MCP_CONFIG = path.join(configDir, 'missing.json');
   eq('no config, no .env → null', getAccessToken(noEnvProj), null);
@@ -264,7 +267,7 @@ async function run(args: string[], base?: string): Promise<{ code: number; out: 
   const env: Record<string, string> = { ...(process.env as Record<string, string>) };
   // Isolate from any real ~/.config/strava-mcp/config.json on the host machine —
   // contract tests must exercise the .env fixture token, not a live operator credential.
-  env.STRAVA_MCP_CONFIG = path.join(os.tmpdir(), 'fitness-lab-no-mcp-config.json');
+  env.STRAVA_MCP_CONFIG = path.join(os.tmpdir(), `fitness-lab-no-mcp-config-${process.pid}.json`);
   if (base) env.STRAVA_API_BASE = base;
   else delete env.STRAVA_API_BASE;
   const proc = Bun.spawn(['bun', SCRIPT, ...args], { env, stdout: 'pipe', stderr: 'pipe' });

--- a/plugins/claude-code-fitness-hermit/scripts/fitness-lab.test.ts
+++ b/plugins/claude-code-fitness-hermit/scripts/fitness-lab.test.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import {
   THRESHOLDS,
   AUTH_RECOVERY_MESSAGE,
+  getAccessToken,
   mean,
   median,
   stddev,
@@ -212,6 +213,42 @@ eq('gap spans exactly 3 consecutive weeks', gapWl.weeks.length, 3);
 eq('interior rest week empty', gapWl.weeks[1].activities, 0);
 eq('older active week km present', gapWl.weeks[2].km, 8);
 
+console.log('\ngetAccessToken (MCP config vs .env fallback):');
+{
+  const envProj = fs.mkdtempSync(path.join(os.tmpdir(), 'fitness-lab-token-'));
+  fs.writeFileSync(path.join(envProj, '.env'), 'STRAVA_ACCESS_TOKEN=env-token\n');
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fitness-lab-mcpcfg-'));
+  const configPath = path.join(configDir, 'config.json');
+  const prevConfig = process.env.STRAVA_MCP_CONFIG;
+
+  process.env.STRAVA_MCP_CONFIG = path.join(configDir, 'missing.json');
+  eq('missing config file → .env fallback', getAccessToken(envProj), 'env-token');
+
+  process.env.STRAVA_MCP_CONFIG = configPath;
+  fs.writeFileSync(configPath, JSON.stringify({ accessToken: 'mcp-token', expiresAt: Date.now() / 1000 + 3600 }));
+  eq('fresh config token wins over .env', getAccessToken(envProj), 'mcp-token');
+
+  fs.writeFileSync(configPath, JSON.stringify({ accessToken: 'mcp-token', expiresAt: Date.now() / 1000 - 3600 }));
+  eq('expired config token → .env fallback', getAccessToken(envProj), 'env-token');
+
+  fs.writeFileSync(configPath, 'not json');
+  eq('unparseable config → .env fallback', getAccessToken(envProj), 'env-token');
+
+  const noEnvProj = fs.mkdtempSync(path.join(os.tmpdir(), 'fitness-lab-noenv-'));
+  process.env.STRAVA_MCP_CONFIG = path.join(configDir, 'missing.json');
+  eq('no config, no .env → null', getAccessToken(noEnvProj), null);
+
+  fs.writeFileSync(path.join(noEnvProj, '.env'), 'STRAVA_ACCESS_TOKEN=replace_me\n');
+  eq('no config, .env placeholder → null', getAccessToken(noEnvProj), null);
+
+  if (prevConfig === undefined) delete process.env.STRAVA_MCP_CONFIG;
+  else process.env.STRAVA_MCP_CONFIG = prevConfig;
+
+  fs.rmSync(envProj, { recursive: true });
+  fs.rmSync(configDir, { recursive: true });
+  fs.rmSync(noEnvProj, { recursive: true });
+}
+
 // ===========================================================================
 // Contract layer
 // ===========================================================================
@@ -225,6 +262,9 @@ function tmpProject(): string {
 
 async function run(args: string[], base?: string): Promise<{ code: number; out: string }> {
   const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+  // Isolate from any real ~/.config/strava-mcp/config.json on the host machine —
+  // contract tests must exercise the .env fixture token, not a live operator credential.
+  env.STRAVA_MCP_CONFIG = path.join(os.tmpdir(), 'fitness-lab-no-mcp-config.json');
   if (base) env.STRAVA_API_BASE = base;
   else delete env.STRAVA_API_BASE;
   const proc = Bun.spawn(['bun', SCRIPT, ...args], { env, stdout: 'pipe', stderr: 'pipe' });

--- a/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
+++ b/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
@@ -19,8 +19,16 @@
  *   --project-root <path>   default process.cwd(); .env + .claude-code-hermit/ live there
  *
  * Env:
- *   STRAVA_API_BASE   test seam; default https://www.strava.com/api/v3
- *   STRAVA_ACCESS_TOKEN is read from <project-root>/.env (read-only parse).
+ *   STRAVA_API_BASE     test seam; default https://www.strava.com/api/v3
+ *   STRAVA_MCP_CONFIG   test seam; default ~/.config/strava-mcp/config.json
+ *
+ * Token resolution (getAccessToken): the Strava MCP server (@r-huijts/strava-mcp-server)
+ * auto-refreshes the OAuth token on 401 and persists it to its own config file
+ * (STRAVA_MCP_CONFIG), independent of this project's .env. To avoid reading a token
+ * that's gone stale the moment the MCP server refreshes, getAccessToken prefers a
+ * non-expired token from that config file and falls back to <project-root>/.env's
+ * STRAVA_ACCESS_TOKEN (read-only parse) only when the config file is absent, unparseable,
+ * or its token is expired.
  *
  * Error contract (deliberately NOT docker-preflight's always-exit-0 — the skill
  * must branch on hard auth failure):
@@ -30,6 +38,7 @@
  */
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 // ---------------------------------------------------------------------------
@@ -118,7 +127,26 @@ export function parseEnv(projectRoot: string): Record<string, string> {
   return out;
 }
 
+function mcpConfigPath(): string {
+  return process.env.STRAVA_MCP_CONFIG || path.join(os.homedir(), '.config', 'strava-mcp', 'config.json');
+}
+
+/** Non-expired accessToken from the Strava MCP server's own refreshed config, or null. */
+function readMcpConfigToken(): string | null {
+  let parsed: { accessToken?: string; expiresAt?: number };
+  try {
+    parsed = JSON.parse(fs.readFileSync(mcpConfigPath(), 'utf-8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || !parsed.accessToken) return null;
+  if (typeof parsed.expiresAt === 'number' && parsed.expiresAt <= Date.now() / 1000 + 60) return null;
+  return parsed.accessToken;
+}
+
 export function getAccessToken(projectRoot: string): string | null {
+  const mcpToken = readMcpConfigToken();
+  if (mcpToken) return mcpToken;
   const v = parseEnv(projectRoot)['STRAVA_ACCESS_TOKEN'];
   return v && v !== 'replace_me' ? v : null;
 }

--- a/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
+++ b/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
@@ -140,7 +140,9 @@ function readMcpConfigToken(): string | null {
     return null;
   }
   if (!parsed || typeof parsed !== 'object' || !parsed.accessToken) return null;
-  if (typeof parsed.expiresAt === 'number' && parsed.expiresAt <= Date.now() / 1000 + 60) return null;
+  // Require a numeric, non-expired expiresAt: a token we can't date isn't
+  // verifiably "non-expired", so fall back to .env rather than trust it forever.
+  if (typeof parsed.expiresAt !== 'number' || parsed.expiresAt <= Date.now() / 1000 + 60) return null;
   return parsed.accessToken;
 }
 


### PR DESCRIPTION
## Summary
`fitness-lab.ts` resolved its Strava access token only from the project's `.env` file, written once at hatch time. The Strava MCP server (`@r-huijts/strava-mcp-server`) auto-refreshes the OAuth token independently and persists it to its own file (`~/.config/strava-mcp/config.json`), never touching `.env`. Once the MCP server refreshed, `.env` silently went stale and `fitness-lab.ts` eventually 401'd — with no early warning, since the `strava-health-check` routine checks the MCP server's own (refreshed, healthy) connection, not the `.env` copy.

## Changes
- `getAccessToken` now prefers a non-expired token from the MCP server's persisted config file, falling back to the existing `.env` read only when that file is absent, unparseable, or its token is expired (60s skew guard).
- New `STRAVA_MCP_CONFIG` test seam (mirrors the existing `STRAVA_API_BASE` seam), defaulting to `~/.config/strava-mcp/config.json`.
- Contract-test harness now pins `STRAVA_MCP_CONFIG` to a nonexistent path so a real local Strava MCP config on the dev/CI machine can't leak into fixture-based tests.
- Guarded against `JSON.parse` on a literal `"null"` config file crashing outside the try/catch (caught in the /simplify pass).

Closes #582

## Test plan
- `bun test` (plugin dir): 115 passed, 0 failed — includes 6 new `getAccessToken` cases (fresh config wins, expired config falls back, unparseable config falls back, no config + no `.env`, `.env` placeholder guard).
- `bunx tsc --noEmit`: clean.