### PR TITLE
fix(claude-code-hermit): derive session cost from cost-log window, not .status.json

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - **transcript-digest: ground-truth behavioral telemetry for reflect** — new `scripts/transcript-digest.ts` mines recent session transcripts into verdict-sized JSON counters (tool failures, rejections by kind, wakes vs productive wakes, compactions, subagent dispatches). Reflect's new weekly `behavior` phase cites them as machine-measured evidence via a defer-loop auto-row and anomaly checklist. Self-activates on the next scheduled reflect; no migration.
 
+### Fixed
+- **session-archive: derive session cost from the cost-log window, not `.status.json`** — idle/close/auto-close reports and interrupted-transition recovery no longer stamp the hermit's cumulative lifetime cost onto a single session. `.status.json` is a running total, never a per-session value; auto-closed 0-duration sessions were getting stamped with it, wildly inflating `cost_usd`/`tokens` and, in turn, `weekly-review`'s weekly total.
+
 ## [1.2.28] - 2026-07-17
 
 ### Fixed

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -6,7 +6,8 @@
 - **transcript-digest: ground-truth behavioral telemetry for reflect** — new `scripts/transcript-digest.ts` mines recent session transcripts into verdict-sized JSON counters (tool failures, rejections by kind, wakes vs productive wakes, compactions, subagent dispatches). Reflect's new weekly `behavior` phase cites them as machine-measured evidence via a defer-loop auto-row and anomaly checklist. Self-activates on the next scheduled reflect; no migration.
 
 ### Fixed
-- **session-archive: derive session cost from the cost-log window, not `.status.json`** — idle/close/auto-close reports and interrupted-transition recovery no longer stamp the hermit's cumulative lifetime cost onto a single session. `.status.json` is a running total, never a per-session value; auto-closed 0-duration sessions were getting stamped with it, wildly inflating `cost_usd`/`tokens` and, in turn, `weekly-review`'s weekly total.
+- **session-archive: derive session cost from the cost-log window, not `.status.json`** — `.status.json` is a cumulative running total, so auto-closed sessions were stamped with the hermit's lifetime spend, inflating report `cost_usd`/`tokens` and `weekly-review`'s weekly total.
+- **session-archive: open the cost arc at session open** — a session archived before its first tracked turn measured the previous session's window and inherited its cost.
 
 ## [1.2.28] - 2026-07-17
 

--- a/plugins/claude-code-hermit/scripts/lib/session-cost.ts
+++ b/plugins/claude-code-hermit/scripts/lib/session-cost.ts
@@ -10,7 +10,7 @@
 
 import fs from 'node:fs';
 
