### PR TITLE
fix(feed-hermit): route channel delivery through core's Operator Notification protocol

### DIFF
--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -11,9 +11,5 @@ All notable changes to this project will be documented in this file.
 - **`fetch-guard` PreToolUse hook** — WebFetch domain allowlist derived from `feed-sources.md` plus an infra list; blocks off-allowlist fetches (fail-open on unreadable registry) as prompt-injection containment.
 - **`hatch`** — seeds empty `feed-sources.md`/`feed-categories.md`/`FEEDS.md` (opt-in starter pack), registers morning/evening/weekly routines and a monthly `source-scout` scheduled check, and appends the Feed Workflow block to the consumer's `CLAUDE.md`.
 
-### Fixed
-- **feed-brief/weekly-digest/deep-dive: route channel delivery through core's Operator Notification protocol** — the skills invoked core's channel-resolver script via the feed-hermit plugin root, where it doesn't exist, so scheduled/proactive delivery silently degraded to `pending-delivery.md` every time.
-- **compiled-state paths: normalize to `.claude-code-hermit/compiled/`** — bare `compiled/` paths resolved outside the hermit dir, invisible to core's retention/injection logic.
-
 ### Upgrade Instructions
 No manual steps. New plugin — run `/feed-hermit:hatch` in a project that already has the core hermit hatched.

--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -11,5 +11,9 @@ All notable changes to this project will be documented in this file.
 - **`fetch-guard` PreToolUse hook** — WebFetch domain allowlist derived from `feed-sources.md` plus an infra list; blocks off-allowlist fetches (fail-open on unreadable registry) as prompt-injection containment.
 - **`hatch`** — seeds empty `feed-sources.md`/`feed-categories.md`/`FEEDS.md` (opt-in starter pack), registers morning/evening/weekly routines and a monthly `source-scout` scheduled check, and appends the Feed Workflow block to the consumer's `CLAUDE.md`.
 
+### Fixed
+- **feed-brief/weekly-digest/deep-dive: route channel delivery through core's Operator Notification protocol** — the skills invoked core's channel-resolver script via the feed-hermit plugin root, where it doesn't exist, so scheduled/proactive delivery silently degraded to `pending-delivery.md` every time.
+- **compiled-state paths: normalize to `.claude-code-hermit/compiled/`** — bare `compiled/` paths resolved outside the hermit dir, invisible to core's retention/injection logic.
+
 ### Upgrade Instructions
 No manual steps. New plugin — run `/feed-hermit:hatch` in a project that already has the core hermit hatched.

