### PR TITLE
fix(claude-code-hermit): monitor wake notifications no longer stamp operator activity

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **heartbeat/routines: monitor wake notifications no longer count as operator activity** — `HEARTBEAT_EVALUATE`/`HEARTBEAT_ERROR`/`ROUTINE_DUE`/`ROUTINE_MONITOR_ERROR` prompts were stamping `last-operator-action.json`, spuriously resetting the AUTO_CLOSE lull and suppressing daily-close drains. The UserPromptSubmit filter now drops the monitor emission grammar.
+
 ## [1.2.25] - 2026-07-14
 
 ### Fixed

--- a/plugins/claude-code-hermit/scripts/heartbeat-monitor.sh
+++ b/plugins/claude-code-hermit/scripts/heartbeat-monitor.sh
@@ -23,6 +23,8 @@ while true; do
   printf '{"last_peek_at":"%s"}\n' "$_ts" > "$HB_DIR/state/.heartbeat-liveness.tmp" \
     && mv "$HB_DIR/state/.heartbeat-liveness.tmp" "$HB_DIR/state/heartbeat-liveness.json" \
     || true
+  # Emission grammar is load-bearing: record-operator-action.ts isRoutinePrompt()
+  # drops these lines; tests/auto-close.test.ts drift guard syncs them.
   case "$verdict" in
     EVALUATE*)
       [[ -n "$first" ]] || echo "HEARTBEAT_EVALUATE" ;;

--- a/plugins/claude-code-hermit/scripts/record-operator-action.ts
+++ b/plugins/claude-code-hermit/scripts/record-operator-action.ts
@@ -16,6 +16,9 @@ process.stdout.on('error', () => {});
 //   [hermit-routine:…   — cron-delivered routine prompts (hermit-routines/SKILL.md:43-54)
 //   <channel…           — unauthorized DMs arrive here before channel-responder's allowlist
 //                          check; recording them would let bot traffic suppress AUTO_CLOSE
+//   HEARTBEAT_EVALUATE/HEARTBEAT_ERROR/ROUTINE_DUE/ROUTINE_MONITOR_ERROR — Monitor-delivered
+//                          scheduler wake notifications (heartbeat-monitor.sh, routine-due.ts,
+//                          routine-monitor.sh) — see isRoutinePrompt below
 //   hermit's own tmux-injected slash commands — see INJECTED_EXACT below. Every
 //   other bare `/…` prompt counts as operator activity (see isRoutinePrompt).
 