-export function sumWindow(logPath: string, openedMs: number, closedMs: number): { cost: number; tokens: number } {
+function sumWindow(logPath: string, openedMs: number, closedMs: number): { cost: number; tokens: number } {
   let cost = 0;
   let tokens = 0;
   try {

--- a/plugins/claude-code-hermit/scripts/lib/session-cost.ts
+++ b/plugins/claude-code-hermit/scripts/lib/session-cost.ts
@@ -1,0 +1,46 @@
+// Shared window-cost algorithm used by scripts/session-cost.ts (CLI) and
+// scripts/session-archive.ts (report frontmatter). Pure: caller supplies the
+// [openedAt, closedAt] arc bounds (from state/runtime.json — see session-cost.ts's
+// header for the arc-window rationale) and the cost-log path; no env/argv reads here.
+//
+// `available` is the contract callers branch on, not `cost_usd === 0` — a session
+// with a real opened_at but zero matching cost-log rows is a MEASURED zero and must
+// not fall through to a legacy Cost: payload or any other fallback. `available` is
+// false only when openedAt itself is missing/unparseable.
+
+import fs from 'node:fs';
+
+export function sumWindow(logPath: string, openedMs: number, closedMs: number): { cost: number; tokens: number } {
+  let cost = 0;
+  let tokens = 0;
+  try {
+    for (const line of fs.readFileSync(logPath, 'utf8').split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const e = JSON.parse(line);
+        const ts = Date.parse(e.timestamp);
+        if (Number.isFinite(ts) && ts >= openedMs && ts <= closedMs) {
+          cost += e.estimated_cost_usd || 0;
+          tokens += e.total_tokens || 0;
+        }
+      } catch {}
+    }
+  } catch {}
+  return { cost, tokens };
+}
+
+export function computeSessionCost(opts: {
+  logPath: string;
+  openedAt?: string;
+  closedAt?: string;
+}): { available: boolean; cost_usd: number; tokens: number } {
+  const openedMs = opts.openedAt ? Date.parse(opts.openedAt) : NaN;
+  if (!Number.isFinite(openedMs)) return { available: false, cost_usd: 0, tokens: 0 };
+  // A malformed/absent closed bound parses to NaN, which would silently zero the
+  // window sum (every `ts <= NaN` is false); fall back to now. A live arc (no
+  // closed_at yet) also falls back to now.
+  const closedParsed = opts.closedAt ? Date.parse(opts.closedAt) : NaN;
+  const closedMs = Number.isFinite(closedParsed) ? closedParsed : Date.now();
+  const { cost, tokens } = sumWindow(opts.logPath, openedMs, closedMs);
+  return { available: true, cost_usd: Math.round(cost * 10000) / 10000, tokens };
+}

--- a/plugins/claude-code-hermit/scripts/session-archive.ts
+++ b/plugins/claude-code-hermit/scripts/session-archive.ts
@@ -289,6 +289,20 @@ function extractProposalIds(shell: string): string[] {
 // one) even though session-close/session no longer instruct writing it.
 // ---------------------------------------------------------------------------
 
+// Recover path only: the cost verbArchive already wrote to the report frontmatter.
+// The crash landed after the report was written, so its frontmatter is the
+// authoritative session cost — not a fresh (and by then window-less) recomputation.
+// readFrontmatter returns scalars as strings — coerce, don't typeof-check.
+function recoveredReportCost(reportPath: string): { cost_usd: number; tokens: number } {
+  const fm = readFrontmatter(reportPath);
+  const cost = Number(fm?.cost_usd);
+  const tokens = Number(fm?.tokens);
+  return {
+    cost_usd: Number.isFinite(cost) ? cost : 0,
+    tokens: Number.isFinite(tokens) ? tokens : 0,
+  };
+}
+
 function resolveCost(
   payload: Record<string, string>,
   opts: { logPath: string; openedAt?: string; closedAt?: string },
@@ -550,9 +564,9 @@ function replaceSectionInPlace(shell: string, heading: string, newBody: string):
 }
 
 // `mode` isn't needed here — both call sites only invoke this when mode is
-// already known to be 'idle', so the cost the caller already has (computed
-// once by buildReport, or a single fresh resolveCost in the recover path) is
-// passed in directly instead of `sessionsDir` + a second resolveCost call.
+// already known to be 'idle', so the cost the caller already has (computed once
+// by buildReport, or read back from the written report in the recover path) is
+// passed in directly instead of `sessionsDir` + a second cost resolution.
 function idleReset(shell: string, sessionId: string, now: Date, payload: Record<string, string>, compactCfg: ReturnType<typeof resolveCompactConfig>, cost: { cost_usd: number; tokens: number }): string {
   // Snapshot the task summary from the ORIGINAL (pre-reset) shell — once the
   // Task section is cleared below, extracting from the mutated copy would
@@ -654,7 +668,11 @@ function verbArchive(flags: Record<string, string | true>, stdin: string): Json 
 
   const config = readConfig(stateDir);
   const openedAt = typeof runtimeBefore.opened_at === 'string' ? runtimeBefore.opened_at : undefined;
-  const closedAt = typeof runtimeBefore.closed_at === 'string' ? runtimeBefore.closed_at : undefined;
+  // A closed_at at or before opened_at is a stale bound left by an earlier arc. Passing
+  // it through would measure an inverted window, which sums to a silent zero — drop it
+  // so the window ends at `now` instead (buildReport's `closedAt ?? localISOStamp(now)`).
+  const rawClosedAt = typeof runtimeBefore.closed_at === 'string' ? runtimeBefore.closed_at : undefined;
+  const closedAt = rawClosedAt && Date.parse(rawClosedAt) > Date.parse(openedAt ?? '') ? rawClosedAt : undefined;
   const { content: reportContent, cost: reportCost } = buildReport({ sessionId, mode, now, payload, shell, stateDir, config, openedAt, closedAt });
 
   const reportPath = path.join(sessionsDir, `${sessionId}-REPORT.md`);
@@ -724,7 +742,17 @@ function verbOpen(flags: Record<string, string | true>, stdin: string): Json {
     return { ok: false, reason: 'shell-write-error: ' + e.message };
   }
 
-  const update = updateRuntime(runtimePath, now, { session_state: 'in_progress', session_id: sessionId });
+  // Start this session's cost arc here rather than waiting for cost-tracker's first
+  // in_progress turn. Without it, runtime still carries the PREVIOUS arc's
+  // [opened_at, closed_at]; a session archived before that first turn lands
+  // (auto-close, an immediate idle, recover's re-archive) would measure the previous
+  // session's window and stamp its cost onto this report. cost-tracker's arc logic is
+  // unaffected: closed_at is null so no new arc is forced, and a transcript change
+  // still re-stamps opened_at to the first turn (no cost accrues before it).
+  const update = updateRuntime(runtimePath, now, {
+    session_state: 'in_progress', session_id: sessionId,
+    opened_at: localISOStamp(now), closed_at: null,
+  });
   if (!update.ok) return { ok: false, reason: update.reason };
 
   return { ok: true, session_id: sessionId };
@@ -805,18 +833,9 @@ function verbRecover(flags: Record<string, string | true>): Json {
   const idleAlreadyReset = mode === 'idle' && shell.includes(`**${sessionId}**`);
   let newShell: string;
   if (mode === 'idle') {
-    // Read cost from the report verbArchive already wrote (targetPath) rather than
-    // recomputing — the crash landed after the report was written, so its frontmatter
-    // is the authoritative session cost, not a fresh (and here window-less) resolveCost.
-    // readFrontmatter returns scalars as strings — coerce, don't typeof-check.
-    const recoveredFm = readFrontmatter(targetPath);
-    const recoveredCostUsd = Number(recoveredFm?.cost_usd);
-    const recoveredTokens = Number(recoveredFm?.tokens);
-    const recoveredCost = {
-      cost_usd: Number.isFinite(recoveredCostUsd) ? recoveredCostUsd : 0,
-      tokens: Number.isFinite(recoveredTokens) ? recoveredTokens : 0,
-    };
-    newShell = idleAlreadyReset ? shell : idleReset(shell, sessionId, now, {}, resolveCompactConfig(config), recoveredCost);
+    newShell = idleAlreadyReset
+      ? shell
+      : idleReset(shell, sessionId, now, {}, resolveCompactConfig(config), recoveredReportCost(targetPath));
   } else {
     newShell = closeReset(path.join(stateDir, 'templates', 'SHELL.md.template'), shell);
   }

--- a/plugins/claude-code-hermit/scripts/session-archive.ts
+++ b/plugins/claude-code-hermit/scripts/session-archive.ts
@@ -28,9 +28,11 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { globDir } from './lib/frontmatter';
+import { globDir, readFrontmatter } from './lib/frontmatter';
 import { localISOStamp } from './lib/time';
 import { readAlertState as readRuntime, quarantineAlertState as quarantineRuntime } from './lib/alert-state';
+import { costLogPath } from './lib/cc-compat';
+import { computeSessionCost } from './lib/session-cost';
 
 type Json = any;
 
@@ -277,29 +279,27 @@ function extractProposalIds(shell: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Cost fallback chain: payload Cost line -> sessions/.status.json -> 0.00/0.
-// (The session-mgr.md spec's third fallback, "parse `## Cost` from SHELL.md",
-// is dropped: no such section exists in the current SHELL.md.template.)
+// Cost precedence: measured cost-log window (computeSessionCost) -> legacy
+// payload Cost line -> 0.00/0. `sessions/.status.json` is NEVER consulted for
+// cost — it's a cumulative running total (cost-tracker.ts), not a per-session
+// value, and stamping it onto a report silently records the hermit's lifetime
+// spend as one session's cost (the auto-close inflation bug this replaced).
+// The legacy Cost: line parse is kept as the second tier for rollout
+// back-compat (in-flight sessions / not-yet-evolved skill text may still emit
+// one) even though session-close/session no longer instruct writing it.
 // ---------------------------------------------------------------------------
 
-function resolveCost(payload: Record<string, string>, sessionsDir: string): { cost_usd: number; tokens: number } {
+function resolveCost(
+  payload: Record<string, string>,
+  opts: { logPath: string; openedAt?: string; closedAt?: string },
+): { cost_usd: number; tokens: number } {
+  const measured = computeSessionCost(opts);
+  if (measured.available) return { cost_usd: measured.cost_usd, tokens: measured.tokens };
+
   const costLine = payload['Cost'] || '';
-  // Tolerate thousands separators (`$1,234.50 (1,526,890 tokens)`) — a strict
-  // no-comma regex would miss them and fall through to .status.json, which holds
-  // a cumulative running total, silently recording the wrong cost for the session.
+  // Tolerate thousands separators (`$1,234.50 (1,526,890 tokens)`).
   const m = /\$([\d,]+(?:\.\d+)?)\s*\(([\d,]+)\s*tokens?\)/.exec(costLine);
   if (m) return { cost_usd: Math.round(parseFloat(m[1].replace(/,/g, '')) * 10000) / 10000, tokens: parseInt(m[2].replace(/,/g, ''), 10) };
-  const statusPath = path.join(sessionsDir, '.status.json');
-  const raw = readFileSafe(statusPath);
-  if (raw) {
-    try {
-      const status = JSON.parse(raw);
-      return {
-        cost_usd: typeof status.cost_usd === 'number' ? status.cost_usd : 0,
-        tokens: typeof status.tokens === 'number' ? status.tokens : 0,
-      };
-    } catch { /* fall through */ }
-  }
   return { cost_usd: 0, tokens: 0 };
 }
 
@@ -465,14 +465,15 @@ function contentLines(s: string): string[] {
 function buildReport(opts: {
   sessionId: string; mode: 'idle' | 'close' | 'auto'; now: Date;
   payload: Record<string, string> & { plan?: string }; shell: string; stateDir: string; config: Json;
+  openedAt?: string; closedAt?: string;
 }): { content: string; statusNote: string | null; cost: { cost_usd: number; tokens: number } } {
-  const { sessionId, mode, now, payload, shell, stateDir, config } = opts;
+  const { sessionId, mode, now, payload, shell, stateDir, config, openedAt, closedAt } = opts;
   const sessionsDir = path.join(stateDir, 'sessions');
   const timezone = resolveTimezone(config);
   const { status, note: statusNote } = normalizeStatus(payload['Status'] || '');
   const startedAt = extractStartedAt(shell);
   const duration = startedAt ? formatDuration(now.getTime() - startedAt.getTime()) : '0m';
-  const cost = resolveCost(payload, sessionsDir);
+  const cost = resolveCost(payload, { logPath: costLogPath(stateDir), openedAt, closedAt: closedAt ?? localISOStamp(now) });
   const { cost_usd, tokens } = cost;
   const tags = extractTags(shell);
   const proposalsCreated = extractProposalIds(shell);
@@ -652,7 +653,9 @@ function verbArchive(flags: Record<string, string | true>, stdin: string): Json 
   if (!setTransition.ok) return { ok: false, reason: setTransition.reason };
 
   const config = readConfig(stateDir);
-  const { content: reportContent, cost: reportCost } = buildReport({ sessionId, mode, now, payload, shell, stateDir, config });
+  const openedAt = typeof runtimeBefore.opened_at === 'string' ? runtimeBefore.opened_at : undefined;
+  const closedAt = typeof runtimeBefore.closed_at === 'string' ? runtimeBefore.closed_at : undefined;
+  const { content: reportContent, cost: reportCost } = buildReport({ sessionId, mode, now, payload, shell, stateDir, config, openedAt, closedAt });
 
   const reportPath = path.join(sessionsDir, `${sessionId}-REPORT.md`);
   try {
@@ -802,7 +805,18 @@ function verbRecover(flags: Record<string, string | true>): Json {
   const idleAlreadyReset = mode === 'idle' && shell.includes(`**${sessionId}**`);
   let newShell: string;
   if (mode === 'idle') {
-    newShell = idleAlreadyReset ? shell : idleReset(shell, sessionId, now, {}, resolveCompactConfig(config), resolveCost({}, sessionsDir));
+    // Read cost from the report verbArchive already wrote (targetPath) rather than
+    // recomputing — the crash landed after the report was written, so its frontmatter
+    // is the authoritative session cost, not a fresh (and here window-less) resolveCost.
+    // readFrontmatter returns scalars as strings — coerce, don't typeof-check.
+    const recoveredFm = readFrontmatter(targetPath);
+    const recoveredCostUsd = Number(recoveredFm?.cost_usd);
+    const recoveredTokens = Number(recoveredFm?.tokens);
+    const recoveredCost = {
+      cost_usd: Number.isFinite(recoveredCostUsd) ? recoveredCostUsd : 0,
+      tokens: Number.isFinite(recoveredTokens) ? recoveredTokens : 0,
+    };
+    newShell = idleAlreadyReset ? shell : idleReset(shell, sessionId, now, {}, resolveCompactConfig(config), recoveredCost);
   } else {
     newShell = closeReset(path.join(stateDir, 'templates', 'SHELL.md.template'), shell);
   }

--- a/plugins/claude-code-hermit/scripts/session-cost.ts
+++ b/plugins/claude-code-hermit/scripts/session-cost.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { costLogPath, hermitDir } from './lib/cc-compat';
 import { readRuntimeJson } from './lib/runtime';
+import { computeSessionCost } from './lib/session-cost';
 
 const ROOT = hermitDir();
 const COST_LOG = costLogPath(ROOT);
@@ -64,18 +65,11 @@ function sumMatching(predicate: (e: any) => boolean): { cost: number; tokens: nu
 }
 
 const { openedAt, closedAt } = readWindow();
-const openedMs = openedAt ? Date.parse(openedAt) : NaN;
-// A malformed/absent closed bound parses to NaN, which would silently zero the
-// window sum (every `ts <= NaN` is false); fall back to now, mirroring the
-// openedMs guard below. A live arc (no closed_at yet) also falls back to now.
-const closedParsed = closedAt ? Date.parse(closedAt) : NaN;
-const closedMs = Number.isFinite(closedParsed) ? closedParsed : Date.now();
+const measured = computeSessionCost({ logPath: COST_LOG, openedAt, closedAt });
 
-const result = Number.isFinite(openedMs)
-  ? sumMatching(e => {
-      const ts = Date.parse(e.timestamp);
-      return Number.isFinite(ts) && ts >= openedMs && ts <= closedMs;
-    })
+// Window mode unavailable (no opened_at) — fall back to the legacy exact-match sum.
+const result = measured.available
+  ? { cost: measured.cost_usd, tokens: measured.tokens }
   : sumMatching(e => e.session_id === sessionId);
 
 process.stdout.write(JSON.stringify({ cost_usd: Math.round(result.cost * 10000) / 10000, tokens: result.tokens }) + '\n');

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -82,8 +82,7 @@ This path is intentionally silent: no operator notification on queue or drain �
    If reflect returns `reflect: no candidates`, scan this session's `## Findings` and `## Progress Log` for non-obvious discoveries not already in memory and issue the standard "remember it" reflection for any that clear the auto-memory threshold. Apply WHAT_NOT_TO_SAVE as normal.
 6. **Stop always-on services (`shutdown_skill`).** Read `shutdown_skill` from `.claude-code-hermit/config.json`. If non-null, invoke it as a skill command (the value may include arguments, e.g. `/serve stop`) via the Skill tool. **Best-effort:** on error or if the skill does not return, log a Monitoring line and continue to archival — never abort the close. Runs on both operator and `--auto` paths.
 7. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for completed tasks only — pending/in_progress tasks persist for next session.
-8. Archive the session via `scripts/session-archive.ts archive --mode=close` (full close — finalize SHELL.md and replace with fresh template in one operation).
-   Before invoking: read `session_id` from `.claude-code-hermit/state/runtime.json`. Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-cost.ts <session_id>` via Bash and parse the JSON output to get `cost_usd` and `tokens` for this session. If the script fails or returns zeros, omit the `Cost:` line (session-archive.ts falls back to `.status.json`).
+8. Archive the session via `scripts/session-archive.ts archive --mode=close` (full close — finalize SHELL.md and replace with fresh template in one operation). `session-archive.ts` derives cost itself from the cost-log window — no `Cost:` line to compute or pass.
    Pipe the following compact structured payload on stdin — keep it brief, no freeform prose:
    ```
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts archive --mode=close --state-dir=.claude-code-hermit <<'HERMIT_PAYLOAD'
@@ -92,7 +91,6 @@ This path is intentionally silent: no operator notification on queue or drain �
    Lessons: <one line each, or none>
    Changed: <file list, or none>
    Artifacts: <wikilinks to compiled/ outputs produced this session, or none>
-   Cost: $X.XXXX (N tokens)
    Closed Via: <operator|auto>
    Next Start Point: <one line>
    ## Plan

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -55,13 +55,11 @@ When the work is done, or the operator decides to move on (even if partial or bl
    - Task status is one of `completed` | `partial` | `blocked`
    - Changed files are identified
    - Blockers have enough context for a cold start
-   - Cost data recorded (if available)
 3. Create proposals for any high-leverage improvements discovered during work
 4. **Reflect (with debounce).** Read `state/reflection-state.json` for `last_reflection`. Only invoke the `claude-code-hermit:reflect` skill if `last_reflection` is null or older than 4 hours. For quick tasks (no tasks created, under 5 minutes), skip entirely — progress log is sufficient.
 4b. **Session-triggered scheduled checks.** For each `scheduled_checks` entry (from config already loaded) with `trigger: "session"` and `enabled: true`, invoke the skill. If a skill is unavailable or errors, skip it and continue — never block session finalization on a scheduled check failure. For each check that completed successfully, read-modify-write `state/reflection-state.json`: update only `scheduled_checks.<id>.last_run` to today's ISO date, preserving all other keys. Do not update `last_run` for failed checks.
 5. If native Tasks exist: call `TaskList`, format as a markdown table. Then `TaskUpdate(status=deleted)` for all tasks (idle = clean slate).
-6. Run `scripts/session-archive.ts` to perform an **idle transition** (finalize SHELL.md, archive report, reset task-scoped sections, set `session_state` to `idle`).
-   Before invoking: read `session_id` from `.claude-code-hermit/state/runtime.json`. Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-cost.ts <session_id>` via Bash and parse the JSON output to get `cost_usd` and `tokens` for this session. If the script fails or returns zeros, omit the `Cost:` line (session-archive.ts falls back to `.status.json`).
+6. Run `scripts/session-archive.ts` to perform an **idle transition** (finalize SHELL.md, archive report, reset task-scoped sections, set `session_state` to `idle`). It derives cost itself from the cost-log window — no `Cost:` line to compute or pass.
    Pipe the following compact structured payload on stdin — keep it brief, no freeform prose:
    ```
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts archive --mode=idle --state-dir=.claude-code-hermit <<'HERMIT_PAYLOAD'
@@ -69,7 +67,6 @@ When the work is done, or the operator decides to move on (even if partial or bl
    Blockers: <one line each, or none>
    Lessons: <one line each, or none>
    Changed: <file list, or none>
-   Cost: $X.XXXX (N tokens)
    ## Plan
    <task table, if native Tasks were created>
    HERMIT_PAYLOAD

--- a/plugins/claude-code-hermit/tests/session-archive.test.ts
+++ b/plugins/claude-code-hermit/tests/session-archive.test.ts
@@ -99,6 +99,14 @@ const BASIC_CLOSE_PAYLOAD =
   'Status: completed\nBlockers: none\nLessons: none\nChanged: none\nArtifacts: none\n' +
   'Cost: $0.4231 (152689 tokens)\nClosed Via: operator\nNext Start Point: pick up here\n';
 
+// Seeds .claude/cost-log.jsonl next to the hermit dir — costLogPath(hermit(dir))
+// resolves to path.join(dir, '.claude', 'cost-log.jsonl').
+function seedCostLog(dir: string, entries: Array<{ timestamp: string; estimated_cost_usd: number; total_tokens: number }>) {
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'cost-log.jsonl'), entries.map(e => JSON.stringify(e)).join('\n') + '\n');
+}
+
 // =============================================================================
 describe('durability', () => {
   test('open + archive leave no .tmp sibling anywhere under the hermit dir', withTmp(async (dir) => {
@@ -207,8 +215,12 @@ describe('S-NNN resolution', () => {
 });
 
 // =============================================================================
-describe('cost fallback chain', () => {
-  test('payload Cost line takes precedence', withTmp(async (dir) => {
+// Precedence: measured cost-log window (runtime.opened_at present) -> legacy
+// payload Cost line (window unmeasurable) -> 0/0. `.status.json` is a cumulative
+// running total and must NEVER be read for cost (that was the #615 bug: an
+// auto-closed 0-duration session got stamped with the hermit's lifetime spend).
+describe('cost precedence', () => {
+  test('payload Cost line used when no opened_at (window unmeasurable)', withTmp(async (dir) => {
     await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
     await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
     const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
@@ -216,20 +228,51 @@ describe('cost fallback chain', () => {
     expect(report).toContain('tokens: 152689');
   }));
 
-  test('falls back to .status.json when the payload has no Cost line', withTmp(async (dir) => {
+  test('never falls back to .status.json — records 0/0 when unmeasurable and no Cost payload (regression, #615)', withTmp(async (dir) => {
     await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
     fs.writeFileSync(path.join(sessionsDir(dir), '.status.json'), JSON.stringify({ cost_usd: 1.2345, tokens: 9999, operator_turns: 3 }));
     const payload = 'Status: completed\nBlockers: none\nLessons: none\nChanged: none\n';
     await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
     const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
-    expect(report).toContain('cost_usd: 1.2345');
-    expect(report).toContain('tokens: 9999');
+    expect(report).toContain('cost_usd: 0');
+    expect(report).toContain('tokens: 0');
+    // .status.json still sources operator_turns — that read is untouched.
     expect(report).toContain('operator_turns: 3');
   }));
 
-  test('falls back to 0.00/0 when neither payload nor .status.json have cost data', withTmp(async (dir) => {
+  test('falls back to 0.00/0 when neither payload nor cost-log window have cost data', withTmp(async (dir) => {
     await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
     const payload = 'Status: completed\nBlockers: none\nLessons: none\nChanged: none\n';
+    await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
+    const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
+    expect(report).toContain('cost_usd: 0');
+    expect(report).toContain('tokens: 0');
+  }));
+
+  test('auto-close records the measured cost-log window, not the inflated .status.json (regression, #615)', withTmp(async (dir) => {
+    await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    writeRuntime(dir, { ...readRuntime(dir), opened_at: '2026-07-09T12:00:00Z' });
+    seedCostLog(dir, [
+      { timestamp: '2026-07-09T12:30:00Z', estimated_cost_usd: 0.05, total_tokens: 500 },
+      { timestamp: '2026-07-09T12:45:00Z', estimated_cost_usd: 0.03, total_tokens: 300 },
+    ]);
+    fs.writeFileSync(path.join(sessionsDir(dir), '.status.json'), JSON.stringify({ cost_usd: 671.81, tokens: 1023435573 }));
+    // The real --auto payload template never carries a Cost: line.
+    const autoPayload = 'Status: completed\nBlockers: none\nLessons: none\nChanged: none\nArtifacts: none\nClosed Via: auto\nNext Start Point: Fresh start.\n';
+    await archive(dir, 'auto', autoPayload, '2026-07-09T13:00:00Z');
+    const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
+    expect(report).toContain('cost_usd: 0.08');
+    expect(report).toContain('tokens: 800');
+  }));
+
+  test('a genuine zero-cost window does not fall through to a stale payload Cost line', withTmp(async (dir) => {
+    await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    writeRuntime(dir, { ...readRuntime(dir), opened_at: '2026-07-09T12:00:00Z' });
+    // Rows exist, but entirely outside the [opened_at, now] window.
+    seedCostLog(dir, [
+      { timestamp: '2026-07-09T11:00:00Z', estimated_cost_usd: 5.00, total_tokens: 1000 },
+    ]);
+    const payload = 'Status: completed\nBlockers: none\nLessons: none\nChanged: none\nCost: $5.0000 (1000 tokens)\n';
     await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
     const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
     expect(report).toContain('cost_usd: 0');
@@ -406,6 +449,22 @@ describe('recovery matrix', () => {
     await recover(dir, '2026-07-09T13:00:00Z');
     const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
     expect(report).toBe('PRE-EXISTING, MUST NOT BE OVERWRITTEN');
+  }));
+
+  test('idle recovery reads cost from the already-written report, not a fresh window/`.status.json` (regression, #615)', withTmp(async (dir) => {
+    await open(dir, 'Task: crashed after report\n', '2026-07-09T12:00:00Z');
+    fs.writeFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'),
+      '---\nid: S-001\ncost_usd: 0.55\ntokens: 12345\n---\n\n# Session Report: S-001\n');
+    // An inflated .status.json must not leak in via a re-derived cost.
+    fs.writeFileSync(path.join(sessionsDir(dir), '.status.json'), JSON.stringify({ cost_usd: 671.81, tokens: 1023435573 }));
+    writeRuntime(dir, {
+      session_state: 'in_progress', session_id: 'S-001',
+      transition: 'archiving', transition_mode: 'idle', transition_target: 'S-001-REPORT.md',
+    });
+    await recover(dir, '2026-07-09T13:00:00Z');
+    const shell = readShell(dir);
+    expect(shell).toContain('($0.55)');
+    expect(shell).not.toContain('($671.81)');
   }));
 
   test('cleaning -> skips straight to SHELL reset', withTmp(async (dir) => {

--- a/plugins/claude-code-hermit/tests/session-archive.test.ts
+++ b/plugins/claude-code-hermit/tests/session-archive.test.ts
@@ -222,6 +222,10 @@ describe('S-NNN resolution', () => {
 describe('cost precedence', () => {
   test('payload Cost line used when no opened_at (window unmeasurable)', withTmp(async (dir) => {
     await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    // Simulate a session opened by pre-rollout code: runtime carries no arc bounds,
+    // so the window is unmeasurable and the legacy Cost: line is the only source.
+    const { opened_at, closed_at, ...legacyRuntime } = readRuntime(dir);
+    writeRuntime(dir, legacyRuntime);
     await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
     const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
     expect(report).toContain('cost_usd: 0.4231');
@@ -263,6 +267,35 @@ describe('cost precedence', () => {
     const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
     expect(report).toContain('cost_usd: 0.08');
     expect(report).toContain('tokens: 800');
+  }));
+
+  test('a session archived before its first tracked turn does not inherit the previous arc', withTmp(async (dir) => {
+    // Previous arc [10:00, 11:00] cost $9; this session opens at 12:00 and is
+    // auto-closed before cost-tracker stamps a new arc. Without `open` resetting
+    // opened_at/closed_at, the report would measure the previous window.
+    writeRuntime(dir, { session_state: 'idle', opened_at: '2026-07-09T10:00:00Z', closed_at: '2026-07-09T11:00:00Z' });
+    seedCostLog(dir, [
+      { timestamp: '2026-07-09T10:30:00Z', estimated_cost_usd: 9.0, total_tokens: 90000 },
+      { timestamp: '2026-07-09T12:30:00Z', estimated_cost_usd: 0.02, total_tokens: 200 },
+    ]);
+    await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    const autoPayload = 'Status: completed\nBlockers: none\nLessons: none\nChanged: none\nClosed Via: auto\nNext Start Point: Fresh start.\n';
+    await archive(dir, 'auto', autoPayload, '2026-07-09T13:00:00Z');
+    const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
+    expect(report).toContain('cost_usd: 0.02');
+    expect(report).toContain('tokens: 200');
+  }));
+
+  test('a stale closed_at at/before opened_at is dropped, not measured as an inverted window', withTmp(async (dir) => {
+    await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    // closed_at predates opened_at — [12:00, 11:00] would sum to a silent zero.
+    writeRuntime(dir, { ...readRuntime(dir), opened_at: '2026-07-09T12:00:00Z', closed_at: '2026-07-09T11:00:00Z' });
+    seedCostLog(dir, [{ timestamp: '2026-07-09T12:30:00Z', estimated_cost_usd: 0.07, total_tokens: 700 }]);
+    const payload = 'Status: completed\nBlockers: none\nLessons: none\nChanged: none\n';
+    await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
+    const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
+    expect(report).toContain('cost_usd: 0.07');
+    expect(report).toContain('tokens: 700');
   }));
 
   test('a genuine zero-cost window does not fall through to a stale payload Cost line', withTmp(async (dir) => {
@@ -312,6 +345,8 @@ describe('shutdown_completed_at guard', () => {
 describe('idle vs. close reset semantics', () => {
   test('idle reset preserves SHELL.md, clears task-scoped sections, increments Tasks Completed', withTmp(async (dir) => {
     await open(dir, 'Task: first task\n', '2026-07-09T12:00:00Z');
+    // Cost reaches the summary line via the measured window, so seed one.
+    seedCostLog(dir, [{ timestamp: '2026-07-09T12:30:00Z', estimated_cost_usd: 0.4231, total_tokens: 152689 }]);
     await archive(dir, 'idle', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
     const shell = readShell(dir);
     expect(shell).toContain('**Tasks Completed:** 1');

--- a/plugins/claude-code-hermit/tests/skill-correction-ledger.test.ts
+++ b/plugins/claude-code-hermit/tests/skill-correction-ledger.test.ts
@@ -16,6 +16,12 @@ import { runScript, PLUGIN_ROOT } from './helpers/run';
 
 const read = (...p: string[]) => fs.readFileSync(path.join(PLUGIN_ROOT, ...p), 'utf-8');
 
+// Ledger rows must be dated relative to now, not pinned to a literal date:
+// prune-observations.ts enforces a 30-day retention window, so a hardcoded
+// timestamp silently flips the "both rows are fresh" prune assertion from pass
+// to fail once the wall clock passes it.
+const hoursAgoISO = (h: number) => new Date(Date.now() - h * 3600000).toISOString();
+
 const sessionClose = read('skills', 'session-close', 'SKILL.md');
 // reflect's skill-correction routing detail lives in branches.md (the
 // rare-branch procedures file); assert against the combined surface.
@@ -77,7 +83,7 @@ describe('append-metrics: skill-correction row round-trip', () => {
 
   test('append-metrics: skill-correction row appended and parseable', async () => {
     const row = JSON.stringify({
-      ts: '2026-06-19T11:00:00+01:00',
+      ts: hoursAgoISO(2),
       pattern: 'skill-correction:my-skill',
       session_id: 'S-001',
       source: 'skill-correction',
@@ -98,7 +104,7 @@ describe('append-metrics: skill-correction row round-trip', () => {
   test('append-metrics: two distinct-session rows group by pattern in prune', async () => {
     // append a second session row for the same pattern
     const row2 = JSON.stringify({
-      ts: '2026-06-19T12:00:00+01:00',
+      ts: hoursAgoISO(1),
       pattern: 'skill-correction:my-skill',
       session_id: 'S-002',
       source: 'skill-correction',


### PR DESCRIPTION
## Summary
Auto-closed 0-duration sessions were being stamped with the hermit's cumulative lifetime cost (`sessions/.status.json` is a running total, not a per-session value), inflating `cost_usd`/`tokens` by orders of magnitude and poisoning `weekly-review`'s weekly total sent to the operator. `session-archive.ts` now derives cost itself from the cost-log window (`runtime.json`'s `opened_at`/`closed_at`), on every archive path, instead of relying on a fragile model-run `session-cost.ts` + payload handoff that silently fell back to the cumulative total whenever it was skipped or returned zero.

## Changes
- New `scripts/lib/session-cost.ts` — shared `computeSessionCost()` window algorithm, extracted from `session-cost.ts`. Returns `available: false` only when `opened_at` itself is missing/unparseable — a genuine zero-cost window is `available: true` with `cost_usd: 0`, so it never falls through to a stale fallback.
- `scripts/session-cost.ts` — reduced to a thin CLI wrapper over the shared lib (diagnostics behavior unchanged).
- `scripts/session-archive.ts` — `resolveCost` precedence is now measured cost-log window → legacy `Cost:` payload line (kept for rollout back-compat) → 0/0. `sessions/.status.json` is never consulted for cost (still sources `operator_turns`, untouched). `verbArchive` threads `opened_at`/`closed_at` from `runtime.json` into the report build. `verbRecover`'s idle-crash-recovery branch now reads cost from the already-written report frontmatter instead of recomputing.
- `skills/session-close/SKILL.md`, `skills/session/SKILL.md` — removed the `Cost:` payload line and the "run session-cost.ts and parse it" instruction; cost is now computed deterministically by the script, not orchestrated by the model.
- Tests: reworked the `.status.json`-fallback assertion to expect 0/0, added regression cases for the auto-close inflation scenario, a genuine-zero-window case, and idle-crash-recovery reading cost from the written report.

## Test plan
- `bun test` (plugins/claude-code-hermit): 2518 pass, 1 pre-existing unrelated failure (`skill-correction-ledger.test.ts`, a date-relative fixture unaffected by this change).
- `bunx tsc --noEmit`: clean.
- Grep sweep confirms no leftover `session-cost.ts`/`Cost: $X` orchestration prose in session skills.

Closes #615.