--- a/plugins/feed-hermit/CLAUDE.md
+++ b/plugins/feed-hermit/CLAUDE.md
@@ -37,7 +37,7 @@ After install, run `/feed-hermit:hatch` in the target project. The core hermit (
 
 ## Data ownership
 
-- **Plugin owns:** `.claude-code-hermit/briefs/` archive (daily + `weekly/`), `compiled/story-arcs-*.md`, `compiled/pending-delivery.md`, `compiled/brief-feedback-YYYY-MM.md`, `compiled/brief-summary-last-*.md`, `compiled/source-candidates-*.md`, `state/brief-message-registry.json`, and `tmp/` fetch scratch (3-day retention; hatch adds `tmp/` to the consumer `.gitignore`).
+- **Plugin owns:** `.claude-code-hermit/briefs/` archive (daily + `weekly/`), `.claude-code-hermit/compiled/story-arcs-*.md`, `.claude-code-hermit/compiled/pending-delivery.md`, `.claude-code-hermit/compiled/brief-feedback-YYYY-MM.md`, `.claude-code-hermit/compiled/brief-summary-last-*.md`, `.claude-code-hermit/compiled/source-candidates-*.md`, `state/brief-message-registry.json`, and `tmp/` fetch scratch (3-day retention; hatch adds `tmp/` to the consumer `.gitignore`).
 - **Operator owns:** `feed-sources.md`, `feed-categories.md`, `FEEDS.md` at the project root — plugin-validated, never overwritten by hatch once present.
 
 The two data contracts (registry table + archive frontmatter) are documented verbatim in `docs/schema.md`; treat them as the product's spine and do not drift them. The `sources_skipped` (fetch failed) vs `sources_quiet` (returned clean, 0 items) distinction powers `source-health` — never collapse the two.

--- a/plugins/feed-hermit/docs/schema.md
+++ b/plugins/feed-hermit/docs/schema.md
@@ -195,7 +195,7 @@ Full contract lives in `agents/source-fetcher.md`.
 
 ## 6. brief-feedback
 
-Monthly reaction log at `compiled/brief-feedback-YYYY-MM.md`. One line per reaction event:
+Monthly reaction log at `.claude-code-hermit/compiled/brief-feedback-YYYY-MM.md`. One line per reaction event:
 
 ```
 2026-01-15 morning | 👍 | source: Example Blog | topic: example-topic-slug
@@ -233,7 +233,7 @@ give every part's message ID the same metadata.
 
 ## 8. pending-delivery
 
-`compiled/pending-delivery.md` — a singleton holding a brief whose send failed, so it can be
+`.claude-code-hermit/compiled/pending-delivery.md` — a singleton holding a brief whose send failed, so it can be
 delivered on the operator's next inbound message. Overwritten on each failure; cleared once
 delivered.
 
@@ -253,7 +253,7 @@ Frontmatter keys: `title, type, created, brief_path`.
 
 ## 9. brief-summary
 
-`compiled/brief-summary-last-<date>.md` — a compact one-line summary of the last
+`.claude-code-hermit/compiled/brief-summary-last-<date>.md` — a compact one-line summary of the last
 delivered brief, injected at every session start. Accumulates; the newest is chosen for injection.
 
 ```yaml

--- a/plugins/feed-hermit/skills/deep-dive/SKILL.md
+++ b/plugins/feed-hermit/skills/deep-dive/SKILL.md
@@ -56,9 +56,8 @@ The argument is the slug from the brief CTA (e.g., `local-first-sync`, `apex-one
    Omit sections where data is unavailable rather than filling with unknowns. Keep it tight — a quick
    reference, not a full report.
 
-4. **Deliver via channel.** Use the core channel-resolution protocol: run
-   `bun ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-outbound-channel.ts .claude-code-hermit`, parse stdout JSON,
-   then call `mcp__plugin_<id>_<id>__reply` with `{ chat_id, text }`.
+4. **Deliver via channel.** Use the Operator Notification protocol in CLAUDE.md § Operator Notification
+   (core resolves the channel and falls back to push / SHELL.md logging when no channel is reachable). `text` is the analysis from step 3.
 
 5. **Fallback.** If the slug matches nothing in recent briefs and web research returns nothing useful, reply:
    "Couldn't find enough on `<slug>` to write a useful analysis — the item may have been in an older brief.

--- a/plugins/feed-hermit/skills/deep-dive/SKILL.md
+++ b/plugins/feed-hermit/skills/deep-dive/SKILL.md
@@ -57,7 +57,9 @@ The argument is the slug from the brief CTA (e.g., `local-first-sync`, `apex-one
    reference, not a full report.
 
 4. **Deliver via channel.** Use the Operator Notification protocol in CLAUDE.md § Operator Notification
-   (core resolves the channel and falls back to push / SHELL.md logging when no channel is reachable). `text` is the analysis from step 3.
+   (core resolves the channel and falls back to push when no channel is reachable). `text` is the analysis
+   from step 3. For the push-fallback branch, condense to a single line (≤200 chars, no markdown): the
+   one-sentence verdict on `<slug>`, then `open CC to read the full analysis`.
 
 5. **Fallback.** If the slug matches nothing in recent briefs and web research returns nothing useful, reply:
    "Couldn't find enough on `<slug>` to write a useful analysis — the item may have been in an older brief.

--- a/plugins/feed-hermit/skills/feed-brief/SKILL.md
+++ b/plugins/feed-hermit/skills/feed-brief/SKILL.md
@@ -35,7 +35,8 @@ Dispatch the `@feed-hermit:source-fetcher` subagent (model: haiku) to fetch all 
 sources from `feed-sources.md`. Pass the full source list (URLs + names) and the resolved `<slot>`.
 
 **Output-path contract:** the agent writes its extracted items to `tmp/feed-source-items-<slot>.json`
-in the project root (never `/tmp/`). Each item: `{title, summary, url, source, date}`. No scoring —
+in the project root (never `/tmp/`). Items are nested under `sources[]`, each item:
+`{title, summary, url, published_at, source, section, author}`. No scoring —
 extraction only. After the agent returns, read that file for the collected items.
 
 ### Phase 2 — Chrome, reddit, and X sources
@@ -77,7 +78,7 @@ a. **Score and filter.** Apply the internal scoring in `FEEDS.md`. Deduplicate a
    Filter aggressively — penalize recycled discourse, reward concrete changes and primary sources.
 
 b. **Story-arc cross-reference** — run only if `config.feed.enrichments.story_arcs === true`.
-   Glob `compiled/story-arcs-*.md` and read the most recent (newest filename date suffix wins). Read arcs
+   Glob `.claude-code-hermit/compiled/story-arcs-*.md` and read the most recent (newest filename date suffix wins). Read arcs
    under `## Active` only — extract each arc's name, approximate start date (from the `started:`
    parenthetical), and Watch-clause keywords. For each surviving item, check case-insensitive substring
    overlap between the item's title/summary and any arc's name tokens, context prose, or Watch terms.
@@ -106,9 +107,9 @@ Write the brief per `FEEDS.md` philosophy, tone, and format. Apply the slot's or
 
 ### Phase 5 — Deliver
 
-Deliver via the core channel-resolution protocol:
-1. Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-outbound-channel.ts .claude-code-hermit` and parse stdout JSON.
-2. On success (`id`/`chat_id` present) call `mcp__plugin_<id>_<id>__reply` with `{ chat_id, text }` where `text` is the brief.
+Deliver via the Operator Notification protocol in CLAUDE.md § Operator Notification (core resolves the
+channel and falls back to push / SHELL.md logging when no channel is reachable). On success, `text` is
+the brief.
 
 **On delivery failure** (resolve miss, partial channel object, send error) write the full brief to
 `.claude-code-hermit/compiled/pending-delivery.md` for delivery on the operator's next inbound message:

--- a/plugins/feed-hermit/skills/feed-brief/SKILL.md
+++ b/plugins/feed-hermit/skills/feed-brief/SKILL.md
@@ -108,10 +108,13 @@ Write the brief per `FEEDS.md` philosophy, tone, and format. Apply the slot's or
 ### Phase 5 — Deliver
 
 Deliver via the Operator Notification protocol in CLAUDE.md § Operator Notification (core resolves the
-channel and falls back to push / SHELL.md logging when no channel is reachable). On success, `text` is
-the brief.
+channel and falls back to push when no channel is reachable). On success, `text` is the brief.
+For the push-fallback branch, condense to a single line (≤200 chars, no markdown): lead with the top P1
+item, then the item count. Example: `Anthropic ships Opus 4.8, 6 more items — open CC to read`.
 
-**On delivery failure** (resolve miss, partial channel object, send error) write the full brief to
+**On delivery failure** (resolve miss, partial channel object, send error) this skill's queue supersedes
+the protocol's SHELL.md-logging branch — do not log the brief to SHELL.md Findings and do not record a
+`channel-send-unavailable` issue. Instead write the full brief to
 `.claude-code-hermit/compiled/pending-delivery.md` for delivery on the operator's next inbound message:
 ```yaml
 ---

--- a/plugins/feed-hermit/skills/hatch/SKILL.md
+++ b/plugins/feed-hermit/skills/hatch/SKILL.md
@@ -192,9 +192,9 @@ Read `.claude-code-hermit/knowledge-schema.md`. If the string `brief-summary:` i
 ```
 - brief: a delivered morning/evening brief. Triggered by feed-brief-morning/evening routines. location: briefs/YYYY-MM-DD-<slot>.md
 - weekly-brief: weekly synthesis over the week's briefs. Triggered by weekly-digest routine. location: briefs/weekly/YYYY-WNN.md
-- brief-summary: one-line last-brief summary injected at session start. Triggered by feed-brief. location: .claude-code-hermit/compiled/brief-summary-last-<YYYY-MM-DD>.md
-- story-arcs: developing-story tracker. Triggered by story-arcs skill. location: .claude-code-hermit/compiled/story-arcs-<slug>.md
-- pending-delivery: queued brief awaiting redelivery. Triggered by feed-brief on send failure. location: .claude-code-hermit/compiled/pending-delivery.md
+- brief-summary: one-line last-brief summary injected at session start. Triggered by feed-brief. location: compiled/brief-summary-last-<YYYY-MM-DD>.md
+- story-arcs: developing-story tracker. Triggered by story-arcs skill. location: compiled/story-arcs-<YYYY-MM-DD>.md
+- pending-delivery: queued brief awaiting redelivery. Triggered by feed-brief on send failure. location: compiled/pending-delivery.md
 ```
 
 And under `## Raw Captures` (create if absent):

--- a/plugins/feed-hermit/skills/hatch/SKILL.md
+++ b/plugins/feed-hermit/skills/hatch/SKILL.md
@@ -192,9 +192,9 @@ Read `.claude-code-hermit/knowledge-schema.md`. If the string `brief-summary:` i
 ```
 - brief: a delivered morning/evening brief. Triggered by feed-brief-morning/evening routines. location: briefs/YYYY-MM-DD-<slot>.md
 - weekly-brief: weekly synthesis over the week's briefs. Triggered by weekly-digest routine. location: briefs/weekly/YYYY-WNN.md
-- brief-summary: one-line last-brief summary injected at session start. Triggered by feed-brief. location: compiled/brief-summary-last-<YYYY-MM-DD>.md
-- story-arcs: developing-story tracker. Triggered by story-arcs skill. location: compiled/story-arcs-<slug>.md
-- pending-delivery: queued brief awaiting redelivery. Triggered by feed-brief on send failure. location: compiled/pending-delivery.md
+- brief-summary: one-line last-brief summary injected at session start. Triggered by feed-brief. location: .claude-code-hermit/compiled/brief-summary-last-<YYYY-MM-DD>.md
+- story-arcs: developing-story tracker. Triggered by story-arcs skill. location: .claude-code-hermit/compiled/story-arcs-<slug>.md
+- pending-delivery: queued brief awaiting redelivery. Triggered by feed-brief on send failure. location: .claude-code-hermit/compiled/pending-delivery.md
 ```
 
 And under `## Raw Captures` (create if absent):
@@ -230,7 +230,7 @@ Next steps:
   - Optional reddit auth: see docs/reddit.md (works unauthenticated by default).
 
 Suggested HEARTBEAT check (add to HEARTBEAT.md if you run heartbeats):
-  - If compiled/pending-delivery.md exists and is older than 30 min, a brief failed to deliver — retry or alert.
+  - If .claude-code-hermit/compiled/pending-delivery.md exists and is older than 30 min, a brief failed to deliver — retry or alert.
 
 Go always-on (recommended):
   - Docker:     /claude-code-hermit:docker-setup

--- a/plugins/feed-hermit/skills/source-scout/SKILL.md
+++ b/plugins/feed-hermit/skills/source-scout/SKILL.md
@@ -26,7 +26,7 @@ Proactively discover and add new RSS/web sources to `feed-sources.md`. Complemen
 1. **Read current state** (in parallel):
    - `feed-sources.md` — extract active source names, URLs, categories. Count sources per category.
    - `feed-categories.md` — all P1/P2 categories and their priorities.
-   - Glob `compiled/story-arcs-*.md`, read the most recent. Extract Watch-clause keywords from each active arc under `## Active`.
+   - Glob `.claude-code-hermit/compiled/story-arcs-*.md`, read the most recent. Extract Watch-clause keywords from each active arc under `## Active`.
 
 2. **Identify gaps:**
    - Any P1 or P2 category with fewer than 3 active sources is a **gap category**.
@@ -62,7 +62,7 @@ Proactively discover and add new RSS/web sources to `feed-sources.md`. Complemen
    URL, the gap it addresses, and a one-line "why this looked promising" note.
 
    **`--scheduled` only:** notify the operator per CLAUDE.md § Operator Notification with a one-line summary
-   ("N unverified source candidate(s) found — see compiled/source-candidates-<date>.md"). Don't queue a
+   ("N unverified source candidate(s) found — see .claude-code-hermit/compiled/source-candidates-<date>.md"). Don't queue a
    micro-approval: verification requires an interactive WebFetch only the operator can trigger. The operator
    reviews the file and, for any candidate they want, runs `/source-scout` interactively (or edits
    `feed-sources.md` manually) so verification happens with them present.

--- a/plugins/feed-hermit/skills/story-arcs/SKILL.md
+++ b/plugins/feed-hermit/skills/story-arcs/SKILL.md
@@ -2,7 +2,7 @@
 name: story-arcs
 description: >-
   Manage developing story arcs tracked across briefs — add, resolve, and list active
-  arcs in .claude-code-hermit/compiled/story-arcs-*.md. Arc Watch keywords drive the feed-brief arc-tagging
+  arcs in compiled/story-arcs-*.md. Arc Watch keywords drive the feed-brief arc-tagging
   enrichment. Invoke with /feed-hermit:story-arcs add|resolve|list.
 ---
 

--- a/plugins/feed-hermit/skills/story-arcs/SKILL.md
+++ b/plugins/feed-hermit/skills/story-arcs/SKILL.md
@@ -2,7 +2,7 @@
 name: story-arcs
 description: >-
   Manage developing story arcs tracked across briefs — add, resolve, and list active
-  arcs in compiled/story-arcs-*.md. Arc Watch keywords drive the feed-brief arc-tagging
+  arcs in .claude-code-hermit/compiled/story-arcs-*.md. Arc Watch keywords drive the feed-brief arc-tagging
   enrichment. Invoke with /feed-hermit:story-arcs add|resolve|list.
 ---
 
@@ -22,8 +22,8 @@ Manage the developing-story-arcs file that feeds the `feed-brief` arc-tagging en
 
 ### 1. Find the active arcs file
 
-Glob `compiled/story-arcs-*.md`. Sort by filename date suffix descending (newest first). Read the most
-recent. If none exists, create `compiled/story-arcs-<today>.md` with the standard template
+Glob `.claude-code-hermit/compiled/story-arcs-*.md`. Sort by filename date suffix descending (newest first). Read the most
+recent. If none exists, create `.claude-code-hermit/compiled/story-arcs-<today>.md` with the standard template
 (frontmatter + `## Active` + `## Recently Resolved` sections).
 
 ### 2. Execute subcommand

--- a/plugins/feed-hermit/skills/weekly-digest/SKILL.md
+++ b/plugins/feed-hermit/skills/weekly-digest/SKILL.md
@@ -62,9 +62,8 @@ Produce a weekly synthesis from the archived brief notes. All data comes from
 
    Tone: slightly more reflective than an evening brief. One paragraph of narrative before the lists is fine.
 
-5. **Deliver** via the core channel-resolution protocol:
-   - Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-outbound-channel.ts .claude-code-hermit`, parse stdout JSON.
-   - On success call `mcp__plugin_<id>_<id>__reply` with `{ chat_id, text }`.
+5. **Deliver** via the Operator Notification protocol in CLAUDE.md § Operator Notification (core resolves
+   the channel and falls back to push / SHELL.md logging when no channel is reachable). `text` is the digest from step 4.
    - On resolve miss or send failure, write the digest to `.claude-code-hermit/compiled/pending-delivery.md` (frontmatter `title`, `type: pending-delivery`, `created`, `brief_path` pointing at the weekly archive path). Do not retry.
 
 6. **Archive** to `.claude-code-hermit/briefs/weekly/YYYY-WNN.md` (create the directory if absent).
@@ -83,7 +82,7 @@ Produce a weekly synthesis from the archived brief notes. All data comes from
    ---
    ```
 
-7. **Reaction-feedback aggregation.** Glob `compiled/brief-feedback-*.md`.
+7. **Reaction-feedback aggregation.** Glob `.claude-code-hermit/compiled/brief-feedback-*.md`.
    **If no such files exist, SKIP this step silently** — the reaction-feedback producer is a channel-layer
    concern not shipped with this plugin, so its absence is expected, not an error. When logs do exist:
    - Read the two most recent files (current + previous month if both exist).

--- a/plugins/feed-hermit/skills/weekly-digest/SKILL.md
+++ b/plugins/feed-hermit/skills/weekly-digest/SKILL.md
@@ -63,8 +63,10 @@ Produce a weekly synthesis from the archived brief notes. All data comes from
    Tone: slightly more reflective than an evening brief. One paragraph of narrative before the lists is fine.
 
 5. **Deliver** via the Operator Notification protocol in CLAUDE.md § Operator Notification (core resolves
-   the channel and falls back to push / SHELL.md logging when no channel is reachable). `text` is the digest from step 4.
-   - On resolve miss or send failure, write the digest to `.claude-code-hermit/compiled/pending-delivery.md` (frontmatter `title`, `type: pending-delivery`, `created`, `brief_path` pointing at the weekly archive path). Do not retry.
+   the channel and falls back to push when no channel is reachable). `text` is the digest from step 4.
+   - For the push-fallback branch, condense to a single line (≤200 chars, no markdown): lead with the week's
+     dominant theme, then the brief count. Example: `Quiet week on AI infra, 12 briefs — open CC to read`.
+   - On resolve miss or send failure, write the digest to `.claude-code-hermit/compiled/pending-delivery.md` (frontmatter `title`, `type: pending-delivery`, `created`, `brief_path` pointing at the weekly archive path). Do not retry. This queue supersedes the protocol's SHELL.md-logging branch — don't also log the digest to SHELL.md Findings or record a `channel-send-unavailable` issue.
 
 6. **Archive** to `.claude-code-hermit/briefs/weekly/YYYY-WNN.md` (create the directory if absent).
    Use the ISO week number (e.g. `2026-W15`). Use actual counts from steps 1–3, not placeholders:

