### PR TITLE
fix(claude-code-hermit): guard against stale Docker entrypoint and stale-clone command errors

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [Unreleased]
 
 ### Fixed
-- **hermit-docker: warns when the container runs a stale baked entrypoint** — `up` and `update --plugins-only` content-hash the on-disk `docker-entrypoint.hermit.sh` against the image's baked copy and warn to rebuild on mismatch. Closes the silent gap where an entrypoint-template release left an updating hermit on the old baked entrypoint until some future rebuild (it stranded a fleet hermit in a boot-loop); `update`'s evolve chain now also flags when a second rebuild is needed.
-- **hermit-docker / hermit-exec: version-aware error for a stale plugin clone** — a subcommand whose backing script the container's clone predates (e.g. `setup-token` on a pre-1.2.30 clone) reports the version skew and points at `update`, instead of the misleading "plugin may be corrupted, reinstall" that a reinstall of the same stale clone wouldn't fix.
+- **hermit-docker: warns when the container runs a stale baked entrypoint** — `up`, `restart`, and `update --plugins-only` content-hash the on-disk `docker-entrypoint.hermit.sh` against the image's baked copy and warn to rebuild on mismatch; `update`'s evolve chain flags when a second rebuild is needed.
+- **hermit-docker / hermit-exec: version-aware error for a stale plugin clone** — a subcommand the container's clone predates (e.g. `setup-token` on a pre-1.2.30 clone) reports the version skew and points at `update` instead of the misleading "plugin may be corrupted, reinstall".
 
 ## [1.2.30] - 2026-07-21
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **hermit-docker: warns when the container runs a stale baked entrypoint** — `up` and `update --plugins-only` content-hash the on-disk `docker-entrypoint.hermit.sh` against the image's baked copy and warn to rebuild on mismatch. Closes the silent gap where an entrypoint-template release left an updating hermit on the old baked entrypoint until some future rebuild (it stranded a fleet hermit in a boot-loop); `update`'s evolve chain now also flags when a second rebuild is needed.
+- **hermit-docker / hermit-exec: version-aware error for a stale plugin clone** — a subcommand whose backing script the container's clone predates (e.g. `setup-token` on a pre-1.2.30 clone) reports the version skew and points at `update`, instead of the misleading "plugin may be corrupted, reinstall" that a reinstall of the same stale clone wouldn't fix.
+
 ## [1.2.30] - 2026-07-21
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/hermit-exec.sh
+++ b/plugins/claude-code-hermit/scripts/hermit-exec.sh
@@ -21,7 +21,7 @@ fi
 # A missing script is far more often a stale plugin clone (this dispatcher predates
 # the requested command) than actual corruption — so report the resolved version and
 # point at an update, not a reinstall (a reinstall of the same stale clone wouldn't help).
-VER="$(grep -o '"version"[^,]*' "$SCRIPT_DIR/../.claude-plugin/plugin.json" 2>/dev/null | head -1 | cut -d'"' -f4)"
+VER="$(grep -o '"version"[^,]*' "$SCRIPT_DIR/../.claude-plugin/plugin.json" 2>/dev/null | head -1 | cut -d'"' -f4 || true)"
 echo "[hermit] $NAME not found in $SCRIPT_DIR (.ts)" >&2
 echo "[hermit] Plugin v${VER:-unknown} may predate this command. Update it:" >&2
 echo "[hermit]   Docker: .claude-code-hermit/bin/hermit-docker update" >&2

--- a/plugins/claude-code-hermit/scripts/hermit-exec.sh
+++ b/plugins/claude-code-hermit/scripts/hermit-exec.sh
@@ -18,6 +18,12 @@ if [ -f "$SCRIPT_DIR/$NAME.ts" ]; then
   exec bun "$SCRIPT_DIR/$NAME.ts" "$@"
 fi
 
+# A missing script is far more often a stale plugin clone (this dispatcher predates
+# the requested command) than actual corruption — so report the resolved version and
+# point at an update, not a reinstall (a reinstall of the same stale clone wouldn't help).
+VER="$(grep -o '"version"[^,]*' "$SCRIPT_DIR/../.claude-plugin/plugin.json" 2>/dev/null | head -1 | cut -d'"' -f4)"
 echo "[hermit] $NAME not found in $SCRIPT_DIR (.ts)" >&2
