### PR TITLE
docs(claude-code-hermit): clarify DNS log-only mode ignores allowlist

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **docker-security docs: clarify that DNS log-only mode ignores the allowlist entirely** — static `address=` records only apply in enforce mode; documented `extra_hosts` on the `hermit` service as the mode-independent way to pin an internal hostname to an IP.
+
 ## [1.2.26] - 2026-07-15
 
 ### Fixed

--- a/plugins/claude-code-hermit/docs/docker-security.md
+++ b/plugins/claude-code-hermit/docs/docker-security.md
@@ -111,6 +111,8 @@ In **enforce mode**, the same command surfaces NXDOMAIN denials. Decide which do
 
 The wizard does not auto-promote blocked domains. Manual review keeps the trust boundary at the operator.
 
+**Pinning an internal/private hostname (e.g. Tailscale MagicDNS) to an IP is not something the allowlist supports** — it only takes `server=` forwarding rules and the catchall, and log-only mode skips the allowlist file entirely (dnsmasq isn't even loaded with `--conf-file` in that mode), so a hand-added static record would silently resolve in enforce mode but not log-only. Use `extra_hosts` on the `hermit` service in your compose file instead — it resolves via `/etc/hosts` before any DNS query is made, so it works identically regardless of DNS mode.
+
 ## GitHub CLI authentication {#gh-cli-authentication}
 
 `gh` is pre-installed in the hermit Docker baseline image. By default it runs anonymously — fine for read-only public-repo operations, but subject to GitHub's unauthenticated rate limit (60 req/hr per IP).


### PR DESCRIPTION
## Summary
- Closes #602 as won't-fix: the underlying mechanism (log-only mode never loads `dnsmasq.allowlist`) is real, but the affected workflow — a hand-added static `address=` record — isn't something the plugin generates or documents anywhere.
- Documents `extra_hosts` on the `hermit` service as the mode-independent fix for pinning an internal hostname to an IP (resolves via `/etc/hosts` before any DNS query, so it works the same in log-only and enforce mode).
- Adds a CHANGELOG `[Unreleased]` entry per convention.

## Test plan
- [x] Docs-only change; no code paths affected. Read the surrounding section to confirm placement and tone match the existing "Tuning the DNS allowlist" section.