@@ -58,6 +61,20 @@ function isRoutinePrompt(prompt: string): boolean {
   const t = prompt.trim();
   if (t.startsWith('<channel')) return true;
   if (INJECTED_EXACT.has(t)) return true;
+  // Monitor-delivered scheduler notifications — not operator activity. Grammar
+  // must match the emitters exactly (verified against source, NOT live-probed —
+  // a 2026-07-15 probe attempt hit an unrelated harness setup issue where no
+  // UserPromptSubmit hook fired at all in scratch tmux sessions; revisit if a
+  // future probe contradicts this):
+  //   heartbeat-monitor.sh:26-34 → "HEARTBEAT_EVALUATE" (bare) | "HEARTBEAT_ERROR: <detail>"
+  //   routine-due.ts:219         → "ROUTINE_DUE [hermit-routine:<id>] ..."
+  //   routine-monitor.sh:26      → "ROUTINE_MONITOR_ERROR: <detail>"
+  // tests/auto-close.test.ts monitor-emission drift guard re-derives this list
+  // from the emitters' source — extend both together.
+  if (t === 'HEARTBEAT_EVALUATE') return true;
+  if (t.startsWith('HEARTBEAT_ERROR: ')) return true;
+  if (t.startsWith('ROUTINE_DUE [hermit-routine:')) return true;
+  if (t.startsWith('ROUTINE_MONITOR_ERROR: ')) return true;
   // Watchdog hygiene injections (hermit-watchdog.ts:421,620,754). Native
   // commands may never reach this hook at all; dropping them is safe either
   // way — typing /clear or /compact ends a context, it doesn't signal presence.

--- a/plugins/claude-code-hermit/scripts/routine-due.ts
+++ b/plugins/claude-code-hermit/scripts/routine-due.ts
@@ -8,7 +8,8 @@
 //   ROUTINE_DUE [hermit-routine:<id1>] [hermit-routine:<id2>] ...
 // The bracketed markers are load-bearing — cost-tracker.ts classifySource reads this
 // ROUTINE_DUE line to attribute the wake turn: one id → routine:<id>, ≥2 ids (a co-fire)
-// → the routine:multi bucket.
+// → the routine:multi bucket. Also load-bearing: record-operator-action.ts
+// isRoutinePrompt() drops this line; tests/auto-close.test.ts drift guard syncs it.
 //
 // State model (state/routine-schedule.json): { "<id>": { "last_consumed_mark": "<ISO minute>" } }
 // A routine is due when a cron-matching minute mark exists in (last_consumed_mark, now],

--- a/plugins/claude-code-hermit/scripts/routine-monitor.sh
+++ b/plugins/claude-code-hermit/scripts/routine-monitor.sh
@@ -16,6 +16,9 @@ INTERVAL="${1:?usage: routine-monitor.sh <interval_seconds> <hermit_state_dir>}"
 RT_DIR="${2:?usage: routine-monitor.sh <interval_seconds> <hermit_state_dir>}"
 DUE="${ROUTINE_DUE_SCRIPT:-$(dirname "$0")/routine-due.ts}"
 fail_count=0
+# Emission grammar (this line's "$out" and the ROUTINE_MONITOR_ERROR line below) is
+# load-bearing: record-operator-action.ts isRoutinePrompt() drops these lines;
+# tests/auto-close.test.ts drift guard syncs them.
 while true; do
   if out="$(bun "$DUE" "$RT_DIR" 2>/dev/null)"; then
     fail_count=0

--- a/plugins/claude-code-hermit/tests/auto-close.test.ts
+++ b/plugins/claude-code-hermit/tests/auto-close.test.ts
@@ -14,7 +14,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { runScript, PLUGIN_ROOT } from './helpers/run';
+import { runScript, PLUGIN_ROOT, SCRIPTS_DIR } from './helpers/run';
 import { fixturesDir } from './helpers/workdir';
 
 // ---------- fixture scaffolding ----------
@@ -300,6 +300,32 @@ describe('last-operator-action.json signal', () => {
     expect(fs.existsSync(lastOp(dir))).toBe(false);
   }));
 