-echo "[hermit] Plugin may be corrupted. Reinstall with: claude plugin install claude-code-hermit@claude-code-hermit --scope local" >&2
+echo "[hermit] Plugin v${VER:-unknown} may predate this command. Update it:" >&2
+echo "[hermit]   Docker: .claude-code-hermit/bin/hermit-docker update" >&2
+echo "[hermit]   Host:   claude plugin update claude-code-hermit" >&2
 exit 1

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -80,7 +80,7 @@ _warn_if_entrypoint_stale() {
   [ -f "$ondisk" ] || return 0   # non-entrypoint layout — nothing to compare
 
   local cid image rc=0
-  cid="$(cd "$PROJECT_DIR" && "${DC[@]}" ps -a -q "$SERVICE" 2>/dev/null | head -1)"
+  cid="$(cd "$PROJECT_DIR" && "${DC[@]}" ps -a -q "$SERVICE" 2>/dev/null | head -1 || true)"
   [ -n "$cid" ] || return 0   # never created — first boot, nothing baked yet
   image="$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || true)"
   [ -n "$image" ] || return 0
@@ -335,6 +335,7 @@ case "$CMD" in
     fi
     echo "[hermit] Restarting container..."
     cd "$PROJECT_DIR" && "${DC[@]}" down && "${DC[@]}" up -d
+    _warn_if_entrypoint_stale
     echo "[hermit] Container restarted."
     _oauth_hint
     ;;

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -61,6 +61,57 @@ _require_running() {
   fi
 }
 
+_entrypoint_stale_warn() {
+  echo "[hermit] Warning: docker-entrypoint.hermit.sh changed since the image was built —" >&2
+  echo "[hermit]          the container is running a stale entrypoint. Rebuild to apply:" >&2
+  echo "[hermit]          .claude-code-hermit/bin/hermit-docker update" >&2
+}
+
+# Warn when the container's baked entrypoint no longer matches the on-disk
+# docker-entrypoint.hermit.sh. hermit-evolve refreshes the on-disk copy from the
+# plugin template AFTER `update` has already rebuilt, so an entrypoint-template
+# release leaves the baked copy stale until the next rebuild — silently, since
+# nothing else compares them (this stranded a hermit in a boot-loop on the fleet).
+# Content hash, computed in-container off the image so it works whether the
+# container is running or boot-looping, and stays shell-portable. Never blocks:
+# warn and continue, fail open on any docker error.
+_warn_if_entrypoint_stale() {
+  local ondisk="$PROJECT_DIR/docker-entrypoint.hermit.sh"
+  [ -f "$ondisk" ] || return 0   # non-entrypoint layout — nothing to compare
+
+  local cid image rc=0
+  cid="$(cd "$PROJECT_DIR" && "${DC[@]}" ps -a -q "$SERVICE" 2>/dev/null | head -1)"
+  [ -n "$cid" ] || return 0   # never created — first boot, nothing baked yet
+  image="$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || true)"
+  [ -n "$image" ] || return 0
+
+  # Hash both copies with the same in-container sha256sum: the baked entrypoint at
+  # its image path, and the on-disk copy bind-mounted read-only. exit 3 => mismatch;
+  # exit 0 => in sync or a copy was unreadable; any other code => docker error (fail open).
+  docker run --rm --entrypoint sh -v "$ondisk:/tmp/hermit-ondisk-entrypoint:ro" "$image" -c \
+    'a=$(sha256sum /tmp/hermit-ondisk-entrypoint 2>/dev/null | cut -d" " -f1); b=$(sha256sum /home/claude/docker-entrypoint.sh 2>/dev/null | cut -d" " -f1); { [ -n "$a" ] && [ -n "$b" ]; } || exit 0; [ "$a" != "$b" ] && exit 3; exit 0' \
+    2>/dev/null || rc=$?
+  [ "$rc" = 3 ] && _entrypoint_stale_warn
+  return 0
+}
+
+# Guard a subcommand whose backing script shipped in a specific core version. A
+# container whose marketplace clone predates that version can't run it — surface
+# the version skew and point at `update`, instead of letting the in-container
+# dispatcher raise its "plugin may be corrupted" error on what is only a stale
+# (not corrupt) clone. Fail open when the version can't be read: the in-container
+# error still catches it, just with less-precise wording.
+_require_core_version_at_least() {
+  local need="$1" subcmd="$2" have
+  have="$(_enumerate_plugins 2>/dev/null | awk -F'\t' '$1 ~ /^claude-code-hermit@/ {print $3; exit}')"
+  [ -n "$have" ] || return 0
+  if [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | head -1)" != "$need" ]; then
+    echo "[hermit] Container plugin v$have predates '$subcmd' (needs v$need)." >&2
+    echo "[hermit] Update first: .claude-code-hermit/bin/hermit-docker update" >&2
+    exit 1
+  fi
+}
+
 # Poll tmux pane for the Claude Code REPL input box. The exact rendering varies by
 # CC version / TUI / terminal width, so match the prompt char ❯ plus ANY structural
 # marker of the rendered input box: a horizontal rule (──── or older ╭─/╰─ corners)
@@ -140,6 +191,7 @@ case "$CMD" in
   up)
     echo "[hermit] Starting Docker container..."
     cd "$PROJECT_DIR" && "${DC[@]}" up -d "$@"
