### PR TITLE
fix(feed-hermit): register brief archive for drift checks

### DIFF
--- a/plugins/claude-code-hermit/docs/plugin-hermit-storage.md
+++ b/plugins/claude-code-hermit/docs/plugin-hermit-storage.md
@@ -1,19 +1,21 @@
 # Plugin Hermit Storage Convention
 
-Plugin hermits must store all domain artifacts in exactly two directories:
+Plugin hermits store session-facing domain artifacts in exactly two directories:
 
 - `.claude-code-hermit/raw/` — ephemeral inputs (fetched content, snapshots, logs, API dumps).
 - `.claude-code-hermit/compiled/` — durable outputs (briefings, digests, assessments, audit results).
 
-Everything else is infra managed by the base hermit (`state/`, `sessions/`, `proposals/`, `templates/`, operator-curated docs). Domain plugins must not add top-level directories for knowledge artifacts — the one exception is a hermit-owned runtime directory declared in `config.storage_drift.ignore` (see below).
+Everything else is infra managed by the base hermit (`state/`, `sessions/`, `proposals/`, `templates/`, operator-curated docs). Domain plugins must not add top-level directories for knowledge artifacts unless the directory is an intentional plugin-owned archive with its own documented lifecycle. Plugin-owned archives and runtime directories must be declared in `config.storage_drift.ignore` (see below).
 
 ## Why these two and nothing else
 
 The `compiled/` directory is scanned at session start to inject foundational context. `scripts/archive-raw.ts` and the weekly review run retention against `raw/`, covering both dated `.md` and `.json` artifacts. Fixed-name `-latest.*` aliases are never archived. Anything outside these two paths is invisible to both mechanisms — your audits won't surface at session start, and your snapshots will never be archived.
 
-## Runtime dirs (`storage_drift.ignore`)
+## Intentional plugin-owned dirs (`storage_drift.ignore`)
 
 Some domain plugins install a hermit-owned runtime tree that is **not** a knowledge artifact — for example, `laravel-forge-hermit` puts a Composer vendor tree at `.claude-code-hermit/forge-runtime/`. The same applies to a downstream agent that overrides a core plugin script (e.g. keeping a project-specific `hermit-start.ts` wrapper at `.claude-code-hermit/scripts/`) — it's live code, not an artifact, and must not be moved into `raw/` or `compiled/`. These dirs are legitimate, so the storage-drift check must not flag them.
+
+A domain plugin may also own an archive that is intentionally outside core's context injection and rotation. The declaring plugin owns the archive's readers, format, and retention policy, and exposes any session-facing projection through `compiled/`. Allowlisting the archive suppresses false remediation but does not make core inject or rotate it.
 
 Declare such dirs in `config.json`:
 
@@ -25,15 +27,16 @@ Declare such dirs in `config.json`:
 
 The entry must be the **bare directory name** (`"forge-runtime"`, `"scripts"`), not a path (`".claude-code-hermit/scripts/"` or `"scripts/"`) — the check matches against `entry.name` from a directory listing, so a path-form entry silently fails to match and the drift warning keeps recurring.
 
-When a domain plugin calls hatch, its Step 8 (config.json rewrite) appends its runtime dir name to `storage_drift.ignore` idempotently. The drift check (`scripts/lib/drift.ts`) reads this list at runtime and skips declared dirs — in both the session-start Storage Drift block and the reflect observations ledger.
+When a domain plugin calls hatch, its config rewrite appends each intentional directory name to `storage_drift.ignore` idempotently. The drift check (`scripts/lib/drift.ts`) reads this list at runtime and skips declared dirs — in both the session-start Storage Drift block and the reflect observations ledger.
 
-Rules for a compliant runtime dir:
+Rules for a compliant plugin-owned dir:
 - One per domain plugin (keep it scoped).
 - Hermit-owned only — not the application's own `vendor/` or `node_modules/`.
-- Never write archivable knowledge content into it; use `raw/` or `compiled/` for that.
+- Runtime dirs never contain archivable knowledge content; use `raw/` or `compiled/` for that.
+- Archive dirs document their consumers and lifecycle, and expose any session-facing projection through `compiled/`.
 - Register it in `storage_drift.ignore` during hatch — never rely on it being silently ignored.
 
-This mirrors the Karpathy raw-vs-compiled split: raw is the immutable ground truth, compiled is the LLM-maintained derivative. The filesystem layout is fixed; the `type` field in frontmatter is what differentiates work products within each directory.
+The session-facing layout still mirrors the Karpathy raw-vs-compiled split: raw is the immutable ground truth, compiled is the LLM-maintained derivative. The `type` field in frontmatter differentiates work products within each directory; allowlisted archives stay behind their declaring plugin's interface.
 
 ## File naming
 

