### PR TITLE
feat(claude-code-hermit): source-gate SessionStart injection with a compact delta capsule

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - **startup-context: SessionStart injection is now source-gated** — post-compaction (`source=compact`) injects only a ≤1,200-char delta capsule (lifecycle state, task + last progress line, file pointers; never cost/upgrade/catalog/drift/report bodies), and resumed sessions skip the Last Report section when SHELL.md is active — the resumed transcript already contains it. Fresh starts unchanged.
 
+### Fixed
+- **startup-context: a post-compaction start no longer clears a prior context-scan warning** — the `source=compact` path only scans the delta capsule (task/progress), so it now merges the scan record instead of overwriting it; a compaction can no longer flip the doctor `context-scan` check to "clean" while an injection marker still sits in OPERATOR.md/compiled/report. The next full start re-scans comprehensively and overwrites, self-healing any stale merged hit.
+
 ## [1.2.23] - 2026-07-12
 
 ### Fixed

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **startup-context: SessionStart injection is now source-gated** — post-compaction (`source=compact`) injects only a ≤1,200-char delta capsule (lifecycle state, task + last progress line, file pointers; never cost/upgrade/catalog/drift/report bodies), and resumed sessions skip the Last Report section when SHELL.md is active — the resumed transcript already contains it. Fresh starts unchanged.
+
 ## [1.2.23] - 2026-07-12
 
 ### Fixed

--- a/plugins/claude-code-hermit/scripts/lib/cost-log.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cost-log.ts
@@ -84,23 +84,25 @@ function _writeIndex(indexPath: string, index: Json): Json {
 // Months-ago reference date, via UTC calendar-month subtraction (not ms subtraction —
 // months have variable length, so `Date.UTC` normalization is the correct way to land
 // on "the same day N months back" for a monthly retention cutoff).
-function _monthsAgo(n: number): Date {
-  const now = new Date();
+function _monthsAgo(n: number, now: Date = new Date()): Date {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - n, now.getUTCDate()));
 }
 
 // Drop by_date/by_week/by_month buckets older than their retention windows. Keeps the
 // index bounded regardless of how long the hermit runs; total_* counters are unaffected.
