### PR TITLE
feat(laravel-forge-hermit): add site/background-process log reads

### DIFF
--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Added
+- **forge.php: `background-process-log <server> <process-id>` command + `backgroundProcessLog` read** — log access for apps running as Forge background processes (#606)
+- **forge.php: `site-log <server> <site> <type>` command (application, nginx-access, nginx-error)** — site-level logs, previously unreachable
+- **forge.php: read allowlist expanded with 43 SDK detail/output/config read methods** — secret-bearing reads (`siteEnvironment`, `deploymentTriggerUrl`, credential methods) deliberately excluded and test-enforced
+
 ## [0.0.6] - 2026-07-10
 
 ### Fixed

--- a/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
+++ b/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
@@ -59,7 +59,8 @@ function main(): void {
 
   const SAFE_SUBCOMMANDS = [
     'check', 'servers', 'server', 'sites', 'site', 'logs',
-    'server-log', 'deploy-history', 'deploy-log', 'deploy-status',
+    'server-log', 'site-log', 'background-process-log',
+    'deploy-history', 'deploy-log', 'deploy-status',
     'preview-deploy', 'preview-reboot',
     'failed-deploys', 'call',
     'help', '--help',

--- a/plugins/laravel-forge-hermit/php/forge-lib.php
+++ b/plugins/laravel-forge-hermit/php/forge-lib.php
@@ -40,6 +40,30 @@ const READ_ALLOWLIST = [
     'monitors', 'webhooks', 'backgroundProcesses', 'commands',
     // org
     'organizations',
+    // singular detail + output counterparts
+    'backgroundProcess', 'backgroundProcessLog',
+    'command', 'commandOutput',
+    'scheduledJob', 'scheduledJobOutput', 'siteScheduledJob', 'siteScheduledJobOutput',
+    'serverEvent', 'serverEventOutput',
+    // site logs + site/domain config
+    'siteApplicationLog', 'siteNginxAccessLog', 'siteNginxErrorLog',
+    'siteNginx', 'domainNginxConfig', 'domainConfigurations', 'siteHealthcheck',
+    // deployment config
+    'deploymentScript',
+    // laravel integrations
+    'getMaintenance', 'getHorizon', 'getOctane', 'getScheduler', 'getPulse', 'getReverb', 'getInertia',
+    // monitoring detail
+    'monitor', 'heartbeats', 'heartbeat',
+    // singular parity getters
+    'organizationSite', 'domain', 'databaseUser', 'webhook', 'backupConfiguration',
+    'phpVersion', 'activeDomainCertificate',
+    // php config reads
+    'phpCli', 'phpCliVersion', 'phpFpm', 'phpMaxExecutionTime', 'phpMaxUploadSize',
+    'phpOpcache', 'phpPool', 'phpSiteVersion',
+    // Deliberately NOT allowlisted (do not add): siteEnvironment (env vars are
+    // secrets), deploymentTriggerUrl (secret URL), composerCredential(s),
+    // npmCredential(s), serverCredential(s), serverKey, deployKey (credentials).
+    // The global cross-org sites() stays out too (org-scoped reads only).
 ];
 
 // Raw transports — blocked even if somehow allowlisted (defense-in-depth).

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -396,8 +396,6 @@ if ($cmd === 'server-log') {
 // ---------------------------------------------------------------------------
 if ($cmd === 'site-log') {
     check(isset($positional[2]), "Usage: forge.php site-log <server> <site> <application|nginx-access|nginx-error>");
-    $server = resolveServer($forge, $org, $positional[0]);
-    $site   = resolveSite($forge, $org, $server, $positional[1]);
 
     $methods = [
         'application'  => 'siteApplicationLog',
@@ -409,6 +407,9 @@ if ($cmd === 'site-log') {
         fwrite(STDERR, "Unknown log type '$type'. Valid types: " . implode(', ', array_keys($methods)) . "\n");
         exit(1);
     }
+
+    $server = resolveServer($forge, $org, $positional[0]);
+    $site   = resolveSite($forge, $org, $server, $positional[1]);
 
     try {
         $log = $forge->{$methods[$type]}($org, $server->id, $site->id);

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -193,6 +193,8 @@ if ($cmd === '' || $cmd === '--help' || $cmd === 'help') {
       site <server> <site>        Show site detail
       logs <server> <site>        Show latest deployment log for a site
       server-log <server> <key>   Read a server log by key (keys are hyphenated: nginx-error, nginx-access; 'php' auto-resolves to php-<major>.<minor>)
+      site-log <server> <site> <type>  Read a site log (type: application, nginx-access, nginx-error)
+      background-process-log <server> <process-id>  Fetch a background process's log output
       deploy-history <server> <site>          List recent deployments
       deploy-log <server> <site> <deploy-id>  Fetch a specific deployment log
       deploy-status <server-id> <site-id> <deploy-id>  Print a deployment's status (raw IDs)
@@ -390,6 +392,35 @@ if ($cmd === 'server-log') {
 }
 
 // ---------------------------------------------------------------------------
+// site-log <server> <site> <type>
+// ---------------------------------------------------------------------------
+if ($cmd === 'site-log') {
+    check(isset($positional[2]), "Usage: forge.php site-log <server> <site> <application|nginx-access|nginx-error>");
+    $server = resolveServer($forge, $org, $positional[0]);
+    $site   = resolveSite($forge, $org, $server, $positional[1]);
+
+    $methods = [
+        'application'  => 'siteApplicationLog',
+        'nginx-access' => 'siteNginxAccessLog',
+        'nginx-error'  => 'siteNginxErrorLog',
+    ];
+    $type = $positional[2];
+    if (!isset($methods[$type])) {
+        fwrite(STDERR, "Unknown log type '$type'. Valid types: " . implode(', ', array_keys($methods)) . "\n");
+        exit(1);
+    }
+
+    try {
+        $log = $forge->{$methods[$type]}($org, $server->id, $site->id);
+    } catch (NotFoundException $e) {
+        fwrite(STDERR, "No $type log found for site {$site->name} on server {$server->name}.\n");
+        exit(1);
+    }
+    echo $log . "\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
 // deploy-history <server> <site>
 // ---------------------------------------------------------------------------
 if ($cmd === 'deploy-history') {
@@ -414,6 +445,23 @@ if ($cmd === 'deploy-log') {
     $site     = resolveSite($forge, $org, $server, $positional[1]);
     $deployId = (int)$positional[2];   // SDK param is int; argv gives a string under strict_types
     $log      = $forge->deploymentLog($org, $server->id, $site->id, $deployId);
+    echo $log . "\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// background-process-log <server> <process-id>
+// ---------------------------------------------------------------------------
+if ($cmd === 'background-process-log') {
+    check(isset($positional[1]), "Usage: forge.php background-process-log <server> <process-id>");
+    $server    = resolveServer($forge, $org, $positional[0]);
+    $processId = (int)$positional[1];   // SDK param is int; argv gives a string under strict_types
+    try {
+        $log = $forge->backgroundProcessLog($org, $server->id, $processId);
+    } catch (NotFoundException $e) {
+        fwrite(STDERR, "No background process $processId on server {$server->name}. List processes with: echo '[{$server->id}]' | forge.php call backgroundProcesses\n");
+        exit(1);
+    }
     echo $log . "\n";
     exit(0);
 }

--- a/plugins/laravel-forge-hermit/php/tests/run.php
+++ b/plugins/laravel-forge-hermit/php/tests/run.php
@@ -174,6 +174,23 @@ check(!isAllowed('rebootServer'), 'rebootServer rejected (not on allowlist)');
 check(isAllowed('servers'), 'servers allowed');
 check(isAllowed('deployment'), 'deployment allowed');
 check(isAllowed('serverLog'), 'serverLog allowed');
+check(isAllowed('backgroundProcessLog'), 'backgroundProcessLog allowed');
+check(isAllowed('siteApplicationLog'), 'siteApplicationLog allowed');
+check(!isAllowed('siteEnvironment'), 'siteEnvironment rejected (env vars are secrets)');
+check(!isAllowed('deploymentTriggerUrl'), 'deploymentTriggerUrl rejected (secret URL)');
+check(!isAllowed('composerCredentials'), 'composerCredentials rejected (credentials)');
+check(!isAllowed('updateSiteEnvironment'), 'updateSiteEnvironment rejected (mutator)');
+
+// Every allowlist entry must be a real public method on the SDK (typo guard —
+// previously a misspelled entry would pass the suite and only fail at runtime).
+$missingMethods = array_values(array_filter(
+    READ_ALLOWLIST,
+    fn($m) => !method_exists(Forge::class, $m)
+));
+$allMethodsExist = $missingMethods === [];
+check($allMethodsExist,
+    'every READ_ALLOWLIST entry exists on Forge SDK'
+    . ($allMethodsExist ? '' : ' (missing: ' . implode(', ', $missingMethods) . ')'));
 
 // ---------------------------------------------------------------------------
 // Tests: NO_ORG_METHODS — org slug must not be prepended for global methods

--- a/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forge-logs
-description: Read site deployment logs, server logs, and specific deployment logs from Laravel Forge. Includes a triage mode that bundles recent logs with deployment history for rapid incident analysis. Triggers on "show logs", "read logs", "deployment log", "server log", "what happened to the deployment", "triage failing site".
+description: Read site deployment logs, server logs, site application/nginx logs, background process logs, and specific deployment logs from Laravel Forge. Includes a triage mode that bundles recent logs with deployment history for rapid incident analysis. Triggers on "show logs", "read logs", "deployment log", "server log", "what happened to the deployment", "triage failing site".
 ---
 
 # Forge Logs
@@ -33,6 +33,26 @@ php ${CLAUDE_PLUGIN_ROOT}/php/forge.php server-log <server> <key>
 
 Common keys: `php`, `mysql`, `cron`, `daemon`, `nginx-error`, `nginx-access`. Nginx keys are hyphenated; `nginx_error` (underscored) returns a 404. The PHP-FPM log key is dot-version notation matching the server's installed PHP (`php-8.3`, not `php`) — passing the literal `php` key auto-resolves it against the server's `php_version`. `mysql`/`cron`/`daemon` may 404 outright on servers with a custom, non-Forge-provisioned install of that service (no Forge-tracked log path) — a 404 there isn't necessarily a wrong key. Key list depends on the server's installed services.
 
+## Site logs
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php site-log <server> <site> <type>
+```
+
+`<type>` is one of `application` (the Laravel app log), `nginx-access`, `nginx-error`. Application and access logs leak PII and tokens more readily than deploy logs — the Secret hygiene rules below apply with extra force.
+
+## Background process log
+
+```bash
+php ${CLAUDE_PLUGIN_ROOT}/php/forge.php background-process-log <server> <process-id>
+```
+
+The log path for apps that run as a Forge Background Process instead of PHP-FPM (Node apps, queue workers, custom daemons). `server-log` does not cover these. Find the process ID first:
+
+```bash
+echo '[<server-id>]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call backgroundProcesses
+```
+
 ---
 
 ## Triage mode
@@ -60,3 +80,4 @@ When the operator says something like "what's wrong with myapp.com" or "triage t
 
 - `<server>` and `<site>` accept name, hostname, or numeric ID.
 - For a failed deployment you triggered via `forge-deploy`, the `deploy-incident` artifact (written by `forge-deploy` when its watch Monitor sees a failed terminal status) already contains the scrubbed log tail — check `compiled/deploy-incident-<site>-<date>.md` before re-fetching.
+- Other output reads (`commandOutput`, `scheduledJobOutput`, `siteScheduledJobOutput`, `serverEventOutput`) are reachable via `call <method>` with JSON args on stdin; their content comes back JSON-encoded.

--- a/plugins/laravel-forge-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/laravel-forge-hermit/state-templates/CLAUDE-APPEND.md
@@ -24,10 +24,12 @@ A wrong reboot causes an outage. A wrong deploy targets the wrong site. The `wri
 Skills self-advertise through their own `SKILL.md` descriptions — they are not catalogued here. The curated `php forge.php` commands cover the hot paths. For any other SDK read — server events, firewall rules, databases, scheduled jobs, certificates, etc. — use read-only generic dispatch:
 
 ```bash
-# Args as JSON array on stdin; the org slug is prepended automatically
-# (except global methods like `organizations` and `sites`).
-echo '["<server-id>"]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call databases
-echo '["<server-id>", "<site-id>"]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call deployments
+# Args as JSON array on stdin — keep IDs as bare numbers, not quoted strings
+# (SDK params are typed ints; strict_types rejects "123"). The org slug is
+# prepended automatically (except global methods like `organizations`).
+echo '[123]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call databases
+echo '[123, 456]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call deployments
+echo '[123]' | php ${CLAUDE_PLUGIN_ROOT}/php/forge.php call backgroundProcesses
 ```
 
 Only read methods on the closed allowlist are accepted — this path cannot mutate anything.

--- a/plugins/laravel-forge-hermit/tests/hook.test.ts
+++ b/plugins/laravel-forge-hermit/tests/hook.test.ts
@@ -66,6 +66,16 @@ describe('write-confirm-gate: pass-through cases', () => {
     const r = runHook({ tool_name: 'Bash', tool_input: { command: 'echo \'["s1"]\' | php /plugin/php/forge.php call servers' } });
     expect(r.exitCode).toBe(0);
   });
+
+  test('site-log (read command) passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php site-log web-1 example.com application' } });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('background-process-log (read command) passes', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php background-process-log web-1 123' } });
+    expect(r.exitCode).toBe(0);
+  });
 });
 
 describe('write-confirm-gate: blocked cases', () => {


### PR DESCRIPTION
## Summary
Expands the Forge SDK read surface the plugin exposes: the allowlist consistently had *list* methods but not their *detail/output/log* counterparts, and issue #606 was one instance of that pattern (no way to read a background process's log). This ships the #606 fix together with the rest of the read-only detail/output/config methods (43 total), plus two curated commands for the highest-value log surfaces.

Closes #606

## Changes
- **`php/forge-lib.php`**: `READ_ALLOWLIST` expanded from 35 to 78 entries — singular detail/output counterparts (`backgroundProcess(Log)`, `command(Output)`, `scheduledJob(Output)`, `serverEvent(Output)`, etc.), site logs (`siteApplicationLog`, `siteNginxAccessLog`, `siteNginxErrorLog`), site/domain/PHP config reads, and Laravel integration reads (Horizon, Octane, Pulse, Reverb, Scheduler, Inertia, Maintenance). Secret-bearing methods (`siteEnvironment`, `deploymentTriggerUrl`, credential methods) are explicitly documented as excluded and test-enforced.
- **`php/forge.php`**: two new curated read commands — `site-log <server> <site> <type>` (application/nginx-access/nginx-error) and `background-process-log <server> <process-id>` — that echo raw log content rather than the generic `call` path's JSON-escaped string.
- **`skills/forge-logs/SKILL.md`**: documents both new commands under the existing secret-hygiene rules, plus a note on the other output reads reachable via `call`.
- **`state-templates/CLAUDE-APPEND.md`**: fixes two defects in the generic-dispatch example — quoted string IDs that TypeError against `strict_types` int SDK params (now bare numeric JSON), and a stale claim that `sites()` is a no-org method (only `organizations` is).
- **Tests**: `php/tests/run.php` adds allowlist membership/negative checks plus a `method_exists` validity loop over all 78 entries (previously a typo in the allowlist would pass the suite silently). `tests/hook.test.ts` adds pass-through cases for the two new commands.

## Test plan
- `bash tests/run-all.sh` from `plugins/laravel-forge-hermit/` — 43/43 PHP checks, 23/23 hook tests, 42/42 skill-structure checks, all green.
- `bunx tsc --noEmit` from repo root — clean.
- `php -r 'require "php/forge-lib.php"; echo count(READ_ALLOWLIST);'` → `78`.
- `php php/forge.php --help` confirms both new commands are listed.