### PR TITLE
fix(claude-code-hermit): park stored /login credentials so they can't shadow the setup-token

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **setup-token: stored `/login` credentials no longer shadow the login token** — token install and the Docker boot gate now park a stale `.credentials.json` (rename to `.credentials.json.pre-token.bak`). Interactive Claude Code sessions authenticate with a stored `/login` credential ahead of `CLAUDE_CODE_OAUTH_TOKEN` (the reverse of the documented precedence, confirmed live on CC 2.1.218), so a converted hermit that kept its old login file 401'd ~8h later when that stored access token lapsed, while its valid year-long token sat unused.
+- **doctor: `credential-expiry` warns when a live `/login` credential shadows the token** — in token mode, a `.credentials.json` still carrying an access token is flagged with the exact park command. A parked file or a `/logout` stub is inert and stays `ok`. Check count unchanged.
+
+### Upgrade Instructions
+1. **Docker hermits — refresh the on-disk entrypoint BEFORE rebuilding.** `hermit-docker update` rebuilds with the operator's on-disk `docker-entrypoint.hermit.sh`, not the plugin template. Re-run `/claude-code-hermit:docker-setup` (or patch the on-disk copy from `state-templates/docker/docker-entrypoint.hermit.sh.template`) first, then `hermit-docker update`. This carries the §0c credential-parking guard.
+2. **Already-converted token-mode hermits — park the stale credential now.** If the hermit uses `setup-token` auth and still has a `.credentials.json`, park it: `docker exec <stack>-hermit-1 mv /home/claude/.claude/.credentials.json /home/claude/.claude/.credentials.json.pre-token.bak`, then restart the container. The refreshed entrypoint (step 1) also does this automatically at the next boot; this step recovers a hermit that is already dark now.
+3. **Returning to `/login` auth (rare).** The parking guard only fires while a setup-token is present, so to switch a hermit back to `/login`, delete `.hermit-setup-token` first, then run `hermit-docker login`.
+
 ## [1.2.31] - 2026-07-22
 
 ### Fixed

--- a/plugins/claude-code-hermit/docs/troubleshooting.md
+++ b/plugins/claude-code-hermit/docs/troubleshooting.md
@@ -181,7 +181,8 @@ Notes:
 
 - **Never run `/logout` inside the container.** It wipes the stored credentials *and* resets first-launch state, after which the interactive wizard demands a login and refuses the token — turning a two-minute renewal into a rebuild. Renewal never needs it.
 - If the relay never messages you, the hermit has no reachable channel. It stops rather than minting a link it can't deliver; renew from the terminal with `hermit-docker setup-token`.
-- `hermit-docker login` on a token-mode hermit deliberately does nothing but tell you so — the leftover `.credentials.json` from the original login is stale by design and is not what the hermit is using.
+- `hermit-docker login` on a token-mode hermit deliberately does nothing but tell you so — the hermit authenticates with its login token, not `/login` credentials.
+- The original login's `.credentials.json` is parked to `.credentials.json.pre-token.bak` when the token installs (and at boot). This matters: an interactive session prefers a stored `/login` credential over the token, so a hermit that kept the file would 401 once that stored login lapsed (~8h), even with a valid year-long token. If you converted before this behavior shipped and the hermit is dark, park it by hand (`mv .../.credentials.json .../.credentials.json.pre-token.bak`) and restart.
 
 ## Permission Denied Inside Container
 

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -15,7 +15,7 @@ import { PRICING } from './lib/pricing';
 import { getEnabledChannels } from './hermit-start';
 import { readChannelToken } from './lib/channel-token';
 import { siblingPluginDirs, versionedCacheCoreDir, readHermitMeta, readCoreName } from './lib/plugin-siblings';
-import { tokenModeActive, defaultConfigDir, credentialsFilePath, CREDENTIALS_FILENAME, PARKED_CREDENTIALS_FILENAME } from './lib/setup-token';
+import { tokenModeActive, defaultConfigDir, credentialsFilePath, parkedCredentialsFilePath, CREDENTIALS_FILENAME } from './lib/setup-token';
 
 type Json = any;
 
