### PR TITLE
fix(fitness): read cardiac drift from frontmatter, not rendered prose

### DIFF
--- a/plugins/claude-code-fitness-hermit/CHANGELOG.md
+++ b/plugins/claude-code-fitness-hermit/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 - `strava-sync` and `strava-health-check` routines removed — `fitness-brief` (morning + evening) now owns Strava connectivity, activity sync, RPE binding, and Run deep-dive as the plugin's two daily beats.
+- Activity notes carry `cardiac_drift_bpm` in frontmatter; `weekly-patterns` reads it there and falls back to the rendered line for older notes.
 
 ### Upgrade Instructions
 For already-installed hermits, `hermit-evolve` should:

--- a/plugins/claude-code-fitness-hermit/scripts/fitness-lab.test.ts
+++ b/plugins/claude-code-fitness-hermit/scripts/fitness-lab.test.ts
@@ -28,6 +28,7 @@ import {
   recoveryBand,
   recoveryWindow,
   extractDrift,
+  readDrift,
   isStrictlyIncreasing,
   weeklyPatterns,
   aggregateWeeklyLoad,
@@ -488,6 +489,64 @@ console.log('\nweekly-patterns unit (trail steady excluded → insufficient):');
   const r = weeklyPatterns(proj);
   eq('steady found 4 but drift series short → insufficient-data', r.trend, 'insufficient-data');
   eq('series only 3 (trail excluded at extraction)', r.series.length, 3);
+  fs.rmSync(proj, { recursive: true });
+}
+
+console.log('\nreadDrift unit:');
+{
+  eq('frontmatter value used', readDrift({ cardiac_drift_bpm: '6' }, 'Cardiac drift: +99 bpm'), 6);
+  eq('frontmatter zero honored (not falsy fallthrough)', readDrift({ cardiac_drift_bpm: '0' }, 'Cardiac drift: +99 bpm'), 0);
+  eq('frontmatter negative honored', readDrift({ cardiac_drift_bpm: '-5' }, ''), -5);
+  eq('missing field falls back to body', readDrift({}, 'Cardiac drift: +7 bpm'), 7);
+  eq('malformed field falls back to body', readDrift({ cardiac_drift_bpm: 'n/a' }, 'Cardiac drift: +7 bpm'), 7);
+  eq('malformed field, no body line, returns null', readDrift({ cardiac_drift_bpm: 'n/a' }, 'no drift here'), null);
+}
+
+console.log('\nweekly-patterns unit (frontmatter-first read):');
+{
+  const proj = fs.mkdtempSync(path.join(os.tmpdir(), 'fitness-lab-wp3-'));
+  const compiled = path.join(proj, '.claude-code-hermit', 'compiled');
+  fs.mkdirSync(compiled, { recursive: true });
+  const mk = (id: number, created: string, drift: number) =>
+    fs.writeFileSync(
+      path.join(compiled, `activity-${id}-${created}.md`),
+      `---\ntype: activity-note\ncreated: ${created}T10:00:00Z\nsession_kind: steady\ncardiac_drift_bpm: ${drift}\n---\nActivity: x (no rendered drift line)\n`,
+    );
+  mk(1, '2026-05-04', 4);
+  mk(2, '2026-05-11', 7);
+  mk(3, '2026-05-18', 9);
+  mk(4, '2026-05-25', 13);
+  const r = weeklyPatterns(proj);
+  eq('steady_sessions_found', r.steady_sessions_found, 4);
+  eq('trend upward (frontmatter-only, no prose line)', r.trend, 'upward');
+  eq('series length', r.series.length, 4);
+  eq('series oldest first', r.series[0]?.drift, 4);
+  fs.rmSync(proj, { recursive: true });
+}
+
+console.log('\nweekly-patterns unit (mixed frontmatter + legacy prose notes):');
+{
+  const proj = fs.mkdtempSync(path.join(os.tmpdir(), 'fitness-lab-wp4-'));
+  const compiled = path.join(proj, '.claude-code-hermit', 'compiled');
+  fs.mkdirSync(compiled, { recursive: true });
+  const mkFm = (id: number, created: string, drift: number) =>
+    fs.writeFileSync(
+      path.join(compiled, `activity-${id}-${created}.md`),
+      `---\ntype: activity-note\ncreated: ${created}T10:00:00Z\nsession_kind: steady\ncardiac_drift_bpm: ${drift}\n---\nActivity: x\n`,
+    );
+  const mkProse = (id: number, created: string, drift: number) =>
+    fs.writeFileSync(
+      path.join(compiled, `activity-${id}-${created}.md`),
+      `---\ntype: activity-note\ncreated: ${created}T10:00:00Z\nsession_kind: steady\n---\nActivity: x\nCardiac drift: ${drift >= 0 ? '+' : ''}${drift} bpm\n`,
+    );
+  mkProse(1, '2026-05-04', 4);
+  mkProse(2, '2026-05-11', 7);
+  mkFm(3, '2026-05-18', 9);
+  mkFm(4, '2026-05-25', 13);
+  const r = weeklyPatterns(proj);
+  eq('steady_sessions_found', r.steady_sessions_found, 4);
+  eq('trend upward across mixed readers', r.trend, 'upward');
+  eq('series length', r.series.length, 4);
   fs.rmSync(proj, { recursive: true });
 }
 

