### PR TITLE
fix(claude-code-hermit): anchor cost-log resolution to hermit root, not cwd

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **cost scripts: cwd-anchored cost-log resolution** — `today-cost.ts`, `session-cost.ts`, and `weekly-review.ts` resolved cost-log paths against `process.cwd()`, silently reporting `$0.00`/zeros after a cwd drift. All three now anchor to `hermitDir()`; `today-cost.ts` reports `cost data unavailable` instead of a misleading `$0.00` when the log can't be read.
+- **cost scripts: cwd-anchored cost-log resolution** — `today-cost.ts`, `session-cost.ts`, `weekly-review.ts`, `cost-reflect.ts`, and `reflect-precheck.ts` resolved cost-log paths against `process.cwd()`, silently reporting `$0.00`/zeros (or suppressing the reflect cost-spike phase) after a cwd drift. All now anchor to `hermitDir()`; `today-cost.ts` reports `cost data unavailable` instead of a misleading `$0.00` when the log can't be read.
 
 ## [1.2.24] - 2026-07-13
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **cost scripts: cwd-anchored cost-log resolution** — `today-cost.ts`, `session-cost.ts`, and `weekly-review.ts` resolved cost-log paths against `process.cwd()`, silently reporting `$0.00`/zeros after a cwd drift. All three now anchor to `hermitDir()`; `today-cost.ts` reports `cost data unavailable` instead of a misleading `$0.00` when the log can't be read.
+
 ## [1.2.24] - 2026-07-13
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/cost-reflect.ts
+++ b/plugins/claude-code-hermit/scripts/cost-reflect.ts
@@ -5,6 +5,7 @@ import { costByType } from './lib/pricing';
 import { loadConfig } from './lib/channel-auth';
 import { money, resolveTimezone, budgetLine } from './lib/spend-status';
 import { todayYMD } from './lib/time';
+import { costLogPath, hermitDir } from './lib/cc-compat';
 
 type Json = any;
 