+    _warn_if_entrypoint_stale
     echo ""
     echo "Container is up. To attach to the hermit's tmux session:"
     echo ""
@@ -201,6 +253,7 @@ case "$CMD" in
 
   setup-token)
     _require_running
+    _require_core_version_at_least "1.2.30" "setup-token"
     echo "[hermit] Minting a long-lived login token inside the container."
     echo "[hermit] → Open the link it prints, sign in, and paste the code back here"
     echo "[hermit] → The token is written straight to the container's config volume — it is never printed"
@@ -302,6 +355,10 @@ case "$CMD" in
       { echo "[hermit] --cc-only and --plugins-only are mutually exclusive" >&2; exit 2; }
 
     _require_running
+
+    # --plugins-only never rebuilds, so a stale baked entrypoint stays stale — warn.
+    # In rebuild modes the build below refreshes it, so no warning is needed there.
+    [ "$PLUGINS_ONLY" = true ] && _warn_if_entrypoint_stale
 
     CC_BEFORE=$(cd "$PROJECT_DIR" && "${DC[@]}" exec -T "$SERVICE" claude --version 2>/dev/null \
       | grep -oP '[\d.]+' | head -1 || echo "unknown")
@@ -480,6 +537,14 @@ case "$CMD" in
           echo "[hermit] Warning: prompt not detected — hermit-evolve not auto-started." >&2
           echo "[hermit]          The pin is already durable; run /claude-code-hermit:hermit-evolve when you attach." >&2
         fi
+      fi
+      # The image was already rebuilt above, before evolve ran. If evolve now refreshes
+      # docker-entrypoint.hermit.sh from the new template, the just-built image is stale
+      # against it — a second rebuild is required, and no in-band check can see the async
+      # evolve's result from here. Flag it so the operator knows to run update again.
+      if [ "$EVOLVE_SENT" = true ]; then
+        echo "[hermit] Note: if hermit-evolve reports it refreshed docker-entrypoint.hermit.sh," >&2
+        echo "[hermit]       run 'hermit-docker update' once more so the image rebuilds with it." >&2
       fi
     fi
 

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -183,6 +183,43 @@ describe('static file checks', () => {
     expect(marketplaceIdx).toBeLessThan(updateLoopIdx);
     expect(src).toContain('.sort((a, b) =>');
   });