--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -11,7 +11,13 @@ All notable changes to this project will be documented in this file.
 
 ### Upgrade Instructions
 
-Read `.claude-code-hermit/config.json`. Ensure `storage_drift.ignore` is an array that includes `"briefs"`: if `storage_drift` or `ignore` is absent or malformed, normalize it while preserving valid sibling keys and existing array entries; if the array is valid but does not contain `"briefs"`, append it. Write the updated file. Do not move or rewrite anything under `.claude-code-hermit/briefs/`.
+1. **Read `.claude-code-hermit/config.json`.**
+2. **Ensure `storage_drift` is an object** — create it if absent or malformed, preserving any valid sibling keys.
+3. **Ensure `storage_drift.ignore` is an array** — create it as an empty array if absent or malformed, preserving any existing entries.
+4. **Append `"briefs"` to `storage_drift.ignore`** if it is not already present.
+5. **Write the updated `config.json`.**
+
+**Note:** `.claude-code-hermit/briefs/` is feed-hermit's own archive — nothing under it is moved or rewritten.
 
 ---
 

--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **hatch: register the `briefs` archive in `storage_drift.ignore`** — prevents core session-start and reflect checks from reporting feed-hermit's canonical archive as layout drift.
+
+### Upgrade Instructions
+
+Read `.claude-code-hermit/config.json`. Ensure `storage_drift.ignore` is an array that includes `"briefs"`: if `storage_drift` or `ignore` is absent or malformed, normalize it while preserving valid sibling keys and existing array entries; if the array is valid but does not contain `"briefs"`, append it. Write the updated file. Do not move or rewrite anything under `.claude-code-hermit/briefs/`.
+
+---
+
 ## [0.1.0] - 2026-07-20
 
 ### Added

