### PR TITLE
fix(feed-hermit): drop no-op Write(path) permission rules

### DIFF
--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **settings: drop no-op `Write(path)` rules** — Claude Code only matches file-permission checks against `Edit(path)` (which already covers Write), so the `Write(...)` allow/deny entries were dead and tripped a boot warning. `Write(tmp/**)` becomes `Edit(tmp/**)` so tmp fetch-scratch writes are actually auto-approved (the old `Write(...)` rule never matched, so they weren't before).
+
 ## [0.1.1] - 2026-07-21
 
 ### Fixed

--- a/plugins/feed-hermit/settings.json
+++ b/plugins/feed-hermit/settings.json
@@ -8,14 +8,10 @@
       "Bash(bun *validate-sources.ts*)",
       "Bash(bun test*)",
       "Edit(feed-sources.md)",
-      "Write(feed-sources.md)",
       "Edit(feed-categories.md)",
-      "Write(feed-categories.md)",
       "Edit(FEEDS.md)",
-      "Write(FEEDS.md)",
       "Edit(.claude-code-hermit/**)",
-      "Write(.claude-code-hermit/**)",
-      "Write(tmp/**)"
+      "Edit(tmp/**)"
     ],
     "deny": [
       "Bash(rm -rf *)",
@@ -25,9 +21,7 @@
       "Bash(curl * | bash*)",
       "Bash(wget * | bash*)",
       "Edit(**/.claude-code-hermit/OPERATOR.md)",
-      "Write(**/.claude-code-hermit/OPERATOR.md)",
-      "Edit(.env)",
-      "Write(.env)"
+      "Edit(.env)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Claude Code only matches file-permission checks against `Edit(path)` rules — `Edit` already covers Write, and CC v2.1.211+ warns at boot on any `Write(path)` rule. `plugins/feed-hermit/settings.json` still shipped several dead `Write(...)` allow/deny entries, tripping that boot warning on every feed-hermit install; the other domain plugins (HA, laravel-forge, fitness) already had this cleanup.

## Changes
- Drop redundant `Write(feed-sources.md)`, `Write(feed-categories.md)`, `Write(FEEDS.md)`, `Write(.claude-code-hermit/**)`, `Write(**/.claude-code-hermit/OPERATOR.md)`, `Write(.env)` — each already had a matching `Edit(...)` rule doing the real work.
- `Write(tmp/**)` had no `Edit` twin, so it becomes `Edit(tmp/**)` — this is the one real behavior fix in the diff: tmp fetch-scratch writes are now actually auto-approved (the old rule never matched anything).
- CHANGELOG `[Unreleased]` entry recording the fix.

## Test plan
- `cd plugins/feed-hermit && bun test` — 53 pass, 0 fail.
- `bunx tsc --noEmit` (repo root) — clean, exit 0.
- `grep -n 'Write(' plugins/feed-hermit/settings.json` — no matches.