--- a/plugins/feed-hermit/state-templates/compiled/routine-feed-brief-evening.md
+++ b/plugins/feed-hermit/state-templates/compiled/routine-feed-brief-evening.md
@@ -16,5 +16,5 @@ Produce and deliver the evening brief.
 ## Steps
 
 1. Invoke `/feed-hermit:feed-brief --evening`.
-2. The skill owns the full 7-phase pipeline and delivers via the configured channel; on send failure it queues to `compiled/pending-delivery.md`.
+2. The skill owns the full 7-phase pipeline and delivers via the configured channel; on send failure it queues to `.claude-code-hermit/compiled/pending-delivery.md`.
 3. Close session idle when the brief is delivered or queued.

--- a/plugins/feed-hermit/state-templates/compiled/routine-feed-brief-morning.md
+++ b/plugins/feed-hermit/state-templates/compiled/routine-feed-brief-morning.md
@@ -16,5 +16,5 @@ Produce and deliver the morning brief.
 ## Steps
 
 1. Invoke `/feed-hermit:feed-brief --morning`.
-2. The skill owns the full 7-phase pipeline (fetch → score → write → deliver → archive → summary) and delivers via the configured channel. If no channel is configured, it queues to `compiled/pending-delivery.md`.
+2. The skill owns the full 7-phase pipeline (fetch → score → write → deliver → archive → summary) and delivers via the configured channel. If no channel is configured, it queues to `.claude-code-hermit/compiled/pending-delivery.md`.
 3. Close session idle when the brief is delivered or queued.