+  // g5. hook smoke: Monitor-delivered scheduler notifications → file NOT written
+  for (const notification of [
+    'HEARTBEAT_EVALUATE',
+    'HEARTBEAT_ERROR: precheck failed',
+    'ROUTINE_DUE [hermit-routine:morning-brief]',
+    'ROUTINE_DUE [hermit-routine:reflect] [hermit-routine:doctor]',
+    'ROUTINE_MONITOR_ERROR: routine-due failed (3 consecutive)',
+  ]) {
+    test(`hook smoke: monitor notification "${notification}" → file NOT written`, withTmp(async (dir) => {
+      await recordHook(dir, JSON.stringify({ prompt: notification }));
+      expect(fs.existsSync(lastOp(dir))).toBe(false);
+    }));
+  }
+
+  // g6. hook smoke: prose merely containing/echoing a monitor token → file IS written
+  // (tight grammar — a mid-sentence or near-miss token still counts as operator activity)
+  test('hook smoke: prose mentioning HEARTBEAT_EVALUATE mid-sentence → file IS written', withTmp(async (dir) => {
+    await recordHook(dir, JSON.stringify({ prompt: 'why did HEARTBEAT_EVALUATE fire twice?' }));
+    expect(fs.existsSync(lastOp(dir))).toBe(true);
+  }));
+
+  test('hook smoke: near-miss "HEARTBEAT_EVALUATE looks weird" → file IS written', withTmp(async (dir) => {
+    await recordHook(dir, JSON.stringify({ prompt: 'HEARTBEAT_EVALUATE looks weird' }));
+    expect(fs.existsSync(lastOp(dir))).toBe(true);
+  }));
+
   // h. hook smoke: legacy wrapped shape (never actually reaches stdin per the
   // 2026-07-10 probe, but must not regress to dropped if some future CC version emits it)
   test('hook smoke: legacy <command-message> wrapped shape → file IS written', withTmp(async (dir) => {
@@ -418,6 +444,52 @@ describe('record-operator-action: hermit-injected commands stay in sync', () => 
 });
 
 // -------------------------------------------------------
+// monitor-emission drift guard: every scheduler notification string emitted by
+// heartbeat-monitor.sh / routine-monitor.sh / routine-due.ts must be dropped by
+// record-operator-action.ts's isRoutinePrompt. Prevents a future emission-grammar
+// rename from silently reopening the AUTO_CLOSE defer-loop.
+// -------------------------------------------------------
+
+describe('record-operator-action: monitor emission strings stay in sync', () => {
+  function extractEchoLiterals(file: string): string[] {
+    const src = fs.readFileSync(path.join(SCRIPTS_DIR, file), 'utf-8');
+    const literals: string[] = [];
+    for (const m of src.matchAll(/echo "((?:HEARTBEAT|ROUTINE)_[A-Z_]+[^"]*)"/g)) {
+      literals.push(m[1].replace(/\$\{[^}]*\}|\$[a-zA-Z_]+/g, 'x'));
+    }
+    return literals;
+  }
+
+  const literals = [
+    ...extractEchoLiterals('heartbeat-monitor.sh'),
+    ...extractEchoLiterals('routine-monitor.sh'),
+  ];
+
+  test('sweep finds the known monitor emission literals', () => {
+    expect(literals.length).toBeGreaterThanOrEqual(4); // EVALUATE, 2x ERROR variants, MONITOR_ERROR
+  });
+
+  // routine-due.ts builds its line from a template literal rather than a bare echo —
+  // assert the grammar anchor is still present in source.
+  test('routine-due.ts still emits the ROUTINE_DUE [hermit-routine: grammar', () => {
+    const src = fs.readFileSync(path.join(SCRIPTS_DIR, 'routine-due.ts'), 'utf-8');
+    expect(src).toContain('ROUTINE_DUE ');
+    expect(src).toContain('[hermit-routine:');
+  });
+
+  for (const literal of [...new Set([...literals, 'ROUTINE_DUE [hermit-routine:x]'])]) {
+    test(`monitor emission "${literal}" is dropped by record-operator-action.ts`, withTmp(async (dir) => {
+      const r = await runScript('record-operator-action.ts', {
+        stdin: JSON.stringify({ prompt: literal }),
+        cwd: dir,
+      });
+      expect(r.exitCode).toBe(0);
+      expect(fs.existsSync(hermit(dir, 'state', 'last-operator-action.json'))).toBe(false);
+    }));
+  }
+});
+
+// -------------------------------------------------------
 // daily-auto-close lull + pending-close drain
 // -------------------------------------------------------
 
