### PR TITLE
fix(watchdog): damp and pause-gate the step-5 re-arm fallback

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **watchdog: re-arm fallback damped and pause-gated** — step 5 re-injected both bootstrap prompts every ~5-min tick while the heartbeat-restart fired-age stayed >26h (up to ~24h of full-context wakes, since the fired metric only advances at the routine's next real fire); now one attempt per 6h window, and never while paused.
+
 ## [1.2.30] - 2026-07-21
 
 ### Added

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **watchdog: re-arm fallback damped and pause-gated** — step 5 re-injected both bootstrap prompts every ~5-min tick while the heartbeat-restart fired-age stayed >26h (up to ~24h of full-context wakes, since the fired metric only advances at the routine's next real fire); now one attempt per 6h window, and never while paused.
+- **watchdog: re-arm fallback damped and pause-gated** — the step-5 heartbeat-restart re-arm re-injected both bootstrap prompts every ~5-min tick while the fired-age stayed >26h; now one attempt per 6h window, and never while paused.
 
 ## [1.2.30] - 2026-07-21
 

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -13,6 +13,7 @@
  *       un-redirectable dialog (native permission prompt, harness prompt)
  *   4. Wedge detection — nudge-then-escalate when heartbeat is stale
  *   5. Re-arm fallback — re-arm when heartbeat-restart routine missed its window
+ *                        (damped + pause-gated, like step 6)
  *   6. Monitor re-arm  — re-arm a heartbeat/routine Monitor whose liveness file
  *                        went stale mid-session (any cause), damped per monitor
  *
@@ -531,7 +532,8 @@ function routineMonitorStale(config: Json): boolean {
   return monitorLivenessStale('routine-monitor-liveness.json', monRt, thresholdSecs);
 }
 
-/** Damper open when this monitor hasn't been re-armed within MONITOR_REARM_DAMPER_SECS. */
+/** Damper open when the given re-arm timestamp is older than MONITOR_REARM_DAMPER_SECS
+ *  (or missing). Shared by the step-6 monitor re-arm and the step-5 routine fallback. */
 function rearmDamperOpen(lastStamp: unknown): boolean {
   if (typeof lastStamp !== 'string') return true;
   const age = ageSecs(lastStamp);
@@ -1211,16 +1213,23 @@ async function main(): Promise<void> {
     }
   }
 
-  // 5. Re-arm fallback: fire if heartbeat-restart routine hasn't fired in ~26h
+  // 5. Re-arm fallback: fire if heartbeat-restart routine hasn't fired in ~26h.
+  // Damped like step 6 (one attempt per MONITOR_REARM_DAMPER_SECS): the fired
+  // metric only advances at the routine's next real fire, so an undamped check
+  // re-injects both bootstrap prompts every tick for up to ~24h. Never inject
+  // while paused (PROP-015), mirroring the other send paths.
   let rearmedThisTick = false;
   const rearmThresholdSecs = 26 * 3600;
   const routineAge = getLastRoutineFiredAgeSecs('heartbeat-restart');
-  if (routineAge !== null && routineAge > rearmThresholdSecs) {
+  if (routineAge !== null && routineAge > rearmThresholdSecs && !isPaused(HERMIT_ROOT).paused) {
     const opAge = getOperatorLastActionAgeSecs();
     // Only re-arm when operator is silent (not in the middle of a conversation)
     if (opAge === null || opAge >= operatorGraceSecs) {
-      if (tmuxSessionAlive(sessionName)) {
+      const watchdogState = readWatchdogState();
+      if (rearmDamperOpen(watchdogState.last_rearm_fallback) && tmuxSessionAlive(sessionName)) {
         doRearm(sessionName);
+        watchdogState.last_rearm_fallback = utcStamp();
+        writeWatchdogState(watchdogState);
         rearmedThisTick = true;
       }
     }

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -724,6 +724,53 @@ test('started event does not count as fired for re-arm check', withHermit(async 
 }));
 
 // -------------------------------------------------------
+// 11d/e. Step-5 re-arm damper: the fired metric only advances at the routine's
+//        next real fire, so an undamped >26h check re-injects every tick. One
+//        attempt per 6h window, mirroring step 6.
+// -------------------------------------------------------
+
+// Shared setup: heartbeat-restart fired 28h ago (> 26h), .heartbeat fresh so wedge
+// detection stays out of the way, live session.
+const armStep5 = (h: Hermit) => {
+  writeConfig(h);
+  touchAgo(state(h, '.heartbeat'), 1800);
+  fs.writeFileSync(state(h, 'routine-metrics.jsonl'), JSON.stringify({
+    ts: isoAgoSeconds(28), routine_id: 'heartbeat-restart', event: 'fired', delivery: 'cron-create',
+  }) + '\n');
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 0);
+};
+
+test('re-arm fallback within damper window → no second re-arm', withHermit(async (h) => {
+  armStep5(h);
+  // Fallback re-armed 1h ago: inside the 6h damper.
+  writeState(h, 'watchdog-state.json', { last_rearm_fallback: isoAgo(1) });
+  const r = await watchdog(h, 'run');
+  expect(r.exitCode).toBe(0);
+  expect(events(h)).not.toContain('re-arm-fallback');
+}));
+
+test('re-arm fallback past damper window → fires and refreshes damper stamp', withHermit(async (h) => {
+  armStep5(h);
+  const stale = isoAgo(7); // last fallback 7h ago, past the 6h damper
+  writeState(h, 'watchdog-state.json', { last_rearm_fallback: stale });
+  const r = await watchdog(h, 'run');
+  expect(r.exitCode).toBe(0);
+  expect(events(h)).toContain('re-arm-fallback');
+  const stamp = readWatchdogStateFile(h).last_rearm_fallback;
+  expect(typeof stamp).toBe('string');
+  expect(stamp).not.toBe(stale);
+}));
+
+test('re-arm fallback suppressed while paused', withHermit(async (h) => {
+  armStep5(h);
+  writePauseFlag(h);
+  const r = await watchdog(h, 'run');
+  expect(r.exitCode).toBe(0);
+  expect(events(h)).not.toContain('re-arm-fallback');
+}));
+
+// -------------------------------------------------------
 // 11c. Monitor-liveness re-arm (step 6): recover a Monitor that died mid-session,
 //      detected via its stale liveness file rather than step 5's fired-age heuristic.
 //      No .heartbeat file → wedge (step 4) skipped; no routine-metrics.jsonl →


### PR DESCRIPTION
## Summary

The watchdog's step-5 re-arm fallback re-injected both bootstrap prompts (`hermit-routines load` + `heartbeat start`) into the running session on **every ~5-minute tick** whenever the `heartbeat-restart` routine's last `fired` age stayed past 26h. It wrote no state on fire, and the `fired` metric only advances at the routine's next real fire, so the condition never cleared on its own — up to ~24h of full-context wakes per episode (e.g. after a reauth restart that misses the nightly fire).

The sibling step-6 monitor re-arm already solved exactly this with a 6h per-target damper. This change gives step 5 the same damper and the pause guard the other injection paths already carry.

Closes #631.

## Changes

- **`scripts/hermit-watchdog.ts`** — step 5 now reads `watchdog-state.json`, fires only when `rearmDamperOpen(last_rearm_fallback)` (one attempt per `MONITOR_REARM_DAMPER_SECS` = 6h), stamps `last_rearm_fallback` on fire, and short-circuits when the hermit is paused. Reuses the existing `rearmDamperOpen` / `readWatchdogState` / `writeWatchdogState` / `utcStamp` helpers; `rearmDamperOpen`'s doc generalized now that it has a second caller.
- **`tests/watchdog.test.ts`** — three cases: within-damper → no re-arm; past-damper → fires and refreshes the stamp; paused → suppressed.
- **`CHANGELOG.md`** — `[Unreleased]` Fixed entry.

## Not in scope

The issue also reported a `hermit-watchdog.py not found … marketplaces/…` line in `watchdog.log`. That was **falsified**: those two log lines predate the Bun migration (the log is append-only and was first written when the `.py` watchdog shipped); the on-disk shims and installed plugin are current-generation and resolve the `.ts` scripts correctly. No code change — will be noted on the issue.

## Test plan

- `cd plugins/claude-code-hermit && bun test tests/watchdog.test.ts` — 132 pass (incl. 3 new), 0 fail.
- Full plugin suite `bun test` — 2702 pass, 0 fail.
- `bunx tsc --noEmit` (repo root) — clean.
- Post-merge, on the next missed-fire episode: at most one `re-arm-fallback` event per 6h window in `watchdog-events.jsonl`.