--- a/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
+++ b/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
@@ -537,8 +537,8 @@ export function extractDrift(body: string): number | null {
  * for notes written before `cardiac_drift_bpm` was in the template.
  */
 export function readDrift(fm: Record<string, string>, body: string): number | null {
-  const raw = fm.cardiac_drift_bpm;
-  if (raw !== undefined && /^[+-]?\d+$/.test(raw.trim())) return parseInt(raw, 10);
+  const raw = fm.cardiac_drift_bpm?.trim();
+  if (raw !== undefined && /^[+-]?\d+$/.test(raw)) return parseInt(raw, 10);
   return extractDrift(body);
 }
 

--- a/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
+++ b/plugins/claude-code-fitness-hermit/scripts/fitness-lab.ts
@@ -532,6 +532,16 @@ export function extractDrift(body: string): number | null {
   return m ? parseInt(m[1], 10) : null;
 }
 
+/**
+ * Frontmatter-first drift read. Falls back to the legacy rendered prose line
+ * for notes written before `cardiac_drift_bpm` was in the template.
+ */
+export function readDrift(fm: Record<string, string>, body: string): number | null {
+  const raw = fm.cardiac_drift_bpm;
+  if (raw !== undefined && /^[+-]?\d+$/.test(raw.trim())) return parseInt(raw, 10);
+  return extractDrift(body);
+}
+
 /** Strict-monotonic increasing across all adjacent pairs. */
 export function isStrictlyIncreasing(values: number[]): boolean {
   for (let i = 1; i < values.length; i++) if (values[i] <= values[i - 1]) return false;
@@ -561,7 +571,7 @@ export function weeklyPatterns(projectRoot: string): {
     const fm = parseFrontmatter(text);
     if (!fm || fm.type !== 'activity-note' || fm.session_kind !== 'steady') continue;
     const body = text.slice(text.indexOf('\n---\n') + 5);
-    steady.push({ file: f, created: fm.created || '', drift: extractDrift(body) });
+    steady.push({ file: f, created: fm.created || '', drift: readDrift(fm, body) });
   }
   // Most-recent-first, take 4.
   steady.sort((a, b) => (a.created < b.created ? 1 : a.created > b.created ? -1 : 0));

--- a/plugins/claude-code-fitness-hermit/skills/activity-deep-dive/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/activity-deep-dive/SKILL.md
@@ -129,6 +129,8 @@ cardiac_drift_flagged: <bool>            # include only when drift was computed 
 ```
 Body: the full output above.
 
+**CRITICAL — `cardiac_drift_bpm` must be a bare signed integer** (`6`, `-5`), not a formatted value like `+6 bpm`. `weekly-coaching-patterns` reads this field to build its trend series; renaming the key or writing a non-numeric value breaks the trend detector. It falls back to parsing the body's `Cardiac drift:` line only for notes written before this field existed.
+
 7. Write signal-only coaching observations to `.claude-code-hermit/sessions/SHELL.md` Findings.
 
    From the computed metrics and coaching note, derive 0–N observations that carry a coaching signal worth tracking across sessions: a flagged cardiac drift, a zone-distribution anomaly, a recovery estimate that conflicts with subjective RPE, an efficiency regression vs the prior mean, a flagged cadence (low average or high within-run variability), a notable VAM value, or a trail recovery extension. Do NOT write routine confirmations ("session completed normally") unless they represent a pattern break. If nothing clears the signal bar, skip this step.

--- a/plugins/claude-code-fitness-hermit/skills/activity-deep-dive/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/activity-deep-dive/SKILL.md
@@ -108,8 +108,6 @@ Interval sessions get work-interval HR progression and between-bout recovery qua
    Coaching: <2–3 sentences>
    ```
 
-   **CRITICAL — the `Cardiac drift: +N bpm` line must render the signed integer with an explicit sign** (`+6`, `-5`). `weekly-coaching-patterns` parses this exact line format from pre-existing artifacts; changing the prefix or dropping the sign breaks the trend detector.
-
 6. Save compiled artifact to `.claude-code-hermit/compiled/activity-<id>-<YYYY-MM-DD>.md`:
 ```yaml
 ---
@@ -125,6 +123,8 @@ terrain: <road|trail>
 session_kind: <interval|steady>
 rpe: <int>                               # include only when RPE data exists from step 1
 subjective_notes: "<string>"             # include only when notes exist from step 1
+cardiac_drift_bpm: <int>                 # include only when drift was computed from step 3
+cardiac_drift_flagged: <bool>            # include only when drift was computed from step 3
 ---
 ```
 Body: the full output above.

--- a/plugins/claude-code-fitness-hermit/skills/weekly-coaching-patterns/SKILL.md
+++ b/plugins/claude-code-fitness-hermit/skills/weekly-coaching-patterns/SKILL.md
@@ -19,7 +19,7 @@ Scheduled-check skill: reads the last 4 `compiled/activity-*.md` artifacts for s
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/fitness-lab.ts weekly-patterns
    ```
 
-   The script does the whole deterministic pass — filesystem only, no Strava token: globs `.claude-code-hermit/compiled/activity-*.md`, keeps entries whose frontmatter has `type: activity-note` AND `session_kind: steady`, takes the 4 most recent by `created`, extracts the **signed** integer from each body's `Cardiac drift:` line (missing line → excluded; a negative value compares as smaller than any positive — the sign is never stripped), and evaluates a strict oldest-to-newest monotonic rise across all 3 adjacent pairs. It emits:
+   The script does the whole deterministic pass — filesystem only, no Strava token: globs `.claude-code-hermit/compiled/activity-*.md`, keeps entries whose frontmatter has `type: activity-note` AND `session_kind: steady`, takes the 4 most recent by `created`, reads each note's **signed** drift from the `cardiac_drift_bpm` frontmatter field, falling back to the body's `Cardiac drift:` line for notes written before that field existed (neither present → excluded; a negative value compares as smaller than any positive — the sign is never stripped), and evaluates a strict oldest-to-newest monotonic rise across all 3 adjacent pairs. It emits:
 
    ```json
    {"steady_sessions_found": <int>, "series": [{"file": "…", "date": "…", "drift": <signed int>}], "trend": "upward" | "none" | "insufficient-data"}


### PR DESCRIPTION
## Summary
`weekly-patterns` regex-parsed the rendered "Cardiac drift: +N bpm" display line for a number the script already computed and had available structurally — the note's frontmatter is parsed two lines earlier in the same function. A CRITICAL warning in `activity-deep-dive` froze the display format solely to protect that parse.

## Changes
- Add `readDrift()` to `fitness-lab.ts`: reads `cardiac_drift_bpm` from frontmatter first, falls back to the existing `extractDrift()` prose parse for notes written before the field existed.
- `weeklyPatterns()` now calls `readDrift()` instead of `extractDrift()` directly.
- Activity-note frontmatter template gains `cardiac_drift_bpm` / `cardiac_drift_flagged`, sourced from the `analyze` JSON the skill already holds.
- Drop the CRITICAL sign-format warning — the rendered line is now display-only, no longer a parsed interface.

## Test plan
- `bash tests/run-all.sh` (from `plugins/claude-code-fitness-hermit/`) — 129 passed, 0 failed, including new coverage for the frontmatter-first read, the legacy prose fallback, zero/negative drift values, malformed-value fallback, and mixed old/new notes in one series.
- `bunx tsc --noEmit` from repo root — clean.
- Grep confirms the CRITICAL warning is gone from `activity-deep-dive/SKILL.md`.