--- a/plugins/feed-hermit/CLAUDE.md
+++ b/plugins/feed-hermit/CLAUDE.md
@@ -37,7 +37,7 @@ After install, run `/feed-hermit:hatch` in the target project. The core hermit (
 
 ## Data ownership
 
-- **Plugin owns:** `.claude-code-hermit/briefs/` archive (daily + `weekly/`), `.claude-code-hermit/compiled/story-arcs-*.md`, `.claude-code-hermit/compiled/pending-delivery.md`, `.claude-code-hermit/compiled/brief-feedback-YYYY-MM.md`, `.claude-code-hermit/compiled/brief-summary-last-*.md`, `.claude-code-hermit/compiled/source-candidates-*.md`, `state/brief-message-registry.json`, and `tmp/` fetch scratch (3-day retention; hatch adds `tmp/` to the consumer `.gitignore`).
+- **Plugin owns:** `.claude-code-hermit/briefs/` archive (daily + `weekly/`; hatch registers `"briefs"` in `config.storage_drift.ignore` so core's drift check skips it — never move it into `raw/`/`compiled/`), `.claude-code-hermit/compiled/story-arcs-*.md`, `.claude-code-hermit/compiled/pending-delivery.md`, `.claude-code-hermit/compiled/brief-feedback-YYYY-MM.md`, `.claude-code-hermit/compiled/brief-summary-last-*.md`, `.claude-code-hermit/compiled/source-candidates-*.md`, `state/brief-message-registry.json`, and `tmp/` fetch scratch (3-day retention; hatch adds `tmp/` to the consumer `.gitignore`).
 - **Operator owns:** `feed-sources.md`, `feed-categories.md`, `FEEDS.md` at the project root — plugin-validated, never overwritten by hatch once present.
 
 The two data contracts (registry table + archive frontmatter) are documented verbatim in `docs/schema.md`; treat them as the product's spine and do not drift them. The `sources_skipped` (fetch failed) vs `sources_quiet` (returned clean, 0 items) distinction powers `source-health` — never collapse the two.

--- a/plugins/feed-hermit/docs/schema.md
+++ b/plugins/feed-hermit/docs/schema.md
@@ -276,5 +276,9 @@ injection. Body: <=250 chars, one line.
 - **source-items** (`tmp/feed-source-items-<slot>.json`): 3-day retention. The pipeline is
   daily, so items older than 3 days are stale scratch.
 - **All other compiled artifacts**: default 14-day retention (core `knowledge.raw_retention_days`
-  in `config.json`). Archive files under `briefs/` and living pages are exempt from rotation
-  per core knowledge rules.
+  in `config.json`). Living pages are exempt from rotation per core knowledge rules.
+- **`briefs/`**: never rotated. It is a plugin-owned archive registered in
+  `config.storage_drift.ignore` (by hatch step 7e), so core neither injects nor rotates it —
+  feed-hermit owns its retention, and the retention policy is "keep everything". Its
+  session-facing projection is `compiled/brief-summary-last-*.md`; its readers are
+  `weekly-digest`, `story-arcs`, and `source-health`.

--- a/plugins/feed-hermit/skills/hatch/SKILL.md
+++ b/plugins/feed-hermit/skills/hatch/SKILL.md
@@ -226,7 +226,7 @@ Installation summary:
   ✓ Prerequisite: claude-code-hermit {base_version} confirmed
   ✓ Registries: feed-sources.md / feed-categories.md / FEEDS.md seeded (or already present){; starter pack applied if opted in}
   ✓ .gitignore: tmp/ covered
-  ✓ config.json: feed block written, _hermit_versions stamped, {K}/3 routines added, source-scout check registered
+  ✓ config.json: feed block written, _hermit_versions stamped, {K}/3 routines added, source-scout check registered, briefs archive registered in storage_drift.ignore
   ✓ Routine prompts: {N}/3 dropped, {M}/3 already present
   ✓ CLAUDE.md: Feed Workflow block injected (or already present)
   ✓ knowledge-schema.md: brief types added (or already present)

--- a/plugins/feed-hermit/skills/hatch/SKILL.md
+++ b/plugins/feed-hermit/skills/hatch/SKILL.md
@@ -181,6 +181,14 @@ In `config.scheduled_checks`, check for `id: "source-scout"`. If absent, append;
 {"id": "source-scout", "plugin": "feed-hermit", "skill": "feed-hermit:source-scout", "enabled": true, "trigger": "interval", "interval_days": 30}
 ```
 
+### 7e — Register the brief archive
+
+Ensure `config.storage_drift` is an object and `config.storage_drift.ignore` is an array. If either is
+absent or malformed, normalize it while preserving any valid sibling keys and existing array entries.
+Append the bare directory name `"briefs"` when it is absent; if already present, leave the array
+unchanged. This registers feed-hermit's plugin-owned archive without teaching core about a
+domain-specific directory.
+
 Write the updated `config.json` using the Write tool (full-file replacement to keep valid JSON).
 
 ---

--- a/plugins/feed-hermit/tests/skill-structure.test.ts
+++ b/plugins/feed-hermit/tests/skill-structure.test.ts
@@ -70,8 +70,8 @@ test("CLAUDE-APPEND has matched block markers", () => {
 test("hatch idempotently registers the plugin-owned brief archive", () => {
   const raw = readFileSync(join(ROOT, "skills", "hatch", "SKILL.md"), "utf8");
   expect(raw).toContain("config.storage_drift.ignore");
-  expect(raw).toContain('Append the bare directory name `"briefs"` when it is absent');
-  expect(raw).toContain("if already present, leave the array");
+  expect(raw).toMatch(/`"briefs"`[\s\S]{0,80}absent/);
+  expect(raw).toMatch(/already present[\s\S]{0,60}leave the array\s+unchanged/);
 });
 
 for (const f of [

--- a/plugins/feed-hermit/tests/skill-structure.test.ts
+++ b/plugins/feed-hermit/tests/skill-structure.test.ts
@@ -67,6 +67,13 @@ test("CLAUDE-APPEND has matched block markers", () => {
   expect(raw).toContain("<!-- /feed-hermit: Feed Workflow -->");
 });
 
+test("hatch idempotently registers the plugin-owned brief archive", () => {
+  const raw = readFileSync(join(ROOT, "skills", "hatch", "SKILL.md"), "utf8");
+  expect(raw).toContain("config.storage_drift.ignore");
+  expect(raw).toContain('Append the bare directory name `"briefs"` when it is absent');
+  expect(raw).toContain("if already present, leave the array");
+});
+
 for (const f of [
   "routine-feed-brief-morning.md",
   "routine-feed-brief-evening.md",


### PR DESCRIPTION
## Summary

- register feed-hermit's plugin-owned `briefs` archive in `storage_drift.ignore` during hatch
- backfill the registration for existing installs through the changelog migration
- document plugin-owned archives generically in the core storage convention

## Changes

- preserve existing valid drift-ignore entries and append the bare `briefs` directory idempotently
- keep brief paths, core drift detection, and retention behavior unchanged
- add a feed-hermit contract test for the hatch registration

## Test plan

- `cd plugins/feed-hermit && bun test` — 53 passed
- `cd plugins/claude-code-hermit && bun test tests/storage-drift.test.ts` — 6 passed
- `bunx tsc --noEmit` — passed
- `graphify update .` — completed

Closes #626
