### PR TITLE
feat(forge): replace hand-transcribed deploy watch loop with a subcommand

### DIFF
--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- `forge.php deploy-watch <server-id> <site-id> <deploy-id>` replaces the hand-transcribed watch loop in `forge-deploy`; terminal statuses now come from the shared `STATUS_*` constants.
+- `forge.php deploy-watch <server-id> <site-id> <deploy-id>` replaces the hand-transcribed watch loop in `forge-deploy`; terminal statuses now come from the shared `STATUS_*` constants. `deploy` points at it in its `Watch with:` hint, and a failing poll now emits the exception class as a watch event instead of surfacing only as a `status=timeout` 15 minutes on.
 
 ## [0.0.8] - 2026-07-21
 

--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Added
+- `forge.php deploy-watch <server-id> <site-id> <deploy-id>` replaces the hand-transcribed watch loop in `forge-deploy`; terminal statuses now come from the shared `STATUS_*` constants.
+
 ## [0.0.8] - 2026-07-21
 
 ### Fixed

--- a/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
+++ b/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
@@ -60,7 +60,7 @@ function main(): void {
   const SAFE_SUBCOMMANDS = [
     'check', 'servers', 'server', 'sites', 'site', 'logs',
     'server-log', 'site-log', 'background-process-log',
-    'deploy-history', 'deploy-log', 'deploy-status',
+    'deploy-history', 'deploy-log', 'deploy-status', 'deploy-watch',
     'preview-deploy', 'preview-reboot',
     'failed-deploys', 'call',
     'help', '--help',

--- a/plugins/laravel-forge-hermit/php/forge-lib.php
+++ b/plugins/laravel-forge-hermit/php/forge-lib.php
@@ -74,14 +74,20 @@ const NO_ORG_METHODS = ['organizations'];
 
 // ---------------------------------------------------------------------------
 // Deployment status enums.
-// Terminal states are authoritative (the watch grep keys off these). The
-// in-progress set is documentation only — anything not terminal is treated as
-// still-running, which keeps the watch robust to undocumented states (e.g.
-// 'running', seen in the SDK docs but absent from the OpenAPI enum).
+// Terminal states are authoritative (deploy-watch keys off isTerminalStatus()
+// below). The in-progress set is documentation only — anything not terminal is
+// treated as still-running, which keeps the watch robust to undocumented
+// states (e.g. 'running', seen in the SDK docs but absent from the OpenAPI enum).
 // ---------------------------------------------------------------------------
 const STATUS_SUCCESS     = ['finished'];
 const STATUS_FAILURE     = ['failed', 'failed-build', 'cancelled'];
 const STATUS_IN_PROGRESS = ['pending', 'queued', 'running', 'deploying'];
+
+/** True when a deployment status is terminal (success or failure). */
+function isTerminalStatus(string $status): bool
+{
+    return in_array($status, array_merge(STATUS_SUCCESS, STATUS_FAILURE), true);
+}
 
 // ---------------------------------------------------------------------------
 // Matchers — resolve a user-supplied query to candidate server/site records.

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -198,6 +198,7 @@ if ($cmd === '' || $cmd === '--help' || $cmd === 'help') {
       deploy-history <server> <site>          List recent deployments
       deploy-log <server> <site> <deploy-id>  Fetch a specific deployment log
       deploy-status <server-id> <site-id> <deploy-id>  Print a deployment's status (raw IDs)
+      deploy-watch <server-id> <site-id> <deploy-id>   Poll a deployment until terminal; emits a single TERMINAL line
 
     Preview commands (read-only, never mutate):
       preview-deploy <server> <site>  Show canonical target before deploying
@@ -533,6 +534,41 @@ if ($cmd === 'deploy-status') {
         exit(1);
     }
     echo ($d->status ?? 'unknown') . "\n";
+    exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// deploy-watch <server-id> <site-id> <deploy-id>
+//
+// Polls deployment status until terminal or timeout (180 x 5s ~= 15 min),
+// echoing only on change. Emits one TERMINAL line and exits 0. The TERMINAL
+// line carries only numeric IDs — Forge server names can contain spaces,
+// which would break the space-delimited fields.
+// ---------------------------------------------------------------------------
+if ($cmd === 'deploy-watch') {
+    check(isset($positional[2]), "Usage: forge.php deploy-watch <server-id> <site-id> <deploy-id>");
+    [$serverId, $siteId, $deployId] = $positional;
+    $prev = null;
+    for ($n = 0; $n < 180; $n++) {
+        try {
+            $d  = $forge->deployment($org, (int)$serverId, (int)$siteId, (int)$deployId);
+            $st = $d->status ?? 'unknown';
+        } catch (\Throwable $e) {
+            $st = null; // transient API error — keep polling
+        }
+        if ($st !== null) {
+            if ($st !== $prev) {
+                echo "deploy {$deployId}: {$st}\n";
+            }
+            if (isTerminalStatus($st)) {
+                echo "TERMINAL deploy={$deployId} server-id={$serverId} site-id={$siteId} status={$st}\n";
+                exit(0);
+            }
+        }
+        $prev = $st;
+        sleep(5);
+    }
+    echo "TERMINAL deploy={$deployId} server-id={$serverId} site-id={$siteId} status=timeout\n";
     exit(0);
 }
 

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -205,7 +205,7 @@ if ($cmd === '' || $cmd === '--help' || $cmd === 'help') {
       preview-reboot <server>         Show canonical target before rebooting
 
     Write commands (require --confirm):
-      deploy <server> <site>      Trigger deployment (fire-and-return; watch via deploy-status)
+      deploy <server> <site>      Trigger deployment (fire-and-return; watch via deploy-watch)
       server-reboot <server>      Reboot server
 
     Estate scan:
@@ -497,8 +497,8 @@ if ($cmd === 'preview-reboot') {
 // deploy <server> <site> --confirm   (fire-and-return)
 //
 // Triggers the deployment and returns immediately with the canonical IDs.
-// Watching is decoupled: the forge-deploy skill arms a CC Monitor that polls
-// `deploy-status` until terminal, so a long deploy never blocks a foreground
+// Watching is decoupled: the forge-deploy skill arms a CC Monitor that runs
+// `deploy-watch` until terminal, so a long deploy never blocks a foreground
 // Bash call (which the tool would kill at its timeout).
 // ---------------------------------------------------------------------------
 if ($cmd === 'deploy') {
@@ -512,7 +512,7 @@ if ($cmd === 'deploy') {
 
     $deployment = $forge->createDeployment($org, $server->id, $site->id, []);
     echo "Deployment started: deploy-id={$deployment->id} server-id={$server->id} site-id={$site->id} status={$deployment->status}\n";
-    echo "Watch with: forge.php deploy-status {$server->id} {$site->id} {$deployment->id}\n";
+    echo "Watch with: forge.php deploy-watch {$server->id} {$site->id} {$deployment->id}\n";
     exit(0);
 }
 
@@ -548,13 +548,25 @@ if ($cmd === 'deploy-status') {
 if ($cmd === 'deploy-watch') {
     check(isset($positional[2]), "Usage: forge.php deploy-watch <server-id> <site-id> <deploy-id>");
     [$serverId, $siteId, $deployId] = $positional;
-    $prev = null;
+    $prev    = null;
+    $prevErr = null;
     for ($n = 0; $n < 180; $n++) {
         try {
             $d  = $forge->deployment($org, (int)$serverId, (int)$siteId, (int)$deployId);
             $st = $d->status ?? 'unknown';
         } catch (\Throwable $e) {
             $st = null; // transient API error — keep polling
+            // A permanent error (bad IDs, revoked token) would otherwise surface
+            // only as an opaque `status=timeout` 15 minutes on. The watcher's
+            // notification stream is stdout, so the signal goes there — but as
+            // the exception class alone, holding the metadata-only contract
+            // (messages can carry response bodies). The message goes to stderr,
+            // which reaches the monitor's output file, never a notification.
+            if (get_class($e) !== $prevErr) {
+                $prevErr = get_class($e);
+                echo "deploy {$deployId}: poll error ({$prevErr})\n";
+                fwrite(STDERR, "deploy {$deployId}: poll error: {$e->getMessage()}\n");
+            }
         }
         if ($st !== null) {
             if ($st !== $prev) {

--- a/plugins/laravel-forge-hermit/php/tests/run.php
+++ b/plugins/laravel-forge-hermit/php/tests/run.php
@@ -95,6 +95,21 @@ check(phpLogKey('nonsense') === null, "non-matching input returns null");
 check(phpLogKey('') === null, "empty input returns null");
 
 // ---------------------------------------------------------------------------
+// Tests: isTerminalStatus (the binding deploy-watch relies on)
+// ---------------------------------------------------------------------------
+echo "\nisTerminalStatus:\n";
+foreach (STATUS_SUCCESS as $s) {
+    check(isTerminalStatus($s) === true, "success status '$s' is terminal");
+}
+foreach (STATUS_FAILURE as $s) {
+    check(isTerminalStatus($s) === true, "failure status '$s' is terminal");
+}
+foreach (STATUS_IN_PROGRESS as $s) {
+    check(isTerminalStatus($s) === false, "in-progress status '$s' is not terminal");
+}
+check(isTerminalStatus('unknown') === false, "unrecognized status 'unknown' is not terminal");
+
+// ---------------------------------------------------------------------------
 // Tests: matchSite
 // ---------------------------------------------------------------------------
 echo "\nmatchSite:\n";

--- a/plugins/laravel-forge-hermit/skills/forge-deploy/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-deploy/SKILL.md
@@ -59,17 +59,7 @@ Do **not** poll in a foreground Bash call: a real deploy can outlast the Bash to
 Resolve `${CLAUDE_PLUGIN_ROOT}` to its **absolute path now** (at skill-execution time): the variable is NOT available inside the watch subprocess. Then arm the watch by invoking `/claude-code-hermit:watch` with this command (substitute the absolute path and the three IDs):
 
 ```bash
-prev=""; n=0
-while [ "$n" -lt 180 ]; do
-  st=$(php /ABS/php/forge.php deploy-status <server-id> <site-id> <deploy-id> 2>/dev/null || true)
-  [ -n "$st" ] && [ "$st" != "$prev" ] && echo "deploy <deploy-id>: $st"
-  case "$st" in
-    finished) echo "TERMINAL deploy=<deploy-id> server-id=<server-id> site-id=<site-id> status=finished"; exit 0;;
-    failed|failed-build|cancelled) echo "TERMINAL deploy=<deploy-id> server-id=<server-id> site-id=<site-id> status=$st"; exit 0;;
-  esac
-  prev="$st"; n=$((n+1)); sleep 5
-done
-echo "TERMINAL deploy=<deploy-id> server-id=<server-id> site-id=<site-id> status=timeout"
+php /ABS/php/forge.php deploy-watch <server-id> <site-id> <deploy-id>
 ```
 
 The `TERMINAL` line carries only numeric IDs (never display names) — Forge server names can contain spaces, which would break the space-delimited fields.

--- a/plugins/laravel-forge-hermit/skills/forge-deploy/SKILL.md
+++ b/plugins/laravel-forge-hermit/skills/forge-deploy/SKILL.md
@@ -45,7 +45,7 @@ This triggers the deployment and returns immediately (no blocking wait):
 
 ```
 Deployment started: deploy-id=991 server-id=12345 site-id=67890 status=queued
-Watch with: forge.php deploy-status 12345 67890 991
+Watch with: forge.php deploy-watch 12345 67890 991
 ```
 
 Capture the canonical `deploy-id`, `server-id`, and `site-id` — Step 4 needs them.

--- a/plugins/laravel-forge-hermit/tests/hook.test.ts
+++ b/plugins/laravel-forge-hermit/tests/hook.test.ts
@@ -62,6 +62,11 @@ describe('write-confirm-gate: pass-through cases', () => {
     expect(r.exitCode).toBe(0);
   });
 
+  test('deploy-watch passes (read-only poll loop, not a write)', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy-watch 12 34 8821' } });
+    expect(r.exitCode).toBe(0);
+  });
+
   test('call method passes', () => {
     const r = runHook({ tool_name: 'Bash', tool_input: { command: 'echo \'["s1"]\' | php /plugin/php/forge.php call servers' } });
     expect(r.exitCode).toBe(0);


### PR DESCRIPTION
## Summary
The deploy watch loop shipped as a fill-in-the-blanks bash template in `forge-deploy/SKILL.md`, with 14 placeholder occurrences across 3 IDs to substitute by hand. A mis-transcribed value is swallowed silently (`2>/dev/null || true`), so the loop just times out — and a timeout is read as "no incident," silently converting a real deploy failure into a non-event. The terminal status vocabulary was also duplicated: hardcoded in the bash `case` statement while `forge-lib.php` separately owned `STATUS_SUCCESS`/`STATUS_FAILURE`, with nothing binding the two.

## Changes
- `forge.php deploy-watch <server-id> <site-id> <deploy-id>` — new subcommand, placed next to the existing `deploy-status` polling primitive. Owns the poll loop (180 × 5s), change-only echo, and the `TERMINAL` line format.
- `forge-lib.php`: `isTerminalStatus()` helper, single-sourcing terminal-status checks from `STATUS_SUCCESS`/`STATUS_FAILURE`.
- `forge-deploy/SKILL.md`: the 14-substitution bash template collapses to one command line. The `TERMINAL` semantics and active-session requirement stay documented — that contract is forge-local, not something core's `/claude-code-hermit:watch` knows about.
- `--help` text gains the `deploy-watch` entry.

## Test plan
- `bash tests/run-all.sh` (from `plugins/laravel-forge-hermit/`) — 52 PHP + 42 bun tests passed, 0 failed, including new coverage binding every `STATUS_SUCCESS`/`STATUS_FAILURE`/`STATUS_IN_PROGRESS` member through `isTerminalStatus()`.
- `bunx tsc --noEmit` from repo root — clean.
- Grep confirms the old `<deploy-id>`-placeholder bash fence is gone from `forge-deploy/SKILL.md`.
- **Not yet run**: a live `deploy-watch` call against a real Forge deployment (needs Forge credentials this session doesn't have). Recommend running `php php/forge.php deploy-watch <server-id> <site-id> <deploy-id>` against a known-finished deployment before merge and confirming a single `TERMINAL … status=finished` line.