@@ -441,6 +513,25 @@ describe('daily-auto-close lull + pending-close drain', () => {
     writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T22:40:00+00:00"}');
     writeState(dir, 'runtime.json', RUNTIME_IN_PROGRESS);
     expect(await precheck(dir, { now: NOW })).not.toBe('AUTO_CLOSE');
+  }));
+
+  // drain.2b. Regression for the overnight defer-loop (compiled/audit-1225-wake-economics-
+  // validation-2026-07-15.md § R1): AUTO_CLOSE peek → HEARTBEAT_EVALUATE wake → the
+  // notification itself must NOT stamp the clock, or the mutating precheck inside the wake
+  // sees fresh "activity" and falls through to SKIP|outside active hours, and the queued
+  // close never drains.
+  test('drain: HEARTBEAT_EVALUATE through the hook does not stamp clock; AUTO_CLOSE still drains', withTmp(async (dir) => {
+    hbSetup(dir);
+    writeState(dir, 'pending-close.json', PENDING);
+    writeState(dir, 'last-operator-action.json', '{"at":"2026-05-20T22:30:00+00:00"}'); // 15 min before NOW
+    writeState(dir, 'runtime.json', RUNTIME_IN_PROGRESS);
+    await runScript('record-operator-action.ts', {
+      stdin: JSON.stringify({ prompt: 'HEARTBEAT_EVALUATE' }),
+      cwd: dir,
+    });
+    expect(fs.readFileSync(hermit(dir, 'state', 'last-operator-action.json'), 'utf-8'))
+      .toContain('2026-05-20T22:30:00'); // unmoved
+    expect(await precheck(dir, { now: NOW })).toBe('AUTO_CLOSE');
   }));
 
   // drain.3. pending-close.json + session_state == idle + lull > 10min → AUTO_CLOSE


### PR DESCRIPTION
## Summary
`HEARTBEAT_EVALUATE`/`HEARTBEAT_ERROR`/`ROUTINE_DUE`/`ROUTINE_MONITOR_ERROR` — the notification strings emitted by the Monitor-delivered heartbeat and routine schedulers — were passing `record-operator-action.ts`'s `isRoutinePrompt()` filter unfiltered, so every scheduler wake stamped `last-operator-action.json` as if the operator had just acted.

That broke the AUTO_CLOSE pending-close drain, which requires a >10-minute operator lull: peek sees a lull → emits AUTO_CLOSE → the monitor delivers a `HEARTBEAT_EVALUATE` wake → the notification itself stamps the clock → the mutating precheck inside that same wake sees seconds-old "activity" → falls through to `SKIP|outside active hours` → the queued close never drains → next tick repeats. Measured live on the fleet: 13 consecutive overnight wakes (~3.07M cache_read tokens) on a 30-minute-interval hermit with a close stuck 9.5h+. `ROUTINE_DUE` stamping additionally suppressed AUTO_CLOSE on every routine fire, independent of heartbeat interval.

## Changes
- `record-operator-action.ts`: `isRoutinePrompt()` now drops the exact monitor emission grammar (`HEARTBEAT_EVALUATE`, `HEARTBEAT_ERROR: …`, `ROUTINE_DUE [hermit-routine:…`, `ROUTINE_MONITOR_ERROR: …`), matched as a tight grammar so prose that merely mentions a token still counts as operator activity.
- `heartbeat-monitor.sh`, `routine-monitor.sh`, `routine-due.ts`: one-line comments at each emission site pointing back at the filter/drift-guard coupling.
- `tests/auto-close.test.ts`: per-string hook smoke tests, a drift-guard describe block that re-derives the emission literals from the emitters' own source (so a future rename breaks the test instead of silently reopening the bug), and a regression test reproducing the defer-loop end to end (queued close + real lull + `HEARTBEAT_EVALUATE` through the hook → clock unmoved → AUTO_CLOSE still fires).
- `CHANGELOG.md`: `[Unreleased]` Fixed entry.

Shape caveat: the exact filter match was verified against the emitters' source grammar (`heartbeat-monitor.sh`, `routine-due.ts`, `routine-monitor.sh`), not against a live capture of the hook's raw stdin — a probe attempt hit an unrelated harness/environment issue (no `UserPromptSubmit` hook fired at all in scratch tmux sessions, even for a plain typed prompt) and was abandoned rather than block the fix. Live fleet evidence already confirms the notifications reach the hook and stamp the clock; only the exact string shape is unconfirmed. Flagged in the `isRoutinePrompt()` comment for anyone who re-probes this later.

## Test plan
- `bun test` from `plugins/claude-code-hermit/`: 2484 pass, 0 fail (full suite, including 89/89 in `auto-close.test.ts`).
- `bunx tsc --noEmit` from repo root: clean.
- Existing smoke tests confirming plain prompts and operator slash commands still stamp the clock are unaffected (unchanged, still green).