### PR TITLE
fix(fleet): retire brainstorm-emit; domain-brainstorm rides the triage ledger

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixed
 - `domain-brainstorm` no longer writes its own `brainstorm-emit` event — the call pointed at core's `append-metrics.ts`, unreachable from this plugin, so nothing was ever recorded. Proposals now carry `tags: [capability-brainstorm]` instead, counting toward the brainstorm kill-criteria segment rather than `reflect`'s.
-- `skill-structure` tests now fail on any `${CLAUDE_PLUGIN_ROOT}/scripts/…` reference that doesn't resolve to a shipped script.
 - The `hatch` summary described `/dev-quality` as running code-review; it runs a cleanup pass and only suggests code-review.
 
 ## [0.4.7] - 2026-07-03

--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Fixed
+- `domain-brainstorm` no longer writes its own `brainstorm-emit` event — the call pointed at core's `append-metrics.ts`, unreachable from this plugin, so nothing was ever recorded. Proposals now carry `tags: [capability-brainstorm]` instead, counting toward the brainstorm kill-criteria segment rather than `reflect`'s.
+- `skill-structure` tests now fail on any `${CLAUDE_PLUGIN_ROOT}/scripts/…` reference that doesn't resolve to a shipped script.
 - The `hatch` summary described `/dev-quality` as running code-review; it runs a cleanup pass and only suggests code-review.
 
 ## [0.4.7] - 2026-07-03

--- a/plugins/claude-code-dev-hermit/skills/domain-brainstorm/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/domain-brainstorm/SKILL.md
@@ -7,7 +7,7 @@ description: On-demand dev-voice brainstorm — reads codebase friction signals 
 
 ## Kill criteria (read before running)
 
-After ≥8 invocations, read `.claude-code-hermit/state/proposal-metrics.jsonl` and filter events where `type:"brainstorm-emit"` and `skill:"domain-brainstorm"`. Count CREATE vs total emits with ideas (triage-survival) and read `status:` of the resulting PROP files (PROP-acceptance). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there.
+After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report (`--source=capability-brainstorm`). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
 
 ### Gate 0 — Gather inputs
 
