### PR TITLE
feat(claude-code-hermit): collapse open proposals on the proposals artifact page

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **proposals artifact page: open proposals are now collapsible** — collapsed-by-default one-line summaries with an open count, matching the dashboard; deep-link anchor moved onto the `<details>`.
+
 ## [1.2.22] - 2026-07-12
 
 ### Fixed

--- a/plugins/claude-code-hermit/docs/artifacts.md
+++ b/plugins/claude-code-hermit/docs/artifacts.md
@@ -70,26 +70,34 @@ notes.
 
 ## Proposals page
 
-`config.artifacts.proposals`, state key `proposals`. Full text of every open
-(`proposed`/`accepted`) proposal, each in its own anchored `<section id="prop-nnn">`
-(lowercased `PROP-NNN` prefix) for deep-linking; deferred/resolved/dismissed proposals
-are one-line history entries — the same "other" bucket the dashboard already computes.
-Rendered by `scripts/lib/proposals-page.ts` (reuses the dashboard's proposal loader,
-markdown converter, and CSS). `<title>` is `Hermit Proposals`. Deliberately omits
-proposal age-in-days (unlike the dashboard) — age is `Date.now()`-derived and would
+`config.artifacts.proposals`, state key `proposals`. Every open (`proposed`/`accepted`)
+proposal renders as a collapsed-by-default `<details class="proposal" id="prop-nnn">`
+(lowercased `PROP-NNN` prefix as the `id`, for deep-linking) — a one-line summary (status
+chip, id, title, created-date) that expands to the full body on click, the same pattern
+the dashboard already uses for its proposals card. A heading above the list shows the open
+count (e.g. "3 Open"); deferred/resolved/dismissed proposals stay one-line history entries
+— the same "other" bucket the dashboard already computes. Rendered by
+`scripts/lib/proposals-page.ts` (reuses the dashboard's proposal loader, markdown
+converter, and CSS — no CSS changes were needed since `.proposal`/`.proposal-body` already
+existed for the dashboard's own `<details>`). `<title>` is `Hermit Proposals`. Deliberately
+omits proposal age-in-days (unlike the dashboard) — age is `Date.now()`-derived and would
 otherwise mint a new artifact version once a day even with zero activity; created-date
-is shown instead, keeping the hash purely activity-driven.
+is shown instead, keeping the hash purely activity-driven (the open count is likewise
+activity-driven, not date-driven, so it doesn't reintroduce that churn).
 
 Refresh triggers: `proposal-create` (step 6), `proposal-act` (every accept/defer/
 dismiss/resolve flow, after its Respond step). Both refresh silently by default,
 matching the dashboard's existing no-URL-re-post convention — with one exception:
 `proposal-create`'s own announcement message carries a deep link to the just-created
 proposal, since that's the moment the operator is most likely to want to jump straight
-to it: `📎 <url>#prop-nnn ("PROP-NNN: <title>")`. Fragment scroll-to-anchor behavior in
-the claude.ai artifact viewer itself is unverified (no browser access at the time this
-was written, though the anchor element's presence in the rendered DOM was confirmed) —
-the section name is included in text unconditionally so the link is useful whether or
-not the viewer auto-scrolls.
+to it: `📎 <url>#prop-nnn ("PROP-NNN: <title>")`. The anchor lives on the `<details>`
+element itself, so a browser that auto-opens the `:target`ed `<details>` (current Chrome/
+Safari/Firefox) lands the operator directly on the expanded proposal. Where a viewer
+doesn't do that — the claude.ai artifact viewer's fragment behavior is unverified (no
+browser access at the time this was written, though the anchor element's presence in the
+rendered DOM was confirmed) — the link still scrolls to the correct proposal's collapsed
+summary line, which already shows the chip, id, and title; the section name is included in
+text unconditionally so the link is useful either way.
 
 ## Localization
 

--- a/plugins/claude-code-hermit/scripts/lib/artifact-strings.ts
+++ b/plugins/claude-code-hermit/scripts/lib/artifact-strings.ts
@@ -54,6 +54,7 @@ export const DEFAULT_STRINGS = {
 
   // Proposals page
   proposals_history: 'History',
+  proposals_open_count: '{n} Open',
 
   // Weekly card
   weekly_heading: "This week's evolution",

--- a/plugins/claude-code-hermit/scripts/lib/dashboard.ts
+++ b/plugins/claude-code-hermit/scripts/lib/dashboard.ts
@@ -455,10 +455,11 @@ function renderStatus(state: DashboardState): string {
     </section>`;
 }
 
-// Shared label for a proposal row: status chip, id, title, age — used both in the
-// expandable open-proposal summary and the one-line history entries.
-function proposalLabel(p: ProposalRow, s: ArtifactStrings): string {
-  return `${chip(p.status)} <strong>${escapeHtml(p.id)}</strong> — ${escapeHtml(p.title)}${ageParen(p.ageDays, s)}`;
+// Shared label for a proposal row: status chip, id, title, plus a caller-supplied
+// suffix (age paren here; proposals-page.ts passes a created-date paren instead).
+// Exported so proposals-page.ts's open/history rows reuse the same template.
+export function proposalLabel(p: ProposalRow, suffix: string): string {
+  return `${chip(p.status)} <strong>${escapeHtml(p.id)}</strong> — ${escapeHtml(p.title)}${suffix}`;
 }
 
 function renderProposals(state: DashboardState): string {
@@ -469,7 +470,7 @@ function renderProposals(state: DashboardState): string {
     ? open
         .map(
           p => `<details class="proposal">
-            <summary>${proposalLabel(p, s)}</summary>
+            <summary>${proposalLabel(p, ageParen(p.ageDays, s))}</summary>
             <div class="proposal-body">${mdToHtml(p.body)}</div>
           </details>`
         )
@@ -478,7 +479,7 @@ function renderProposals(state: DashboardState): string {
 
   const otherHtml = other.length
     ? `<ul class="proposal-history">${other
-        .map(p => `<li>${proposalLabel(p, s)}</li>`)
+        .map(p => `<li>${proposalLabel(p, ageParen(p.ageDays, s))}</li>`)
         .join('')}${otherOmitted > 0 ? `<li class="muted">${fmt(s.common_more_not_shown, { n: otherOmitted })}</li>` : ''}</ul>`
     : '';
 

--- a/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
+++ b/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
@@ -1,8 +1,9 @@
 // Deterministic renderer for the Hermit Proposals-page artifact — mirrors
 // scripts/lib/dashboard.ts's render/hash-gate discipline (see docs/artifacts.md).
-// Full text for open (proposed/accepted) proposals, each in its own anchored
-// <section id="prop-nnn"> for deep-linking from channel messages; deferred/
-// resolved/dismissed proposals are one-line history entries, same bucket the
+// Open (proposed/accepted) proposals render as collapsed-by-default
+// <details class="proposal" id="prop-nnn"> — a one-line summary that expands to
+// full text on click, each anchored for deep-linking from channel messages;
+// deferred/resolved/dismissed proposals are one-line history entries, same bucket the
 // dashboard already computes. Self-contained fragment — no
 // <!DOCTYPE>/<html>/<head>/<body> (Artifact tool wraps it).
 

--- a/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
+++ b/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
@@ -6,7 +6,7 @@
 // dashboard already computes. Self-contained fragment — no
 // <!DOCTYPE>/<html>/<head>/<body> (Artifact tool wraps it).
 
-import { loadProposals, mdToHtml, escapeHtml, CSS, chip, type ProposalRow, type OpenProposalRow } from './dashboard';
+import { loadProposals, mdToHtml, escapeHtml, CSS, proposalLabel, type ProposalRow, type OpenProposalRow } from './dashboard';
 import { sha256 } from './hash';
 import { loadStrings, fmt, type ArtifactStrings } from './artifact-strings';
 
@@ -39,19 +39,22 @@ function createdLabel(created: string | null): string {
 
 function renderOpen(open: OpenProposalRow[], s: ArtifactStrings): string {
   if (!open.length) return `<p class="muted">${s.proposals_none_open}</p>`;
-  return open
-    .map(p => `<section class="card" id="${proposalAnchorId(p.id)}">
-      <h2>${chip(p.status)} ${escapeHtml(p.id)}</h2>
-      <p>${escapeHtml(p.title)}${createdLabel(p.created)}</p>
+  const items = open
+    .map(p => `<details class="proposal" id="${proposalAnchorId(p.id)}">
+      <summary>${proposalLabel(p, createdLabel(p.created))}</summary>
       <div class="proposal-body">${mdToHtml(p.body)}</div>
-    </section>`)
+    </details>`)
     .join('');
+  return `<section class="card">
+    <h2>${fmt(s.proposals_open_count, { n: open.length })}</h2>
+    ${items}
+  </section>`;
 }
 
 function renderOther(other: ProposalRow[], otherOmitted: number, s: ArtifactStrings): string {
   if (!other.length) return '';
   const items = other
-    .map(p => `<li>${chip(p.status)} <strong>${escapeHtml(p.id)}</strong> — ${escapeHtml(p.title)}${createdLabel(p.created)}</li>`)
+    .map(p => `<li>${proposalLabel(p, createdLabel(p.created))}</li>`)
     .join('');
   const omittedLine = otherOmitted > 0 ? `<li class="muted">${fmt(s.common_more_not_shown, { n: otherOmitted })}</li>` : '';
   return `

--- a/plugins/claude-code-hermit/tests/proposals-page.test.ts
+++ b/plugins/claude-code-hermit/tests/proposals-page.test.ts
@@ -87,13 +87,31 @@ describe('renderProposalsPage', () => {
     expect(html).toContain('<title>Hermit Proposals</title>');
   }));
 
-  test('renders an anchored section per open proposal', withHermitDir((hermitDir) => {
+  test('renders each open proposal as a collapsed <details> anchored for deep-linking', withHermitDir((hermitDir) => {
     writeProposal(hermitDir, 'PROP-025-hub-spoke-100000.md',
       { id: 'PROP-025-hub-spoke-100000', title: '"Hub and spoke"', status: 'proposed', created: '2026-07-01T10:00:00Z' },
       'Full text of the proposal.');
     const { html } = renderProposalsPage(loadProposalsPageState(hermitDir));
-    expect(html).toContain('id="prop-025"');
-    expect(html).toContain('Full text of the proposal.');
+    expect(html).toContain('<details class="proposal" id="prop-025">');
+    expect(html).not.toMatch(/<details class="proposal" id="prop-025"[^>]*\sopen/);
+    expect(html).toContain('Full text of the proposal.'); // present in markup even though collapsed by default
+  }));
+
+  test('shows an open-proposal count heading, absent when there are none open', withHermitDir((hermitDir) => {
+    writeProposal(hermitDir, 'PROP-001-open-a-100000.md',
+      { id: 'PROP-001-open-a-100000', title: '"Open A"', status: 'proposed', created: '2026-07-01T10:00:00Z' },
+      'body a');
+    writeProposal(hermitDir, 'PROP-002-open-b-100000.md',
+      { id: 'PROP-002-open-b-100000', title: '"Open B"', status: 'accepted', created: '2026-07-02T10:00:00Z' },
+      'body b');
+    const { html } = renderProposalsPage(loadProposalsPageState(hermitDir));
+    expect(html).toContain('2 Open');
+  }));
+
+  test('omits the open count heading when there are no open proposals', withHermitDir((hermitDir) => {
+    const { html } = renderProposalsPage(loadProposalsPageState(hermitDir));
+    expect(html).not.toContain('Open</h2>');
+    expect(html).toContain('No open proposals.');
   }));
 
   test('omits age-in-days so the hash stays activity-driven, not date-driven', withHermitDir((hermitDir) => {


### PR DESCRIPTION
## Summary
The standalone `Hermit Proposals` artifact page rendered every open proposal fully expanded, making it a long scroll on any hermit with several open proposals. This brings it in line with the dashboard's existing collapsible pattern.

## Changes
- Open proposals now render as collapsed-by-default `<details class="proposal" id="prop-nnn">` elements (status chip, id, title, created-date summary; full body on click) instead of always-expanded `<section>` cards.
- A new heading shows the open-proposal count (e.g. "3 Open") — count-driven, not date-driven, so the artifact's activity-driven hash gate is unaffected.
- The `#prop-nnn` deep-link anchor moves onto the `<details>` element so browsers that auto-open a `:target`ed `<details>` land the operator on the expanded proposal; where a viewer doesn't do that, the link still scrolls to the correct collapsed summary line.
- Deduplicated the chip+id+title label template: generalized and exported `dashboard.ts`'s existing `proposalLabel` helper (was hardcoded to an age suffix) so both the dashboard and the proposals page share one implementation instead of three near-identical copies. No behavior change to the dashboard's rendered output.
- Updated `docs/artifacts.md` § Proposals page and added a CHANGELOG `[Unreleased]` entry.

## Test plan
- `bun test` — 2331 pass, 0 fail (full core plugin suite, including updated/adjacent `proposals-page.test.ts`, `artifact-strings.test.ts`, `dashboard.test.ts`).
- `bunx tsc --noEmit` — clean.
- Rendered a fixture proposals page via `render-proposals-page.ts` and confirmed: each open proposal is a collapsed `<details>` (no `open` attribute) with the correct summary; the open-count heading renders; the hash is byte-stable across two renders of identical state.