@@ -1368,7 +1368,7 @@ function shadowingCredentialNote(): string | null {
   } catch {
     return null; // absent or unreadable — nothing to shadow
   }
-  return `stored ${CREDENTIALS_FILENAME} will shadow the login token in interactive sessions — park it (mv ${CREDENTIALS_FILENAME} ${PARKED_CREDENTIALS_FILENAME}) and restart`;
+  return `stored ${CREDENTIALS_FILENAME} will shadow the login token in interactive sessions — park it (mv ${credentialsFilePath(configDir)} ${parkedCredentialsFilePath(configDir)}) and restart`;
 }
 
 function checkCredentialExpiry() {

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -15,6 +15,7 @@ import { PRICING } from './lib/pricing';
 import { getEnabledChannels } from './hermit-start';
 import { readChannelToken } from './lib/channel-token';
 import { siblingPluginDirs, versionedCacheCoreDir, readHermitMeta, readCoreName } from './lib/plugin-siblings';
+import { tokenModeActive, defaultConfigDir, credentialsFilePath, CREDENTIALS_FILENAME, PARKED_CREDENTIALS_FILENAME } from './lib/setup-token';
 
 type Json = any;
 
@@ -1351,11 +1352,32 @@ function probeDeclaredCredentials(): { okCount: number; badNotes: string[] } {
   return { okCount, badNotes };
 }
 
+// A stored /login credential sitting next to a setup-token is a live hazard, not
+// an expiry question: interactive Claude Code sessions prefer .credentials.json
+// over CLAUDE_CODE_OAUTH_TOKEN, so the hermit 401s when that stored access token
+// lapses (~8h) even though the year-long token is valid. Only a credential that
+// still carries a token shadows — a parked file or a /logout stub (empty
+// accessToken) is inert, so those return null.
+function shadowingCredentialNote(): string | null {
+  const configDir = defaultConfigDir();
+  if (!tokenModeActive(configDir)) return null;
+  try {
+    const creds = JSON.parse(fs.readFileSync(credentialsFilePath(configDir), 'utf8'));
+    const token = creds?.claudeAiOauth?.accessToken;
+    if (typeof token !== 'string' || token.length === 0) return null;
+  } catch {
+    return null; // absent or unreadable — nothing to shadow
+  }
+  return `stored ${CREDENTIALS_FILENAME} will shadow the login token in interactive sessions — park it (mv ${CREDENTIALS_FILENAME} ${PARKED_CREDENTIALS_FILENAME}) and restart`;
+}
+
 function checkCredentialExpiry() {
   try {
     const sib = probeDeclaredCredentials();
-    const status = sib.badNotes.length > 0 ? 'warn' : 'ok';
+    const shadow = shadowingCredentialNote();
     const parts = [...sib.badNotes];
+    if (shadow) parts.push(shadow);
+    const status = parts.length > 0 ? 'warn' : 'ok';
     if (sib.okCount > 0) parts.push(`${sib.okCount} plugin credential(s) ok`);
     if (parts.length === 0) parts.push('no plugin declares a credential to probe');
     return { id: 'credential-expiry', status, detail: parts.join('; ') };

--- a/plugins/claude-code-hermit/scripts/lib/setup-token.ts
+++ b/plugins/claude-code-hermit/scripts/lib/setup-token.ts
@@ -27,6 +27,9 @@ import path from 'node:path';
 
 export const TOKEN_FILENAME = '.hermit-setup-token';
 export const TOKEN_ENV_VAR = 'CLAUDE_CODE_OAUTH_TOKEN';
+/** Where a stored /login credential is parked once a setup-token takes over. */
+export const CREDENTIALS_FILENAME = '.credentials.json';
+export const PARKED_CREDENTIALS_FILENAME = '.credentials.json.pre-token.bak';
 /** setup-token mints a 1-year credential. */
 export const TOKEN_TTL_MS = 365 * 24 * 3600 * 1000;
 
@@ -39,6 +42,39 @@ export function defaultConfigDir(): string {
 
 export function tokenFilePath(configDir: string): string {
   return path.join(configDir, TOKEN_FILENAME);
+}
+
+export function credentialsFilePath(configDir: string): string {
+  return path.join(configDir, CREDENTIALS_FILENAME);
+}
+
+export function parkedCredentialsFilePath(configDir: string): string {
+  return path.join(configDir, PARKED_CREDENTIALS_FILENAME);
+}
+
+/**
+ * Park a stored /login credential out of the way so it can't shadow the
+ * setup-token. Interactive Claude Code sessions authenticate with
+ * .credentials.json when it holds a token, ahead of CLAUDE_CODE_OAUTH_TOKEN
+ * (confirmed live on CC 2.1.218) — the reverse of the documented precedence.
+ * A hermit that keeps its old /login file therefore 401s the moment that stored
+ * access token lapses (~8h), while the valid year-long token sits unused. Renamed
+ * rather than deleted so a deliberate return to /login can restore it.
+ *
+ * Returns true when a file was moved. Never throws: the token is already
+ * installed by the time this runs, and a failed park must not fail the mint.
+ */
+export function parkCredentialsFile(configDir: string): boolean {
+  const src = credentialsFilePath(configDir);
+  try {
+    if (!fs.existsSync(src)) return false;
+    const dest = parkedCredentialsFilePath(configDir);
+    fs.renameSync(src, dest); // atomically overwrites any prior backup on POSIX
+    return true;
+  } catch (e) {
+    process.stderr.write(`[setup-token] could not park ${CREDENTIALS_FILENAME}: ${e}\n`);
+    return false;
+  }
 }
 
 /**
@@ -123,6 +159,10 @@ export function installToken(hermitDir: string, configDir: string, token: string
   fs.writeFileSync(tmp, `${value}\n`, { mode: 0o600 });
   fs.chmodSync(tmp, 0o600);
   fs.renameSync(tmp, dest);
+
+  // Retire any stored /login credential so it can't shadow the token we just
+  // installed (see parkCredentialsFile). Best-effort — never fails the install.
+  parkCredentialsFile(configDir);
 
   const now = new Date();
   const record: TokenRecord = {

--- a/plugins/claude-code-hermit/skills/relogin/SKILL.md
+++ b/plugins/claude-code-hermit/skills/relogin/SKILL.md
@@ -9,7 +9,7 @@ Renews this hermit's `setup-token` credential without anyone touching the box. T
 
 Use this when doctor warns that `setup-token` is expiring, or the operator asks to renew. If the hermit is *already* dead from an expired token, this skill is not the path — the watchdog runs the same flow deterministically without a model (`setup-token-mint.ts relay`), because a dead hermit can't run a skill.
 
-**Never run `/logout`.** It deletes `.credentials.json` *and* resets first-launch state, after which the interactive wizard demands a login and refuses the env token. Renewal never needs it.
+**Never run `/logout`.** Renewal never needs it. Retiring the old `.credentials.json` is fine — the install does it for you (see Notes) — but `/logout` *also* resets first-launch state, after which the interactive wizard demands a login and refuses the env token. That reset is the hazard, not the credential removal.
 
 ## Step 0 — Preflight
 
@@ -61,5 +61,6 @@ It fires the restart detached and returns immediately. Anything you write after 
 ## Notes
 
 - The one-time link and the login code cross the channel; the token never does.
+- Installing the token parks any stored `/login` credential (`.credentials.json` → `.credentials.json.pre-token.bak`). Interactive sessions prefer a stored login over the env token, so an unparked file would 401 the hermit once its old access token lapsed. The rename is restorable; nothing is deleted.
 - Expiry is hermit-tracked in `state/setup-token.json` — the CLI exposes no expiry surface for these tokens, so that record is the only source of truth. Doctor's `credential-expiry` check reads it and warns 14 days out.
 - Renewal is container-internal on purpose: the token lives on the persistent config volume, not in `.env`, so nothing on the host has to be recreated.

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -151,7 +151,7 @@ fi
 # --- 0c. Park a stale /login credential when a setup-token is present ---
 # Interactive Claude Code sessions authenticate with .credentials.json whenever
 # it holds a token, ahead of CLAUDE_CODE_OAUTH_TOKEN — the reverse of the
-# documented precedence (confirmed live on CC 2.1.216+). A converted hermit that
+# documented precedence (confirmed live on CC 2.1.218). A converted hermit that
 # keeps its old /login file therefore 401s the moment that stored access token
 # lapses (~8h), while the valid year-long token sits unused in the env.
 # hermit-start's token install parks it too; this covers hermits converted before

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -148,7 +148,24 @@ try {
   fi
 fi
 
-# --- 0c. Plugin install audit log helper ---
+# --- 0c. Park a stale /login credential when a setup-token is present ---
+# Interactive Claude Code sessions authenticate with .credentials.json whenever
+# it holds a token, ahead of CLAUDE_CODE_OAUTH_TOKEN — the reverse of the
+# documented precedence (confirmed live on CC 2.1.216+). A converted hermit that
+# keeps its old /login file therefore 401s the moment that stored access token
+# lapses (~8h), while the valid year-long token sits unused in the env.
+# hermit-start's token install parks it too; this covers hermits converted before
+# that shipped, and any stray /login left behind on a token-mode hermit.
+# Renamed (not deleted) so a deliberate return to /login can restore it — an
+# operator switching back removes "$SETUP_TOKEN_FILE" first (hermit-docker login
+# refuses while it exists), so this gate no longer fires.
+if [ -f "$SETUP_TOKEN_FILE" ] && [ -f "$CRED_FILE" ]; then
+  if mv -f "$CRED_FILE" "${CRED_FILE}.pre-token.bak" 2>/dev/null; then
+    echo "[docker-entrypoint] Parked stale .credentials.json (login token is authoritative; stored /login creds would shadow it in an interactive session)."
+  fi
+fi
+
+# --- 0d. Plugin install audit log helper ---
 # Gated on HERMIT_PLUGIN_INSTALL_AUDIT=1, which the security overlay
 # (/claude-code-hermit:docker-security toggle 4) sets when the audit-log
 # toggle is on. No-op when unset, so default flow is unchanged.

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -2061,6 +2061,7 @@ describe('doctor context-age check', () => {
 
 describe('doctor credential-expiry check', () => {
   const credCheck = (report: any) => (report.checks ?? []).find((c: any) => c.id === 'credential-expiry');
+  const VALID_OAT = 'sk-ant-oat01-abcdefghijklmnopqrstuvwxyz0123456789';
 
   /** Write a setup-token record expiring `days` from now (negative = already lapsed). */
   const writeTokenRecord = (dir: string, days: number) => {
@@ -2171,6 +2172,66 @@ describe('doctor credential-expiry check', () => {
     });
     const report = JSON.parse(r.stdout);
     expect(credCheck(report).status).toBe('ok');
+  }), 20000);
+
+  // In token mode, a stored .credentials.json that still holds a live token is a
+  // hazard, not an expiry question: interactive sessions prefer it over the env
+  // token, so the hermit 401s ~8h after the stored token lapses. Doctor must warn
+  // to park it. A token FILE in the config dir is what makes token mode active.
+  const writeSetupTokenFile = (credDir: string) => {
+    fs.mkdirSync(credDir, { recursive: true });
+    fs.writeFileSync(path.join(credDir, '.hermit-setup-token'), `${VALID_OAT}\n`);
+  };
+
+  test('token mode + stored credential with a live token → warn to park it', withTmpdir(async (dir) => {
+    writeConfig(dir, {});
+    writeTokenRecord(dir, 300); // probe stays ok; the shadow is the only warn source
+    const credDir = path.join(dir, 'creds');
+    writeSetupTokenFile(credDir);
+    fs.writeFileSync(path.join(credDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'live', expiresAt: Date.now() - 3600000 },
+    }));
+    const r = await runScript('doctor-check.ts', {
+      args: ['.claude-code-hermit'], cwd: dir,
+      env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT, CLAUDE_CONFIG_DIR: credDir, ANTHROPIC_API_KEY: '', CLAUDE_CODE_OAUTH_TOKEN: '' },
+    });
+    const c = credCheck(JSON.parse(r.stdout));
+    expect(c.status).toBe('warn');
+    expect(c.detail).toContain('shadow');
+  }), 20000);
+
+  test('token mode + /logout stub (empty accessToken) → ok, no shadow warning', withTmpdir(async (dir) => {
+    writeConfig(dir, {});
+    writeTokenRecord(dir, 300);
+    const credDir = path.join(dir, 'creds');
+    writeSetupTokenFile(credDir);
+    fs.writeFileSync(path.join(credDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: '', expiresAt: 0 },
+    }));
+    const r = await runScript('doctor-check.ts', {
+      args: ['.claude-code-hermit'], cwd: dir,
+      env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT, CLAUDE_CONFIG_DIR: credDir, ANTHROPIC_API_KEY: '', CLAUDE_CODE_OAUTH_TOKEN: '' },
+    });
+    const c = credCheck(JSON.parse(r.stdout));
+    expect(c.status).toBe('ok');
+    expect(c.detail).not.toContain('shadow');
+  }), 20000);
+
+  test('token mode with the credential already parked → ok', withTmpdir(async (dir) => {
+    writeConfig(dir, {});
+    writeTokenRecord(dir, 300);
+    const credDir = path.join(dir, 'creds');
+    writeSetupTokenFile(credDir);
+    fs.writeFileSync(path.join(credDir, '.credentials.json.pre-token.bak'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'live', expiresAt: 1 },
+    }));
+    const r = await runScript('doctor-check.ts', {
+      args: ['.claude-code-hermit'], cwd: dir,
+      env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT, CLAUDE_CONFIG_DIR: credDir, ANTHROPIC_API_KEY: '', CLAUDE_CODE_OAUTH_TOKEN: '' },
+    });
+    const c = credCheck(JSON.parse(r.stdout));
+    expect(c.status).toBe('ok');
+    expect(c.detail).not.toContain('shadow');
   }), 20000);
 });
 