### PR DESCRIPTION
## Summary
feed-brief, weekly-digest, and deep-dive invoked core's `resolve-outbound-channel.ts` via `${CLAUDE_PLUGIN_ROOT}`, which resolves to feed-hermit's own plugin root — the script only exists in core's `scripts/`, so the resolve step errored and scheduled/proactive delivery silently degraded to `pending-delivery.md` every time. Swaps to the channel-agnostic "notify per CLAUDE.md § Operator Notification" convention the HA and fitness domain plugins already use correctly, restoring actual channel delivery.

## Changes
- **feed-brief/weekly-digest/deep-dive**: replaced the broken direct script invocation with the Operator Notification protocol convention, matching the wording of the working `ha-morning-brief`/`ha-evening-brief` sibling skills.
- **Path normalization**: bare `compiled/` references (in `docs/schema.md`, `hatch/SKILL.md`, `story-arcs`, `source-scout`, `weekly-digest`, feed-hermit's own `CLAUDE.md`, and the two routine prompt templates) normalized to `.claude-code-hermit/compiled/` — the bare form resolved outside the hermit dir, invisible to core's retention/injection logic.
- **feed-brief item schema**: corrected the documented source-fetcher output-path contract (`published_at`/`section`/`author` under a nested `sources[]`, replacing a stale flat `date` shorthand) to match what the agent and `docs/schema.md` actually specify.

Closes #622

## Test plan
- `cd plugins/feed-hermit && bun test` — 52 pass, 0 fail.
- `bunx tsc --noEmit` from repo root — clean (docs-only change, no `.ts` files touched).
- `grep -rn "resolve-outbound-channel" plugins/feed-hermit/` — empty.
- `grep -rn "compiled/" plugins/feed-hermit/skills plugins/feed-hermit/docs/schema.md | grep -v ".claude-code-hermit/compiled/"` — empty except the intentionally-untouched `config.json.routines[].prompt_file` values in `hatch/SKILL.md`, which are a distinct config-key convention resolved relative to `.claude-code-hermit/`, not prose paths.