+
+  test('hermit-docker warns when the container runs a stale baked entrypoint', () => {
+    const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'state-templates', 'bin', 'hermit-docker'), 'utf8');
+    // The guard content-hashes the on-disk entrypoint against the image's baked copy.
+    expect(src).toContain('_warn_if_entrypoint_stale()');
+    expect(src).toContain('/home/claude/docker-entrypoint.sh');
+    expect(src).toContain('sha256sum');
+    // `up` invokes it after bringing the container up.
+    const upIdx = src.indexOf('"${DC[@]}" up -d "$@"');
+    const upGuardIdx = src.indexOf('_warn_if_entrypoint_stale', upIdx);
+    expect(upIdx).toBeGreaterThan(-1);
+    expect(upGuardIdx).toBeGreaterThan(upIdx);
+    // `update` warns only in --plugins-only mode (rebuild modes fix it inline).
+    expect(src).toContain('[ "$PLUGINS_ONLY" = true ] && _warn_if_entrypoint_stale');
+    // ...and flags a needed second rebuild when the async evolve chain ran.
+    expect(src).toContain('run \'hermit-docker update\' once more');
+  });
+
+  test('hermit-docker setup-token gates on the container core version', () => {
+    const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'state-templates', 'bin', 'hermit-docker'), 'utf8');
+    expect(src).toContain('_require_core_version_at_least()');
+    expect(src).toContain('sort -V');
+    // The gate runs before the mint dispatch, so a stale clone is caught up front.
+    const gateIdx = src.indexOf('_require_core_version_at_least "1.2.30" "setup-token"');
+    const mintIdx = src.indexOf('hermit-run setup-token-mint terminal');
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(mintIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(mintIdx);
+  });
+
+  test('hermit-exec reports version skew, not corruption, on a missing script', () => {
+    const src = fs.readFileSync(path.join(PLUGIN_ROOT, 'scripts', 'hermit-exec.sh'), 'utf8');
+    expect(src).not.toContain('may be corrupted');
+    expect(src).toContain('may predate this command');
+    expect(src).toContain('hermit-docker update');
+    expect(src).toContain('claude plugin update claude-code-hermit');
+  });
 });
 
 // -------------------------------------------------------


### PR DESCRIPTION
## Summary
`hermit-docker update` rebuilds the image **before** the auto-chained (async) `hermit-evolve` refreshes the on-disk `docker-entrypoint.hermit.sh`, so any release that changes the entrypoint template could ship a stale baked entrypoint — one live case boot-looped a fleet hermit whose stale entrypoint gate blocked token-mode boot. Nothing in the flow compared on-disk vs baked. Separately, a subcommand whose backing script the container's marketplace clone predates (e.g. `setup-token` on a pre-1.2.30 clone) raised a misleading "plugin may be corrupted, reinstall" — a reinstall of the same stale clone wouldn't fix it.

Scoped to defects A + C of the originating investigation; the `.env` token-shadow defect (B) and the auth-scope follow-ups are deliberately deferred to a separate change.

## Changes
- **Entrypoint staleness guard** (`state-templates/bin/hermit-docker`): new `_warn_if_entrypoint_stale` content-hashes the on-disk entrypoint against the image's baked `/home/claude/docker-entrypoint.sh` in a throwaway in-container `sha256sum` (works whether the container is running or boot-looping; fails open, never blocks). Called after `up -d` in `up`, and in `update` only under `--plugins-only` (rebuild modes fix it inline). `update`'s evolve chain also prints a heads-up that a second rebuild may be needed, since the async evolve's entrypoint refresh can't be observed in-band.
- **Version-aware skew errors** (defect C): host-side, `setup-token` gates on the container's core version via the existing `_enumerate_plugins` + `sort -V` and points at `update` when it predates 1.2.30; in-plugin, `scripts/hermit-exec.sh` reads the resolved `plugin.json` version and reports version skew instead of "may be corrupted".
- **Tests** (`tests/scripts.test.ts`): three content-assertion tests covering the guard, the setup-token version gate ordering, and the corrected hermit-exec error text.

## Test plan
- `cd plugins/claude-code-hermit && bun test` — full suite green (2701 pass; the one lockfile concurrency test that flaked under full-suite load passes cleanly on isolated retry and is unrelated to this change).
- `bunx tsc --noEmit` from repo root — exit 0.
- `bash -n` on both edited scripts — syntax OK.
- Reviewers (reuse / quality / efficiency) over the staged diff returned no findings; quality reviewer independently verified the `sort -V` comparison, `rc=$?` scoping, the awk column, and the baked-entrypoint path.
- Not yet exercised live end-to-end on a real container (requires an entrypoint-template release on a test hermit) — left for a follow-up live check.

Note: both changed scripts propagate to existing operators automatically (`bin/hermit-docker` via hermit-evolve's boot-critical `bin/` refresh, `hermit-exec.sh` via `/plugin update`), so no Upgrade Instructions are needed.