@@ -50,23 +50,14 @@ Evidence Source: capability-brainstorm
 Evidence: <one paragraph: friction sentence + named grounding items>
 ```
 
-Set frontmatter: `source: auto-detected`, `category: improvement`.
+Set frontmatter: `source: auto-detected`, `category: improvement`, `tags: [capability-brainstorm]`.
 
-> `Evidence Source: capability-brainstorm` is reused intentionally: it is the only source `proposal-triage` recognizes for the single-pass recurrence bypass, and adding a dedicated `domain-brainstorm` source is a core edit this skill deliberately avoids. The cost: domain-brainstorm proposals carry capability-brainstorm provenance to any consumer that buckets by evidence source. Per-skill kill metrics are unaffected (they read the `brainstorm-emit` events below, which are tagged `skill:"domain-brainstorm"`). If this skill graduates from pilot, promote it to a first-class triage bypass source.
+> `Evidence Source: capability-brainstorm` is reused intentionally: it is the only source `proposal-triage` recognizes for the single-pass recurrence bypass, and adding a dedicated `domain-brainstorm` source is a core edit this skill deliberately avoids. Provenance is carried by the `tags` above, which `proposal-create` writes onto both the `triage-verdict` row and the proposal frontmatter. The cost: these proposals share core `capability-brainstorm`'s kill-criteria segment, so the numbers are combined rather than per-skill.
 
 Parse the verdict:
 - `CREATE` — note PROP-NNN.
 - `SUPPRESS — <code>` — record suppression code; don't retry.
 - `DUPLICATE:<PROP-ID>` — record existing ID; don't create.
-
-After each verdict, append a metrics event via the shared helper:
-
-```bash
-bun "${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts" .claude-code-hermit/state/proposal-metrics.jsonl '{"ts":"<now ISO>","type":"brainstorm-emit","skill":"domain-brainstorm","verdict":"<CREATE|SUPPRESS|DUPLICATE>","proposal_id":null}'
-```
-Set `"proposal_id":"PROP-NNN"` for CREATE events; use JSON `null` for SUPPRESS/DUPLICATE events.
-
-This event is what the kill-criteria audit reads — `proposal-create`'s own `created` event does not carry per-skill provenance.
 
 Do NOT invoke `proposal-triage` directly — `/proposal-create` handles it.
 

--- a/plugins/claude-code-dev-hermit/skills/domain-brainstorm/SKILL.md
+++ b/plugins/claude-code-dev-hermit/skills/domain-brainstorm/SKILL.md
@@ -7,7 +7,7 @@ description: On-demand dev-voice brainstorm — reads codebase friction signals 
 
 ## Kill criteria (read before running)
 
-After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report (`--source=capability-brainstorm`). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
+After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report — run `bun scripts/proposal-metrics-report.ts .claude-code-hermit --source=capability-brainstorm` from the `claude-code-hermit` plugin root (not this plugin's; `${CLAUDE_PLUGIN_ROOT}` cannot reach it), or read the `capability-brainstorm` row of the table `/claude-code-hermit:hermit-evolution` prints. If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
 
 ### Gate 0 — Gather inputs
 

--- a/plugins/claude-code-dev-hermit/tests/skill-structure.test.ts
+++ b/plugins/claude-code-dev-hermit/tests/skill-structure.test.ts
@@ -80,7 +80,10 @@ for (const { name, gates } of SKILLS) {
 // the gate-shaped skills, while hatch/dev-test/dev-quality also carry refs.
 console.log('\nscript references:');
 const scriptsDir = path.join(import.meta.dir, '..', 'scripts');
-const scriptRefRe = /\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/([A-Za-z0-9._/-]+)/g;
+// Trailing `.`/`/` are excluded from the capture so a ref at the end of a prose
+// sentence ("… see ${CLAUDE_PLUGIN_ROOT}/scripts/render-append.ts.") doesn't
+// report a bogus dangling ref.
+const scriptRefRe = /\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/([A-Za-z0-9._/-]*[A-Za-z0-9_-])/g;
 const danglingRefs: string[] = [];
 let refsChecked = 0;
 

--- a/plugins/claude-code-dev-hermit/tests/skill-structure.test.ts
+++ b/plugins/claude-code-dev-hermit/tests/skill-structure.test.ts
@@ -72,4 +72,31 @@ for (const { name, gates } of SKILLS) {
   ok(`internal links resolve (${linksChecked} checked)`, linksBad === 0, `${linksBad} bad`);
 }
 
+// Every ${CLAUDE_PLUGIN_ROOT}/scripts/<file> reference must resolve to a script
+// this plugin actually ships. Installed plugins cannot reach outside their own
+// root, so a reference to a sibling plugin's script (e.g. core's
+// append-metrics.ts) fails silently at runtime — see #648.
+// Walks the skills dir rather than the SKILLS list above: that list covers only
+// the gate-shaped skills, while hatch/dev-test/dev-quality also carry refs.
+console.log('\nscript references:');
+const scriptsDir = path.join(import.meta.dir, '..', 'scripts');
+const scriptRefRe = /\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/([A-Za-z0-9._/-]+)/g;
+const danglingRefs: string[] = [];
+let refsChecked = 0;
+
+for (const entry of fs.readdirSync(SKILL_DIR, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const skillFile = path.join(SKILL_DIR, entry.name, 'SKILL.md');
+  if (!fs.existsSync(skillFile)) continue;
+
+  for (const [, script] of fs.readFileSync(skillFile, 'utf-8').matchAll(scriptRefRe)) {
+    refsChecked += 1;
+    if (!fs.existsSync(path.join(scriptsDir, script))) {
+      danglingRefs.push(`${entry.name} → scripts/${script}`);
+    }
+  }
+}
+
+ok(`script refs resolve (${refsChecked} checked)`, danglingRefs.length === 0, danglingRefs.join(', '));
+
 process.exit(summary() === 0 ? 0 : 1);

--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Two new routines, `morning-brief` and `evening-brief`, registered by `hatch`.
 
 ### Fixed
+- `domain-brainstorm` no longer writes its own `brainstorm-emit` event — core's triage gate already records every verdict. Proposals now carry `tags: [capability-brainstorm]` instead of `[domain-brainstorm, ideation]`, so they count toward the brainstorm kill-criteria segment rather than `reflect`'s.
 - `hatch` no longer tells the operator to `cp .env.example .env`; a `.env.example` does not ship with the plugin.
 
 ### Changed

--- a/plugins/claude-code-fitness-hermit/skills/domain-brainstorm/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/domain-brainstorm/SKILL.md
@@ -7,7 +7,7 @@ description: On-demand fitness-voice brainstorm — reads Strava history and tra
 
 ## Kill criteria (read before running)
 
-After ≥8 invocations, read `.claude-code-hermit/state/proposal-metrics.jsonl` and filter events where `type:"brainstorm-emit"` and `skill:"domain-brainstorm"`. Count CREATE vs total emits with ideas (triage-survival) and read `status:` of the resulting PROP files (PROP-acceptance). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there.
+After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report (`--source=capability-brainstorm`). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
 
 ### Gate 0 — Gather inputs
 
@@ -57,22 +57,14 @@ Evidence Source: capability-brainstorm
 Evidence: <one paragraph: gap sentence + named grounding items>
 ```
 