@@ -137,11 +138,14 @@ function run() {
   const rawArgs = process.argv.slice(2);
   const plainMode = rawArgs.includes('--plain');
   const positional = rawArgs.filter(a => a !== '--plain');
-  const stateDir = positional[0] || '.claude-code-hermit';
+  // An absolute arg (as tests pass) is used verbatim; a relative/absent arg is
+  // resolved via the anchored hermitDir() so cost-log and config reads survive
+  // cwd drift (the calling shell persists cd across Bash calls).
+  const stateArg = positional[0];
+  const stateDir = stateArg && path.isAbsolute(stateArg) ? stateArg : hermitDir();
   const days = Math.max(1, parseInt(positional[1], 10) || 7);
 
-  // cost-log.jsonl is a sibling of the state dir (both under the project root).
-  const costLog = path.resolve(stateDir, '..', '.claude', 'cost-log.jsonl');
+  const costLog = costLogPath(stateDir);
 
   if (plainMode) {
     process.stdout.write(buildPlainStatement(stateDir, costLog));

--- a/plugins/claude-code-hermit/scripts/lib/runtime.ts
+++ b/plugins/claude-code-hermit/scripts/lib/runtime.ts
@@ -23,10 +23,12 @@ function writeRuntimeJson(data: Json): void {
   fs.renameSync(RUNTIME_TMP, RUNTIME_JSON);
 }
 
-/** Read state/runtime.json; null when missing or invalid. */
-function readRuntimeJson(): Json | null {
+/** Read state/runtime.json; null when missing or invalid. Pass an absolute
+ *  stateDir to read from an anchored location instead of the cwd-relative default. */
+function readRuntimeJson(stateDir?: string): Json | null {
+  const p = stateDir ? path.join(stateDir, 'runtime.json') : RUNTIME_JSON;
   try {
-    return JSON.parse(fs.readFileSync(RUNTIME_JSON, 'utf-8'));
+    return JSON.parse(fs.readFileSync(p, 'utf-8'));
   } catch {
     return null;
   }

--- a/plugins/claude-code-hermit/scripts/reflect-precheck.ts
+++ b/plugins/claude-code-hermit/scripts/reflect-precheck.ts
@@ -22,6 +22,7 @@ import { readFrontmatter, isEmptyAutoArchive } from './lib/frontmatter';
 import { findStorageDrift, findSchemaDrift } from './lib/drift';
 import { sha256 } from './lib/hash';
 import { appendToProgressLog } from './lib/progress-log';
+import { costLogPath as resolveCostLog, hermitDir as resolveHermitRoot } from './lib/cc-compat';
 
 type Json = any;
 
@@ -239,7 +240,10 @@ if (hasAcceptedProposals(stateDir) && daysSince(lastResolutionCheck) > 7) {
   phases.resolution_check = true;
 }
 
-const costLogPath = path.resolve(stateDir, '..', '.claude', 'cost-log.jsonl');
+// Anchor cost-log resolution: a relative stateDir (real invocation passes
+// `.claude-code-hermit`) would otherwise resolve against a drifted cwd and
+// silently suppress the cost-spike phase. Absolute (as tests pass) is verbatim.
+const costLogPath = resolveCostLog(path.isAbsolute(stateDir) ? stateDir : resolveHermitRoot());
 if (checkCostSpike(costLogPath, lastRunAt)) phases.cost_spike = true;
 
 if (phase === 'juvenile' && daysSince(reflectionState.last_digest_at) > 7) {

--- a/plugins/claude-code-hermit/scripts/session-cost.ts
+++ b/plugins/claude-code-hermit/scripts/session-cost.ts
@@ -17,10 +17,12 @@
 // Fails open throughout: missing log or unreadable state prints {"cost_usd": 0, "tokens": 0}.
 
 import fs from 'node:fs';
-import { costLogPath } from './lib/cc-compat';
+import path from 'node:path';
+import { costLogPath, hermitDir } from './lib/cc-compat';
 import { readRuntimeJson } from './lib/runtime';
 
-const COST_LOG = costLogPath('.claude-code-hermit');
+const ROOT = hermitDir();
+const COST_LOG = costLogPath(ROOT);
 
 const argv = process.argv.slice(2);
 let sessionId = '';
@@ -36,7 +38,7 @@ for (let i = 0; i < argv.length; i++) {
 // Arc-window rationale is in the file header above; this just applies the
 // --opened-at / --closed-at overrides on top of runtime.json's values.
 function readWindow(): { openedAt?: string; closedAt?: string } {
-  const rt = readRuntimeJson() || {};
+  const rt = readRuntimeJson(path.join(ROOT, 'state')) || {};
   return {
     openedAt: openedAtOverride ?? (typeof rt.opened_at === 'string' ? rt.opened_at : undefined),
     closedAt: closedAtOverride ?? (typeof rt.closed_at === 'string' ? rt.closed_at : undefined),

--- a/plugins/claude-code-hermit/scripts/today-cost.ts
+++ b/plugins/claude-code-hermit/scripts/today-cost.ts
@@ -1,19 +1,28 @@
-// Fails open: missing log or parse errors print $0.00 and exit 0.
+// Prints today's spend: "$X.XX (<tokens>) across N session(s)".
+// Log resolved against the anchored hermit root (survives cwd drift), not cwd.
+// Unreadable log -> "cost data unavailable" (not a misleading $0.00); a readable
+// log with no rows today -> honest $0.00.
 
 import fs from 'node:fs';
-import path from 'node:path';
 import { formatTokens } from './lib/format';
+import { costLogPath, hermitDir } from './lib/cc-compat';
 
-const COST_LOG = path.resolve('.claude/cost-log.jsonl');
+const COST_LOG = costLogPath(hermitDir());
+const UNAVAILABLE = 'cost data unavailable';
 
-try {
-  const today = new Date().toISOString().slice(0, 10);
-  let cost = 0;
-  let tokens = 0;
-  const sessions = new Set<string>();
-
+function render(): string {
+  let raw: string;
   try {
-    for (const line of fs.readFileSync(COST_LOG, 'utf8').split('\n')) {
+    raw = fs.readFileSync(COST_LOG, 'utf8');
+  } catch {
+    return UNAVAILABLE;
+  }
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    let cost = 0;
+    let tokens = 0;
+    const sessions = new Set<string>();
+    for (const line of raw.split('\n')) {
       if (!line.trim()) continue;
       try {
         const e = JSON.parse(line);
@@ -24,13 +33,10 @@ try {
         }
       } catch {}
     }
-  } catch (err: any) {
-    if (err.code !== 'ENOENT') throw err;
+    return `$${cost.toFixed(2)} (${formatTokens(tokens)}) across ${sessions.size} session(s)`;
+  } catch {
+    return UNAVAILABLE;
   }
-
-  process.stdout.write(
-    `$${cost.toFixed(2)} (${formatTokens(tokens)}) across ${sessions.size} session(s)\n`
-  );
-} catch {
-  process.stdout.write('$0.00 (0 tokens) across 0 session(s)\n');
 }
+
+process.stdout.write(render() + '\n');

--- a/plugins/claude-code-hermit/scripts/weekly-review.ts
+++ b/plugins/claude-code-hermit/scripts/weekly-review.ts
@@ -7,14 +7,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { readFrontmatter, readFileWithFrontmatter, parseFrontmatter, isEmptyAutoArchive, newestByType, globDir } from './lib/frontmatter';
-import { costLogPath } from './lib/cc-compat';
+import { costLogPath, hermitDir as resolveHermitRoot } from './lib/cc-compat';
 import { formatTokens } from './lib/format';
 import { lint as knowledgeLint } from './knowledge-lint';
 
 type Json = any;
 
 // --- Args ---
-const hermitDir = process.argv[2] || '.claude-code-hermit';
+// An absolute arg (as tests pass) is used verbatim; a relative/absent arg is
+// resolved via the anchored hermitDir() so state access survives cwd drift.
+const hermitArg = process.argv[2];
+const hermitDir = hermitArg && path.isAbsolute(hermitArg) ? hermitArg : resolveHermitRoot();
 
 // --- ISO week calculation ---
 
@@ -134,11 +137,11 @@ let totalTokens = 0;
 if (allHaveTokens) {
   totalTokens = weekSessions.reduce((sum, s) => sum + s.fm.tokens, 0);
 } else {
-  const costLogPath = path.resolve(process.cwd(), '.claude/cost-log.jsonl');
+  const weekCostLog = costLogPath(hermitDir);
   const weekStartStr = weekStart.toISOString().slice(0, 10);
   const weekEndStr = weekEnd.toISOString().slice(0, 10);
   try {
-    const lines = fs.readFileSync(costLogPath, 'utf-8').trim().split('\n');
+    const lines = fs.readFileSync(weekCostLog, 'utf-8').trim().split('\n');
     for (const line of lines) {
       if (!line.trim()) continue;
       try {

--- a/plugins/claude-code-hermit/tests/session-cost.test.ts
+++ b/plugins/claude-code-hermit/tests/session-cost.test.ts
@@ -6,6 +6,13 @@ import os from 'node:os';
 import path from 'node:path';
 import { runScript, PLUGIN_ROOT } from './helpers/run';
 
+// Explicit env per case: runScript merges process.env into the child, so an
+// ambient CLAUDE_PROJECT_DIR/AGENT_DIR would otherwise leak in and resolve
+// against this repo's real .claude-code-hermit/ instead of the fixture.
+function baseEnv(dir: string) {
+  return { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT, CLAUDE_PROJECT_DIR: dir, AGENT_DIR: '' };
+}
+
 function withTmpdir(fn: (dir: string) => Promise<void>) {
   return async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-session-cost-'));
@@ -45,7 +52,7 @@ describe('session-cost.ts', () => {
     ]);
 
     const r = await runScript('session-cost.ts', {
-      args: ['S-001'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      args: ['S-001'], cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
@@ -59,7 +66,7 @@ describe('session-cost.ts', () => {
     ]);
 
     const r = await runScript('session-cost.ts', {
-      args: ['S-999'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      args: ['S-999'], cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
@@ -70,7 +77,7 @@ describe('session-cost.ts', () => {
   test('returns zeros when cost-log is absent', withTmpdir(async (dir) => {
     // no cost-log seeded
     const r = await runScript('session-cost.ts', {
-      args: ['S-001'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      args: ['S-001'], cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
@@ -85,7 +92,7 @@ describe('session-cost.ts', () => {
     ]);
 
     const r = await runScript('session-cost.ts', {
-      args: ['S-001'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      args: ['S-001'], cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
@@ -113,7 +120,7 @@ describe('session-cost.ts: window-delta mode', () => {
     ]);
     const r = await runScript('session-cost.ts', {
       args: ['S-XXX', '--opened-at', '2026-06-01T10:00:00Z', '--closed-at', '2026-06-01T11:00:00Z'],
-      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
@@ -127,7 +134,7 @@ describe('session-cost.ts: window-delta mode', () => {
       { timestamp: '2026-06-01T10:30:00Z', session_id: 'uuid-1', estimated_cost_usd: 0.50, total_tokens: 500, source: 'other' },  // after opened_at
     ]);
     seedRuntime(dir, { opened_at: '2026-06-01T10:00:00Z' });
-    const r = await runScript('session-cost.ts', { args: ['S-XXX'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+    const r = await runScript('session-cost.ts', { args: ['S-XXX'], cwd: dir, env: baseEnv(dir) });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.cost_usd).toBeCloseTo(0.50, 4);
@@ -142,7 +149,7 @@ describe('session-cost.ts: window-delta mode', () => {
     ]);
     const r = await runScript('session-cost.ts', {
       args: ['S-YYY', '--opened-at', '2026-06-01T13:00:00Z', '--closed-at', '2026-06-01T15:00:00Z'],
-      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
@@ -156,7 +163,7 @@ describe('session-cost.ts: window-delta mode', () => {
       { timestamp: '2026-06-01T11:00:00Z', session_id: 'S-002', estimated_cost_usd: 0.9999, total_tokens: 99999, source: 'other' },
     ]);
     seedRuntime(dir, { session_state: 'in_progress' }); // no opened_at key
-    const r = await runScript('session-cost.ts', { args: ['S-001'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+    const r = await runScript('session-cost.ts', { args: ['S-001'], cwd: dir, env: baseEnv(dir) });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.cost_usd).toBeCloseTo(0.1234, 4);
@@ -168,7 +175,7 @@ describe('session-cost.ts: window-delta mode', () => {
       { timestamp: '2026-06-01T10:00:00Z', session_id: 'S-001', estimated_cost_usd: 0.5, total_tokens: 500, source: 'other' },
     ]);
     seedRuntime(dir, { opened_at: 'not-a-date' });
-    const r = await runScript('session-cost.ts', { args: ['S-001'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+    const r = await runScript('session-cost.ts', { args: ['S-001'], cwd: dir, env: baseEnv(dir) });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.cost_usd).toBeCloseTo(0.5, 4);
@@ -183,7 +190,7 @@ describe('session-cost.ts: window-delta mode', () => {
     // 2026-06-01T12:00:00+02:00 == 2026-06-01T10:00:00Z
     const r = await runScript('session-cost.ts', {
       args: ['S-XXX', '--opened-at', '2026-06-01T12:00:00+0200'],
-      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
@@ -195,7 +202,7 @@ describe('session-cost.ts: window-delta mode', () => {
     // no cost-log seeded
     const r = await runScript('session-cost.ts', {
       args: ['S-XXX', '--opened-at', '2026-06-01T10:00:00Z'],
-      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
@@ -209,7 +216,7 @@ describe('session-cost.ts: window-delta mode', () => {
       { timestamp: '2026-06-01T14:00:00Z', session_id: 'uuid-1', estimated_cost_usd: 0.99, total_tokens: 999, source: 'routine:reflect' }, // autonomous, after closed_at → excluded
     ]);
     seedRuntime(dir, { opened_at: '2026-06-01T10:00:00Z', closed_at: '2026-06-01T11:00:00Z' });
-    const r = await runScript('session-cost.ts', { args: ['S-XXX'], cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+    const r = await runScript('session-cost.ts', { args: ['S-XXX'], cwd: dir, env: baseEnv(dir) });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.cost_usd).toBeCloseTo(0.20, 4);
@@ -223,11 +230,27 @@ describe('session-cost.ts: window-delta mode', () => {
     // Unparseable --closed-at previously → closedMs NaN → `ts <= NaN` false for every row → false 0.
     const r = await runScript('session-cost.ts', {
       args: ['S-XXX', '--opened-at', '2026-06-01T10:00:00Z', '--closed-at', 'not-a-date'],
-      cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+      cwd: dir, env: baseEnv(dir),
     });
     expect(r.exitCode).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.cost_usd).toBeCloseTo(0.20, 4);
     expect(out.tokens).toBe(200);
+  }));
+
+  test('drift regression: window resolves when cwd has drifted into a subdir', withTmpdir(async (dir) => {
+    seedCostLog(dir, [
+      { timestamp: '2026-06-01T09:00:00Z', session_id: 'uuid-1', estimated_cost_usd: 1.00, total_tokens: 1000, source: 'other' }, // before opened_at
+      { timestamp: '2026-06-01T10:30:00Z', session_id: 'uuid-1', estimated_cost_usd: 0.50, total_tokens: 500, source: 'other' },  // inside window
+    ]);
+    seedRuntime(dir, { opened_at: '2026-06-01T10:00:00Z' });
+    const hermitRoot = path.join(dir, '.claude-code-hermit');
+    fs.writeFileSync(path.join(hermitRoot, 'config.json'), '{}');
+    const drifted = path.join(hermitRoot, 'state');
+    const r = await runScript('session-cost.ts', { args: ['S-XXX'], cwd: drifted, env: baseEnv(dir) });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.cost_usd).toBeCloseTo(0.50, 4);
+    expect(out.tokens).toBe(500);
   }));
 });

--- a/plugins/claude-code-hermit/tests/today-cost.test.ts
+++ b/plugins/claude-code-hermit/tests/today-cost.test.ts
@@ -1,0 +1,99 @@
+// Tests for scripts/today-cost.ts: today's spend summary from cost-log.jsonl.
+// Cost-path resolution must be anchored to the hermit root, not process.cwd() —
+// the calling shell (brief, invoked inline in main) persists cd across calls,
+// so a drifted cwd must not silently misreport $0.00.
+
+import { describe, test, expect } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runScript, PLUGIN_ROOT } from './helpers/run';
+
+function withTmpdir(fn: (dir: string) => Promise<void>) {
+  return async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-today-cost-'));
+    try {
+      await fn(dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  };
+}
+
+function seedCostLog(dir: string, entries: object[]): void {
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  const logPath = path.join(claudeDir, 'cost-log.jsonl');
+  fs.writeFileSync(logPath, entries.map(e => JSON.stringify(e)).join('\n') + '\n');
+}
+
+function seedHermitRoot(dir: string): void {
+  const hermitDir = path.join(dir, '.claude-code-hermit');
+  fs.mkdirSync(hermitDir, { recursive: true });
+  fs.writeFileSync(path.join(hermitDir, 'config.json'), '{}');
+}
+
+// Explicit env per case: runScript merges process.env into the child, so an
+// ambient CLAUDE_PROJECT_DIR/AGENT_DIR would otherwise leak in and resolve
+// against this repo's real .claude-code-hermit/ instead of the fixture.
+function baseEnv(projectDir: string) {
+  return { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT, CLAUDE_PROJECT_DIR: projectDir, AGENT_DIR: '' };
+}
+
+const today = new Date().toISOString().slice(0, 10);
+
+describe('today-cost.ts', () => {
+  test('drift regression: reports the real total when cwd has drifted into a subdir', withTmpdir(async (dir) => {
+    seedCostLog(dir, [
+      { timestamp: `${today}T10:00:00Z`, session_id: 'S-001', estimated_cost_usd: 14.91, total_tokens: 28500000, source: 'other' },
+    ]);
+    seedHermitRoot(dir);
+    const drifted = path.join(dir, '.claude-code-hermit', 'proposals');
+    fs.mkdirSync(drifted, { recursive: true });
+
+    const r = await runScript('today-cost.ts', { cwd: drifted, env: baseEnv(dir) });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('$14.91 (28.5M tokens) across 1 session(s)');
+  }));
+
+  test('drift regression: walk-up anchor resolves without CLAUDE_PROJECT_DIR set', withTmpdir(async (dir) => {
+    seedCostLog(dir, [
+      { timestamp: `${today}T10:00:00Z`, session_id: 'S-001', estimated_cost_usd: 1.5, total_tokens: 1000, source: 'other' },
+    ]);
+    seedHermitRoot(dir);
+    const drifted = path.join(dir, '.claude-code-hermit', 'proposals');
+    fs.mkdirSync(drifted, { recursive: true });
+
+    const r = await runScript('today-cost.ts', {
+      cwd: drifted,
+      env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT, CLAUDE_PROJECT_DIR: '', AGENT_DIR: '' },
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('$1.50 (1.0K tokens) across 1 session(s)');
+  }));
+
+  test('unavailable: cost log absent', withTmpdir(async (dir) => {
+    seedHermitRoot(dir);
+    const r = await runScript('today-cost.ts', { cwd: dir, env: baseEnv(dir) });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('cost data unavailable');
+  }));
+
+  test('unavailable: cost log path is a directory (non-ENOENT read failure)', withTmpdir(async (dir) => {
+    seedHermitRoot(dir);
+    fs.mkdirSync(path.join(dir, '.claude', 'cost-log.jsonl'), { recursive: true });
+    const r = await runScript('today-cost.ts', { cwd: dir, env: baseEnv(dir) });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('cost data unavailable');
+  }));
+
+  test('honest zero: log present but no rows dated today', withTmpdir(async (dir) => {
+    seedCostLog(dir, [
+      { timestamp: '2020-01-01T10:00:00Z', session_id: 'S-001', estimated_cost_usd: 5, total_tokens: 5000, source: 'other' },
+    ]);
+    seedHermitRoot(dir);
+    const r = await runScript('today-cost.ts', { cwd: dir, env: baseEnv(dir) });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('$0.00 (0 tokens) across 0 session(s)');
+  }));
+});


### PR DESCRIPTION
## Summary
`today-cost.ts`, `session-cost.ts`, and `weekly-review.ts` resolved the cost log relative to `process.cwd()`. Because these scripts run inline in a long-lived main session shell where `cd` persists across Bash calls, a drifted cwd caused them to silently report `$0.00`/zeros instead of the real spend — caught live when a brief reported `$0.00` for a ~$14.91 day.

## Changes
- `lib/cc-compat.ts`'s existing anchored resolvers (`hermitDir()` + `costLogPath()`) are now the reuse target for all three scripts, replacing ad-hoc `path.resolve(process.cwd(), ...)` calls.
- `session-cost.ts` anchors **both** its cost-log path and its `runtime.json` window read (`lib/runtime.ts` gains an optional, backward-compatible `stateDir` param) — anchoring only the log would have left it falling back to an always-miss `session_id` sum on drift.
- `weekly-review.ts`'s hermit-root arg now resolves through the anchored helper when relative/absent (absolute test args still win), and a local `const costLogPath = costLogPath(...)` name-shadow bug is fixed.
- `today-cost.ts` now distinguishes an unreadable log (`cost data unavailable`) from a genuine zero-spend day (`$0.00 ...`), instead of collapsing both into `$0.00`.

## Test plan
- Wrote failing drift-regression tests first, confirmed they reproduced the bug against the unfixed code, then applied the fix and watched them pass.
- `cd plugins/claude-code-hermit && bun test` — 2427 pass, 0 fail.
- `bunx tsc --noEmit` — clean.
- Manual: ran `today-cost.ts` from a drifted subdir; confirmed no crash and correct behavior on a fixture with real data (verified via the automated drift tests) and honest `cost data unavailable` when no log exists in that context.

Closes #595