--- a/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
@@ -154,6 +154,17 @@ describe('Entrypoint: setup-token auth gates', () => {
     expect(condition).toContain('[ ! -f "$SETUP_TOKEN_FILE" ]');
     expect(condition).toContain('[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]');
   });
+
+  // §0c parks a stale /login credential when a setup-token is present: interactive
+  // sessions prefer .credentials.json over the env token, so an unparked stored
+  // login 401s the hermit ~8h after its token lapses. Guards hermits converted
+  // before install-time parking shipped.
+  test('entrypoint: §0c parks a stale credential in token mode', () => {
+    const guard = entrypoint.slice(entrypoint.indexOf('# --- 0c.'));
+    const block = guard.slice(0, guard.indexOf('# --- 0d.'));
+    expect(block).toContain('[ -f "$SETUP_TOKEN_FILE" ] && [ -f "$CRED_FILE" ]');
+    expect(block).toContain('mv -f "$CRED_FILE" "${CRED_FILE}.pre-token.bak"');
+  });
 });
 
 describe('Entrypoint: placeholder-free session name resolution', () => {

--- a/plugins/claude-code-hermit/tests/setup-token.test.ts
+++ b/plugins/claude-code-hermit/tests/setup-token.test.ts
@@ -6,9 +6,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
 import {
+  credentialsFilePath,
   installToken,
   isPlausibleToken,
   msUntilExpiry,
+  parkCredentialsFile,
+  parkedCredentialsFilePath,
   readTokenRecord,
   readTokenValue,
   tokenFilePath,
@@ -86,6 +89,37 @@ describe('token storage', () => {
     expect(readTokenRecord(hermitDir)).toBeNull();
     fs.writeFileSync(path.join(hermitDir, 'state', 'setup-token.json'), JSON.stringify({ expires_at: 'soon' }));
     expect(readTokenRecord(hermitDir)).toBeNull();
+  }));
+});
+
+describe('parking a stored /login credential on install', () => {
+  const CRED = JSON.stringify({ claudeAiOauth: { accessToken: 'stored', expiresAt: 1 } });
+
+  test('install parks an existing .credentials.json, preserving its contents', withDirs((hermitDir, configDir) => {
+    fs.writeFileSync(credentialsFilePath(configDir), CRED);
+    installToken(hermitDir, configDir, VALID);
+    // The live credential is gone from the path the CLI reads...
+    expect(fs.existsSync(credentialsFilePath(configDir))).toBe(false);
+    // ...but preserved verbatim under the parked name, so /login can be restored.
+    expect(fs.readFileSync(parkedCredentialsFilePath(configDir), 'utf8')).toBe(CRED);
+    expect(readTokenValue(configDir)).toBe(VALID);
+  }));
+
+  test('install with no stored credential leaves no parked file behind', withDirs((hermitDir, configDir) => {
+    installToken(hermitDir, configDir, VALID);
+    expect(fs.existsSync(parkedCredentialsFilePath(configDir))).toBe(false);
+  }));
+
+  test('a second park replaces the previous backup rather than failing', withDirs((hermitDir, configDir) => {
+    fs.writeFileSync(parkedCredentialsFilePath(configDir), '{"old":true}');
+    fs.writeFileSync(credentialsFilePath(configDir), CRED);
+    expect(parkCredentialsFile(configDir)).toBe(true);
+    expect(fs.readFileSync(parkedCredentialsFilePath(configDir), 'utf8')).toBe(CRED);
+    expect(fs.existsSync(credentialsFilePath(configDir))).toBe(false);
+  }));
+
+  test('park is a no-op (returns false) when there is nothing to park', withDirs((_hermitDir, configDir) => {
+    expect(parkCredentialsFile(configDir)).toBe(false);
   }));
 });
 