-`Evidence Source: capability-brainstorm` is intentional, not a copy-paste: it is the recurrence-bypass token recognized by `proposal-create`'s three-condition rule (a brainstorm pass establishes the candidate, so condition 1 is waived). There is no separate `domain-brainstorm` token. Real provenance is carried by the `tags` below and the `brainstorm-emit` metrics event.
+`Evidence Source: capability-brainstorm` is intentional, not a copy-paste: it is the recurrence-bypass token recognized by `proposal-create`'s three-condition rule (a brainstorm pass establishes the candidate, so condition 1 is waived). There is no separate `domain-brainstorm` token. Provenance is carried by the `tags` below, which `proposal-create` writes onto both the `triage-verdict` row and the proposal frontmatter. The cost: these proposals share core `capability-brainstorm`'s kill-criteria segment, so the numbers are combined rather than per-skill.
 
-Set frontmatter: `source: auto-detected`, `category: improvement`, `tags: [domain-brainstorm, ideation]`.
+Set frontmatter: `source: auto-detected`, `category: improvement`, `tags: [capability-brainstorm]`.
 
 Parse the verdict:
 - `CREATE` — note PROP-NNN.
 - `SUPPRESS — <code>` — record suppression code; don't retry.
 - `DUPLICATE:<PROP-ID>` — record existing ID; don't create.
-
-After each verdict, append a metrics event (Node stdlib, no deps):
-
-```bash
-bun -e "const fs=require('fs'); fs.appendFileSync('.claude-code-hermit/state/proposal-metrics.jsonl', JSON.stringify({ts:'<now ISO>',type:'brainstorm-emit',skill:'domain-brainstorm',verdict:'<CREATE|SUPPRESS|DUPLICATE>',proposal_id:'<PROP-NNN or null>'})+'\n','utf-8');"
-```
-
-Use the `config.json` timezone for `<now ISO>` (matching `proposal-create`), so this file isn't a mix of UTC and local timestamps. This event is what the kill-criteria audit reads — `proposal-create`'s own `created` event does not carry per-skill provenance.
 
 Do NOT invoke `proposal-triage` directly — `/claude-code-hermit:proposal-create` handles it.
 

--- a/plugins/claude-code-fitness-hermit/skills/domain-brainstorm/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/domain-brainstorm/SKILL.md
@@ -7,7 +7,7 @@ description: On-demand fitness-voice brainstorm — reads Strava history and tra
 
 ## Kill criteria (read before running)
 
