### PR TITLE
chore: parallelize test suites, cut full-suite runtime from ~166s to ~44s

### DIFF
--- a/.claude/skills/test-run/SKILL.md
+++ b/.claude/skills/test-run/SKILL.md
@@ -21,10 +21,10 @@ Examples:
 
 ### 0. Resolve target slugs
 
-- If a slug arg was passed, validate `plugins/<slug>/.claude-plugin/plugin.json` exists. If not, abort with: `Plugin 'plugins/<slug>/' not found. Available: <comma-separated slugs>.`
-- If no slug, glob `plugins/*/.claude-plugin/plugin.json` and collect the directory names. Run tests for each in sequence.
+- If no slug arg was passed, run `bash scripts/test-all.sh` from the repo root (launches every plugin's suite in parallel; wall time is bounded by the slowest suite instead of their sum) and report its summary table directly — skip Steps 0-1 below entirely.
+- If a slug arg was passed, validate `plugins/<slug>/.claude-plugin/plugin.json` exists. If not, abort with: `Plugin 'plugins/<slug>/' not found. Available: <comma-separated slugs>.` Then continue to Step 1 for that single plugin.
 
-### 1. Run each suite (per slug)
+### 1. Run the suite (single-plugin arg only)
 
 Plugins ship one of two test conventions. Detect and dispatch:
 
@@ -32,10 +32,10 @@ Plugins ship one of two test conventions. Detect and dispatch:
   ```bash
   bash plugins/<slug>/tests/run-all.sh 2>&1
   ```
-- **Bun entrypoint** — else if any `plugins/<slug>/tests/*.test.ts` exists (core/HA convention): `cd plugins/<slug> && bun test 2>&1`.
+- **Bun entrypoint** — else if any `plugins/<slug>/tests/*.test.ts` exists (core/HA/feed convention): `cd plugins/<slug> && bun test 2>&1`.
 - **Neither marker** — mark `no tests configured` and continue.
 
-Capture full output. Extract pass/fail counts from each suite's summary line.
+Capture full output. Extract pass/fail counts from the suite's summary line.
 
 ### 2. Report
 

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -37,6 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - name: Run test suite
         run: bash tests/run-all.sh

--- a/.github/workflows/test-feed.yml
+++ b/.github/workflows/test-feed.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -37,6 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - name: Run test suite
         run: bun test

--- a/.github/workflows/test-fitness.yml
+++ b/.github/workflows/test-fitness.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -37,6 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - name: Run test suite
         run: bash tests/run-all.sh

--- a/.github/workflows/test-forge.yml
+++ b/.github/workflows/test-forge.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -44,6 +44,6 @@ jobs:
         run: composer install --no-dev --no-interaction --no-progress --working-dir=php
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - name: Run test suite (PHP unit + hook + skill-structure)
         run: bash tests/run-all.sh

--- a/.github/workflows/test-ha.yml
+++ b/.github/workflows/test-ha.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       # Python here is a TEST FIXTURE only (nothing shipped runs it): the
       # golden-corpus test replays the retired Python hooks against the TS
       # ports, and yaml-parity.test.ts compares against PyYAML.

--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - run: bun install --frozen-lockfile
       # No-op until the first .ts lands; tsc exits 18003 on zero inputs, so gate on file presence.
       - run: |
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       # The repo-internal /simplify mirror must stay byte-identical to the shipped skill.
       - name: Guard .claude/skills/simplify mirror
         run: diff -r .claude/skills/simplify plugins/claude-code-hermit/skills/simplify

--- a/.github/workflows/test-scribe.yml
+++ b/.github/workflows/test-scribe.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -37,6 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - name: Run test suite
         run: bash tests/run-all.sh

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "claude-code-hermit-monorepo",
   "private": true,
   "description": "Dev-only toolchain for the hermit plugin monorepo. Shipped plugins have zero runtime dependencies — bun runs their .ts sources directly; these devDependencies exist solely for `bunx tsc --noEmit` typechecking and test-only fuzzing.",
+  "scripts": {
+    "test": "bash scripts/test-all.sh"
+  },
   "devDependencies": {
     "@types/bun": "~1.3.11",
     "fast-check": "^4.1.0",

--- a/plugins/claude-code-hermit/bunfig.toml
+++ b/plugins/claude-code-hermit/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+concurrentTestGlob = ["**/*.test.ts"]

--- a/plugins/claude-code-hermit/tests/apply-settings-artifact-allow.test.ts
+++ b/plugins/claude-code-hermit/tests/apply-settings-artifact-allow.test.ts
@@ -1,20 +1,11 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-artifact-allow-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-artifact-allow-');
+afterAll(cleanup);
 
 function seedSettings(dir: string, settings: any): string {
   const claude = path.join(dir, '.claude');

--- a/plugins/claude-code-hermit/tests/apply-settings-automode-seed.test.ts
+++ b/plugins/claude-code-hermit/tests/apply-settings-automode-seed.test.ts
@@ -1,20 +1,11 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-automode-seed-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-automode-seed-');
+afterAll(cleanup);
 
 function seedFile(dir: string, name: string, settings: any): string {
   const claude = path.join(dir, '.claude');

--- a/plugins/claude-code-hermit/tests/apply-settings-channel-env.test.ts
+++ b/plugins/claude-code-hermit/tests/apply-settings-channel-env.test.ts
@@ -1,20 +1,11 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-channel-env-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-channel-env-');
+afterAll(cleanup);
 
 function seedSettings(dir: string, settings: any): string {
   const claude = path.join(dir, '.claude');

--- a/plugins/claude-code-hermit/tests/apply-settings-deny.test.ts
+++ b/plugins/claude-code-hermit/tests/apply-settings-deny.test.ts
@@ -1,20 +1,11 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-deny-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-deny-');
+afterAll(cleanup);
 
 function seedSettings(dir: string, settings: any): string {
   const claude = path.join(dir, '.claude');

--- a/plugins/claude-code-hermit/tests/cc-compat-hermitdir.test.ts
+++ b/plugins/claude-code-hermit/tests/cc-compat-hermitdir.test.ts
@@ -89,7 +89,7 @@ describe('hermitDir()', () => {
     expect(hermitDir()).toBe(path.join(tmp, '.claude-code-hermit'));
   });
 
-  it('(c) CLAUDE_PROJECT_DIR set, cwd drifted — env branch wins', () => {
+  it.serial('(c) CLAUDE_PROJECT_DIR set, cwd drifted — env branch wins', () => {
     // Simulate the #384 trigger: cwd drifted inside .claude-code-hermit/
     delete process.env.AGENT_DIR;
     process.env.CLAUDE_PROJECT_DIR = tmp;
@@ -97,14 +97,14 @@ describe('hermitDir()', () => {
     expect(hermitDir()).toBe(path.join(tmp, '.claude-code-hermit'));
   });
 
-  it('(d) no env vars, cwd drifted into subdir — walk-up recovers', () => {
+  it.serial('(d) no env vars, cwd drifted into subdir — walk-up recovers', () => {
     delete process.env.AGENT_DIR;
     delete process.env.CLAUDE_PROJECT_DIR;
     process.chdir(path.join(tmp, '.claude-code-hermit', 'state'));
     expect(hermitDir()).toBe(path.join(tmp, '.claude-code-hermit'));
   });
 
-  it('(e) no env vars, unrelated cwd — fail-open returns resolved .claude-code-hermit', () => {
+  it.serial('(e) no env vars, unrelated cwd — fail-open returns resolved .claude-code-hermit', () => {
     delete process.env.AGENT_DIR;
     delete process.env.CLAUDE_PROJECT_DIR;
     // Use a tmpdir with no hermit (walk-up finds nothing)
@@ -119,7 +119,7 @@ describe('hermitDir()', () => {
     }
   });
 
-  it('(b2) CLAUDE_PROJECT_DIR set but .claude-code-hermit subdir absent — falls to walk-up', () => {
+  it.serial('(b2) CLAUDE_PROJECT_DIR set but .claude-code-hermit subdir absent — falls to walk-up', () => {
     // existsSync guard: if CLAUDE_PROJECT_DIR doesn't actually have a .cch dir, skip it
     delete process.env.AGENT_DIR;
     const noHermit = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-noh-'));

--- a/plugins/claude-code-hermit/tests/channel-send.test.ts
+++ b/plugins/claude-code-hermit/tests/channel-send.test.ts
@@ -4,12 +4,12 @@
 // (HERMIT_TELEGRAM_API_URL override), so no real bot token or network access
 // is needed.
 
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { runScript } from './helpers/run';
 import { setupWorkdir, type Workdir } from './helpers/workdir';
-import { startHttpStub, type Stub } from './helpers/http-stub';
+import { startHttpStub } from './helpers/http-stub';
 import { unconsolidated, dbExists } from '../scripts/lib/channel-log';
 
 const hermit = (dir: string, ...p: string[]) => path.join(dir, '.claude-code-hermit', ...p);
@@ -27,115 +27,146 @@ function setupChannelWorkdir(): Workdir {
 }
 
 describe('channel-send CLI', () => {
-  let stub: Stub | undefined;
-  let wd: Workdir | undefined;
-
-  afterEach(() => {
-    stub?.stop();
-    stub = undefined;
-    wd?.cleanup();
-    wd = undefined;
-  });
-
   test('success: 2xx -> exit 0, request reaches the stub, out-log row written', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await runScript('channel-send.ts', {
-      args: [hermit(wd.dir), 'hello operator'],
-      env: { HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(1);
-    expect(stub.requests[0].body.text).toBe('hello operator');
-    expect(stub.requests[0].body.chat_id).toBe('12345');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await runScript('channel-send.ts', {
+        args: [hermit(wd.dir), 'hello operator'],
+        env: { HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(1);
+      expect(stub.requests[0].body.text).toBe('hello operator');
+      expect(stub.requests[0].body.chat_id).toBe('12345');
 
-    const rows = unconsolidated(hermit(wd.dir)).rows;
-    expect(rows.length).toBe(1);
-    expect(rows[0]).toMatchObject({ source: 'telegram', chat_id: '12345', direction: 'out', text: 'hello operator' });
+      const rows = unconsolidated(hermit(wd.dir)).rows;
+      expect(rows.length).toBe(1);
+      expect(rows[0]).toMatchObject({ source: 'telegram', chat_id: '12345', direction: 'out', text: 'hello operator' });
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('truncates text over the telegram 4096-char limit', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const longText = 'x'.repeat(5000);
-    const r = await runScript('channel-send.ts', {
-      args: [hermit(wd.dir), longText],
-      env: { HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests[0].body.text.length).toBe(4096);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const longText = 'x'.repeat(5000);
+      const r = await runScript('channel-send.ts', {
+        args: [hermit(wd.dir), longText],
+        env: { HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests[0].body.text.length).toBe(4096);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('reads the message from stdin when the text arg is "-"', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await runScript('channel-send.ts', {
-      args: [hermit(wd.dir), '-'],
-      stdin: 'from stdin',
-      env: { HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests[0].body.text).toBe('from stdin');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await runScript('channel-send.ts', {
+        args: [hermit(wd.dir), '-'],
+        stdin: 'from stdin',
+        env: { HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests[0].body.text).toBe('from stdin');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('whitespace-only stdin -> empty text, exit non-zero, no request sent', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await runScript('channel-send.ts', {
-      args: [hermit(wd.dir), '-'],
-      stdin: '   \n  ',
-      env: { HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).not.toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await runScript('channel-send.ts', {
+        args: [hermit(wd.dir), '-'],
+        stdin: '   \n  ',
+        env: { HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).not.toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('non-2xx platform response -> exit non-zero, no out-log row', async () => {
-    stub = startHttpStub();
+    const stub = startHttpStub();
     stub.setStatus(400);
-    wd = setupChannelWorkdir();
-    const r = await runScript('channel-send.ts', {
-      args: [hermit(wd.dir), 'hello'],
-      env: { HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).not.toBe(0);
-    expect(dbExists(hermit(wd.dir))).toBe(false);
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await runScript('channel-send.ts', {
+        args: [hermit(wd.dir), 'hello'],
+        env: { HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).not.toBe(0);
+      expect(dbExists(hermit(wd.dir))).toBe(false);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('dead listener -> exit non-zero with a stderr reason', async () => {
-    wd = setupChannelWorkdir();
-    const r = await runScript('channel-send.ts', {
-      args: [hermit(wd.dir), 'hello'],
-      env: { HERMIT_TELEGRAM_API_URL: 'http://127.0.0.1:1' },
-    });
-    expect(r.exitCode).not.toBe(0);
-    expect(r.stderr.length).toBeGreaterThan(0);
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await runScript('channel-send.ts', {
+        args: [hermit(wd.dir), 'hello'],
+        env: { HERMIT_TELEGRAM_API_URL: 'http://127.0.0.1:1' },
+      });
+      expect(r.exitCode).not.toBe(0);
+      expect(r.stderr.length).toBeGreaterThan(0);
+    } finally {
+      wd.cleanup();
+    }
   });
 
   test('missing token file -> exit non-zero, missing_token reason', async () => {
-    wd = setupWorkdir();
-    write(hermit(wd.dir, 'config.json'), JSON.stringify({
-      channels: { telegram: { enabled: true, dm_channel_id: '12345', state_dir: '.claude.local/channels/telegram' } },
-    }));
-    const r = await runScript('channel-send.ts', { args: [hermit(wd.dir), 'hello'] });
-    expect(r.exitCode).not.toBe(0);
-    expect(r.stderr).toContain('missing_token');
+    const wd = setupWorkdir();
+    try {
+      write(hermit(wd.dir, 'config.json'), JSON.stringify({
+        channels: { telegram: { enabled: true, dm_channel_id: '12345', state_dir: '.claude.local/channels/telegram' } },
+      }));
+      const r = await runScript('channel-send.ts', { args: [hermit(wd.dir), 'hello'] });
+      expect(r.exitCode).not.toBe(0);
+      expect(r.stderr).toContain('missing_token');
+    } finally {
+      wd.cleanup();
+    }
   });
 
   test('no eligible channel -> exit non-zero, no_reachable_channel reason', async () => {
-    wd = setupWorkdir();
-    write(hermit(wd.dir, 'config.json'), JSON.stringify({ channels: {} }));
-    const r = await runScript('channel-send.ts', { args: [hermit(wd.dir), 'hello'] });
-    expect(r.exitCode).not.toBe(0);
-    expect(r.stderr).toContain('no_reachable_channel');
+    const wd = setupWorkdir();
+    try {
+      write(hermit(wd.dir, 'config.json'), JSON.stringify({ channels: {} }));
+      const r = await runScript('channel-send.ts', { args: [hermit(wd.dir), 'hello'] });
+      expect(r.exitCode).not.toBe(0);
+      expect(r.stderr).toContain('no_reachable_channel');
+    } finally {
+      wd.cleanup();
+    }
   });
 
   test('unreadable config -> exit non-zero, config_read_failed reason', async () => {
-    wd = setupWorkdir();
-    // No config.json written at all.
-    const r = await runScript('channel-send.ts', { args: [hermit(wd.dir), 'hello'] });
-    expect(r.exitCode).not.toBe(0);
-    expect(r.stderr).toContain('config_read_failed');
+    const wd = setupWorkdir();
+    try {
+      // No config.json written at all.
+      const r = await runScript('channel-send.ts', { args: [hermit(wd.dir), 'hello'] });
+      expect(r.exitCode).not.toBe(0);
+      expect(r.stderr).toContain('config_read_failed');
+    } finally {
+      wd.cleanup();
+    }
   });
 
   test('missing arguments -> usage error, exit non-zero', async () => {

--- a/plugins/claude-code-hermit/tests/channel-status-responder.test.ts
+++ b/plugins/claude-code-hermit/tests/channel-status-responder.test.ts
@@ -7,12 +7,12 @@
 // (only emit {"decision":"block"} after a confirmed send; a failed send must
 // never leave both a blocked prompt and a silent operator).
 
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { runScript } from './helpers/run';
 import { setupWorkdir, type Workdir } from './helpers/workdir';
-import { startHttpStub, type Stub } from './helpers/http-stub';
+import { startHttpStub } from './helpers/http-stub';
 
 const hermit = (dir: string, ...p: string[]) => path.join(dir, '.claude-code-hermit', ...p);
 const write = (p: string, content: string) => fs.writeFileSync(p, content);
@@ -47,93 +47,117 @@ async function run(wd: Workdir, body: string, stubUrl: string, user = 'u1') {
 }
 
 describe('channel-status-responder', () => {
-  let stub: Stub | undefined;
-  let wd: Workdir | undefined;
-
-  afterEach(() => {
-    stub?.stop();
-    stub = undefined;
-    wd?.cleanup();
-    wd = undefined;
-  });
-
   test('exact "status" + allowed sender -> send-then-block', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    fs.writeFileSync(hermit(wd.dir, 'sessions', '.status.json'), JSON.stringify({ status: 'in_progress', task: 'writing the plan' }));
-    const r = await run(wd, 'status', stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(JSON.parse(r.stdout.trim())).toMatchObject({ decision: 'block' });
-    expect(stub.requests.length).toBe(1);
-    expect(stub.requests[0].body.text).toContain('writing the plan');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      fs.writeFileSync(hermit(wd.dir, 'sessions', '.status.json'), JSON.stringify({ status: 'in_progress', task: 'writing the plan' }));
+      const r = await run(wd, 'status', stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(JSON.parse(r.stdout.trim())).toMatchObject({ decision: 'block' });
+      expect(stub.requests.length).toBe(1);
+      expect(stub.requests[0].body.text).toContain('writing the plan');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('routes the reply to the chat it was asked on (group id), not dm_channel_id', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    // Asked in a Telegram group: chat_id is the group id, distinct from dm_channel_id (12345).
-    const groupPayload = JSON.stringify({ prompt: envelope('status', 'u1', '-1001234567890') });
-    const r = await runScript('channel-status-responder.ts', {
-      stdin: groupPayload,
-      cwd: wd.dir,
-      env: { HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).toBe(0);
-    expect(JSON.parse(r.stdout.trim())).toMatchObject({ decision: 'block' });
-    expect(stub.requests.length).toBe(1);
-    expect(stub.requests[0].body.chat_id).toBe('-1001234567890');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      // Asked in a Telegram group: chat_id is the group id, distinct from dm_channel_id (12345).
+      const groupPayload = JSON.stringify({ prompt: envelope('status', 'u1', '-1001234567890') });
+      const r = await runScript('channel-status-responder.ts', {
+        stdin: groupPayload,
+        cwd: wd.dir,
+        env: { HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).toBe(0);
+      expect(JSON.parse(r.stdout.trim())).toMatchObject({ decision: 'block' });
+      expect(stub.requests.length).toBe(1);
+      expect(stub.requests[0].body.chat_id).toBe('-1001234567890');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('case-insensitive and surrounding whitespace still match exactly', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await run(wd, '  STATUS  ', stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(JSON.parse(r.stdout.trim())).toMatchObject({ decision: 'block' });
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run(wd, '  STATUS  ', stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(JSON.parse(r.stdout.trim())).toMatchObject({ decision: 'block' });
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('near-miss body falls through to the model (no block, no send)', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await run(wd, 'what is the status of the task you are working on?', stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout.trim()).toBe('');
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run(wd, 'what is the status of the task you are working on?', stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('');
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('unauthorized sender -> no block, no send', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await run(wd, 'status', stub.url, 'not-allowed');
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout.trim()).toBe('');
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run(wd, 'status', stub.url, 'not-allowed');
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('');
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   // #10b: a failed deterministic send no longer falls through to a blind model turn —
   // it injects the composed status via stdout (probe-verified to reach the model) for
   // the model to relay verbatim, and does NOT block.
   test('failed send -> injects composed status for the model to relay (not a blind fallthrough)', async () => {
-    wd = setupChannelWorkdir();
-    const r = await run(wd, 'status', 'http://127.0.0.1:1'); // dead listener -> send fails
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).not.toContain('"decision":"block"'); // not blocked — model turn proceeds
-    expect(r.stdout).toContain('[status]');               // relay instruction emitted
-    expect(r.stdout).toContain('reply tool');             // tells the model to relay
-    expect(r.stdout).toContain('All quiet');              // carries the composed status text
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run(wd, 'status', 'http://127.0.0.1:1'); // dead listener -> send fails
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).not.toContain('"decision":"block"'); // not blocked — model turn proceeds
+      expect(r.stdout).toContain('[status]');               // relay instruction emitted
+      expect(r.stdout).toContain('reply tool');             // tells the model to relay
+      expect(r.stdout).toContain('All quiet');              // carries the composed status text
+    } finally {
+      wd.cleanup();
+    }
   });
 
   test('non-channel prompt -> no-op', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await runScript('channel-status-responder.ts', {
-      stdin: JSON.stringify({ prompt: 'status' }),
-      cwd: wd.dir,
-      env: { HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout.trim()).toBe('');
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await runScript('channel-status-responder.ts', {
+        stdin: JSON.stringify({ prompt: 'status' }),
+        cwd: wd.dir,
+        env: { HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('');
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('empty stdin -> fail open, exit 0', async () => {
@@ -142,70 +166,100 @@ describe('channel-status-responder', () => {
   });
 
   test('reply never leaks internal vocabulary (PROP/S-NNN)', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    fs.writeFileSync(hermit(wd.dir, 'sessions', '.status.json'), JSON.stringify({ status: 'in_progress', task: 'PROP-020 implementation' }));
-    await run(wd, 'status', stub.url);
-    const sent = stub.requests[0].body.text as string;
-    expect(sent).not.toMatch(/S-\d{3}/);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      fs.writeFileSync(hermit(wd.dir, 'sessions', '.status.json'), JSON.stringify({ status: 'in_progress', task: 'PROP-020 implementation' }));
+      await run(wd, 'status', stub.url);
+      const sent = stub.requests[0].body.text as string;
+      expect(sent).not.toMatch(/S-\d{3}/);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('paused session -> reply mentions the pause without reading .status.json', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    fs.mkdirSync(hermit(wd.dir, 'state'), { recursive: true });
-    write(hermit(wd.dir, 'state', 'pause.json'), JSON.stringify({
-      paused: true, paused_until: null, reason: 'operator', by: 'test', ts: new Date().toISOString(),
-    }));
-    const r = await run(wd, 'status', stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests[0].body.text).toContain('Paused');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      fs.mkdirSync(hermit(wd.dir, 'state'), { recursive: true });
+      write(hermit(wd.dir, 'state', 'pause.json'), JSON.stringify({
+        paused: true, paused_until: null, reason: 'operator', by: 'test', ts: new Date().toISOString(),
+      }));
+      const r = await run(wd, 'status', stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests[0].body.text).toContain('Paused');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('pending micro-proposal -> reply names the reply hint', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    write(hermit(wd.dir, 'state', 'micro-proposals.json'), JSON.stringify({
-      pending: [{ id: 'MP-20260705-0', status: 'pending', tier: 1, question: 'ok?' }],
-    }));
-    await run(wd, 'status', stub.url);
-    expect(stub.requests[0].body.text).toContain('MP-20260705-0');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      write(hermit(wd.dir, 'state', 'micro-proposals.json'), JSON.stringify({
+        pending: [{ id: 'MP-20260705-0', status: 'pending', tier: 1, question: 'ok?' }],
+      }));
+      await run(wd, 'status', stub.url);
+      expect(stub.requests[0].body.text).toContain('MP-20260705-0');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('over-budget -> reply names the cap', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir({ budget: { daily_usd: 5, weekly_usd: null, monthly_usd: null, action: 'alert' } });
-    await run(wd, 'status', stub.url);
-    expect(stub.requests[0].body.text).toContain('$5.00 cap');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir({ budget: { daily_usd: 5, weekly_usd: null, monthly_usd: null, action: 'alert' } });
+    try {
+      await run(wd, 'status', stub.url);
+      expect(stub.requests[0].body.text).toContain('$5.00 cap');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('empty/fresh state -> "all quiet" fallback', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    await run(wd, 'status', stub.url);
-    expect(stub.requests[0].body.text).toContain('All quiet');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      await run(wd, 'status', stub.url);
+      expect(stub.requests[0].body.text).toContain('All quiet');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   // #10a: an accepted-but-untrusted sender (no allowlist configured, message from a
   // chat that isn't the operator DM) gets a coarse reply — never spend, task, or IDs.
   test('untrusted sender (no allowlist, non-DM chat) -> redacted coarse status', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir({
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir({
       channels: { telegram: { enabled: true, dm_channel_id: '12345', state_dir: '.claude.local/channels/telegram' } },
       budget: { daily_usd: 5, weekly_usd: null, monthly_usd: null, action: 'alert' },
     });
-    fs.mkdirSync(hermit(wd.dir, 'sessions'), { recursive: true });
-    fs.mkdirSync(hermit(wd.dir, 'state'), { recursive: true });
-    write(hermit(wd.dir, 'sessions', '.status.json'), JSON.stringify({ task: 'secret-migration', status: 'in_progress' }));
-    write(hermit(wd.dir, 'state', 'micro-proposals.json'), JSON.stringify({ pending: [{ id: 'MP-20260705-0', status: 'pending', tier: 1, question: 'ok?' }] }));
+    try {
+      fs.mkdirSync(hermit(wd.dir, 'sessions'), { recursive: true });
+      fs.mkdirSync(hermit(wd.dir, 'state'), { recursive: true });
+      write(hermit(wd.dir, 'sessions', '.status.json'), JSON.stringify({ task: 'secret-migration', status: 'in_progress' }));
+      write(hermit(wd.dir, 'state', 'micro-proposals.json'), JSON.stringify({ pending: [{ id: 'MP-20260705-0', status: 'pending', tier: 1, question: 'ok?' }] }));
 
-    const stranger = JSON.stringify({ prompt: '<channel source="telegram" chat_id="999" user="stranger">status</channel>' });
-    const r = await runScript('channel-status-responder.ts', { stdin: stranger, cwd: wd.dir, env: { HERMIT_TELEGRAM_API_URL: stub.url } });
-    expect(r.exitCode).toBe(0);
-    const text = stub.requests[0].body.text;
-    expect(text).not.toContain('secret-migration'); // task text withheld
-    expect(text).not.toContain('$5.00');             // budget figure withheld
-    expect(text).not.toContain('MP-20260705-0');     // approval id withheld
-    expect(text).toContain('Working');               // coarse state only
+      const stranger = JSON.stringify({ prompt: '<channel source="telegram" chat_id="999" user="stranger">status</channel>' });
+      const r = await runScript('channel-status-responder.ts', { stdin: stranger, cwd: wd.dir, env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+      expect(r.exitCode).toBe(0);
+      const text = stub.requests[0].body.text;
+      expect(text).not.toContain('secret-migration'); // task text withheld
+      expect(text).not.toContain('$5.00');             // budget figure withheld
+      expect(text).not.toContain('MP-20260705-0');     // approval id withheld
+      expect(text).toContain('Working');               // coarse state only
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 });

--- a/plugins/claude-code-hermit/tests/cost-reflect-plain.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-reflect-plain.test.ts
@@ -7,7 +7,7 @@
 // Subprocess test (via runScript): cost-reflect.ts is invoked as a standalone
 // script, exactly how the SKILL.md Step 1 command runs it.
 
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -16,7 +16,7 @@ import { costByType } from '../scripts/lib/pricing';
 
 const dirs: string[] = [];
 
-afterEach(() => {
+afterAll(() => {
   while (dirs.length) {
     const d = dirs.pop()!;
     fs.rmSync(d, { recursive: true, force: true });

--- a/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
@@ -169,7 +169,7 @@ describe('Entrypoint: placeholder-free session name resolution', () => {
   // Crux: the resolved name must equal what getSessionName() produces — that is what
   // hermit-start uses to CREATE the session. Both sides must chdir into the same temp
   // dir because getSessionName() reads process.cwd() for {project_name}.
-  test('entrypoint: session-name resolution matches lib/tmux.getSessionName — default config', () => {
+  test.serial('entrypoint: session-name resolution matches lib/tmux.getSessionName — default config', () => {
     const originalCwd = process.cwd();
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-session-name-'));
     try {

--- a/plugins/claude-code-hermit/tests/docker-preflight.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-preflight.test.ts
@@ -1,20 +1,11 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-dpf-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-dpf-');
+afterAll(cleanup);
 
 async function run(projectRoot: string) {
   const r = await runScript('docker-preflight.ts', { args: [projectRoot] });

--- a/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript, PLUGIN_ROOT } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 
 const TEMPLATE_PATH = path.join(PLUGIN_ROOT, 'state-templates', 'config.json.template');
 const OWN_PLUGIN_JSON = JSON.parse(
@@ -10,17 +10,8 @@ const OWN_PLUGIN_JSON = JSON.parse(
 );
 const CORE_VERSION: string = OWN_PLUGIN_JSON.version;
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-hatch-config-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-hatch-config-');
+afterAll(cleanup);
 
 function configPathFor(projectRoot: string): string {
   return path.join(projectRoot, '.claude-code-hermit', 'config.json');

--- a/plugins/claude-code-hermit/tests/hatch-scaffold.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-scaffold.test.ts
@@ -1,23 +1,14 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript, PLUGIN_ROOT } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 
 const TEMPLATES = path.join(PLUGIN_ROOT, 'state-templates');
 const ISO_OFFSET = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}$/;
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-scaffold-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-scaffold-');
+afterAll(cleanup);
 
 async function scaffold(projectRoot: string, reinit = false) {
   const args = reinit ? [projectRoot, '--reinit=true'] : [projectRoot];

--- a/plugins/claude-code-hermit/tests/helpers/workdir.ts
+++ b/plugins/claude-code-hermit/tests/helpers/workdir.ts
@@ -31,6 +31,38 @@ export function setupWorkdir(): Workdir {
   };
 }
 
+// Test-body factory: wraps a test in a throwaway workdir, always cleaning up.
+// Safe under `bun test --concurrent` — each call gets its own mkdtemp dir and
+// cleans up only its own dir. Usage: test('name', withDir(async (dir) => {...}))
+export function withDir(fn: (dir: string) => Promise<void> | void) {
+  return async () => {
+    const wd = setupWorkdir();
+    try { await fn(wd.dir); } finally { wd.cleanup(); }
+  };
+}
+
+// Batch-cleanup factory for the freshDir()/tmpdirs pattern duplicated across
+// several test files (each mkdtemps eagerly per-test but defers all removal to
+// a single afterAll). Safe under `bun test --concurrent`: cleanup runs only
+// after every test in the file has finished, so no concurrently-running
+// test's dir is ever deleted out from under it.
+// Usage: const { freshDir, cleanup } = freshDirFactory('hermit-foo-'); afterAll(cleanup);
+export function freshDirFactory(prefix: string) {
+  const tmpdirs: string[] = [];
+  return {
+    freshDir(): string {
+      const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+      tmpdirs.push(d);
+      return d;
+    },
+    cleanup(): void {
+      for (const d of tmpdirs.splice(0)) {
+        try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+      }
+    },
+  };
+}
+
 // Same as setupWorkdir but initialises a git repo (needed by session-diff).
 export function setupGitWorkdir(): Workdir {
   const wd = setupWorkdir();

--- a/plugins/claude-code-hermit/tests/hermit-start.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-start.test.ts
@@ -20,7 +20,7 @@
 //
 // Usage: bun test tests/hermit-start.test.ts   (from the plugin root)
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test as bunTest, expect, beforeEach, afterEach } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -38,6 +38,12 @@ import {
   hydrateSetupTokenEnv,
 } from '../scripts/hermit-start';
 import { TOKEN_ENV_VAR } from '../scripts/lib/setup-token';
+
+// The top-level beforeEach/afterEach below process.chdir()s into a fresh
+// tempdir for every test in this file — a process-global mutation two
+// concurrently-running tests can't both have. Alias `test` to force the
+// whole file to run serially under `bun test --concurrent`.
+const test = bunTest.serial;
 
 const PLUGIN_ROOT = path.resolve(import.meta.dir, '..');
 

--- a/plugins/claude-code-hermit/tests/hermit-stop.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-stop.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -13,36 +13,31 @@ const STOP_IMPL = fs.existsSync(path.join(SCRIPTS_DIR, 'hermit-stop.ts'))
 const STOP_CMD = STOP_IMPL.endsWith('.ts') ? ['bun', STOP_IMPL] : ['python3', STOP_IMPL];
 const IS_TS = STOP_IMPL.endsWith('.ts');
 
-let dir: string;
-
-beforeEach(() => {
-  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-stop-'));
+function makeDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-stop-'));
   fs.mkdirSync(path.join(dir, '.claude-code-hermit', 'state'), { recursive: true });
   fs.mkdirSync(path.join(dir, '.claude-code-hermit', 'sessions'), { recursive: true });
-});
+  return dir;
+}
 
-afterEach(() => {
-  fs.rmSync(dir, { recursive: true, force: true });
-});
-
-function writeConfig(extra: Record<string, any> = {}) {
+function writeConfig(dir: string, extra: Record<string, any> = {}) {
   fs.writeFileSync(
     path.join(dir, '.claude-code-hermit', 'config.json'),
     JSON.stringify({ agent_name: 't', always_on: true, tmux_session_name: 'hermit-test', ...extra }, null, 2)
   );
 }
 
-function writeRuntime(data: Record<string, any>) {
+function writeRuntime(dir: string, data: Record<string, any>) {
   fs.writeFileSync(path.join(dir, '.claude-code-hermit', 'state', 'runtime.json'), JSON.stringify(data));
 }
 
-function readJson(rel: string) {
+function readJson(dir: string, rel: string) {
   return JSON.parse(fs.readFileSync(path.join(dir, rel), 'utf-8'));
 }
 
 // Stateful fake tmux: `has-session` consults a marker file so tests can make
 // the session "exit" mid-run; every invocation is logged for assertions.
-function installFakeTmux(opts: { hasSession?: boolean; dieOnSessionClose?: boolean } = {}) {
+function installFakeTmux(dir: string, opts: { hasSession?: boolean; dieOnSessionClose?: boolean } = {}) {
   const bin = path.join(dir, 'fake-bin');
   fs.mkdirSync(bin, { recursive: true });
   const log = path.join(dir, 'tmux.log');
@@ -67,7 +62,7 @@ esac
   return { log, aliveMarker, bin };
 }
 
-async function runStop(args: string[], fakeBin?: string) {
+async function runStop(dir: string, args: string[], fakeBin?: string) {
   const env: Record<string, string> = { ...process.env } as any;
   if (fakeBin) env.PATH = `${fakeBin}:${env.PATH}`;
   const proc = Bun.spawn([...STOP_CMD, ...args], {
@@ -84,92 +79,122 @@ async function runStop(args: string[], fakeBin?: string) {
 
 describe('hermit-stop contract', () => {
   test('no config → exit 1 with guidance', async () => {
-    const { exitCode, stdout } = await runStop([]);
-    expect(exitCode).toBe(1);
-    expect(stdout).toContain('No config found');
+    const dir = makeDir();
+    try {
+      const { exitCode, stdout } = await runStop(dir, []);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('No config found');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('no session, interactive runtime → guidance, always_on reset, lifecycle untouched', async () => {
-    writeConfig();
-    writeRuntime({ runtime_mode: 'interactive', session_state: 'in_progress' });
-    const { bin } = installFakeTmux({ hasSession: false });
-    const { exitCode, stdout } = await runStop([], bin);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain('running in interactive mode');
-    expect(readJson('.claude-code-hermit/config.json').always_on).toBe(false);
-    // The Stop hook owns the idle transition — stop must not have written it.
-    expect(readJson('.claude-code-hermit/state/runtime.json').session_state).toBe('in_progress');
+    const dir = makeDir();
+    try {
+      writeConfig(dir);
+      writeRuntime(dir, { runtime_mode: 'interactive', session_state: 'in_progress' });
+      const { bin } = installFakeTmux(dir, { hasSession: false });
+      const { exitCode, stdout } = await runStop(dir, [], bin);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('running in interactive mode');
+      expect(readJson(dir, '.claude-code-hermit/config.json').always_on).toBe(false);
+      // The Stop hook owns the idle transition — stop must not have written it.
+      expect(readJson(dir, '.claude-code-hermit/state/runtime.json').session_state).toBe('in_progress');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('no session, non-interactive → idle written with cleared transition', async () => {
-    writeConfig();
-    writeRuntime({ runtime_mode: 'tmux', session_state: 'in_progress', transition: 'stopping' });
-    fs.writeFileSync(path.join(dir, '.claude-code-hermit', 'sessions', 'S-001-REPORT.md'), '# r');
-    const { bin } = installFakeTmux({ hasSession: false });
-    const { exitCode, stdout } = await runStop([], bin);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain('No running session: hermit-test');
-    expect(stdout).toContain('S-001-REPORT.md');
-    const rt = readJson('.claude-code-hermit/state/runtime.json');
-    expect(rt.session_state).toBe('idle');
-    expect(rt.transition).toBeNull();
-    expect(rt.transition_target).toBeNull();
-    expect(rt.transition_started_at).toBeNull();
-    expect(rt.shutdown_completed_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}$/);
-    expect(rt.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}$/);
-    expect(readJson('.claude-code-hermit/config.json').always_on).toBe(false);
+    const dir = makeDir();
+    try {
+      writeConfig(dir);
+      writeRuntime(dir, { runtime_mode: 'tmux', session_state: 'in_progress', transition: 'stopping' });
+      fs.writeFileSync(path.join(dir, '.claude-code-hermit', 'sessions', 'S-001-REPORT.md'), '# r');
+      const { bin } = installFakeTmux(dir, { hasSession: false });
+      const { exitCode, stdout } = await runStop(dir, [], bin);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('No running session: hermit-test');
+      expect(stdout).toContain('S-001-REPORT.md');
+      const rt = readJson(dir, '.claude-code-hermit/state/runtime.json');
+      expect(rt.session_state).toBe('idle');
+      expect(rt.transition).toBeNull();
+      expect(rt.transition_target).toBeNull();
+      expect(rt.transition_started_at).toBeNull();
+      expect(rt.shutdown_completed_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}$/);
+      expect(rt.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}$/);
+      expect(readJson(dir, '.claude-code-hermit/config.json').always_on).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('--force with live session → kill-session, unclean_shutdown recorded', async () => {
-    writeConfig();
-    writeRuntime({ runtime_mode: 'tmux', session_state: 'in_progress' });
-    const { bin, log } = installFakeTmux({ hasSession: true });
-    const { exitCode, stdout } = await runStop(['--force'], bin);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain('Force-killing session: hermit-test');
-    expect(stdout).toContain('not closed gracefully');
-    expect(fs.readFileSync(log, 'utf-8')).toContain('kill-session -t hermit-test');
-    const rt = readJson('.claude-code-hermit/state/runtime.json');
-    expect(rt.session_state).toBe('idle');
-    expect(rt.last_error).toBe('unclean_shutdown');
-    expect(rt.shutdown_requested_at).toBeDefined();
-    expect(readJson('.claude-code-hermit/config.json').always_on).toBe(false);
+    const dir = makeDir();
+    try {
+      writeConfig(dir);
+      writeRuntime(dir, { runtime_mode: 'tmux', session_state: 'in_progress' });
+      const { bin, log } = installFakeTmux(dir, { hasSession: true });
+      const { exitCode, stdout } = await runStop(dir, ['--force'], bin);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Force-killing session: hermit-test');
+      expect(stdout).toContain('not closed gracefully');
+      expect(fs.readFileSync(log, 'utf-8')).toContain('kill-session -t hermit-test');
+      const rt = readJson(dir, '.claude-code-hermit/state/runtime.json');
+      expect(rt.session_state).toBe('idle');
+      expect(rt.last_error).toBe('unclean_shutdown');
+      expect(rt.shutdown_requested_at).toBeDefined();
+      expect(readJson(dir, '.claude-code-hermit/config.json').always_on).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('graceful: session-close sent, session exits, no report → unclean recorded', async () => {
-    writeConfig({ heartbeat: { enabled: true } });
-    writeRuntime({ runtime_mode: 'tmux', session_state: 'in_progress' });
-    const { bin, log } = installFakeTmux({ hasSession: true, dieOnSessionClose: true });
-    const { exitCode, stdout } = await runStop([], bin);
-    expect(exitCode).toBe(0);
-    const tmuxLog = fs.readFileSync(log, 'utf-8');
-    expect(tmuxLog).toContain('heartbeat stop');
-    expect(tmuxLog).toContain('session-close --shutdown');
-    expect(stdout).toContain('Session exited without generating a report');
-    const rt = readJson('.claude-code-hermit/state/runtime.json');
-    expect(rt.session_state).toBe('idle');
-    expect(rt.last_error).toBe('unclean_shutdown');
-    expect(rt.shutdown_requested_at).toBeDefined();
-    expect(rt.shutdown_completed_at).toBeDefined();
+    const dir = makeDir();
+    try {
+      writeConfig(dir, { heartbeat: { enabled: true } });
+      writeRuntime(dir, { runtime_mode: 'tmux', session_state: 'in_progress' });
+      const { bin, log } = installFakeTmux(dir, { hasSession: true, dieOnSessionClose: true });
+      const { exitCode, stdout } = await runStop(dir, [], bin);
+      expect(exitCode).toBe(0);
+      const tmuxLog = fs.readFileSync(log, 'utf-8');
+      expect(tmuxLog).toContain('heartbeat stop');
+      expect(tmuxLog).toContain('session-close --shutdown');
+      expect(stdout).toContain('Session exited without generating a report');
+      const rt = readJson(dir, '.claude-code-hermit/state/runtime.json');
+      expect(rt.session_state).toBe('idle');
+      expect(rt.last_error).toBe('unclean_shutdown');
+      expect(rt.shutdown_requested_at).toBeDefined();
+      expect(rt.shutdown_completed_at).toBeDefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   }, 20000);
 
   test.if(IS_TS)('lifecycle lock contention → exit 1, no state mutation', async () => {
-    writeConfig();
-    writeRuntime({ runtime_mode: 'tmux', session_state: 'in_progress' });
-    const lock = path.join(dir, '.claude-code-hermit', 'state', '.lifecycle.lock');
-    // A real, signalable, same-user holder — a foreign-user pid (EPERM) is no
-    // longer treated as a hermit holder, so pid 1 would be taken over.
-    const holder = Bun.spawn(['sleep', '30']);
+    const dir = makeDir();
     try {
-      fs.writeFileSync(lock, String(holder.pid));
-      const { bin } = installFakeTmux({ hasSession: false });
-      const { exitCode, stdout } = await runStop([], bin);
-      expect(exitCode).toBe(1);
-      expect(stdout).toContain('Another lifecycle operation in progress');
-      expect(readJson('.claude-code-hermit/state/runtime.json').session_state).toBe('in_progress');
-      expect(readJson('.claude-code-hermit/config.json').always_on).toBe(true);
+      writeConfig(dir);
+      writeRuntime(dir, { runtime_mode: 'tmux', session_state: 'in_progress' });
+      const lock = path.join(dir, '.claude-code-hermit', 'state', '.lifecycle.lock');
+      // A real, signalable, same-user holder — a foreign-user pid (EPERM) is no
+      // longer treated as a hermit holder, so pid 1 would be taken over.
+      const holder = Bun.spawn(['sleep', '30']);
+      try {
+        fs.writeFileSync(lock, String(holder.pid));
+        const { bin } = installFakeTmux(dir, { hasSession: false });
+        const { exitCode, stdout } = await runStop(dir, [], bin);
+        expect(exitCode).toBe(1);
+        expect(stdout).toContain('Another lifecycle operation in progress');
+        expect(readJson(dir, '.claude-code-hermit/state/runtime.json').session_state).toBe('in_progress');
+        expect(readJson(dir, '.claude-code-hermit/config.json').always_on).toBe(true);
+      } finally {
+        holder.kill();
+      }
     } finally {
-      holder.kill();
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/plugins/claude-code-hermit/tests/hook-cwd-drift.test.ts
+++ b/plugins/claude-code-hermit/tests/hook-cwd-drift.test.ts
@@ -54,8 +54,13 @@ function driftEnv(): Record<string, string> {
 // Tier 1: validate-config (the reported bug)
 // -------------------------------------------------------------------------
 
+// The second test overwrites (and restores) the shared hermitDir/config.json
+// fixture in-place — a mutation of tmpRoot, not just a read — which the first
+// test also reads via an absolute path. Empirically confirmed (bun 1.3.14):
+// describe.serial does not reliably force sequential execution of its own
+// child tests under --concurrent — per-test .serial marking does.
 describe('validate-config with drifted cwd (#384 regression)', () => {
-  it('exits 0 for valid config when cwd is inside .claude-code-hermit/', async () => {
+  it.serial('exits 0 for valid config when cwd is inside .claude-code-hermit/', async () => {
     // Before fix: readFileSync(path.resolve('.claude-code-hermit/config.json')) from
     // driftedCwd = .../state → read .../state/.claude-code-hermit/config.json → ENOENT → exit 2
     // After fix: reads filePath (absolute from payload) directly → exit 0
@@ -71,7 +76,7 @@ describe('validate-config with drifted cwd (#384 regression)', () => {
     expect(result.stderr).toContain('[config-validate] OK');
   });
 
-  it('still exits 2 for invalid config (double-path fix does not break validation)', async () => {
+  it.serial('still exits 2 for invalid config (double-path fix does not break validation)', async () => {
     const badConfig = JSON.stringify({ escalation: 'bad-value', channels: {}, env: {}, heartbeat: {}, routines: [], quality_gate: {} });
     const badConfigPath = path.join(hermitDir, 'config-bad.json');
     fs.writeFileSync(badConfigPath, badConfig);

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -149,6 +149,10 @@ describe('cost-tracker', () => {
 // freezes its CWD-relative state paths (.status.json etc.) at import time. So we
 // chdir into ONE shared workdir for the first (and only) import, restore CWD, and
 // both cases rewrite .status.json inside that same frozen workdir.
+// Empirically confirmed (bun 1.3.14): describe.serial does not reliably force
+// sequential execution under --concurrent — per-test .serial marking does,
+// and also keeps this describe's beforeAll (which does a real process.chdir)
+// out of the concurrent pool.
 describe('cost-tracker getCumulativeCost (in-process)', () => {
   let wd: Workdir;
   let getCumulativeCost: typeof import('../scripts/cost-tracker').getCumulativeCost;
@@ -167,7 +171,7 @@ describe('cost-tracker getCumulativeCost (in-process)', () => {
 
   afterAll(() => wd.cleanup());
 
-  test('getCumulativeCost (same session → accumulates)', () => {
+  test.serial('getCumulativeCost (same session → accumulates)', () => {
     write(hermit(wd.dir, 'sessions', '.status.json'),
       '{"session_id":"S-001","cost_usd":698.78,"tokens":300000000,"operator_turns":0}');
     const r = getCumulativeCost(0.10, 1000, false, 'S-001', undefined);
@@ -175,7 +179,7 @@ describe('cost-tracker getCumulativeCost (in-process)', () => {
     expect(r.tokens).toBe(300001000);
   });
 
-  test('getCumulativeCost (session change → resets)', () => {
+  test.serial('getCumulativeCost (session change → resets)', () => {
     write(hermit(wd.dir, 'sessions', '.status.json'),
       '{"session_id":"S-001","cost_usd":698.78,"tokens":300000000,"operator_turns":5}');
     const r = getCumulativeCost(0.10, 1000, false, 'S-002', undefined);

--- a/plugins/claude-code-hermit/tests/lockfile.test.ts
+++ b/plugins/claude-code-hermit/tests/lockfile.test.ts
@@ -1,132 +1,192 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { acquireLock, releaseLock } from '../scripts/lib/lockfile';
 
-let dir: string;
-let lock: string;
-
-beforeEach(() => {
-  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-lock-'));
-  lock = path.join(dir, '.lifecycle.lock');
-});
-
-afterEach(() => {
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+function makeDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-lock-'));
+}
 
 describe('lockfile', () => {
   test('acquire on clean state succeeds and records our pid', () => {
-    expect(acquireLock(lock)).toBe(true);
-    expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      expect(acquireLock(lock)).toBe(true);
+      expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('live contention: fresh lock held by a running same-user pid is not stolen', () => {
-    // A real, signalable, same-user process — pid 1 is no longer usable here
-    // because EPERM (another user) now reads as not-a-hermit-holder.
-    const holder = Bun.spawn(['sleep', '30']);
+    const dir = makeDir();
     try {
-      fs.writeFileSync(lock, String(holder.pid));
-      expect(acquireLock(lock)).toBe(false);
-      expect(fs.readFileSync(lock, 'utf-8')).toBe(String(holder.pid));
+      const lock = path.join(dir, '.lifecycle.lock');
+      // A real, signalable, same-user process — pid 1 is no longer usable here
+      // because EPERM (another user) now reads as not-a-hermit-holder.
+      const holder = Bun.spawn(['sleep', '30']);
+      try {
+        fs.writeFileSync(lock, String(holder.pid));
+        expect(acquireLock(lock)).toBe(false);
+        expect(fs.readFileSync(lock, 'utf-8')).toBe(String(holder.pid));
+      } finally {
+        holder.kill();
+      }
     } finally {
-      holder.kill();
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
   test('foreign-user pid (EPERM) is treated as not-holding, not wedged for the stale window', () => {
-    // pid 1 (init, root-owned) is alive but unsignalable by a non-root test
-    // runner → EPERM. The single-user invariant means it cannot be a hermit
-    // holder, so a FRESH lock naming it is still taken over immediately.
-    fs.writeFileSync(lock, '1'); // mtime = now (fresh)
-    expect(acquireLock(lock)).toBe(true);
-    expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      // pid 1 (init, root-owned) is alive but unsignalable by a non-root test
+      // runner → EPERM. The single-user invariant means it cannot be a hermit
+      // holder, so a FRESH lock naming it is still taken over immediately.
+      fs.writeFileSync(lock, '1'); // mtime = now (fresh)
+      expect(acquireLock(lock)).toBe(true);
+      expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('dead-pid takeover: crashed holder is replaced', () => {
-    // Spawn-and-reap a process so its pid is known-dead.
-    const proc = Bun.spawnSync(['true']);
-    const deadPid = proc.pid ?? 99999;
-    fs.writeFileSync(lock, String(deadPid));
-    expect(acquireLock(lock)).toBe(true);
-    expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      // Spawn-and-reap a process so its pid is known-dead.
+      const proc = Bun.spawnSync(['true']);
+      const deadPid = proc.pid ?? 99999;
+      fs.writeFileSync(lock, String(deadPid));
+      expect(acquireLock(lock)).toBe(true);
+      expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('legacy empty flock file is treated as stale (python holders never wrote pids)', () => {
-    fs.writeFileSync(lock, '');
-    expect(acquireLock(lock)).toBe(true);
-    expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      fs.writeFileSync(lock, '');
+      expect(acquireLock(lock)).toBe(true);
+      expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('garbage content is treated as stale', () => {
-    fs.writeFileSync(lock, 'not-a-pid\n');
-    expect(acquireLock(lock)).toBe(true);
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      fs.writeFileSync(lock, 'not-a-pid\n');
+      expect(acquireLock(lock)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('mtime staleness overrides liveness (pid-reuse-after-reboot guard)', () => {
-    // A genuinely-alive same-user pid, but the lock is an hour old → stale wins.
-    const holder = Bun.spawn(['sleep', '30']);
+    const dir = makeDir();
     try {
-      fs.writeFileSync(lock, String(holder.pid));
-      const old = new Date(Date.now() - 60 * 60 * 1000);
-      fs.utimesSync(lock, old, old);
-      expect(acquireLock(lock, 15 * 60 * 1000)).toBe(true);
-      expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+      const lock = path.join(dir, '.lifecycle.lock');
+      // A genuinely-alive same-user pid, but the lock is an hour old → stale wins.
+      const holder = Bun.spawn(['sleep', '30']);
+      try {
+        fs.writeFileSync(lock, String(holder.pid));
+        const old = new Date(Date.now() - 60 * 60 * 1000);
+        fs.utimesSync(lock, old, old);
+        expect(acquireLock(lock, 15 * 60 * 1000)).toBe(true);
+        expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+      } finally {
+        holder.kill();
+      }
     } finally {
-      holder.kill();
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
   test('real fs errors surface — they are NOT masked as contention', () => {
-    // A lock path whose parent does not exist makes the temp write fail ENOENT;
-    // the old bare catch returned false ("another op in progress"), masking it.
-    const bad = path.join(dir, 'no-such-subdir', '.lifecycle.lock');
-    expect(() => acquireLock(bad)).toThrow();
+    const dir = makeDir();
+    try {
+      // A lock path whose parent does not exist makes the temp write fail ENOENT;
+      // the old bare catch returned false ("another op in progress"), masking it.
+      const bad = path.join(dir, 'no-such-subdir', '.lifecycle.lock');
+      expect(() => acquireLock(bad)).toThrow();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('seeded-stale double-acquire: two racers over one stale lock yield exactly one holder', async () => {
-    // Pre-seed an hour-old stale lock, then race N acquirers. The rename-based
-    // takeover must let exactly one win — unlink-by-path takeover would let the
-    // loser delete the winner's fresh lock and both end up "holding" it.
-    fs.writeFileSync(lock, '999999'); // bogus pid, hour-old → unambiguously stale
-    const old = new Date(Date.now() - 60 * 60 * 1000);
-    fs.utimesSync(lock, old, old);
-    const script = `
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      // Pre-seed an hour-old stale lock, then race N acquirers. The rename-based
+      // takeover must let exactly one win — unlink-by-path takeover would let the
+      // loser delete the winner's fresh lock and both end up "holding" it.
+      fs.writeFileSync(lock, '999999'); // bogus pid, hour-old → unambiguously stale
+      const old = new Date(Date.now() - 60 * 60 * 1000);
+      fs.utimesSync(lock, old, old);
+      const script = `
       import { acquireLock } from '${path.join(import.meta.dir, '../scripts/lib/lockfile.ts')}';
       if (acquireLock('${lock}')) { console.log('WON'); await Bun.sleep(2000); }
       else { console.log('LOST'); }
     `;
-    const procs = Array.from({ length: 8 }, () => Bun.spawn(['bun', '-e', script], { stdout: 'pipe' }));
-    const outs = await Promise.all(procs.map(async (p) => {
-      await p.exited;
-      return (await new Response(p.stdout).text()).trim();
-    }));
-    expect(outs.filter((o) => o === 'WON').length).toBe(1);
-    expect(outs.length).toBe(8);
+      const procs = Array.from({ length: 8 }, () => Bun.spawn(['bun', '-e', script], { stdout: 'pipe' }));
+      const outs = await Promise.all(procs.map(async (p) => {
+        await p.exited;
+        return (await new Response(p.stdout).text()).trim();
+      }));
+      expect(outs.filter((o) => o === 'WON').length).toBe(1);
+      expect(outs.length).toBe(8);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('reentrant: our own pid in the lock is not contention', () => {
-    expect(acquireLock(lock)).toBe(true);
-    expect(acquireLock(lock)).toBe(true);
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      expect(acquireLock(lock)).toBe(true);
+      expect(acquireLock(lock)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('release removes only our own lock', () => {
-    fs.writeFileSync(lock, '1');
-    releaseLock(lock);
-    expect(fs.existsSync(lock)).toBe(true); // not ours — untouched
-    fs.unlinkSync(lock);
-    acquireLock(lock);
-    releaseLock(lock);
-    expect(fs.existsSync(lock)).toBe(false);
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      fs.writeFileSync(lock, '1');
+      releaseLock(lock);
+      expect(fs.existsSync(lock)).toBe(true); // not ours — untouched
+      fs.unlinkSync(lock);
+      acquireLock(lock);
+      releaseLock(lock);
+      expect(fs.existsSync(lock)).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('concurrent acquisition race: exactly one of N parallel processes wins', async () => {
-    // Winners must stay alive while the others contend — a dead winner's lock
-    // is legitimately taken over (that IS the design, mirroring flock's
-    // release-on-exit). Each winner holds the lock for 2s, far longer than
-    // the contention window.
-    const script = `
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      // Winners must stay alive while the others contend — a dead winner's lock
+      // is legitimately taken over (that IS the design, mirroring flock's
+      // release-on-exit). Each winner holds the lock for 2s, far longer than
+      // the contention window.
+      const script = `
       import { acquireLock } from '${path.join(import.meta.dir, '../scripts/lib/lockfile.ts')}';
       if (acquireLock('${lock}')) {
         console.log('WON');
@@ -135,15 +195,18 @@ describe('lockfile', () => {
         console.log('LOST');
       }
     `;
-    const procs = Array.from({ length: 8 }, () =>
-      Bun.spawn(['bun', '-e', script], { stdout: 'pipe' })
-    );
-    const outs = await Promise.all(procs.map(async (p) => {
-      await p.exited;
-      return (await new Response(p.stdout).text()).trim();
-    }));
-    const winners = outs.filter((o) => o === 'WON');
-    expect(winners.length).toBe(1);
-    expect(outs.length).toBe(8);
+      const procs = Array.from({ length: 8 }, () =>
+        Bun.spawn(['bun', '-e', script], { stdout: 'pipe' })
+      );
+      const outs = await Promise.all(procs.map(async (p) => {
+        await p.exited;
+        return (await new Response(p.stdout).text()).trim();
+      }));
+      const winners = outs.filter((o) => o === 'WON');
+      expect(winners.length).toBe(1);
+      expect(outs.length).toBe(8);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/claude-code-hermit/tests/manifest-seed.test.ts
+++ b/plugins/claude-code-hermit/tests/manifest-seed.test.ts
@@ -1,19 +1,13 @@
 // Contract test for scripts/manifest-seed.ts.
 // Exercises the process boundary (stdin in, exit code/file out, fail-loud).
 
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
 import { runScript, PLUGIN_ROOT } from './helpers/run';
-import { setupWorkdir, Workdir } from './helpers/workdir';
+import { withDir } from './helpers/workdir';
 import { sha256 } from '../scripts/lib/hash';
-
-let wd: Workdir | null = null;
-afterEach(() => {
-  wd?.cleanup();
-  wd = null;
-});
 
 function manifestPath(dir: string): string {
   return path.join(dir, '.claude-code-hermit', 'state', 'template-manifest.json');
@@ -26,43 +20,40 @@ function readManifest(dir: string): any {
 }
 
 describe('manifest-seed: hashing + shape', () => {
-  test('hashes a file correctly and stamps plugin_version', async () => {
-    wd = setupWorkdir();
-    const f = path.join(wd.dir, 'sample.txt');
+  test('hashes a file correctly and stamps plugin_version', withDir(async (dir) => {
+    const f = path.join(dir, 'sample.txt');
     fs.writeFileSync(f, 'hello world\n');
 
     const r = await runScript('manifest-seed.ts', {
-      args: [stateArg(wd.dir)],
+      args: [stateArg(dir)],
       stdin: JSON.stringify({ pluginVersion: '1.2.9', entries: [{ key: 'templates/a', file: f }] }),
     });
     expect(r.exitCode).toBe(0);
 
-    const m = readManifest(wd.dir);
+    const m = readManifest(dir);
     expect(m.version).toBe(1);
     expect(m.files['templates/a'].sha256).toBe(sha256(fs.readFileSync(f)));
     expect(m.files['templates/a'].plugin_version).toBe('1.2.9');
-  });
+  }));
 
-  test('every written sha256 is 64-hex (shape evolve-plan validates)', async () => {
-    wd = setupWorkdir();
-    const f = path.join(wd.dir, 'sample.txt');
+  test('every written sha256 is 64-hex (shape evolve-plan validates)', withDir(async (dir) => {
+    const f = path.join(dir, 'sample.txt');
     fs.writeFileSync(f, 'data');
     await runScript('manifest-seed.ts', {
-      args: [stateArg(wd.dir)],
+      args: [stateArg(dir)],
       stdin: JSON.stringify({ pluginVersion: '1.0.0', entries: [{ key: 'bin/x', file: f }] }),
     });
-    const m = readManifest(wd.dir);
+    const m = readManifest(dir);
     for (const v of Object.values(m.files) as any[]) {
       expect(v.sha256).toMatch(/^[0-9a-f]{64}$/);
     }
-  });
+  }));
 });
 
 describe('manifest-seed: foreign-key preservation', () => {
-  test('preserves untouched keys, overwrites re-seeded ones', async () => {
-    wd = setupWorkdir();
+  test('preserves untouched keys, overwrites re-seeded ones', withDir(async (dir) => {
     fs.writeFileSync(
-      manifestPath(wd.dir),
+      manifestPath(dir),
       JSON.stringify({
         version: 1,
         files: {
@@ -72,44 +63,43 @@ describe('manifest-seed: foreign-key preservation', () => {
         },
       }) + '\n',
     );
-    const f = path.join(wd.dir, 'a.txt');
+    const f = path.join(dir, 'a.txt');
     fs.writeFileSync(f, 'new content');
 
     const r = await runScript('manifest-seed.ts', {
-      args: [stateArg(wd.dir)],
+      args: [stateArg(dir)],
       stdin: JSON.stringify({ pluginVersion: '1.2.9', entries: [{ key: 'templates/a', file: f }] }),
     });
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toContain('preserved 2 foreign keys');
 
-    const m = readManifest(wd.dir);
+    const m = readManifest(dir);
     // Foreign keys survive untouched.
     expect(m.files['templates/some-addon'].sha256).toBe('a'.repeat(64));
     expect(m.files['sibling-hermit/CLAUDE-APPEND.md'].sha256).toBe('b'.repeat(64));
     // Re-seeded key overwritten with the real hash + new version.
     expect(m.files['templates/a'].sha256).toBe(sha256(fs.readFileSync(f)));
     expect(m.files['templates/a'].plugin_version).toBe('1.2.9');
-  });
+  }));
 });
 
 describe('manifest-seed: keyPrefix/dir enumeration', () => {
-  test('enumerates the source dir, one entry per file', async () => {
-    wd = setupWorkdir();
-    const binSrc = path.join(wd.dir, 'src-bin');
+  test('enumerates the source dir, one entry per file', withDir(async (dir) => {
+    const binSrc = path.join(dir, 'src-bin');
     fs.mkdirSync(binSrc);
     fs.writeFileSync(path.join(binSrc, 'hermit-start'), '#!/usr/bin/env bun\n');
     fs.writeFileSync(path.join(binSrc, 'hermit-stop'), '#!/usr/bin/env bun\n');
     fs.mkdirSync(path.join(binSrc, 'subdir')); // must be ignored (non-recursive, files only)
 
     const r = await runScript('manifest-seed.ts', {
-      args: [stateArg(wd.dir)],
+      args: [stateArg(dir)],
       stdin: JSON.stringify({ pluginVersion: '1.0.0', entries: [{ keyPrefix: 'bin', dir: binSrc }] }),
     });
     expect(r.exitCode).toBe(0);
 
-    const m = readManifest(wd.dir);
+    const m = readManifest(dir);
     expect(Object.keys(m.files).sort()).toEqual(['bin/hermit-start', 'bin/hermit-stop']);
-  });
+  }));
 });
 
 describe('manifest-seed: invalid existing manifest is fatal', () => {
@@ -122,22 +112,21 @@ describe('manifest-seed: invalid existing manifest is fatal', () => {
     },
   ];
   for (const c of cases) {
-    test(`${c.name} -> exit 1, file unchanged`, async () => {
-      wd = setupWorkdir();
-      fs.writeFileSync(manifestPath(wd.dir), c.content);
-      const before = fs.readFileSync(manifestPath(wd.dir), 'utf8');
-      const f = path.join(wd.dir, 'a.txt');
+    test(`${c.name} -> exit 1, file unchanged`, withDir(async (dir) => {
+      fs.writeFileSync(manifestPath(dir), c.content);
+      const before = fs.readFileSync(manifestPath(dir), 'utf8');
+      const f = path.join(dir, 'a.txt');
       fs.writeFileSync(f, 'x');
 
       const r = await runScript('manifest-seed.ts', {
-        args: [stateArg(wd.dir)],
+        args: [stateArg(dir)],
         stdin: JSON.stringify({ pluginVersion: '1.2.9', entries: [{ key: 'templates/a', file: f }] }),
       });
       expect(r.exitCode).toBe(1);
       expect(r.stderr).toContain('manifest-seed');
       // File left byte-for-byte unchanged.
-      expect(fs.readFileSync(manifestPath(wd.dir), 'utf8')).toBe(before);
-    });
+      expect(fs.readFileSync(manifestPath(dir), 'utf8')).toBe(before);
+    }));
   }
 });
 
@@ -149,12 +138,11 @@ describe('manifest-seed: malformed stdin is fatal', () => {
     { name: 'empty stdin', stdin: '' },
   ];
   for (const b of bad) {
-    test(`${b.name} -> exit 1, no manifest written`, async () => {
-      wd = setupWorkdir();
-      const r = await runScript('manifest-seed.ts', { args: [stateArg(wd.dir)], stdin: b.stdin });
+    test(`${b.name} -> exit 1, no manifest written`, withDir(async (dir) => {
+      const r = await runScript('manifest-seed.ts', { args: [stateArg(dir)], stdin: b.stdin });
       expect(r.exitCode).toBe(1);
-      expect(fs.existsSync(manifestPath(wd.dir))).toBe(false);
-    });
+      expect(fs.existsSync(manifestPath(dir))).toBe(false);
+    }));
   }
 });
 

--- a/plugins/claude-code-hermit/tests/permission-denied-notify.test.ts
+++ b/plugins/claude-code-hermit/tests/permission-denied-notify.test.ts
@@ -4,13 +4,13 @@
 // stub requests out), the same boundary Claude Code sees. This hook cannot
 // block and never emits hookSpecificOutput.retry — every case exits 0.
 
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
 import { runScript } from './helpers/run';
 import { setupWorkdir, type Workdir } from './helpers/workdir';
-import { startHttpStub, type Stub } from './helpers/http-stub';
+import { startHttpStub } from './helpers/http-stub';
 
 const hermit = (dir: string, ...p: string[]) => path.join(dir, '.claude-code-hermit', ...p);
 const write = (p: string, content: string) => fs.writeFileSync(p, content);
@@ -49,138 +49,193 @@ const run = (payload: object, dir: string, stubUrl: string, env: Record<string, 
   });
 
 describe('permission-denied-notify', () => {
-  let stub: Stub | undefined;
-  let wd: Workdir | undefined;
-
-  afterEach(() => {
-    stub?.stop();
-    stub = undefined;
-    wd?.cleanup();
-    wd = undefined;
-  });
-
   test('managed + always_on + eligible channel — sends exactly one notification', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(1);
-    expect(stub.requests[0].body.text).toContain('Auto-mode denied: Bash');
-    // The alert points at *what* was blocked (tool + input), the only signal
-    // the real payload carries — not a reason string it doesn't deliver.
-    expect(stub.requests[0].body.text).toContain('apply-settings.ts');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(1);
+      expect(stub.requests[0].body.text).toContain('Auto-mode denied: Bash');
+      // The alert points at *what* was blocked (tool + input), the only signal
+      // the real payload carries — not a reason string it doesn't deliver.
+      expect(stub.requests[0].body.text).toContain('apply-settings.ts');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('includes the classifier reason when a payload happens to carry one (forward-compat)', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await run({ ...DENIAL_PAYLOAD, reason: '[Self-Modification] blocked' }, wd.dir, stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests[0].body.text).toContain('Self-Modification');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run({ ...DENIAL_PAYLOAD, reason: '[Self-Modification] blocked' }, wd.dir, stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests[0].body.text).toContain('Self-Modification');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('stdout is always empty (never emits hookSpecificOutput)', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    expect(r.stdout.trim()).toBe('');
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      expect(r.stdout.trim()).toBe('');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('HERMIT_MANAGED absent — attended session, no request', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url, { HERMIT_MANAGED: '' });
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url, { HERMIT_MANAGED: '' });
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('HERMIT_DENY_NOTIFY=off — escape hatch, no request', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url, { HERMIT_DENY_NOTIFY: 'off' });
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url, { HERMIT_DENY_NOTIFY: 'off' });
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('always_on: false — no request', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    write(hermit(wd.dir, 'config.json'), JSON.stringify({
-      always_on: false,
-      channels: { primary: 'telegram', telegram: { enabled: true, dm_channel_id: '12345', state_dir: '.claude.local/channels/telegram' } },
-    }));
-    const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      write(hermit(wd.dir, 'config.json'), JSON.stringify({
+        always_on: false,
+        channels: { primary: 'telegram', telegram: { enabled: true, dm_channel_id: '12345', state_dir: '.claude.local/channels/telegram' } },
+      }));
+      const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('no eligible channel — no request', async () => {
-    stub = startHttpStub();
-    wd = setupWorkdir();
-    write(hermit(wd.dir, 'config.json'), JSON.stringify({ always_on: true, channels: {} }));
-    const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupWorkdir();
+    try {
+      write(hermit(wd.dir, 'config.json'), JSON.stringify({ always_on: true, channels: {} }));
+      const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('channel likely down — no request (do not fire into a dead channel)', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    fs.mkdirSync(hermit(wd.dir, 'state'), { recursive: true });
-    write(hermit(wd.dir, 'state', 'channel-health.json'), JSON.stringify({ telegram: { last_success_at: null, consecutive_failures: 3 } }));
-    const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      fs.mkdirSync(hermit(wd.dir, 'state'), { recursive: true });
+      write(hermit(wd.dir, 'state', 'channel-health.json'), JSON.stringify({ telegram: { last_success_at: null, consecutive_failures: 3 } }));
+      const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('dedup: identical payload twice within the window sends only once', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r1 = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    expect(r1.exitCode).toBe(0);
-    const r2 = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    expect(r2.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(1);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r1 = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      expect(r1.exitCode).toBe(0);
+      const r2 = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      expect(r2.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(1);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('dedup: a different payload still sends', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    const other = { tool_name: 'Edit', tool_input: { file_path: '/tmp/x' }, reason: 'different' };
-    await run(other, wd.dir, stub.url);
-    expect(stub.requests.length).toBe(2);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      const other = { tool_name: 'Edit', tool_input: { file_path: '/tmp/x' }, reason: 'different' };
+      await run(other, wd.dir, stub.url);
+      expect(stub.requests.length).toBe(2);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('malformed stdin — exit 0, no request', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await runScript('permission-denied-notify.ts', {
-      stdin: '{broken',
-      cwd: wd.dir,
-      env: { HERMIT_MANAGED: '1', HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await runScript('permission-denied-notify.ts', {
+        stdin: '{broken',
+        cwd: wd.dir,
+        env: { HERMIT_MANAGED: '1', HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('empty stdin — exit 0, no request', async () => {
-    stub = startHttpStub();
-    wd = setupChannelWorkdir();
-    const r = await runScript('permission-denied-notify.ts', {
-      stdin: '',
-      cwd: wd.dir,
-      env: { HERMIT_MANAGED: '1', HERMIT_TELEGRAM_API_URL: stub.url },
-    });
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir();
+    try {
+      const r = await runScript('permission-denied-notify.ts', {
+        stdin: '',
+        cwd: wd.dir,
+        env: { HERMIT_MANAGED: '1', HERMIT_TELEGRAM_API_URL: stub.url },
+      });
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 
   test('missing config.json — fail-open, no request, exit 0', async () => {
-    stub = startHttpStub();
-    wd = setupWorkdir();
-    const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
-    expect(r.exitCode).toBe(0);
-    expect(stub.requests.length).toBe(0);
+    const stub = startHttpStub();
+    const wd = setupWorkdir();
+    try {
+      const r = await run(DENIAL_PAYLOAD, wd.dir, stub.url);
+      expect(r.exitCode).toBe(0);
+      expect(stub.requests.length).toBe(0);
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
   });
 });

--- a/plugins/claude-code-hermit/tests/precompact-stamp.test.ts
+++ b/plugins/claude-code-hermit/tests/precompact-stamp.test.ts
@@ -3,86 +3,121 @@
 // payload with a recognized trigger. See scripts/precompact-stamp.ts and
 // scripts/lib/progress-log.ts.
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { runScript } from './helpers/run';
 
-let hermitDir: string;
-let shellPath: string;
-
-beforeEach(() => {
-  hermitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-precompact-'));
+function makeDir(): string {
+  const hermitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-precompact-'));
   fs.mkdirSync(path.join(hermitDir, 'sessions'), { recursive: true });
-  shellPath = path.join(hermitDir, 'sessions', 'SHELL.md');
-  fs.writeFileSync(shellPath, '## Progress Log\n', 'utf-8');
+  fs.writeFileSync(path.join(hermitDir, 'sessions', 'SHELL.md'), '## Progress Log\n', 'utf-8');
   fs.writeFileSync(path.join(hermitDir, 'config.json'), JSON.stringify({ timezone: 'UTC' }), 'utf-8');
-});
+  return hermitDir;
+}
 
-afterEach(() => {
-  fs.rmSync(hermitDir, { recursive: true, force: true });
-});
-
-async function runHook(stdin: string) {
+async function runHook(stdin: string, hermitDir: string) {
   return runScript('precompact-stamp.ts', { stdin, env: { AGENT_DIR: hermitDir } });
 }
 
 describe('precompact-stamp: valid PreCompact payloads', () => {
   test('trigger:"auto" writes a breadcrumb, empty stdout, exit 0', async () => {
-    const result = await runHook(JSON.stringify({ hook_event_name: 'PreCompact', trigger: 'auto' }));
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe('');
-    const shell = fs.readFileSync(shellPath, 'utf-8');
-    expect(shell).toContain('context compacted (auto)');
-    expect(shell).toContain('arc may have unfinished work');
+    const hermitDir = makeDir();
+    try {
+      const shellPath = path.join(hermitDir, 'sessions', 'SHELL.md');
+      const result = await runHook(JSON.stringify({ hook_event_name: 'PreCompact', trigger: 'auto' }), hermitDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+      const shell = fs.readFileSync(shellPath, 'utf-8');
+      expect(shell).toContain('context compacted (auto)');
+      expect(shell).toContain('arc may have unfinished work');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('trigger:"manual" writes a breadcrumb, empty stdout, exit 0', async () => {
-    const result = await runHook(JSON.stringify({ hook_event_name: 'PreCompact', trigger: 'manual' }));
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe('');
-    const shell = fs.readFileSync(shellPath, 'utf-8');
-    expect(shell).toContain('context compacted (manual)');
+    const hermitDir = makeDir();
+    try {
+      const shellPath = path.join(hermitDir, 'sessions', 'SHELL.md');
+      const result = await runHook(JSON.stringify({ hook_event_name: 'PreCompact', trigger: 'manual' }), hermitDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+      const shell = fs.readFileSync(shellPath, 'utf-8');
+      expect(shell).toContain('context compacted (manual)');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 });
 
 describe('precompact-stamp: no-op on anything that is not a genuine PreCompact payload', () => {
   test('malformed stdin: no write, no stdout, exit 0', async () => {
-    const before = fs.readFileSync(shellPath, 'utf-8');
-    const result = await runHook('not json{{{');
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe('');
-    expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    const hermitDir = makeDir();
+    try {
+      const shellPath = path.join(hermitDir, 'sessions', 'SHELL.md');
+      const before = fs.readFileSync(shellPath, 'utf-8');
+      const result = await runHook('not json{{{', hermitDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+      expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('empty stdin: no write, no stdout, exit 0', async () => {
-    const before = fs.readFileSync(shellPath, 'utf-8');
-    const result = await runHook('');
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe('');
-    expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    const hermitDir = makeDir();
+    try {
+      const shellPath = path.join(hermitDir, 'sessions', 'SHELL.md');
+      const before = fs.readFileSync(shellPath, 'utf-8');
+      const result = await runHook('', hermitDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+      expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('wrong hook_event_name: no write', async () => {
-    const before = fs.readFileSync(shellPath, 'utf-8');
-    const result = await runHook(JSON.stringify({ hook_event_name: 'SessionStart', trigger: 'auto' }));
-    expect(result.exitCode).toBe(0);
-    expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    const hermitDir = makeDir();
+    try {
+      const shellPath = path.join(hermitDir, 'sessions', 'SHELL.md');
+      const before = fs.readFileSync(shellPath, 'utf-8');
+      const result = await runHook(JSON.stringify({ hook_event_name: 'SessionStart', trigger: 'auto' }), hermitDir);
+      expect(result.exitCode).toBe(0);
+      expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('invalid trigger value: no write', async () => {
-    const before = fs.readFileSync(shellPath, 'utf-8');
-    const result = await runHook(JSON.stringify({ hook_event_name: 'PreCompact', trigger: 'bogus' }));
-    expect(result.exitCode).toBe(0);
-    expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    const hermitDir = makeDir();
+    try {
+      const shellPath = path.join(hermitDir, 'sessions', 'SHELL.md');
+      const before = fs.readFileSync(shellPath, 'utf-8');
+      const result = await runHook(JSON.stringify({ hook_event_name: 'PreCompact', trigger: 'bogus' }), hermitDir);
+      expect(result.exitCode).toBe(0);
+      expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('missing trigger: no write', async () => {
-    const before = fs.readFileSync(shellPath, 'utf-8');
-    const result = await runHook(JSON.stringify({ hook_event_name: 'PreCompact' }));
-    expect(result.exitCode).toBe(0);
-    expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    const hermitDir = makeDir();
+    try {
+      const shellPath = path.join(hermitDir, 'sessions', 'SHELL.md');
+      const before = fs.readFileSync(shellPath, 'utf-8');
+      const result = await runHook(JSON.stringify({ hook_event_name: 'PreCompact' }), hermitDir);
+      expect(result.exitCode).toBe(0);
+      expect(fs.readFileSync(shellPath, 'utf-8')).toBe(before);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/claude-code-hermit/tests/proposal-write.test.ts
+++ b/plugins/claude-code-hermit/tests/proposal-write.test.ts
@@ -2,18 +2,12 @@
 // proposal-lifecycle state-dir mutation formerly done via the Write/Edit
 // tools (blocked under the harness background-isolation guard).
 
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
 import { runScript, PLUGIN_ROOT } from './helpers/run';
-import { setupWorkdir, Workdir } from './helpers/workdir';
-
-let wd: Workdir | null = null;
-afterEach(() => {
-  wd?.cleanup();
-  wd = null;
-});
+import { withDir } from './helpers/workdir';
 
 function stateArg(dir: string): string {
   return path.join(dir, '.claude-code-hermit');
@@ -62,15 +56,14 @@ const MIN_BODY = [
 ].join('\n');
 
 describe('proposal.ts create', () => {
-  test('happy path writes proposals/<id>.md and prints the canonical id', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
+  test('happy path writes proposals/<id>.md and prints the canonical id', withDir(async (dir) => {
+    seedState(dir);
     const stdin = heredoc({ Title: 'Fix the thing', Category: 'bug', Tags: '["tag-a","tag-b"]' }, MIN_BODY);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     expect(r.exitCode).toBe(0);
     expect(r.stdout.trim()).toMatch(/^PROP-001-fix-thing-\d{6}$/); // 'the' is a slugify stopword
     const id = r.stdout.trim();
-    const content = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+    const content = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(content).toContain(`id: ${id}`);
     expect(content).toContain('title: "Fix the thing"');
     expect(content).toContain('status: proposed');
@@ -79,38 +72,35 @@ describe('proposal.ts create', () => {
     expect(content).toMatch(/created: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}/);
     expect(content).toContain(`# Proposal: ${id} — Fix the thing`);
     expect(content).toContain('## Context\nctx');
-  });
+  }));
 
-  test('NNN continues from max existing', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    fs.writeFileSync(propPath(wd.dir, 'PROP-007-old-100000'), '---\nid: x\n---\nbody\n');
+  test('NNN continues from max existing', withDir(async (dir) => {
+    seedState(dir);
+    fs.writeFileSync(propPath(dir, 'PROP-007-old-100000'), '---\nid: x\n---\nbody\n');
     const stdin = heredoc({ Title: 'Next one' }, MIN_BODY);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     expect(r.stdout.trim()).toMatch(/^PROP-008-/);
-  });
+  }));
 
-  test('session defaults from runtime.json when Session header omitted', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    fs.writeFileSync(path.join(stateArg(wd.dir), 'state', 'runtime.json'), JSON.stringify({ session_id: 'S-042' }));
+  test('session defaults from runtime.json when Session header omitted', withDir(async (dir) => {
+    seedState(dir);
+    fs.writeFileSync(path.join(stateArg(dir), 'state', 'runtime.json'), JSON.stringify({ session_id: 'S-042' }));
     const stdin = heredoc({ Title: 'Session default test' }, MIN_BODY);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     const id = r.stdout.trim();
-    const content = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+    const content = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(content).toContain('session: S-042');
-  });
+  }));
 
-  test('template missing -> ERROR|template-missing, zero writes', async () => {
-    wd = setupWorkdir();
-    fs.mkdirSync(path.join(stateArg(wd.dir), 'proposals'), { recursive: true });
-    fs.writeFileSync(path.join(stateArg(wd.dir), 'config.json'), JSON.stringify({ timezone: 'UTC' }));
+  test('template missing -> ERROR|template-missing, zero writes', withDir(async (dir) => {
+    fs.mkdirSync(path.join(stateArg(dir), 'proposals'), { recursive: true });
+    fs.writeFileSync(path.join(stateArg(dir), 'config.json'), JSON.stringify({ timezone: 'UTC' }));
     const stdin = heredoc({ Title: 'No template' }, MIN_BODY);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     expect(r.stdout.trim()).toBe('ERROR|template-missing');
-    expect(fs.readdirSync(path.join(stateArg(wd.dir), 'proposals'))).toHaveLength(0);
-    expect(metricsLines(wd.dir)).toHaveLength(0);
-  });
+    expect(fs.readdirSync(path.join(stateArg(dir), 'proposals'))).toHaveLength(0);
+    expect(metricsLines(dir)).toHaveLength(0);
+  }));
 
   const invalidCases: Array<[string, Record<string, string>, string, string]> = [
     ['missing title', {}, MIN_BODY, 'ERROR|missing-title'],
@@ -121,100 +111,92 @@ describe('proposal.ts create', () => {
     ['bad related-sessions JSON', { Title: 'T', 'Related-Sessions': '{not an array}' }, MIN_BODY, 'ERROR|invalid-related-sessions'],
   ];
   for (const [label, header, body, expected] of invalidCases) {
-    test(`validation error: ${label} -> ${expected}, zero writes`, async () => {
-      wd = setupWorkdir();
-      seedState(wd.dir);
+    test(`validation error: ${label} -> ${expected}, zero writes`, withDir(async (dir) => {
+      seedState(dir);
       const stdin = label === 'missing separator'
         ? 'Title: T\nno separator here'
         : heredoc(header, body);
-      const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+      const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
       expect(r.stdout.trim()).toBe(expected);
-      expect(fs.readdirSync(path.join(stateArg(wd.dir), 'proposals'))).toHaveLength(0);
-    });
+      expect(fs.readdirSync(path.join(stateArg(dir), 'proposals'))).toHaveLength(0);
+    }));
   }
 
-  test('unwritable proposals dir -> ERROR, no metrics, SHELL.md unchanged', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const proposalsDir = path.join(stateArg(wd.dir), 'proposals');
+  test('unwritable proposals dir -> ERROR, no metrics, SHELL.md unchanged', withDir(async (dir) => {
+    seedState(dir);
+    const proposalsDir = path.join(stateArg(dir), 'proposals');
     fs.chmodSync(proposalsDir, 0o555);
-    const shellBefore = fs.readFileSync(shellPath(wd.dir), 'utf-8');
+    const shellBefore = fs.readFileSync(shellPath(dir), 'utf-8');
     try {
       const stdin = heredoc({ Title: 'Blocked write' }, MIN_BODY);
-      const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+      const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
       expect(r.stdout.trim()).toMatch(/^ERROR\|/);
-      expect(metricsLines(wd.dir)).toHaveLength(0);
-      expect(fs.readFileSync(shellPath(wd.dir), 'utf-8')).toBe(shellBefore);
+      expect(metricsLines(dir)).toHaveLength(0);
+      expect(fs.readFileSync(shellPath(dir), 'utf-8')).toBe(shellBefore);
     } finally {
       fs.chmodSync(proposalsDir, 0o755);
     }
-  });
+  }));
 
-  test('SHELL.md deleted -> still succeeds, ID printed, stderr warns', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    fs.rmSync(shellPath(wd.dir));
+  test('SHELL.md deleted -> still succeeds, ID printed, stderr warns', withDir(async (dir) => {
+    seedState(dir);
+    fs.rmSync(shellPath(dir));
     const stdin = heredoc({ Title: 'No shell file' }, MIN_BODY);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     expect(r.exitCode).toBe(0);
     expect(r.stdout.trim()).toMatch(/^PROP-001-/);
-    expect(fs.existsSync(propPath(wd.dir, r.stdout.trim()))).toBe(true);
+    expect(fs.existsSync(propPath(dir, r.stdout.trim()))).toBe(true);
     expect(r.stderr).toContain('findings append');
-  });
+  }));
 
-  test('Findings line lands inside ## Findings before the next heading', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
+  test('Findings line lands inside ## Findings before the next heading', withDir(async (dir) => {
+    seedState(dir);
     const stdin = heredoc({ Title: 'Findings placement', Findings: 'custom summary' }, MIN_BODY);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     const id = r.stdout.trim();
-    const shell = fs.readFileSync(shellPath(wd.dir), 'utf-8');
+    const shell = fs.readFileSync(shellPath(dir), 'utf-8');
     const findingsSection = shell.slice(shell.indexOf('## Findings'), shell.indexOf('## Changed'));
     expect(findingsSection).toContain(`- ${id}: custom summary`);
-  });
+  }));
 
-  test('created metrics event carries source/category/tags', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
+  test('created metrics event carries source/category/tags', withDir(async (dir) => {
+    seedState(dir);
     const stdin = heredoc({ Title: 'Metrics test', Source: 'operator-request', Category: 'capability', Tags: '["x"]' }, MIN_BODY);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     const id = r.stdout.trim();
-    const lines = metricsLines(wd.dir);
+    const lines = metricsLines(dir);
     expect(lines).toHaveLength(1);
     expect(lines[0]).toMatchObject({ type: 'created', proposal_id: id, source: 'operator-request', category: 'capability', tags: ['x'] });
-  });
+  }));
 
-  test('rebuilds proposals-index and state-summary', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
+  test('rebuilds proposals-index and state-summary', withDir(async (dir) => {
+    seedState(dir);
     const stdin = heredoc({ Title: 'Index regen test' }, MIN_BODY);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     const id = r.stdout.trim();
-    const index = JSON.parse(fs.readFileSync(path.join(stateArg(wd.dir), 'state', 'proposals-index.json'), 'utf-8'));
+    const index = JSON.parse(fs.readFileSync(path.join(stateArg(dir), 'state', 'proposals-index.json'), 'utf-8'));
     expect(index.proposals.some((p: any) => p.id === id)).toBe(true);
-    expect(fs.existsSync(path.join(stateArg(wd.dir), 'state', 'state-summary.md'))).toBe(true);
-  });
+    expect(fs.existsSync(path.join(stateArg(dir), 'state', 'state-summary.md'))).toBe(true);
+  }));
 
-  test('appends ## Operator Decision when body lacks it', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
+  test('appends ## Operator Decision when body lacks it', withDir(async (dir) => {
+    seedState(dir);
     const bodyNoDecision = '## Context\nctx\n\n## Problem\nprob\n';
     const stdin = heredoc({ Title: 'No decision section' }, bodyNoDecision);
-    const r = await runScript('proposal.ts', { args: ['create', stateArg(wd.dir)], stdin });
+    const r = await runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin });
     const id = r.stdout.trim();
-    const content = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+    const content = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(content).toContain('## Operator Decision');
-  });
+  }));
 });
 
 describe('proposal.ts dispatcher', () => {
-  test('unknown verb -> ERROR|unknown-verb, exit 0', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const r = await runScript('proposal.ts', { args: ['bogus', stateArg(wd.dir)] });
+  test('unknown verb -> ERROR|unknown-verb, exit 0', withDir(async (dir) => {
+    seedState(dir);
+    const r = await runScript('proposal.ts', { args: ['bogus', stateArg(dir)] });
     expect(r.exitCode).toBe(0);
     expect(r.stdout.trim()).toBe('ERROR|unknown-verb');
-  });
+  }));
 
   test('missing state dir arg -> exit 1', async () => {
     const r = await runScript('proposal.ts', { args: ['create'] });
@@ -228,18 +210,17 @@ describe('proposal.ts patch', () => {
     return runScript('proposal.ts', { args: ['create', stateArg(dir)], stdin }).then(r => r.stdout.trim());
   }
 
-  test('accept flip: in-place frontmatter patch, @now expansion, Decision append', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const id = await createProposal(wd.dir);
-    const before = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+  test('accept flip: in-place frontmatter patch, @now expansion, Decision append', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
+    const before = fs.readFileSync(propPath(dir, id), 'utf-8');
 
     const r = await runScript('proposal.ts', {
-      args: ['patch', stateArg(wd.dir), id, '--set', 'status=accepted', '--set', 'accepted_date=@now', '--set', 'responded=true'],
+      args: ['patch', stateArg(dir), id, '--set', 'status=accepted', '--set', 'accepted_date=@now', '--set', 'responded=true'],
       stdin: 'Decision: Accepted on @now.\n',
     });
     expect(r.stdout.trim()).toBe(`OK|${id}`);
-    const after = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+    const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(after).toContain('status: accepted');
     expect(after).toContain('responded: true');
     expect(after).toMatch(/accepted_date: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}/);
@@ -258,94 +239,86 @@ describe('proposal.ts patch', () => {
     const bodyBefore = before.slice(before.indexOf('\n---', 3) + 4);
     const bodyAfter = after.slice(after.indexOf('\n---', 3) + 4);
     expect(bodyAfter.startsWith(bodyBefore.replace(/\n+$/, ''))).toBe(true);
-  });
+  }));
 
-  test('dismiss sets both dismissed_date and resolved_date', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const id = await createProposal(wd.dir);
+  test('dismiss sets both dismissed_date and resolved_date', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
     const r = await runScript('proposal.ts', {
-      args: ['patch', stateArg(wd.dir), id, '--set', 'status=dismissed', '--set', 'dismissed_date=@now', '--set', 'resolved_date=@now'],
+      args: ['patch', stateArg(dir), id, '--set', 'status=dismissed', '--set', 'dismissed_date=@now', '--set', 'resolved_date=@now'],
     });
     expect(r.stdout.trim()).toBe(`OK|${id}`);
-    const after = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+    const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(after).toContain('status: dismissed');
     expect(after.match(/dismissed_date: \S+/)).toBeTruthy();
     expect(after.match(/resolved_date: \S+/)?.[0]).not.toContain('null');
-  });
+  }));
 
-  test('decision-only call leaves frontmatter untouched', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const id = await createProposal(wd.dir);
-    const before = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+  test('decision-only call leaves frontmatter untouched', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
+    const before = fs.readFileSync(propPath(dir, id), 'utf-8');
     const fmBefore = before.slice(0, before.indexOf('\n---', 3) + 4);
     await runScript('proposal.ts', {
-      args: ['patch', stateArg(wd.dir), id],
+      args: ['patch', stateArg(dir), id],
       stdin: 'Decision: just a note.\n',
     });
-    const after = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+    const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     const fmAfter = after.slice(0, after.indexOf('\n---', 3) + 4);
     expect(fmAfter).toBe(fmBefore);
     expect(after).toContain('just a note.');
-  });
+  }));
 
-  test('invalid key / no-such-proposal / missing frontmatter terminator -> ERROR, file byte-identical', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const id = await createProposal(wd.dir);
-    const before = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+  test('invalid key / no-such-proposal / missing frontmatter terminator -> ERROR, file byte-identical', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
+    const before = fs.readFileSync(propPath(dir, id), 'utf-8');
 
-    const r1 = await runScript('proposal.ts', { args: ['patch', stateArg(wd.dir), id, '--set', 'bad key=x'] });
+    const r1 = await runScript('proposal.ts', { args: ['patch', stateArg(dir), id, '--set', 'bad key=x'] });
     expect(r1.stdout.trim()).toMatch(/^ERROR\|invalid-key/);
 
-    const r2 = await runScript('proposal.ts', { args: ['patch', stateArg(wd.dir), 'PROP-999-nope-000000'] });
+    const r2 = await runScript('proposal.ts', { args: ['patch', stateArg(dir), 'PROP-999-nope-000000'] });
     expect(r2.stdout.trim()).toBe('ERROR|no-such-proposal');
 
-    const noTerm = path.join(stateArg(wd.dir), 'proposals', 'PROP-002-broken-000001.md');
+    const noTerm = path.join(stateArg(dir), 'proposals', 'PROP-002-broken-000001.md');
     fs.writeFileSync(noTerm, '---\nid: PROP-002-broken-000001\nno closing fence\n');
-    const r3 = await runScript('proposal.ts', { args: ['patch', stateArg(wd.dir), 'PROP-002-broken-000001', '--set', 'status=accepted'] });
+    const r3 = await runScript('proposal.ts', { args: ['patch', stateArg(dir), 'PROP-002-broken-000001', '--set', 'status=accepted'] });
     expect(r3.stdout.trim()).toBe('ERROR|frontmatter-terminator-missing');
 
-    expect(fs.readFileSync(propPath(wd.dir, id), 'utf-8')).toBe(before);
-  });
+    expect(fs.readFileSync(propPath(dir, id), 'utf-8')).toBe(before);
+  }));
 
-  test('--request-compact writes compact-requested.json with reason proposal-resolve', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const id = await createProposal(wd.dir);
-    await runScript('proposal.ts', { args: ['patch', stateArg(wd.dir), id, '--set', 'status=resolved', '--request-compact'] });
-    const marker = JSON.parse(fs.readFileSync(path.join(stateArg(wd.dir), 'state', 'compact-requested.json'), 'utf-8'));
+  test('--request-compact writes compact-requested.json with reason proposal-resolve', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
+    await runScript('proposal.ts', { args: ['patch', stateArg(dir), id, '--set', 'status=resolved', '--request-compact'] });
+    const marker = JSON.parse(fs.readFileSync(path.join(stateArg(dir), 'state', 'compact-requested.json'), 'utf-8'));
     expect(marker.reason).toBe('proposal-resolve');
     expect(marker.requested_at).toMatch(/\d{4}-\d{2}-\d{2}T/);
-  });
+  }));
 
-  test('rebuilds index and summary after patch', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const id = await createProposal(wd.dir);
-    await runScript('proposal.ts', { args: ['patch', stateArg(wd.dir), id, '--set', 'status=accepted'] });
-    const index = JSON.parse(fs.readFileSync(path.join(stateArg(wd.dir), 'state', 'proposals-index.json'), 'utf-8'));
+  test('rebuilds index and summary after patch', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
+    await runScript('proposal.ts', { args: ['patch', stateArg(dir), id, '--set', 'status=accepted'] });
+    const index = JSON.parse(fs.readFileSync(path.join(stateArg(dir), 'state', 'proposals-index.json'), 'utf-8'));
     expect(index.proposals.find((p: any) => p.id === id)?.status).toBe('accepted');
-  });
+  }));
 
-  test('Set: stdin line carries a free-text multi-word predicate into frontmatter', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const id = await createProposal(wd.dir);
+  test('Set: stdin line carries a free-text multi-word predicate into frontmatter', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
     const r = await runScript('proposal.ts', {
-      args: ['patch', stateArg(wd.dir), id],
+      args: ['patch', stateArg(dir), id],
       stdin: 'Set: success_signal=avg_session_cost_usd < 5 over 7 sessions\n',
     });
     expect(r.stdout.trim()).toBe(`OK|${id}`);
-    const after = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+    const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(after).toContain('success_signal: "avg_session_cost_usd < 5 over 7 sessions"');
-  });
+  }));
 
-  test('re-running an identical patch call is idempotent — no duplicate Decision line', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const dir = wd.dir;
+  test('re-running an identical patch call is idempotent — no duplicate Decision line', withDir(async (dir) => {
+    seedState(dir);
     const id = await createProposal(dir);
     const call = () => runScript('proposal.ts', { args: ['patch', stateArg(dir), id], stdin: 'Decision: Fixed timestamp note.\n' });
     await call();
@@ -353,12 +326,10 @@ describe('proposal.ts patch', () => {
     const content = fs.readFileSync(propPath(dir, id), 'utf-8');
     const occurrences = content.split('Fixed timestamp note.').length - 1;
     expect(occurrences).toBe(1);
-  });
+  }));
 
-  test('an @now Decision line already present with a different timestamp is not duplicated', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const dir = wd.dir;
+  test('an @now Decision line already present with a different timestamp is not duplicated', withDir(async (dir) => {
+    seedState(dir);
     const id = await createProposal(dir);
     // Every SKILL-documented Decision line carries `@now`, which expands to a
     // fresh stamp per run — comparing expanded text would never match, so the
@@ -375,23 +346,22 @@ describe('proposal.ts patch', () => {
     const content = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(content.match(/Accepted on \d{4}-/g)?.length).toBe(1);
     expect(content).toContain('Accepted on 2001-01-01T00:00:00Z.');
-  });
+  }));
 
-  test('a bare Decision: line does not swallow the following Set: line', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const id = await createProposal(wd.dir);
+  test('a bare Decision: line does not swallow the following Set: line', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
     const r = await runScript('proposal.ts', {
-      args: ['patch', stateArg(wd.dir), id],
+      args: ['patch', stateArg(dir), id],
       stdin: 'Decision:\nSet: success_signal=avg_session_cost_usd < 5 over 7 sessions\n',
     });
     expect(r.stdout.trim()).toBe(`OK|${id}`);
-    const after = fs.readFileSync(propPath(wd.dir, id), 'utf-8');
+    const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(after).toContain('success_signal: "avg_session_cost_usd < 5 over 7 sessions"');
     // The Set: line must not also land in the Operator Decision section.
     const decision = after.slice(after.indexOf('## Operator Decision'));
     expect(decision).not.toContain('Set: success_signal');
-  });
+  }));
 
   test('no free-text value rides --set argv in either SKILL.md', () => {
     const proposalCreate = fs.readFileSync(path.join(PLUGIN_ROOT, 'skills', 'proposal-create', 'SKILL.md'), 'utf-8');
@@ -404,33 +374,30 @@ describe('proposal.ts patch', () => {
 });
 
 describe('proposal.ts shell-append', () => {
-  test('findings and progress appends are section-aware', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    await runScript('proposal.ts', { args: ['shell-append', stateArg(wd.dir), '--section', 'findings'], stdin: 'a finding\n' });
-    await runScript('proposal.ts', { args: ['shell-append', stateArg(wd.dir), '--section', 'progress'], stdin: '[10:05] did a thing\n' });
-    const shell = fs.readFileSync(shellPath(wd.dir), 'utf-8');
+  test('findings and progress appends are section-aware', withDir(async (dir) => {
+    seedState(dir);
+    await runScript('proposal.ts', { args: ['shell-append', stateArg(dir), '--section', 'findings'], stdin: 'a finding\n' });
+    await runScript('proposal.ts', { args: ['shell-append', stateArg(dir), '--section', 'progress'], stdin: '[10:05] did a thing\n' });
+    const shell = fs.readFileSync(shellPath(dir), 'utf-8');
     const findingsSection = shell.slice(shell.indexOf('## Findings'), shell.indexOf('## Changed'));
     const progressSection = shell.slice(shell.indexOf('## Progress Log'), shell.indexOf('## Blockers'));
     expect(findingsSection).toContain('a finding');
     expect(progressSection).toContain('[10:05] did a thing');
-  });
+  }));
 
-  test('missing SHELL.md -> ERROR|shell-unreadable, exit 0', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    fs.rmSync(shellPath(wd.dir));
-    const r = await runScript('proposal.ts', { args: ['shell-append', stateArg(wd.dir), '--section', 'findings'], stdin: 'x\n' });
+  test('missing SHELL.md -> ERROR|shell-unreadable, exit 0', withDir(async (dir) => {
+    seedState(dir);
+    fs.rmSync(shellPath(dir));
+    const r = await runScript('proposal.ts', { args: ['shell-append', stateArg(dir), '--section', 'findings'], stdin: 'x\n' });
     expect(r.exitCode).toBe(0);
     expect(r.stdout.trim()).toBe('ERROR|shell-unreadable');
-  });
+  }));
 
-  test('unknown --section -> ERROR', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const r = await runScript('proposal.ts', { args: ['shell-append', stateArg(wd.dir), '--section', 'bogus'], stdin: 'x\n' });
+  test('unknown --section -> ERROR', withDir(async (dir) => {
+    seedState(dir);
+    const r = await runScript('proposal.ts', { args: ['shell-append', stateArg(dir), '--section', 'bogus'], stdin: 'x\n' });
     expect(r.stdout.trim()).toBe('ERROR|unknown-section');
-  });
+  }));
 });
 
 describe('proposal.ts next-task', () => {
@@ -438,29 +405,26 @@ describe('proposal.ts next-task', () => {
     return path.join(stateArg(dir), 'sessions', 'NEXT-TASK.md');
   }
 
-  test('creates with stdin content', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const r = await runScript('proposal.ts', { args: ['next-task', stateArg(wd.dir)], stdin: '# Next\nDo the thing.\n' });
+  test('creates with stdin content', withDir(async (dir) => {
+    seedState(dir);
+    const r = await runScript('proposal.ts', { args: ['next-task', stateArg(dir)], stdin: '# Next\nDo the thing.\n' });
     expect(r.stdout.trim()).toBe('OK');
-    expect(fs.readFileSync(nextTaskPath(wd.dir), 'utf-8')).toBe('# Next\nDo the thing.\n');
-  });
+    expect(fs.readFileSync(nextTaskPath(dir), 'utf-8')).toBe('# Next\nDo the thing.\n');
+  }));
 
-  test('existing file -> ERROR|next-task-exists, file untouched', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    fs.writeFileSync(nextTaskPath(wd.dir), 'original\n');
-    const r = await runScript('proposal.ts', { args: ['next-task', stateArg(wd.dir)], stdin: 'overwrite attempt\n' });
+  test('existing file -> ERROR|next-task-exists, file untouched', withDir(async (dir) => {
+    seedState(dir);
+    fs.writeFileSync(nextTaskPath(dir), 'original\n');
+    const r = await runScript('proposal.ts', { args: ['next-task', stateArg(dir)], stdin: 'overwrite attempt\n' });
     expect(r.stdout.trim()).toBe('ERROR|next-task-exists');
-    expect(fs.readFileSync(nextTaskPath(wd.dir), 'utf-8')).toBe('original\n');
-  });
+    expect(fs.readFileSync(nextTaskPath(dir), 'utf-8')).toBe('original\n');
+  }));
 
-  test('empty stdin -> ERROR', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const r = await runScript('proposal.ts', { args: ['next-task', stateArg(wd.dir)], stdin: '   \n' });
+  test('empty stdin -> ERROR', withDir(async (dir) => {
+    seedState(dir);
+    const r = await runScript('proposal.ts', { args: ['next-task', stateArg(dir)], stdin: '   \n' });
     expect(r.stdout.trim()).toBe('ERROR|empty-content');
-  });
+  }));
 });
 
 describe('proposal.ts routine', () => {
@@ -468,44 +432,41 @@ describe('proposal.ts routine', () => {
     return JSON.parse(fs.readFileSync(path.join(stateArg(dir), 'config.json'), 'utf-8'));
   }
 
-  test('appends to routines array, other config keys byte-preserved', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir, { timezone: 'UTC', routines: [{ id: 'existing', schedule: '0 0 * * *', skill: 'x', enabled: true }] });
+  test('appends to routines array, other config keys byte-preserved', withDir(async (dir) => {
+    seedState(dir, { timezone: 'UTC', routines: [{ id: 'existing', schedule: '0 0 * * *', skill: 'x', enabled: true }] });
     const r = await runScript('proposal.ts', {
-      args: ['routine', stateArg(wd.dir)],
+      args: ['routine', stateArg(dir)],
       stdin: JSON.stringify({ id: 'new-routine', schedule: '0 8 * * *', skill: 'brief', enabled: true }),
     });
     expect(r.stdout.trim()).toBe('OK|added');
-    const cfg = readConfig(wd.dir);
+    const cfg = readConfig(dir);
     expect(cfg.timezone).toBe('UTC');
     expect(cfg.routines).toHaveLength(2);
     expect(cfg.routines.find((x: any) => x.id === 'new-routine')).toBeTruthy();
-  });
+  }));
 
-  test('duplicate id replaces entry, OK|updated', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir, { routines: [{ id: 'r1', schedule: '0 0 * * *', skill: 'old', enabled: false }] });
+  test('duplicate id replaces entry, OK|updated', withDir(async (dir) => {
+    seedState(dir, { routines: [{ id: 'r1', schedule: '0 0 * * *', skill: 'old', enabled: false }] });
     const r = await runScript('proposal.ts', {
-      args: ['routine', stateArg(wd.dir)],
+      args: ['routine', stateArg(dir)],
       stdin: JSON.stringify({ id: 'r1', schedule: '0 9 * * *', skill: 'new', enabled: true }),
     });
     expect(r.stdout.trim()).toBe('OK|updated');
-    const cfg = readConfig(wd.dir);
+    const cfg = readConfig(dir);
     expect(cfg.routines).toHaveLength(1);
     expect(cfg.routines[0].skill).toBe('new');
-  });
+  }));
 
-  test('invalid JSON / missing field -> ERROR, config untouched', async () => {
-    wd = setupWorkdir();
-    seedState(wd.dir);
-    const before = fs.readFileSync(path.join(stateArg(wd.dir), 'config.json'), 'utf-8');
+  test('invalid JSON / missing field -> ERROR, config untouched', withDir(async (dir) => {
+    seedState(dir);
+    const before = fs.readFileSync(path.join(stateArg(dir), 'config.json'), 'utf-8');
 
-    const r1 = await runScript('proposal.ts', { args: ['routine', stateArg(wd.dir)], stdin: 'not json' });
+    const r1 = await runScript('proposal.ts', { args: ['routine', stateArg(dir)], stdin: 'not json' });
     expect(r1.stdout.trim()).toBe('ERROR|invalid-json');
 
-    const r2 = await runScript('proposal.ts', { args: ['routine', stateArg(wd.dir)], stdin: JSON.stringify({ schedule: '0 0 * * *', skill: 'x', enabled: true }) });
+    const r2 = await runScript('proposal.ts', { args: ['routine', stateArg(dir)], stdin: JSON.stringify({ schedule: '0 0 * * *', skill: 'x', enabled: true }) });
     expect(r2.stdout.trim()).toBe('ERROR|missing-field:id');
 
-    expect(fs.readFileSync(path.join(stateArg(wd.dir), 'config.json'), 'utf-8')).toBe(before);
-  });
+    expect(fs.readFileSync(path.join(stateArg(dir), 'config.json'), 'utf-8')).toBe(before);
+  }));
 });

--- a/plugins/claude-code-hermit/tests/reflect-first-sighting.test.ts
+++ b/plugins/claude-code-hermit/tests/reflect-first-sighting.test.ts
@@ -10,7 +10,7 @@
 //
 // Usage: bun test tests/reflect-first-sighting.test.ts   (from the plugin root)
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -79,119 +79,154 @@ async function runPrecheck(hermitDir: string): Promise<string> {
 // ── Section 1: Drift capture ──────────────────────────────────────────────────
 
 describe('reflect-precheck: drift capture', () => {
-  let hermitDir: string;
-
-  beforeEach(() => { hermitDir = makeTmpHermit({ lastRunAt: null }); });
-  afterEach(() => { fs.rmSync(hermitDir, { recursive: true, force: true }); });
-
   test('precheck writes startup-drift row when unknown top-level dir exists', async () => {
-    // Create an unknown top-level dir to trigger storage drift
-    fs.mkdirSync(path.join(hermitDir, 'reports'));
-    fs.writeFileSync(path.join(hermitDir, 'reports', 'foo.md'), '# test', 'utf-8');
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      // Create an unknown top-level dir to trigger storage drift
+      fs.mkdirSync(path.join(hermitDir, 'reports'));
+      fs.writeFileSync(path.join(hermitDir, 'reports', 'foo.md'), '# test', 'utf-8');
 
-    await runPrecheck(hermitDir);
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir);
-    const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:'));
-    expect(driftRow).toBeDefined();
-    expect(driftRow?.source).toBe('startup-drift');
-    expect(driftRow?.origin).toBe('own-work');
+      const rows = readObservations(hermitDir);
+      const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:'));
+      expect(driftRow).toBeDefined();
+      expect(driftRow?.source).toBe('startup-drift');
+      expect(driftRow?.origin).toBe('own-work');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('precheck drift row has required fields (ts, pattern, session_id, source, origin)', async () => {
-    fs.mkdirSync(path.join(hermitDir, 'audits'));
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      fs.mkdirSync(path.join(hermitDir, 'audits'));
 
-    await runPrecheck(hermitDir);
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir);
-    const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:'));
-    expect(driftRow).toBeDefined();
-    expect(typeof driftRow?.ts).toBe('string');
-    expect(typeof driftRow?.pattern).toBe('string');
-    expect(typeof driftRow?.session_id).toBe('string');
-    expect(driftRow?.source).toBe('startup-drift');
-    expect(driftRow?.origin).toBe('own-work');
+      const rows = readObservations(hermitDir);
+      const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:'));
+      expect(driftRow).toBeDefined();
+      expect(typeof driftRow?.ts).toBe('string');
+      expect(typeof driftRow?.pattern).toBe('string');
+      expect(typeof driftRow?.session_id).toBe('string');
+      expect(driftRow?.source).toBe('startup-drift');
+      expect(driftRow?.origin).toBe('own-work');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('session_id resolves to "unknown" when runtime.session_id is null', async () => {
-    fs.mkdirSync(path.join(hermitDir, 'reports'));
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      fs.mkdirSync(path.join(hermitDir, 'reports'));
 
-    await runPrecheck(hermitDir);
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir);
-    const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:'));
-    expect(driftRow?.session_id).toBe('unknown');
+      const rows = readObservations(hermitDir);
+      const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:'));
+      expect(driftRow?.session_id).toBe('unknown');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('session_id resolves to "unknown" when runtime.json is absent', async () => {
-    // Remove runtime.json
-    fs.unlinkSync(path.join(hermitDir, 'state', 'runtime.json'));
-    fs.mkdirSync(path.join(hermitDir, 'reports'));
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      // Remove runtime.json
+      fs.unlinkSync(path.join(hermitDir, 'state', 'runtime.json'));
+      fs.mkdirSync(path.join(hermitDir, 'reports'));
 
-    await runPrecheck(hermitDir);
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir);
-    const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:'));
-    expect(driftRow?.session_id).toBe('unknown');
+      const rows = readObservations(hermitDir);
+      const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:'));
+      expect(driftRow?.session_id).toBe('unknown');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('dedup by pattern: same session does not write duplicate rows', async () => {
-    fs.mkdirSync(path.join(hermitDir, 'reports'));
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      fs.mkdirSync(path.join(hermitDir, 'reports'));
 
-    // Run twice
-    await runPrecheck(hermitDir);
-    await runPrecheck(hermitDir);
+      // Run twice
+      await runPrecheck(hermitDir);
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir).filter(r =>
-      typeof r.pattern === 'string' && r.pattern === 'storage-drift:reports'
-    );
-    expect(rows.length).toBe(1);
+      const rows = readObservations(hermitDir).filter(r =>
+        typeof r.pattern === 'string' && r.pattern === 'storage-drift:reports'
+      );
+      expect(rows.length).toBe(1);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('dedup by pattern: a different session does NOT write a duplicate drift row', async () => {
-    fs.mkdirSync(path.join(hermitDir, 'reports'));
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      fs.mkdirSync(path.join(hermitDir, 'reports'));
 
-    // First run: session_id = "S-001"
-    const runtime1 = { session_state: 'idle', session_id: 'S-001' };
-    fs.writeFileSync(path.join(hermitDir, 'state', 'runtime.json'), JSON.stringify(runtime1), 'utf-8');
-    await runPrecheck(hermitDir);
+      // First run: session_id = "S-001"
+      const runtime1 = { session_state: 'idle', session_id: 'S-001' };
+      fs.writeFileSync(path.join(hermitDir, 'state', 'runtime.json'), JSON.stringify(runtime1), 'utf-8');
+      await runPrecheck(hermitDir);
 
-    // Second run: session_id = "S-002" (different session). Drift is structural, so the
-    // standing pattern is not re-written — otherwise it would flip reflect to RUN every session.
-    const runtime2 = { session_state: 'idle', session_id: 'S-002' };
-    fs.writeFileSync(path.join(hermitDir, 'state', 'runtime.json'), JSON.stringify(runtime2), 'utf-8');
-    await runPrecheck(hermitDir);
+      // Second run: session_id = "S-002" (different session). Drift is structural, so the
+      // standing pattern is not re-written — otherwise it would flip reflect to RUN every session.
+      const runtime2 = { session_state: 'idle', session_id: 'S-002' };
+      fs.writeFileSync(path.join(hermitDir, 'state', 'runtime.json'), JSON.stringify(runtime2), 'utf-8');
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir).filter(r =>
-      typeof r.pattern === 'string' && r.pattern === 'storage-drift:reports'
-    );
-    expect(rows.length).toBe(1);
-    expect(rows[0].session_id).toBe('S-001');
+      const rows = readObservations(hermitDir).filter(r =>
+        typeof r.pattern === 'string' && r.pattern === 'storage-drift:reports'
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].session_id).toBe('S-001');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('storage-drift slug preserves the full subpath under raw/', async () => {
-    fs.mkdirSync(path.join(hermitDir, 'raw', 'sub'), { recursive: true });
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      fs.mkdirSync(path.join(hermitDir, 'raw', 'sub'), { recursive: true });
 
-    await runPrecheck(hermitDir);
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir);
-    const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:raw'));
-    expect(driftRow?.pattern).toBe('storage-drift:raw/sub');
+      const rows = readObservations(hermitDir);
+      const driftRow = rows.find(r => typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:raw'));
+      expect(driftRow?.pattern).toBe('storage-drift:raw/sub');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('precheck writes a schema-drift row for an undeclared compiled type', async () => {
-    fs.writeFileSync(path.join(hermitDir, 'knowledge-schema.md'),
-      '## Work Products\n\n- guide:\n- design:\n', 'utf-8');
-    fs.writeFileSync(path.join(hermitDir, 'compiled', 'note.md'),
-      '---\ntitle: x\ntype: spike\ncreated: 2026-01-01T00:00:00Z\n---\n# x\n', 'utf-8');
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      fs.writeFileSync(path.join(hermitDir, 'knowledge-schema.md'),
+        '## Work Products\n\n- guide:\n- design:\n', 'utf-8');
+      fs.writeFileSync(path.join(hermitDir, 'compiled', 'note.md'),
+        '---\ntitle: x\ntype: spike\ncreated: 2026-01-01T00:00:00Z\n---\n# x\n', 'utf-8');
 
-    await runPrecheck(hermitDir);
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir);
-    const driftRow = rows.find(r => r.pattern === 'schema-drift:spike');
-    expect(driftRow).toBeDefined();
-    expect(driftRow?.source).toBe('startup-drift');
-    expect(driftRow?.origin).toBe('own-work');
+      const rows = readObservations(hermitDir);
+      const driftRow = rows.find(r => r.pattern === 'schema-drift:spike');
+      expect(driftRow).toBeDefined();
+      expect(driftRow?.source).toBe('startup-drift');
+      expect(driftRow?.origin).toBe('own-work');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('precheck is fail-open: exits 0 even when hermitDir is missing', async () => {
@@ -202,80 +237,97 @@ describe('reflect-precheck: drift capture', () => {
   });
 
   test('no drift written when hermit dirs are clean', async () => {
-    await runPrecheck(hermitDir);
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      await runPrecheck(hermitDir);
 
-    const rows = readObservations(hermitDir).filter(r =>
-      typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:')
-    );
-    expect(rows.length).toBe(0);
+      const rows = readObservations(hermitDir).filter(r =>
+        typeof r.pattern === 'string' && r.pattern.startsWith('storage-drift:')
+      );
+      expect(rows.length).toBe(0);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 });
 
 // ── Section 2: Freshness RUN gate ────────────────────────────────────────────
 
 describe('reflect-precheck: freshness RUN gate', () => {
-  let hermitDir: string;
-
-  afterEach(() => { fs.rmSync(hermitDir, { recursive: true, force: true }); });
-
   test('EMPTY when ledger is empty and no other phases', async () => {
-    hermitDir = makeTmpHermit({
+    const hermitDir = makeTmpHermit({
       lastRunAt: new Date(Date.now() - 60_000).toISOString(),
       observations: [],
     });
-
-    const verdict = await runPrecheck(hermitDir);
-    expect(verdict).toBe('EMPTY');
+    try {
+      const verdict = await runPrecheck(hermitDir);
+      expect(verdict).toBe('EMPTY');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('RUN|{observations_fresh:true} when ledger has row newer than last_run_at', async () => {
     const lastRunAt = new Date(Date.now() - 3600_000).toISOString(); // 1h ago
     const freshTs = new Date().toISOString();
 
-    hermitDir = makeTmpHermit({
+    const hermitDir = makeTmpHermit({
       lastRunAt,
       observations: [JSON.stringify({ ts: freshTs, pattern: 'test', session_id: 'S-001', source: 'reflect-noticed', origin: 'own-work' })],
     });
-
-    const verdict = await runPrecheck(hermitDir);
-    expect(verdict).toMatch(/^RUN\|/);
-    const phases = JSON.parse(verdict.slice(4));
-    expect(phases.observations_fresh).toBe(true);
+    try {
+      const verdict = await runPrecheck(hermitDir);
+      expect(verdict).toMatch(/^RUN\|/);
+      const phases = JSON.parse(verdict.slice(4));
+      expect(phases.observations_fresh).toBe(true);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('EMPTY when all ledger rows are older than last_run_at', async () => {
     const oldTs = new Date(Date.now() - 7200_000).toISOString(); // 2h ago
     const lastRunAt = new Date(Date.now() - 3600_000).toISOString(); // 1h ago
 
-    hermitDir = makeTmpHermit({
+    const hermitDir = makeTmpHermit({
       lastRunAt,
       observations: [JSON.stringify({ ts: oldTs, pattern: 'test', session_id: 'S-001', source: 'reflect-noticed', origin: 'own-work' })],
     });
-
-    const verdict = await runPrecheck(hermitDir);
-    expect(verdict).toBe('EMPTY');
+    try {
+      const verdict = await runPrecheck(hermitDir);
+      expect(verdict).toBe('EMPTY');
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('null last_run_at → RUN when any ledger row exists', async () => {
-    hermitDir = makeTmpHermit({
+    const hermitDir = makeTmpHermit({
       lastRunAt: null,
       observations: [JSON.stringify({ ts: new Date(Date.now() - 86400_000).toISOString(), pattern: 'old', session_id: 'S-001', source: 'startup-drift', origin: 'own-work' })],
     });
-
-    const verdict = await runPrecheck(hermitDir);
-    expect(verdict).toMatch(/^RUN\|/);
-    const phases = JSON.parse(verdict.slice(4));
-    expect(phases.observations_fresh).toBe(true);
+    try {
+      const verdict = await runPrecheck(hermitDir);
+      expect(verdict).toMatch(/^RUN\|/);
+      const phases = JSON.parse(verdict.slice(4));
+      expect(phases.observations_fresh).toBe(true);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 
   test('startup-drift rows written in same run trigger observations_fresh on that run', async () => {
     // Fresh hermit with an unknown dir — precheck writes drift rows AND triggers freshness
-    hermitDir = makeTmpHermit({ lastRunAt: null });
-    fs.mkdirSync(path.join(hermitDir, 'reports'));
+    const hermitDir = makeTmpHermit({ lastRunAt: null });
+    try {
+      fs.mkdirSync(path.join(hermitDir, 'reports'));
 
-    const verdict = await runPrecheck(hermitDir);
-    // Should be RUN (either from observations_fresh or other phases)
-    expect(verdict).toMatch(/^RUN\|/);
+      const verdict = await runPrecheck(hermitDir);
+      // Should be RUN (either from observations_fresh or other phases)
+      expect(verdict).toMatch(/^RUN\|/);
+    } finally {
+      fs.rmSync(hermitDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/claude-code-hermit/tests/render-docker-templates.test.ts
+++ b/plugins/claude-code-hermit/tests/render-docker-templates.test.ts
@@ -4,23 +4,14 @@
 //
 // Usage: bun test tests/render-docker-templates.test.ts   (from the plugin root)
 
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript, PLUGIN_ROOT } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-rdt-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-rdt-');
+afterAll(cleanup);
 
 const BASE_INPUT = {
   packages: [] as string[],

--- a/plugins/claude-code-hermit/tests/render-security-overlay.test.ts
+++ b/plugins/claude-code-hermit/tests/render-security-overlay.test.ts
@@ -8,26 +8,17 @@
 //
 // Usage: bun test tests/render-security-overlay.test.ts   (from the plugin root)
 
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 import {
   cidrToRange, overlaps, pickSubnet, validateCandidate, ipv4SubnetsFromInspect,
 } from '../scripts/render-security-overlay';
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-rso-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-rso-');
+afterAll(cleanup);
 
 const CANDIDATES = [
   '172.28.0.0/24', '172.29.0.0/24', '172.30.0.0/24', '172.31.0.0/24',

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -15,7 +15,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { runScript, PLUGIN_ROOT, SCRIPTS_DIR, MONOREPO_ROOT } from './helpers/run';
-import { setupWorkdir, fixturesDir, type Workdir } from './helpers/workdir';
+import { setupWorkdir, fixturesDir, withDir, type Workdir } from './helpers/workdir';
 import { deriveStaleSession, STALE_KEY } from '../scripts/lib/alert-state';
 
 // In-process imports — pure libs with no import-time CWD dependence.
@@ -37,14 +37,6 @@ import { logMessage, searchLog, unconsolidated, markConsolidated, prune, dbExist
 const hermit = (dir: string, ...p: string[]) => path.join(dir, '.claude-code-hermit', ...p);
 const write = (p: string, content: string) => fs.writeFileSync(p, content);
 const readJson = (p: string) => JSON.parse(fs.readFileSync(p, 'utf-8'));
-
-/** Run a test body inside a throwaway workdir, always cleaning up. */
-function withDir(fn: (dir: string) => Promise<void> | void) {
-  return async () => {
-    const wd = setupWorkdir();
-    try { await fn(wd.dir); } finally { wd.cleanup(); }
-  };
-}
 
 /** Subprocess runner for the bash scripts under test (check-upgrade.sh etc.). */
 async function runBash(
@@ -580,6 +572,8 @@ describe('knowledge-lint', () => {
   }));
 
   // 6b. Schema enforcement — undeclared type warned; declared+matching type clean
+  // Both tests write the same compiled/unknown.md path and re-run the linter
+  // against it — order-coupled shared file, so both are marked serial.
   describe('schema enforcement', () => {
     let wd: Workdir;
 
@@ -595,14 +589,14 @@ describe('knowledge-lint', () => {
     });
     afterAll(() => wd.cleanup());
 
-    test('knowledge-lint (schema: undeclared type warned)', async () => {
+    test.serial('knowledge-lint (schema: undeclared type warned)', async () => {
       write(hermit(wd.dir, 'compiled', 'unknown.md'),
         '---\ntitle: unknown\ntype: foo\ncreated: 2026-04-14T00:00:00+00:00\n---\ndata');
       const r = await runLint(wd.dir);
       expect(r.stdout + r.stderr).toContain('undeclared-type');
     });
 
-    test('knowledge-lint (schema: declared type is clean)', async () => {
+    test.serial('knowledge-lint (schema: declared type is clean)', async () => {
       // Matching type: schema has 'briefing', file has type: briefing
       write(hermit(wd.dir, 'compiled', 'unknown.md'),
         `---\ntitle: summary\ntype: briefing\ncreated: ${isoSec(daysAgo(5))}\n---\ndata`);
@@ -2531,6 +2525,9 @@ describe('reflect-precheck', () => {
 describe('log-routine-event', () => {
   const SCRIPT = path.join(SCRIPTS_DIR, 'log-routine-event.sh');
 
+  // Empirically confirmed (bun 1.3.14): describe.serial does not reliably
+  // force sequential execution of its own child tests under --concurrent —
+  // only per-test .serial marking does. So each test below is marked individually.
   describe('hermit root resolution', () => {
     let wd: Workdir;
     const metrics = () => hermit(wd.dir, 'state', 'routine-metrics.jsonl');
@@ -2541,21 +2538,21 @@ describe('log-routine-event', () => {
     });
     afterAll(() => wd.cleanup());
 
-    test('log-routine-event (subdir resolves to ancestor)', async () => {
+    test.serial('log-routine-event (subdir resolves to ancestor)', async () => {
       // Fired from a subdirectory → appends to the ancestor's state file
       await runBash(SCRIPT, { args: ['morning-brief', 'fired'], cwd: path.join(wd.dir, 'app', 'sub') });
       const content = fs.readFileSync(metrics(), 'utf-8');
       expect(content).toContain('"routine_id":"morning-brief","event":"fired"');
     });
 
-    test('log-routine-event (root resolves to state file)', async () => {
+    test.serial('log-routine-event (root resolves to state file)', async () => {
       // Fired from the hermit root → unchanged behavior
       await runBash(SCRIPT, { args: ['weekly-review', 'skipped-waiting'], cwd: wd.dir });
       const content = fs.readFileSync(metrics(), 'utf-8');
       expect(content).toContain('"routine_id":"weekly-review","event":"skipped-waiting"');
     });
 
-    test('log-routine-event (started event serializes correctly)', async () => {
+    test.serial('log-routine-event (started event serializes correctly)', async () => {
       // started marker emitted before skill invocation — must serialize like other events
       await runBash(SCRIPT, { args: ['daily-brief', 'started'], cwd: wd.dir });
       const content = fs.readFileSync(metrics(), 'utf-8');
@@ -2563,6 +2560,8 @@ describe('log-routine-event', () => {
     });
   });
 
+  // Order-coupled: both tests append to the same shared routine-metrics.jsonl
+  // and the second reads a `before` baseline left by the first's writes.
   describe('duplicate fired guard (#464)', () => {
     let wd: Workdir;
     const metrics = () => hermit(wd.dir, 'state', 'routine-metrics.jsonl');
@@ -2577,14 +2576,14 @@ describe('log-routine-event', () => {
     });
     afterAll(() => wd.cleanup());
 
-    test('suppresses a fired that immediately follows another fired', async () => {
+    test.serial('suppresses a fired that immediately follows another fired', async () => {
       await runBash(SCRIPT, { args: ['heartbeat-restart', 'started'], cwd: wd.dir });
       await runBash(SCRIPT, { args: ['heartbeat-restart', 'fired'], cwd: wd.dir });
       await runBash(SCRIPT, { args: ['heartbeat-restart', 'fired'], cwd: wd.dir });
       expect(firedCount()).toBe(1);
     });
 
-    test('allows the next legitimate started→fired cycle', async () => {
+    test.serial('allows the next legitimate started→fired cycle', async () => {
       const before = firedCount();
       await runBash(SCRIPT, { args: ['heartbeat-restart', 'started'], cwd: wd.dir });
       await runBash(SCRIPT, { args: ['heartbeat-restart', 'fired'], cwd: wd.dir });

--- a/plugins/claude-code-hermit/tests/settings-edit.test.ts
+++ b/plugins/claude-code-hermit/tests/settings-edit.test.ts
@@ -1,21 +1,12 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { runScript } from './helpers/run';
 import { getPath, setPath, togglePath } from '../scripts/settings-edit';
+import { freshDirFactory } from './helpers/workdir';
 
-const tmpdirs: string[] = [];
-function freshDir(): string {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-settings-edit-'));
-  tmpdirs.push(d);
-  return d;
-}
-afterEach(() => {
-  for (const d of tmpdirs.splice(0)) {
-    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
-  }
-});
+const { freshDir, cleanup } = freshDirFactory('hermit-settings-edit-');
+afterAll(cleanup);
 
 function seedConfig(dir: string, config: any): string {
   const hermit = path.join(dir, '.claude-code-hermit');

--- a/plugins/claude-code-hermit/tests/skill-correction-ledger.test.ts
+++ b/plugins/claude-code-hermit/tests/skill-correction-ledger.test.ts
@@ -67,6 +67,9 @@ describe('session-close: skill-correction capture', () => {
 
 // ── 2. observations ledger: append-metrics behavioral test ──────────────────
 
+// Empirically confirmed (bun 1.3.14): describe.serial does not reliably force
+// sequential execution of its own child tests under --concurrent — only
+// per-test .serial marking does. So each test below is marked individually.
 describe('append-metrics: skill-correction row round-trip', () => {
   let workdir: string;
   let ledger: string;
@@ -81,7 +84,7 @@ describe('append-metrics: skill-correction row round-trip', () => {
     try { fs.rmSync(workdir, { recursive: true, force: true }); } catch {}
   });
 
-  test('append-metrics: skill-correction row appended and parseable', async () => {
+  test.serial('append-metrics: skill-correction row appended and parseable', async () => {
     const row = JSON.stringify({
       ts: hoursAgoISO(2),
       pattern: 'skill-correction:my-skill',
@@ -101,7 +104,7 @@ describe('append-metrics: skill-correction row round-trip', () => {
     expect(parsed.session_id).toBe('S-001');
   });
 
-  test('append-metrics: two distinct-session rows group by pattern in prune', async () => {
+  test.serial('append-metrics: two distinct-session rows group by pattern in prune', async () => {
     // append a second session row for the same pattern
     const row2 = JSON.stringify({
       ts: hoursAgoISO(1),
@@ -122,7 +125,7 @@ describe('append-metrics: skill-correction row round-trip', () => {
   });
 
   // Depends on both prior append tests having run (shared workdir ledger has 2 rows).
-  test('prune-observations: skill-correction rows survive (both sessions fresh)', async () => {
+  test.serial('prune-observations: skill-correction rows survive (both sessions fresh)', async () => {
     const r = await runScript('prune-observations.ts', {
       args: [path.join(workdir, '.claude-code-hermit')],
     });

--- a/plugins/claude-code-homeassistant-hermit/bunfig.toml
+++ b/plugins/claude-code-homeassistant-hermit/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+concurrentTestGlob = ["**/*.test.ts"]

--- a/plugins/claude-code-homeassistant-hermit/tests/apply.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/apply.test.ts
@@ -4,7 +4,11 @@
 // pytest fixture mapping: MagicMock client -> fakeClient (helpers.ts);
 // side_effect sequences -> closure-queued handlers that throw on demand.
 
-import { afterEach, expect, test } from 'bun:test';
+// Whole file runs serial: afterEach drains the shared tmpDirs array and clears
+// the global policy cache — per-test global state that cannot isolate under
+// `bun test --concurrent`.
+import { afterEach, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 

--- a/plugins/claude-code-homeassistant-hermit/tests/audits.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/audits.test.ts
@@ -5,7 +5,7 @@
 // (async get, sync-raising via rejected promise); `_load_acknowledged` ->
 // exported loadAcknowledged.
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -22,7 +22,7 @@ function tmpPath(): string {
   return dir;
 }
 
-afterEach(() => {
+afterAll(() => {
   for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 

--- a/plugins/claude-code-homeassistant-hermit/tests/automation-diff.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/automation-diff.test.ts
@@ -3,7 +3,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 
 import {
   automationDiff,
@@ -13,7 +13,7 @@ import {
 } from '../src/automation-diff';
 import { cleanupTmp, fakeClient, tmpPath } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function snap(
   automations: AutomationSnapshot['automations'],

--- a/plugins/claude-code-homeassistant-hermit/tests/automode-env.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/automode-env.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -6,7 +6,7 @@ import { tmpPath, cleanupTmp } from './helpers';
 
 const SCRIPT = path.join(import.meta.dir, '..', 'scripts', 'automode-env.ts');
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 const freshDir = () => tmpPath('ha-automode-env-');
 
 function run(target: string, projectDir: string): { exitCode: number; stdout: string; stderr: string } {

--- a/plugins/claude-code-homeassistant-hermit/tests/boot.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/boot.test.ts
@@ -12,7 +12,10 @@
 // _write_launcher is vestigial in the Python suite (command_prefix resolves
 // against the real plugin root, which always has bin/ha-agent-lab) — dropped.
 
-import { afterEach, beforeEach, expect, test } from 'bun:test';
+// Whole file runs serial: beforeEach/afterEach save/restore parent process.env
+// keys — global state per-test dirs cannot isolate under --concurrent.
+import { afterEach, beforeEach, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, isAbsolute, join } from 'node:path';
 

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-call-service.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-call-service.test.ts
@@ -3,7 +3,11 @@
 // calls proceed in both modes; sensitive ones follow strict/ask like every
 // other gate.
 
-import { afterEach, expect, test } from 'bun:test';
+// Whole file runs serial: afterEach drains the shared tmpDirs array and clears
+// the global policy cache — per-test global state that cannot isolate under
+// `bun test --concurrent`.
+import { afterEach, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 
 import { main } from '../src/cli';
 import { HomeAssistantError } from '../src/ha-api';

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-delete.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-delete.test.ts
@@ -4,13 +4,13 @@
 // pytest fixture mapping: patch(cli.load_config/HomeAssistantClient) ->
 // main(argv, { loadConfig, createClient }) dependency injection.
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 
 import { main } from '../src/cli';
 import { HomeAssistantError } from '../src/ha-api';
 import { captureOutput, cleanupTmp, fakeClient, makeMockConfig, type FakeClient } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function runCli(argv: string[], client: FakeClient) {
   const cfg = makeMockConfig();

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-fetch-history.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-fetch-history.test.ts
@@ -1,7 +1,7 @@
 // WP7 tier 3: tests for the 'ha fetch-history' CLI subcommand — 1:1 port of
 // tests/test_cli_fetch_history.py (5 cases).
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -9,7 +9,7 @@ import type { AppConfig } from '../src/config';
 import { main } from '../src/cli';
 import { captureOutput, cleanupTmp, fakeClient, makeMockConfig, type FakeClient } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function makeNormalized(root: string, entities: Record<string, any> | null = null): string {
   const raw = join(root, '.claude-code-hermit', 'raw');

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-get-config.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-get-config.test.ts
@@ -1,13 +1,13 @@
 // WP7 tier 3: tests for cli.ts get-*-config commands — 1:1 port of
 // tests/test_cli_get_config.py (3 cases + 1 parametrized pair).
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 
 import { main } from '../src/cli';
 import { HomeAssistantError } from '../src/ha-api';
 import { captureOutput, cleanupTmp, fakeClient, makeMockConfig, type FakeClient } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function runCli(argv: string[], client: FakeClient) {
   const cfg = makeMockConfig();

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-integration-health.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-integration-health.test.ts
@@ -7,7 +7,7 @@
 // The "stat raises OSError" case uses an ENOTDIR parent (a regular file where
 // raw/ should be) instead of patching Path.stat — same non-ENOENT branch.
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import { mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
@@ -16,7 +16,7 @@ import { handleIntegrationHealth } from '../src/cli';
 import { HomeAssistantError } from '../src/ha-api';
 import { captureOutput, cleanupTmp, fakeClient, tmpPath } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function makeEntities(domain: string, n: number, unavail: number): [Record<string, any>, string[]] {
   const idx: Record<string, any> = {};

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-probe.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-probe.test.ts
@@ -1,13 +1,13 @@
 // WP7 tier 3: tests for the 'ha probe' CLI subcommand — 1:1 port of
 // tests/test_cli_probe.py (2 cases).
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 
 import { main } from '../src/cli';
 import { HomeAssistantError } from '../src/ha-api';
 import { captureOutput, cleanupTmp, fakeClient, makeMockConfig, type FakeClient } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function runCli(argv: string[], client: FakeClient) {
   const cfg = makeMockConfig();

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-reload-entry.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-reload-entry.test.ts
@@ -2,7 +2,11 @@
 // applying gateStructuralMutation directly (not via runWsMutation, which is
 // WS-client-specific) before a plain client.post() call.
 
-import { afterEach, expect, test } from 'bun:test';
+// Whole file runs serial: afterEach drains the shared tmpDirs array and clears
+// the global policy cache — per-test global state that cannot isolate under
+// `bun test --concurrent`.
+import { afterEach, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 
 import { main } from '../src/cli';
 import { AppConfig } from '../src/config';

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-render-template.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-render-template.test.ts
@@ -1,13 +1,13 @@
 // Tests for 'ha render-template' and 'ha check-config' — thin REST wrappers.
 // render-template exercises postText() (HA returns plain text, not JSON).
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 
 import { main } from '../src/cli';
 import { HomeAssistantError } from '../src/ha-api';
 import { cleanupTmp, captureOutput, fakeClient, makeMockConfig, tmpPath, writeArtifact, type FakeClient } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function runCli(argv: string[], client: FakeClient) {
   const cfg = makeMockConfig();

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-silence.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-silence.test.ts
@@ -1,14 +1,14 @@
 // WP7 tier 3: tests that refresh-context paths attach silence_summary to the
 // normalized snapshot — 1:1 port of tests/test_cli_silence.py (2 cases).
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { main } from '../src/cli';
 import { captureOutput, cleanupTmp, fakeClient, makeMockConfig } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function mockStates(): Array<Record<string, any>> {
   return [

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-structure.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-structure.test.ts
@@ -1,7 +1,11 @@
 // Tests for the WebSocket structural CLI commands (helpers, areas, registries)
 // and the safety gate, driven through main() with an injected fake WS client.
 
-import { afterEach, expect, test } from 'bun:test';
+// Whole file runs serial: afterEach drains the shared tmpDirs array and clears
+// the global policy cache — per-test global state that cannot isolate under
+// `bun test --concurrent`.
+import { afterEach, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 
 import { main } from '../src/cli';
 import { AppConfig } from '../src/config';

--- a/plugins/claude-code-homeassistant-hermit/tests/cli-updates.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/cli-updates.test.ts
@@ -1,11 +1,11 @@
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 
 import type { AppConfig } from '../src/config';
 import { handleUpdates } from '../src/cli';
 import { HomeAssistantError } from '../src/ha-api';
 import { captureOutput, cleanupTmp, fakeClient } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 const dummyConfig = {} as AppConfig;
 

--- a/plugins/claude-code-homeassistant-hermit/tests/config.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/config.test.ts
@@ -1,4 +1,8 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+// Whole file runs serial: top-level tests and the projectRoot() describe both
+// mutate process.env/process.chdir — global state per-test dirs cannot isolate
+// under --concurrent.
+import { afterEach, describe, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/plugins/claude-code-homeassistant-hermit/tests/gate-opaque-tools.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/gate-opaque-tools.test.ts
@@ -13,14 +13,14 @@
 // The unresolvable-selector fan-out invariant still hard-blocks in BOTH modes.
 // Hass* intent tools (name/area targeting) hard-block unless ha_assist_control_enabled.
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import { join } from 'node:path';
 
 import { cleanEnv, cleanupTmp, makeHaConfig, makeHaConfigWith, tmpPath } from './helpers';
 
 const MCP_HOOK = join(import.meta.dir, '..', 'hooks', 'mcp-safety-gate.ts');
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function runGate(stdin: string, mode?: string, cwd?: string) {
   const effectiveCwd = cwd ?? (mode !== undefined ? makeHaConfig(mode) : tmpPath());

--- a/plugins/claude-code-homeassistant-hermit/tests/ha-api.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/ha-api.test.ts
@@ -11,7 +11,10 @@
 //   - patch("...probe_home_assistant_url", return_value=False) -> an injected
 //     fetch that rejects (probe catches and returns false)
 
-import { afterEach, beforeEach, expect, test } from 'bun:test';
+// Whole file runs serial: beforeEach/afterEach save/restore parent process.env
+// HOMEASSISTANT_* keys — global state per-test dirs cannot isolate under --concurrent.
+import { afterEach, beforeEach, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/plugins/claude-code-homeassistant-hermit/tests/helpers.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/helpers.ts
@@ -3,7 +3,8 @@
 // (write_artifact), plus a capsys equivalent for CLI tests.
 //
 // Each test file that uses tmpPath()/makeHaRoot()/... must register
-// `afterEach(cleanupTmp)`.
+// `afterAll(cleanupTmp)` — afterEach would drain dirs still in use by
+// sibling tests running concurrently under `bun test --concurrent`.
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/plugins/claude-code-homeassistant-hermit/tests/history.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/history.test.ts
@@ -4,7 +4,7 @@
 // pytest fixture mapping: tmp_path -> mkdtempSync; MagicMock client ->
 // inline { getHistory: async () => ... } stub (HistoryClient interface).
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -25,7 +25,7 @@ function tmpPath(): string {
   return dir;
 }
 
-afterEach(() => {
+afterAll(() => {
   for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 

--- a/plugins/claude-code-homeassistant-hermit/tests/integration-health.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/integration-health.test.ts
@@ -5,7 +5,7 @@
 //
 // pytest fixture mapping: tmp_path -> mkdtempSync.
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -24,7 +24,7 @@ function tmpPath(): string {
   return dir;
 }
 
-afterEach(() => {
+afterAll(() => {
   for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 

--- a/plugins/claude-code-homeassistant-hermit/tests/markdown.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/markdown.test.ts
@@ -7,7 +7,7 @@ import { expect, test } from 'bun:test';
 import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach } from 'bun:test';
+import { afterAll } from 'bun:test';
 
 import { dumpFrontmatter, loadFrontmatter, renderFrontmatter } from '../src/markdown';
 
@@ -19,7 +19,7 @@ function tmpPath(): string {
   return dir;
 }
 
-afterEach(() => {
+afterAll(() => {
   for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 

--- a/plugins/claude-code-homeassistant-hermit/tests/policy.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/policy.test.ts
@@ -12,7 +12,10 @@
 // pytest fixture mapping: make_ha_config -> makeHaConfig helper,
 // monkeypatch.chdir -> process.chdir with afterEach restore.
 
-import { afterEach, expect, test } from 'bun:test';
+// Whole file runs serial: process.chdir + clearPolicyCaches() mutate global
+// process state that per-test dirs cannot isolate under --concurrent.
+import { afterEach, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -185,6 +188,6 @@ test('check_entity includes severity', () => {
   expect(result.severity).toBe('allow');
 });
 
-test.todo('policy-check CLI on a YAML file (needs simulate.collect_references — tier 2)', () => {
+bunTest.todo('policy-check CLI on a YAML file (needs simulate.collect_references — tier 2)', () => {
   throw new Error('cli.py policy-check and simulate.collect_references are not ported yet');
 });

--- a/plugins/claude-code-homeassistant-hermit/tests/safety-gate.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/safety-gate.test.ts
@@ -4,7 +4,7 @@
 // pytest fixture mapping: make_ha_config -> makeHaConfig from helpers.ts
 // (cwd-based config root, same as the conftest tmp_path fixture).
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import { join } from 'node:path';
 
@@ -12,7 +12,7 @@ import { cleanupTmp, makeHaConfig } from './helpers';
 
 const HOOK = join(import.meta.dir, '..', 'hooks', 'mcp-safety-gate.ts');
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function run(payload: unknown, cwd?: string) {
   const data = typeof payload === 'string' ? payload : JSON.stringify(payload);

--- a/plugins/claude-code-homeassistant-hermit/tests/silence.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/silence.test.ts
@@ -4,7 +4,7 @@
 //
 // pytest fixture mapping: tmp_path -> mkdtempSync.
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -20,7 +20,7 @@ function tmpPath(): string {
   return dir;
 }
 
-afterEach(() => {
+afterAll(() => {
   for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 

--- a/plugins/claude-code-homeassistant-hermit/tests/snapshot-restore.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/snapshot-restore.test.ts
@@ -3,7 +3,11 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { afterEach, expect, test } from 'bun:test';
+// Whole file runs serial: afterEach drains the shared tmpDirs array and clears
+// the global policy cache — per-test global state that cannot isolate under
+// `bun test --concurrent`.
+import { afterEach, expect, test as bunTest } from 'bun:test';
+const test = bunTest.serial;
 
 import { clearPolicyCaches } from '../src/policy';
 import { captureStates, restoreStates, type StateSnapshot } from '../src/snapshot-restore';

--- a/plugins/claude-code-homeassistant-hermit/tests/trigger-automation.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/trigger-automation.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, expect, test } from 'bun:test';
+import { afterAll, expect, test } from 'bun:test';
 
 import { main } from '../src/cli';
 import { captureOutput, cleanupTmp, fakeClient, makeMockConfig } from './helpers';
 
-afterEach(cleanupTmp);
+afterAll(cleanupTmp);
 
 function makeDeps(postResult: Record<string, unknown> = {}) {
   const client = fakeClient({ post: () => postResult });

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -11,19 +11,18 @@ BUN_TEST_SLUGS=(claude-code-hermit claude-code-homeassistant-hermit feed-hermit)
 RUN_ALL_SLUGS=(claude-code-dev-hermit claude-code-fitness-hermit hermit-scribe laravel-forge-hermit)
 
 declare -A PIDS
-declare -A STARTS
 
 now() { date +%s; }
 
+# Each job records its own wall time to <slug>.secs so the reported duration is
+# the suite's real runtime, not the moment the fixed-order wait loop reaps it.
 for slug in "${BUN_TEST_SLUGS[@]}"; do
-  STARTS[$slug]=$(now)
-  (cd "$ROOT/plugins/$slug" && bun test) >"$LOGDIR/$slug.log" 2>&1 &
+  ( s=$(now); cd "$ROOT/plugins/$slug" && bun test; rc=$?; echo $(( $(now) - s )) >"$LOGDIR/$slug.secs"; exit "$rc" ) >"$LOGDIR/$slug.log" 2>&1 &
   PIDS[$slug]=$!
 done
 
 for slug in "${RUN_ALL_SLUGS[@]}"; do
-  STARTS[$slug]=$(now)
-  bash "$ROOT/plugins/$slug/tests/run-all.sh" >"$LOGDIR/$slug.log" 2>&1 &
+  ( s=$(now); bash "$ROOT/plugins/$slug/tests/run-all.sh"; rc=$?; echo $(( $(now) - s )) >"$LOGDIR/$slug.secs"; exit "$rc" ) >"$LOGDIR/$slug.log" 2>&1 &
   PIDS[$slug]=$!
 done
 
@@ -32,7 +31,7 @@ printf "%-32s %-6s %6s\n" "PLUGIN" "RESULT" "SECS"
 for slug in "${BUN_TEST_SLUGS[@]}" "${RUN_ALL_SLUGS[@]}"; do
   wait "${PIDS[$slug]}"
   rc=$?
-  elapsed=$(( $(now) - STARTS[$slug] ))
+  elapsed=$(cat "$LOGDIR/$slug.secs" 2>/dev/null || echo '?')
   if [ "$rc" -eq 0 ]; then
     printf "%-32s %-6s %5ss\n" "$slug" "PASS" "$elapsed"
   else

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run every plugin's test suite in parallel and report a per-plugin summary.
+# Wall time is bounded by the slowest suite instead of the sum of all suites.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOGDIR="$(mktemp -d)"
+trap 'rm -rf "$LOGDIR"' EXIT
+
+BUN_TEST_SLUGS=(claude-code-hermit claude-code-homeassistant-hermit feed-hermit)
+RUN_ALL_SLUGS=(claude-code-dev-hermit claude-code-fitness-hermit hermit-scribe laravel-forge-hermit)
+
+declare -A PIDS
+declare -A STARTS
+
+now() { date +%s; }
+
+for slug in "${BUN_TEST_SLUGS[@]}"; do
+  STARTS[$slug]=$(now)
+  (cd "$ROOT/plugins/$slug" && bun test) >"$LOGDIR/$slug.log" 2>&1 &
+  PIDS[$slug]=$!
+done
+
+for slug in "${RUN_ALL_SLUGS[@]}"; do
+  STARTS[$slug]=$(now)
+  bash "$ROOT/plugins/$slug/tests/run-all.sh" >"$LOGDIR/$slug.log" 2>&1 &
+  PIDS[$slug]=$!
+done
+
+overall_rc=0
+printf "%-32s %-6s %6s\n" "PLUGIN" "RESULT" "SECS"
+for slug in "${BUN_TEST_SLUGS[@]}" "${RUN_ALL_SLUGS[@]}"; do
+  wait "${PIDS[$slug]}"
+  rc=$?
+  elapsed=$(( $(now) - STARTS[$slug] ))
+  if [ "$rc" -eq 0 ]; then
+    printf "%-32s %-6s %5ss\n" "$slug" "PASS" "$elapsed"
+  else
+    printf "%-32s %-6s %5ss\n" "$slug" "FAIL" "$elapsed"
+    overall_rc=1
+    echo "--- $slug (last 20 lines) ---"
+    tail -20 "$LOGDIR/$slug.log"
+    echo "---"
+  fi
+done
+
+exit "$overall_rc"


### PR DESCRIPTION
## Summary
The full monorepo test suite took ~166s to run sequentially. The dominant cost was serial waiting on hook-contract subprocess spawns in the core plugin (128s alone), not CPU work — `bun test --concurrent` cut that to ~37s, but exposed 126 pre-existing test failures, all fixture races (module-level `let wd`/`dir` shared across concurrently-running tests), none real bugs.

## Changes
- De-raced ~35 core test files: converted shared/module-level workdir fixtures to per-test-local ones (a new `withDir`/`freshDirFactory` helper pair in `tests/helpers/workdir.ts`, or inline `try/finally`), and marked the handful of genuinely process-global tests (`process.chdir`, `process.env` mutation, shared observations ledger) `test.serial`.
- Added `bunfig.toml` to core and HA plugins (`concurrentTestGlob`) so bare `bun test` runs concurrently by default — no flag needed locally or in CI.
- De-raced the HA plugin's shared-array cleanup timing (`afterEach` → `afterAll` across ~18 files) and serial-marked its 4 process-global files.
- Added `scripts/test-all.sh` + `bun run test`: runs all seven plugin suites in parallel instead of sequentially, bounding wall time to the slowest suite.
- Updated the `/test-run` skill to delegate the no-arg case to the new script.
- Bumped CI's `bun-version` pin (1.3.11 → 1.3.14) across all seven workflows to match the version this was verified against.

## Test plan
- Core (`plugins/claude-code-hermit`): `bun test` green 3x consecutively (2705/2705, ~34s, down from 128s), plus a serial-equivalent run (`--max-concurrency 1`, 2705/2705, ~111s) to confirm no ordering regressions.
- HA (`plugins/claude-code-homeassistant-hermit`): same protocol, 674 pass + 1 pre-existing todo, 3x concurrent green (~29-30s, down from ~30s serial — most of its wall time is python/subprocess spawn overhead, not fixture races).
- Repo root: `bash scripts/test-all.sh` — all 7 plugins PASS, wall ~44s (down from ~166s sequential).
- `bunx tsc --noEmit` clean from repo root.
- Diff reviewed by three parallel `/simplify` passes (reuse, quality, efficiency) before commit; applied findings included consolidating 10 duplicated fixture-cleanup files into a shared `freshDirFactory` helper and fixing one additional untouched race (`docker-preflight.test.ts`) the reuse reviewer surfaced.