### PR DESCRIPTION
## Summary

Docker hermits converted to long-lived `setup-token` auth were going 401-dead ~8h after conversion. Root cause, confirmed live on CC 2.1.218 with a controlled A/B probe (raw API call with the token → 200; `claude -p` → ok; **interactive tmux session with an expired `.credentials.json` present → 401**; interactive with that file removed → ok): **interactive Claude Code sessions authenticate with a stored `/login` credential (`.credentials.json`) ahead of `CLAUDE_CODE_OAUTH_TOKEN`** — the reverse of the documented precedence. Hermits run interactive sessions, so a converted hermit that kept its old `/login` file died the moment that stored access token lapsed, while its valid year-long token sat unused in the environment.

The fix retires the stored credential wherever a `setup-token` takes over, so it can no longer shadow the token.

## Changes

- **`installToken()` parks the stored credential** (`scripts/lib/setup-token.ts`) — on token install, an existing `.credentials.json` is renamed to `.credentials.json.pre-token.bak` (best-effort, never fails the mint). New `parkCredentialsFile()` helper + `CREDENTIALS_FILENAME` / `PARKED_CREDENTIALS_FILENAME` constants. Covers both front doors (`hermit-docker setup-token`, `/relogin`) since both route through `installToken()`.
- **Docker boot guard** (`state-templates/docker/docker-entrypoint.hermit.sh.template`, new §0c) — parks a stale `.credentials.json` at startup whenever a setup-token is present. Recovers hermits converted before install-time parking shipped, and any stray `/login` left on a token-mode hermit. Renamed, not deleted, so a deliberate return to `/login` (remove `.hermit-setup-token` first) can restore it.
- **Doctor warns on a live shadow** (`scripts/doctor-check.ts`) — the `credential-expiry` check flags a `.credentials.json` that still carries an access token while in token mode, with the exact park command. A parked file or a `/logout` stub (empty `accessToken`) is inert and stays `ok`. Check count unchanged.
- Docs/CHANGELOG: `relogin` skill notes, troubleshooting entry, and an `[Unreleased]` entry with `### Upgrade Instructions` (refresh the on-disk entrypoint before `hermit-docker update`; park the credential on already-converted hermits).

## Verification

- `bun test` (full plugin suite): **2713 pass, 0 fail**.
- Affected suites re-run after the simplify cleanup pass: `setup-token`, `contracts`, `docker-baseline-content` → **295 pass, 0 fail**.
- `bunx tsc --noEmit`: exit 0.
- New coverage: install-time parking (preserve/replace/no-op cases), the §0c template guard, and the doctor shadow warn/ok boundary (live token → warn; parked/stub → ok).

## Notes

- The documented auth precedence (env token above stored login) does not match observed interactive behavior on CC 2.1.218; the interactive/headless split is worth reporting upstream. The clean repro matrix is captured for that.
- Reviving the currently-dark fleet hermits is an operator-side action (park each `.credentials.json`, restart) and is intentionally out of this PR's scope.