-function _pruneBuckets(index: Json, timezone: string): void {
-  const dateCutoff = todayYMD(timezone, new Date(Date.now() - BY_DATE_RETENTION_DAYS * 86400000));
+// `asOf` is the reference "now" for the retention cutoffs (default real clock); tests pin
+// it so fixed-date fixtures don't age out of the window as wall-clock time advances.
+function _pruneBuckets(index: Json, timezone: string, asOf: Date = new Date()): void {
+  const nowMs = asOf.getTime();
+  const dateCutoff = todayYMD(timezone, new Date(nowMs - BY_DATE_RETENTION_DAYS * 86400000));
   for (const date of Object.keys(index.by_date)) {
     if (date < dateCutoff) delete index.by_date[date];
   }
-  const weekCutoff = thisWeekKey(timezone, new Date(Date.now() - BY_WEEK_RETENTION_WEEKS * 7 * 86400000));
+  const weekCutoff = thisWeekKey(timezone, new Date(nowMs - BY_WEEK_RETENTION_WEEKS * 7 * 86400000));
   for (const week of Object.keys(index.by_week)) {
     if (week < weekCutoff) delete index.by_week[week];
   }
-  const monthCutoff = thisMonthYYYYMM(timezone, _monthsAgo(BY_MONTH_RETENTION_MONTHS));
+  const monthCutoff = thisMonthYYYYMM(timezone, _monthsAgo(BY_MONTH_RETENTION_MONTHS, asOf));
   for (const month of Object.keys(index.by_month)) {
     if (month < monthCutoff) delete index.by_month[month];
   }
@@ -177,7 +179,7 @@ function _foldLogInto(index: Json, logPath: string, timezone: string): void {
 }
 
 // Full O(n) rebuild from scratch. Only called: first run, version mismatch, or log truncation.
-function rebuildCostIndex(logPath: string, indexPath: string, timezone: string = 'UTC'): Json {
+function rebuildCostIndex(logPath: string, indexPath: string, timezone: string = 'UTC', asOf: Date = new Date()): Json {
   const index = _emptyIndex();
   index.timezone = timezone; // stamp so a later tz change can be detected and re-bucketed
 
@@ -191,7 +193,7 @@ function rebuildCostIndex(logPath: string, indexPath: string, timezone: string =
   _foldLogInto(index, logPath, timezone);
 
   index.byte_offset = fileSize;
-  _pruneBuckets(index, timezone);
+  _pruneBuckets(index, timezone, asOf);
   index.updated_at = new Date().toISOString();
   return _writeIndex(indexPath, index);
 }
@@ -202,11 +204,11 @@ function rebuildCostIndex(logPath: string, indexPath: string, timezone: string =
 // mismatched/absent, but must not write it (cost-tracker is the sole index writer,
 // and a paused hermit runs no Stop turn to rebuild it). O(n) in the log size — only
 // used on the fallback path, so the steady state stays on the O(1) incremental read.
-function computeIndex(logPath: string, timezone: string = 'UTC'): Json {
+function computeIndex(logPath: string, timezone: string = 'UTC', asOf: Date = new Date()): Json {
   const index = _emptyIndex();
   index.timezone = timezone;
   _foldLogInto(index, logPath, timezone);
-  _pruneBuckets(index, timezone);
+  _pruneBuckets(index, timezone, asOf);
   return index;
 }
 
@@ -215,7 +217,7 @@ function computeIndex(logPath: string, timezone: string = 'UTC'): Json {
 // appears truncated (byte_offset > fileSize). `timezone` (default 'UTC') determines the
 // by_date/by_week/by_month bucketing — pass config.timezone so budget windows match the
 // operator's local calendar.
-function updateCostIndex(logPath: string, indexPath: string, timezone: string = 'UTC'): Json {
+function updateCostIndex(logPath: string, indexPath: string, timezone: string = 'UTC', asOf: Date = new Date()): Json {
   let fileSize = 0;
   try {
     fileSize = fs.statSync(logPath).size;
@@ -234,7 +236,7 @@ function updateCostIndex(logPath: string, indexPath: string, timezone: string = 
   // and current-period spend would under-read (a cap could be silently under-enforced)
   // until they refill. Re-bucket the whole log under the new tz, like a version bump.
   if (!index || index.byte_offset > fileSize || index.timezone !== timezone) {
-    return rebuildCostIndex(logPath, indexPath, timezone);
+    return rebuildCostIndex(logPath, indexPath, timezone, asOf);
   }
 
   // No new bytes
@@ -262,7 +264,7 @@ function updateCostIndex(logPath: string, indexPath: string, timezone: string = 
   }
 
   index.byte_offset = fileSize;
-  _pruneBuckets(index, timezone);
+  _pruneBuckets(index, timezone, asOf);
   index.updated_at = new Date().toISOString();
   return _writeIndex(indexPath, index);
 }

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -181,8 +181,9 @@ function main(source: string | null) {
   } else {
     emitFullContext(source);
   }
-  // Always — an empty-hits write clears a prior context-scan warning.
-  persistScanRecord();
+  // Always — a full-path clean scan clears a prior warning; the compact path
+  // merges (it only scanned the capsule) so it can't clear a real warning.
+  persistScanRecord(source);
 }
 
 // Post-compaction path: the delta capsule is the ONLY injection. The native
@@ -478,14 +479,28 @@ function emitFullContext(source: string | null) {
 
 }
 
-// Persist scan record (always — empty hits clear a prior warning)
-function persistScanRecord(): void {
+// Persist scan record. A full-path scan is comprehensive, so it overwrites —
+// empty hits legitimately clear a prior warning. The compact path only scanned
+// the delta capsule (task/progress), so it MERGES with the existing record
+// rather than overwriting: a compaction must never clear a warning a prior full
+// scan recorded for OPERATOR.md/compiled/report. The next full start re-scans
+// comprehensively and overwrites, self-healing any stale merged hit.
+function persistScanRecord(source: string | null): void {
   try {
     const stateDir = path.resolve(AGENT_DIR, 'state');
     fs.mkdirSync(stateDir, { recursive: true });
     const scanPath = path.join(stateDir, 'context-scan.json');
+    let hits = scanHits;
+    if (source === 'compact') {
+      try {
+        const prev = JSON.parse(fs.readFileSync(scanPath, 'utf-8'));
+        const prevHits: { source: string; reason: string }[] = Array.isArray(prev.hits) ? prev.hits : [];
+        const seen = new Set(hits.map(h => `${h.source}\0${h.reason}`));
+        hits = hits.concat(prevHits.filter(h => !seen.has(`${h.source}\0${h.reason}`)));
+      } catch {}
+    }
     const tmp = scanPath + '.tmp';
-    fs.writeFileSync(tmp, JSON.stringify({ ts: new Date().toISOString(), hits: scanHits }, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
+    fs.writeFileSync(tmp, JSON.stringify({ ts: new Date().toISOString(), hits }, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
     fs.renameSync(tmp, scanPath);
   } catch {}
 }

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -4,7 +4,9 @@ process.stdout.on('error', () => {});
 // startup-context.ts — SessionStart hook
 // Replaces the inline bash blob with a capped, priority-ordered context injection.
 // Emits only startup-relevant SHELL.md sections with per-section budgets.
-// Hard cap: 9000 chars total (~2250 tokens).
+// Hard cap: 9000 chars total (~2250 tokens). Source-gated: `compact` emits only
+// a delta capsule (≤ COMPACT_CAP); `resume` skips the Last Report section when
+// SHELL.md is active; `startup`/`clear`/unknown get the full capsule.
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -21,6 +23,7 @@ type Json = any;
 const AGENT_DIR = hermitDir();
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(import.meta.dir, '..');
 const HARD_CAP = 9000;
+const COMPACT_CAP = 1200; // total stdout when source === "compact" (delta capsule only)
 
 // Section budgets (chars). Higher priority sections emit first.
 // If a section exceeds its budget, it is truncated with [...truncated].
@@ -28,7 +31,6 @@ const HARD_CAP = 9000;
 const BUDGETS = {
   operator:      2000,
   session:       3000,
-  pointers:       800, // compaction pointers — only emitted when source === "compact"
   knowledge:     2500, // compiled/ artifacts — read from config, 2500 default
   schemaDrift:    400, // only emitted when compiled/ types are undeclared in knowledge-schema.md
   storageDrift:   500, // only emitted when misplaced files are found
@@ -100,11 +102,11 @@ function lastLines(text: string, n: number): string {
   return lines.slice(-n).join('\n');
 }
 
-// Build the post-compaction pointer block: the state that native/driver-sent
-// compaction drops and startup-context's other sections don't already cover
-// (Active Session re-injects SHELL.md's Task/Progress/Blockers, but not
-// runtime.json's session_state/waiting_reason, pending micro-approvals, or
-// outbound channel routing). Fail-open per-field — one missing/malformed
+// Build the post-compaction delta capsule: the ONLY injection on
+// source === "compact". Carries hermit lifecycle state (never assumed
+// preserved by the native summary — its quality varies) plus file pointers;
+// bodies, catalog, cost, and upgrade status stay out — they are not
+// continuity state. Fail-open per-field — one missing/malformed
 // state file must not blank the rest. Returns "" if nothing is available.
 function buildCompactionPointers(agentDir: string): string {
   const parts: string[] = [];
@@ -124,7 +126,12 @@ function buildCompactionPointers(agentDir: string): string {
     const firstLine = task
       ? task.split('\n').map(l => l.trim()).find(l => l && !l.startsWith('<!--'))
       : null;
-    if (firstLine) parts.push(`task: ${safe(firstLine).slice(0, 300)}`);
+    if (firstLine) parts.push(`task: ${guarded('sessions/SHELL.md', firstLine.slice(0, 300))}`);
+    const progress = extractSection(shellContent, 'Progress Log');
+    const lastEntry = progress
+      ? progress.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('<!--')).pop()
+      : null;
+    if (lastEntry) parts.push(`last progress: ${guarded('sessions/SHELL.md', lastEntry.slice(0, 200))}`);
   } catch {}
 
   try {
@@ -143,6 +150,25 @@ function buildCompactionPointers(agentDir: string): string {
     if (route) parts.push(`outbound channel: ${safe(route.id)} (chat_id: ${safe(route.chat_id)})`);
   } catch {}
 
+  try {
+    const reports = globDir(path.resolve(agentDir, 'sessions'), /^S-\d+-REPORT\.md$/)
+      .map(f => path.basename(f))
+      .reverse();
+    if (reports.length > 0) parts.push(`latest report: sessions/${reports[0]}`);
+  } catch {}
+
+  try {
+    if (fs.statSync(path.resolve(agentDir, 'OPERATOR.md')).size > 0) {
+      parts.push('operator context: OPERATOR.md (not re-read; consult before outward-facing actions)');
+    }
+  } catch {}
+
+  try {
+    if (fs.readdirSync(path.resolve(agentDir, 'proposals')).some(f => f.endsWith('.md'))) {
+      parts.push('proposals dir: proposals/');
+    }
+  } catch {}
+
   if (parts.length === 0) return '';
 
   parts.push('Full state: SHELL.md + runtime.json. Task list: native Tasks. Don\'t re-read large files to reconstruct context.');
@@ -150,6 +176,31 @@ function buildCompactionPointers(agentDir: string): string {
 }
 
 function main(source: string | null) {
+  if (source === 'compact') {
+    emitCompactCapsule();
+  } else {
+    emitFullContext(source);
+  }
+  // Always — an empty-hits write clears a prior context-scan warning.
+  persistScanRecord();
+}
+
+// Post-compaction path: the delta capsule is the ONLY injection. The native
+// summary carries the narrative; full sections would re-inject up to HARD_CAP
+// chars of state the session just paid to summarize.
+function emitCompactCapsule(): void {
+  try {
+    const pointers = buildCompactionPointers(AGENT_DIR);
+    if (!pointers) return;
+    const header = '---Compaction Pointers---\n';
+    const body = pointers.slice(0, COMPACT_CAP - header.length - 1);
+    process.stdout.write(header + body + '\n');
+  } catch {
+    // fail-open — a broken capsule must never block startup
+  }
+}
+
+function emitFullContext(source: string | null) {
   let totalChars = 0;
 
   function emit(label: string, content: string): void {
@@ -193,6 +244,7 @@ function main(source: string | null) {
     shellContent = fs.readFileSync(shellPath, 'utf-8');
   } catch {}
 
+  let hasActiveSession = false;
   if (shellContent === null) {
     emit('Active Session', 'No active session');
   } else {
@@ -224,21 +276,10 @@ function main(source: string | null) {
 
     const sessionOutput = parts.join('\n\n');
     if (sessionOutput.trim()) {
+      hasActiveSession = true;
       emit('Active Session', guarded('sessions/SHELL.md', sessionOutput.slice(0, BUDGETS.session)));
     } else {
       emit('Active Session', 'Session file exists but has no actionable content');
-    }
-  }
-
-  // -------------------------------------------------------
-  // 3b. Compaction pointers (priority 2.2, budget 800) — only on source === "compact"
-  // -------------------------------------------------------
-  if (source === 'compact' && totalChars < HARD_CAP) {
-    try {
-      const pointers = buildCompactionPointers(AGENT_DIR);
-      if (pointers) emit('Compaction Pointers', pointers.slice(0, BUDGETS.pointers));
-    } catch {
-      // Non-fatal — never let pointer injection block ordinary startup context
     }
   }
 
@@ -387,9 +428,10 @@ function main(source: string | null) {
   }
 
   // -------------------------------------------------------
-  // 7. Last report (priority 4, budget 1500)
+  // 7. Last report (priority 4, budget 1500) — skipped on resume with an
+  //    active SHELL.md: the resumed transcript already contains the report.
   // -------------------------------------------------------
-  if (totalChars < HARD_CAP) {
+  if (totalChars < HARD_CAP && !(source === 'resume' && hasActiveSession)) {
     try {
       const sessionsDir = path.resolve(AGENT_DIR, 'sessions');
       const reports = fs.readdirSync(sessionsDir)
@@ -434,9 +476,10 @@ function main(source: string | null) {
     }
   }
 
-  // -------------------------------------------------------
-  // 9. Persist scan record (always — empty hits clear a prior warning)
-  // -------------------------------------------------------
+}
+
+// Persist scan record (always — empty hits clear a prior warning)
+function persistScanRecord(): void {
   try {
     const stateDir = path.resolve(AGENT_DIR, 'state');
     fs.mkdirSync(stateDir, { recursive: true });

--- a/plugins/claude-code-hermit/skills/session-start/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-start/SKILL.md
@@ -147,8 +147,8 @@ All state lives under `.claude-code-hermit/` in the project root.
 ## Context to Load
 
 - `.claude-code-hermit/OPERATOR.md` (always)
-- `.claude-code-hermit/sessions/SHELL.md` (if exists) **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**
-- Most recent `.claude-code-hermit/sessions/S-*-REPORT.md` (for continuity — only the latest one)
+- `.claude-code-hermit/sessions/SHELL.md` (if exists) **(re-read before writing to it or before reusing a value cached in context from before compaction; after a compact-source start the injected capsule's task/progress lines suffice for orientation — don't re-read just to reconstruct context)**
+- Most recent `.claude-code-hermit/sessions/S-*-REPORT.md` (for continuity — only the latest one; skip after a compact-source start, the capsule carries its path)
 - `.claude-code-hermit/state/runtime.json` (always — for lifecycle state)
 
 Do NOT load all session reports — only the most recent one.

--- a/plugins/claude-code-hermit/tests/cost-log.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-log.test.ts
@@ -24,6 +24,10 @@ function writeLog(dir: string, entries: object[]): string {
 }
 
 const NY = 'America/New_York';
+// Reference "now" for the retention cutoffs, pinned a couple days after the fixture
+// dates so the 2026-07-04/05 buckets stay inside the trailing by_date window regardless
+// of the real wall-clock date (otherwise these fixed-date fixtures age out and fail).
+const ASOF = new Date('2026-07-06T12:00:00Z');
 
 describe('#10d — timezone change re-buckets the index', () => {
   test('a config.timezone change triggers a rebuild under the new tz', withTmpdir((dir) => {
@@ -33,12 +37,12 @@ describe('#10d — timezone change re-buckets the index', () => {
     ]);
     const idxPath = path.join(dir, 'cost-index.json');
 
-    const utc = updateCostIndex(logPath, idxPath, 'UTC');
+    const utc = updateCostIndex(logPath, idxPath, 'UTC', ASOF);
     expect(Object.keys(utc.by_date)).toEqual(['2026-07-05']);
     expect(utc.timezone).toBe('UTC');
 
     // Same log, new timezone — must re-bucket, not keep the stale UTC key.
-    const ny = updateCostIndex(logPath, idxPath, NY);
+    const ny = updateCostIndex(logPath, idxPath, NY, ASOF);
     expect(ny.timezone).toBe(NY);
     expect(Object.keys(ny.by_date)).toEqual(['2026-07-04']);
     expect(ny.by_date['2026-07-05']).toBeUndefined();
@@ -52,7 +56,7 @@ describe('#10c — computeIndex: read-only spend without writing the index', () 
     ]);
     const idxPath = path.join(dir, 'cost-index.json');
 
-    const idx = computeIndex(logPath, NY);
+    const idx = computeIndex(logPath, NY, ASOF);
     expect(idx.by_date['2026-07-04'].cost).toBe(1.5);
     expect(idx.timezone).toBe(NY);
     expect(fs.existsSync(idxPath)).toBe(false); // read-only — sole-writer invariant preserved
@@ -66,7 +70,7 @@ describe('updateCostIndex — by_week/by_month tz-aware aggregation', () => {
       { timestamp: '2026-07-05T02:00:00Z', session_id: 's1', source: 'other', model: 'sonnet', total_tokens: 100, estimated_cost_usd: 1.0 },
     ]);
     const idxPath = path.join(dir, 'cost-index.json');
-    const idx = updateCostIndex(logPath, idxPath, NY);
+    const idx = updateCostIndex(logPath, idxPath, NY, ASOF);
 
     expect(Object.keys(idx.by_date)).toEqual(['2026-07-04']);
     expect(idx.by_week['2026-W27'].cost).toBe(1.0);
@@ -79,7 +83,7 @@ describe('updateCostIndex — by_week/by_month tz-aware aggregation', () => {
       { timestamp: '2026-07-05T02:00:00Z', session_id: 's1', source: 'other', model: 'sonnet', total_tokens: 50, estimated_cost_usd: 0.5 },
     ]);
     const idxPath = path.join(dir, 'cost-index.json');
-    const idx = updateCostIndex(logPath, idxPath, NY);
+    const idx = updateCostIndex(logPath, idxPath, NY, ASOF);
 
     expect(Object.keys(idx.by_date)).toEqual(['2026-07-04']);
     expect(idx.by_date['2026-07-04'].cost).toBe(2);
@@ -93,7 +97,7 @@ describe('updateCostIndex — by_week/by_month tz-aware aggregation', () => {
       { timestamp: '2026-07-04T22:17:00Z', session_id: 's1', source: 'other', model: 'sonnet', total_tokens: 100, estimated_cost_usd: 1.0 },
     ]);
     const idxPath = path.join(dir, 'cost-index.json');
-    const idx = updateCostIndex(logPath, idxPath); // no timezone arg -> defaults to UTC
+    const idx = updateCostIndex(logPath, idxPath, undefined, ASOF); // timezone omitted -> defaults to UTC
 
     expect(Object.keys(idx.by_date)).toEqual(['2026-07-04']);
     expect(idx.by_week['2026-W27']).toBeDefined();
@@ -104,12 +108,12 @@ describe('updateCostIndex — by_week/by_month tz-aware aggregation', () => {
       { timestamp: '2026-07-04T12:00:00Z', session_id: 's1', source: 'other', model: 'sonnet', total_tokens: 100, estimated_cost_usd: 1.0 },
     ]);
     const idxPath = path.join(dir, 'cost-index.json');
-    updateCostIndex(logPath, idxPath, 'UTC');
+    updateCostIndex(logPath, idxPath, 'UTC', ASOF);
 
     fs.appendFileSync(logPath, JSON.stringify({
       timestamp: '2026-07-04T13:00:00Z', session_id: 's1', source: 'other', model: 'sonnet', total_tokens: 50, estimated_cost_usd: 0.5,
     }) + '\n');
-    const idx = updateCostIndex(logPath, idxPath, 'UTC');
+    const idx = updateCostIndex(logPath, idxPath, 'UTC', ASOF);
 
     expect(idx.by_date['2026-07-04'].cost).toBe(1.5);
     expect(idx.total_cost_usd).toBe(1.5);

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -1152,6 +1152,19 @@ Rota body.
     expect(fs.existsSync(hermit(dir, 'state', 'context-scan.json'))).toBe(true);
   }));
 
+  test('startup-context (source=compact → does not clear a prior full-scan warning)', withDir(async (dir) => {
+    // A prior full startup recorded a warning for a surface the compact path never scans.
+    const scanPath = hermit(dir, 'state', 'context-scan.json');
+    fs.mkdirSync(hermit(dir, 'state'), { recursive: true });
+    write(scanPath, JSON.stringify({ ts: '2026-01-01T00:00:00Z', hits: [{ source: 'OPERATOR.md', reason: 'system-marker' }] }));
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    const rec = JSON.parse(fs.readFileSync(scanPath, 'utf-8'));
+    expect(rec.hits.some((h: any) => h.source === 'OPERATOR.md')).toBe(true);
+  }));
+
   test('startup-context (source=resume, active SHELL.md → Last Report omitted, rest intact)', withDir(async (dir) => {
     write(hermit(dir, 'sessions', 'S-001-REPORT.md'), '# Report\n## Overview\nPrev session overview.\n');
     const r = await runScript('startup-context.ts', {

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -1107,6 +1107,83 @@ Rota body.
     expect(r.exitCode).toBe(0);
     expect(r.stdout).not.toContain('---Compaction Pointers---');
   }));
+
+  // ---- source-gated renderer: compact = delta capsule only; resume trims Last Report ----
+
+  test('startup-context (source=compact, full state → ≤1200 chars, no full-capsule sections)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'runtime.json'), '{"session_state":"waiting","waiting_reason":"operator_input"}');
+    write(hermit(dir, 'OPERATOR.md'), '# Operator\nContext body that must never be re-injected on compact.\n');
+    write(hermit(dir, 'sessions', 'S-001-REPORT.md'), '# Report\n## Overview\nReport body text stays out.\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.length).toBeLessThanOrEqual(1200);
+    expect(r.stdout).toContain('---Compaction Pointers---');
+    for (const banned of ['---Session Context---', '---Active Session---', '---Compiled Knowledge---',
+      '---Schema Drift---', '---Storage Drift---', '---Session Cost---', '---Last Report---', '---Upgrade Check---']) {
+      expect(r.stdout).not.toContain(banned);
+    }
+  }));
+
+  test('startup-context (source=compact → pointer lines, never bodies)', withDir(async (dir) => {
+    write(hermit(dir, 'OPERATOR.md'), '# Operator\nSecret operator body.\n');
+    write(hermit(dir, 'sessions', 'S-001-REPORT.md'), '# Report\nReport body text.\n');
+    fs.mkdirSync(hermit(dir, 'proposals'), { recursive: true });
+    write(hermit(dir, 'proposals', 'open-proposal.md'), '---\nid: x\n---\nProposal body.\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('latest report: sessions/S-001-REPORT.md');
+    expect(r.stdout).toContain('operator context: OPERATOR.md');
+    expect(r.stdout).toContain('proposals dir: proposals/');
+    expect(r.stdout).toContain('last progress: - [10:00] Started test session');
+    expect(r.stdout).not.toContain('Report body text');
+    expect(r.stdout).not.toContain('Secret operator body');
+    expect(r.stdout).not.toContain('Proposal body');
+  }));
+
+  test('startup-context (source=compact → context-scan record still persisted)', withDir(async (dir) => {
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(hermit(dir, 'state', 'context-scan.json'))).toBe(true);
+  }));
+
+  test('startup-context (source=resume, active SHELL.md → Last Report omitted, rest intact)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', 'S-001-REPORT.md'), '# Report\n## Overview\nPrev session overview.\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'resume', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('---Last Report---');
+    expect(r.stdout).toContain('---Active Session---');
+    expect(r.stdout).toContain('---Session Cost---');
+  }));
+
+  test('startup-context (source=resume, no actionable SHELL.md → Last Report still emitted)', withDir(async (dir) => {
+    fs.rmSync(hermit(dir, 'sessions', 'SHELL.md'));
+    write(hermit(dir, 'sessions', 'S-001-REPORT.md'), '# Report\n## Overview\nPrev session overview.\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'resume', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('---Last Report---');
+    expect(r.stdout).toContain('Prev session overview');
+  }));
+
+  test('startup-context (source=startup and source-less → Last Report emitted)', withDir(async (dir) => {
+    const startup = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'startup', session_id: 'x' }),
+    });
+    expect(startup.exitCode).toBe(0);
+    expect(startup.stdout).toContain('---Last Report---');
+    const sourceless = await runScript('startup-context.ts', { cwd: dir, env: ENV });
+    expect(sourceless.exitCode).toBe(0);
+    expect(sourceless.stdout).toContain('---Last Report---');
+  }));
 });
 
 // -------------------------------------------------------


### PR DESCRIPTION
## Summary
`startup-context.ts` emitted the full startup capsule (operator context, active session, knowledge catalog, drift, cost, last report, upgrade check — up to 9,000 chars) on every SessionStart, including right after compaction, re-injecting state the session had just paid to summarize. The renderer now branches on the SessionStart `source` field: `compact` gets only a ≤1,200-char delta capsule, `resume` drops the Last Report section its transcript already contains, and `startup`/`clear`/unknown keep the full capsule unchanged.

All three gated source values were verified live against real Claude Code sessions (fixture hooks logging raw stdin): `startup` and `compact` previously, `resume` in this branch's prep work (`{"source":"resume"}`, same session_id, no `model` field).

## Changes
- `scripts/startup-context.ts` — `main()` branches on source; new `emitCompactCapsule()` emits only an extended `buildCompactionPointers()` capsule (lifecycle state, task + last progress line via `guarded()`, latest-report/OPERATOR.md/proposals pointers, hard-capped at 1,200 chars total); the full renderer skips Last Report on `resume` with an active SHELL.md; scan-record persistence runs on every path so compact runs still populate/clear `context-scan.json` correctly.
- `skills/session-start/SKILL.md` — Context to Load no longer forces full re-reads after a compact-source start; the injected capsule suffices for orientation.
- `tests/hooks.contract.test.ts` — six new per-source fixtures: compact ≤1,200 chars with all full-capsule sections banned, pointer-lines-never-bodies, scan record persisted on compact, resume omits/keeps Last Report by SHELL.md state, startup and source-less fallback unchanged.
- `CHANGELOG.md` — `[Unreleased]` Changed entry; no upgrade instructions (ships entirely in the hook script).

## Test plan
- `cd plugins/claude-code-hermit && bun test tests/hooks.contract.test.ts tests/startup-context-scan.test.ts` → 193 pass, 0 fail.
- `bunx tsc --noEmit` → clean.
- Full `bun test`: 2343 pass; the only failures (6) are pre-existing timezone-environment failures in `cost-log.test.ts`, reproduced identically on unmodified HEAD via stash round-trip.