-After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report (`--source=capability-brainstorm`). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
+After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report — run `bun scripts/proposal-metrics-report.ts .claude-code-hermit --source=capability-brainstorm` from the `claude-code-hermit` plugin root (not this plugin's; `${CLAUDE_PLUGIN_ROOT}` cannot reach it), or read the `capability-brainstorm` row of the table `/claude-code-hermit:hermit-evolution` prints. If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
 
 ### Gate 0 — Gather inputs
 

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- `domain-brainstorm` no longer writes its own `brainstorm-emit` event — core's triage gate already records every verdict. Proposals now carry `tags: [capability-brainstorm]` instead of `[domain-brainstorm, ideation]`, so they count toward the brainstorm kill-criteria segment rather than `reflect`'s.
 - `ha-boot` and `SAFETY.md` no longer point the operator at a `.env.example` that does not ship; replaced with a direct "create `.env`" instruction.
 
 ## [0.4.6] - 2026-07-21

--- a/plugins/claude-code-homeassistant-hermit/skills/domain-brainstorm/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/domain-brainstorm/SKILL.md
@@ -7,7 +7,7 @@ description: On-demand HA-voice brainstorm — reads entity inventory, automatio
 
 ## Kill criteria (read before running)
 
-After ≥8 invocations, read `state/proposal-metrics.jsonl` and filter events where `type:"brainstorm-emit"` and `skill:"ha-domain-brainstorm"`. Count CREATE vs total emits with ideas (triage-survival) and read `status:` of the resulting PROP files (PROP-acceptance). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there.
+After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report (`--source=capability-brainstorm`). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
 
 ### Gate 0 — Gather inputs
 
@@ -59,20 +59,14 @@ Evidence Source: capability-brainstorm
 Evidence: <one paragraph: friction sentence + named grounding items>
 ```
 
-Set frontmatter: `source: auto-detected`, `category: improvement`, `tags: [domain-brainstorm, ideation]`.
+Set frontmatter: `source: auto-detected`, `category: improvement`, `tags: [capability-brainstorm]`.
+
+Provenance is carried by those `tags`, which `proposal-create` writes onto both the `triage-verdict` row and the proposal frontmatter. The cost: these proposals share core `capability-brainstorm`'s kill-criteria segment, so the numbers are combined rather than per-skill.
 
 Parse the verdict:
 - `CREATE` — note PROP-NNN.
 - `SUPPRESS — <code>` — record suppression code; don't retry.
 - `DUPLICATE:<PROP-ID>` — record existing ID; don't create.
-
-After each verdict, append a metrics event (Node stdlib, no deps). Tag `skill:'ha-domain-brainstorm'` to keep rows attributable to this plugin if other brainstorm skills ever share `proposal-metrics.jsonl`. Inlined here because `append-metrics.js` lives in the core plugin and is unreachable via `${CLAUDE_PLUGIN_ROOT}`; `JSON.stringify` guarantees a valid line:
-
-```bash
-node -e "const fs=require('fs'); fs.appendFileSync('.claude-code-hermit/state/proposal-metrics.jsonl', JSON.stringify({ts:new Date().toISOString(),type:'brainstorm-emit',skill:'ha-domain-brainstorm',verdict:'<CREATE|SUPPRESS|DUPLICATE>',proposal_id:'<PROP-NNN or null>'})+'\n','utf-8');"
-```
-
-This event is what the kill-criteria audit reads — `proposal-create`'s own `created` event does not carry per-skill provenance.
 
 Do NOT invoke `proposal-triage` directly — `/proposal-create` handles it.
 

--- a/plugins/claude-code-homeassistant-hermit/skills/domain-brainstorm/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/domain-brainstorm/SKILL.md
@@ -7,7 +7,7 @@ description: On-demand HA-voice brainstorm — reads entity inventory, automatio
 
 ## Kill criteria (read before running)
 
-After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report (`--source=capability-brainstorm`). If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
+After ≥8 invocations, check the `capability-brainstorm` segment of core's proposal metrics report — run `bun scripts/proposal-metrics-report.ts .claude-code-hermit --source=capability-brainstorm` from the `claude-code-hermit` plugin root (not this plugin's; `${CLAUDE_PLUGIN_ROOT}` cannot reach it), or read the `capability-brainstorm` row of the table `/claude-code-hermit:hermit-evolution` prints. If triage-survival < 25% or PROP-acceptance < 30%, cut this skill rather than tune it — signal-to-noise isn't there. That segment is shared with core's `capability-brainstorm` and the other domain brainstorm skills, so a breach means brainstorm-generated proposals are noisy in general; it does not by itself say which skill to cut.
 
 ### Gate 0 — Gather inputs
 

--- a/plugins/claude-code-homeassistant-hermit/tests/domain-brainstorm-skill.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/tests/domain-brainstorm-skill.test.ts
@@ -1,10 +1,11 @@
-// Structural lint for the /domain-brainstorm skill — 1:1 port of
-// tests/test_domain_brainstorm_skill.py (16 cases).
+// Structural lint for the /domain-brainstorm skill (14 cases). Originally a
+// 1:1 port of tests/test_domain_brainstorm_skill.py; the two metrics-emit
+// cases were retired when the skill stopped writing its own `brainstorm-emit`
+// event and started riding core's triage ledger via proposal tags.
 // Grep-level checks against the skill markdown. No runtime skill execution.
 // Guards:
 //   - 5-gate structure (Gate 0..4)
-//   - contract references (Evidence Source, category, metrics emit with
-//     per-plugin skill name)
+//   - contract references (Evidence Source, category, proposal tags)
 //   - boundary: suppression artifacts appear under a suppression framing,
 //     not as idea sources
 
@@ -71,15 +72,10 @@ test('category improvement', () => {
   expect(skillBody).toContain('category: improvement');
 });
 
-test('metrics emit type', () => {
-  expect(skillBody).toContain('brainstorm-emit');
-});
-
-test('metrics emit skill value', () => {
-  // Must use the HA-specific skill name so brainstorm-emit rows stay
-  // attributable to this plugin if other brainstorm skills ever share
-  // proposal-metrics.jsonl.
-  expect(skillBody).toContain('ha-domain-brainstorm');
+test('proposal tags carry brainstorm provenance', () => {
+  // proposal-create writes these onto both the triage-verdict row and the
+  // proposal frontmatter; that is what the kill-criteria segment reads.
+  expect(skillBody).toContain('tags: [capability-brainstorm]');
 });
 
 test('prefix automation-gap', () => {


### PR DESCRIPTION
## Summary

All three `domain-brainstorm` skills (dev, fitness, homeassistant) invented a private `brainstorm-emit` metrics event to carry per-skill provenance, on the stated premise that `proposal-create`'s `created` event does not carry it. Core's triage gate already records the same data — `record-gate.ts:79-96` appends a `triage-verdict` row for CREATE, SUPPRESS **and** DUPLICATE, carrying `caller`, `evidence_source`, and caller-supplied `tags`. The extra write was redundant, so this deletes it rather than repairing it.

That reframes #648. dev-hermit's copy called `${CLAUDE_PLUGIN_ROOT}/scripts/append-metrics.ts`, which ships only in core — installed plugins cannot reference files outside their own root, so it failed on every verdict. Fitness and HA reached the same event through `bun -e` / `node -e` writes that succeeded into a ledger nothing reads.

A second defect surfaced while tracing it: all three dropped or mistagged proposal tags. dev set none; fitness and HA set `[domain-brainstorm, ideation]`, which no consumer reads. Either way their `created` rows matched `reflect`'s accept filter and counted toward **reflect's** acceptance number. They now tag `capability-brainstorm` — the one tag that does mechanical work, excluded by `reflect.accept` and included by `capability-brainstorm.accept`.

## Changes

- **All three plugins** — deleted the `brainstorm-emit` write; proposals now set `tags: [capability-brainstorm]`; kill criteria now names core's shared brainstorm segment instead of instructing a raw read of `proposal-metrics.jsonl` (which also violated the repo's token-discipline rule against skills reading unbounded JSONL directly).
- **Provenance footnotes** corrected — the old text claimed per-skill kill metrics were unaffected because they read `brainstorm-emit`. They now state plainly that the segment is shared with core's `capability-brainstorm`, so a threshold breach does not by itself identify which skill to cut.
- **dev-hermit** — new lint in `tests/skill-structure.test.ts` failing any `${CLAUDE_PLUGIN_ROOT}/scripts/…` reference that doesn't resolve to a shipped script. Walks the skills dir rather than the curated `SKILLS` array, which would have missed `hatch`/`dev-test`/`dev-quality`.
- **homeassistant** — retired the two test cases asserting the removed event; replaced with one asserting the tags contract.

No core changes, no version bumps.

### Why not the alternatives

The issue proposed inlining the write, symlinking core's script, or adding a core entrypoint. Cross-plugin file access is unsupported: *"Installed plugins cannot reference files outside their directory… will not work after installation because those external files are not copied to the cache."* Install layout is `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`, so a sibling is not one level up. The documented symlink workaround was checked against the live plugin cache — of 34 symlinks present, every one is inside `node_modules/` or its own plugin root, so the dereference branch it depends on has no observed instance. A dedicated `domain-brainstorm` segment in core was considered and dropped: it buys only the ability to cut one brainstorm skill independently of another, at the cost of a core `SEGMENTS` entry, two exclusions, contract tests and a `required_core_version` bump.

## Test plan

All run and passing:

- `plugins/claude-code-dev-hermit` → `bash tests/run-all.sh` — 19 passed. New lint checks 9 refs. Verified it goes **red** by pointing a skill at a bogus script (`✗ script refs resolve (10 checked) — dev-test → scripts/does-not-exist.ts`), then restored.
- `plugins/claude-code-fitness-hermit` → `bash tests/run-all.sh` — 116 passed.
- `plugins/claude-code-homeassistant-hermit` → `bun test` — 673 pass, 0 fail.
- `bunx tsc --noEmit` from repo root — exit 0.
- Fleet-wide dangling-script-ref sweep — clean (previously printed exactly the #648 line).

End-to-end, at script level (driving `/proposal-create` would need a live model session, so this exercises the scripts directly): piped `Verdict: CREATE` into `record-gate.ts … --evidence-source capability-brainstorm --tags '["capability-brainstorm"]'`, then confirmed routing:

```
capability-brainstorm: triage-survival 100% (1/1), acceptance -, sample 1
reflect:               triage-survival -,          acceptance -, sample 0
```

The row lands in the brainstorm segment and **not** in reflect's — the miscount this fixes.

## Follow-up

Fitness and HA compiled-artifact frontmatter still carries `tags: [domain-brainstorm, ideation]` at Gate 4. That's a separate surface from proposal tags and was deliberately left alone.

Closes #648