### PR TITLE
fix(claude-code-hermit): confirm cached-context model switches

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- A trusted channel `/model <arg>` no longer stalls on Claude Code's cached-context confirmation. The Stop hook recognizes only that freshly-triggered model-switch dialog and confirms its selected `Yes`; context-free switches still complete without an extra keypress, and unrelated native prompts remain untouched.
+
 ## [1.2.34] - 2026-07-26
 
 ### Added

--- a/plugins/claude-code-hermit/docs/security.md
+++ b/plugins/claude-code-hermit/docs/security.md
@@ -109,7 +109,7 @@ A channel-primary hermit (`always_on: true`, at least one reachable channel) has
 4. **Fail-loud** — when a prompt can't be redirected, notify the operator that something is stuck rather than silently hanging.
 5. **Native bridge** — defer to a first-party mirror/answer path once Anthropic ships one, and shrink custom machinery accordingly.
 
-Never bypass — no auto-answering a permission prompt, no sending Escape on the operator's behalf. Deciding what an unattended agent is allowed to do is always the operator's call, made in advance (config) or asynchronously (channel reply), never invented by the hermit in the moment.
+Never bypass — no auto-answering a permission prompt, no sending Escape on the operator's behalf. Deciding what an unattended agent is allowed to do is always the operator's call, made in advance (config) or asynchronously (channel reply), never invented by the hermit in the moment. The narrow exception is Claude Code's cached-context warning immediately after a trusted sender requested an exact `/model <arg>`: that sender already made the model decision, so the Stop hook confirms only a model-specific, freshly-correlated dialog. Every other native dialog remains untouched.
 
 Two binding instances exist today:
 

--- a/plugins/claude-code-hermit/scripts/lib/harness-command.ts
+++ b/plugins/claude-code-hermit/scripts/lib/harness-command.ts
@@ -63,6 +63,30 @@ export type PendingCommand = {
  * wedged for an hour should not suddenly clear its context when it recovers.
  */
 export const COMMAND_MARKER_TTL_SECS = 3600;
+/** One render beat after submitting /model before inspecting the pane. */
+export const MODEL_CONFIRM_RENDER_MS = 500;
+const MODEL_CONFIRM_TAIL_LINES = 20;
+
+/**
+ * Match only Claude Code's cached-context model-switch confirmation.
+ *
+ * Whitespace is collapsed because the warning wraps according to pane width. The
+ * model label is deliberately not matched: a stable request alias such as `opus`
+ * renders as a release display name such as "Opus 5".
+ */
+export function isModelSwitchConfirmation(paneContent: string): boolean {
+  const tail = paneContent
+    .split('\n')
+    .slice(-MODEL_CONFIRM_TAIL_LINES)
+    .join(' ')
+    .replace(/\s+/g, ' ');
+
+  return tail.includes('Switch model?')
+    && tail.includes('Your next response will be slower and use more tokens')
+    && tail.includes('This conversation is cached for the current model.')
+    && tail.includes('Yes, switch to')
+    && tail.includes('No, go back');
+}
 
 function markerPath(hermitRoot: string): string {
   return path.join(hermitRoot, 'state', 'pending-harness-command.json');

--- a/plugins/claude-code-hermit/scripts/lib/tmux.ts
+++ b/plugins/claude-code-hermit/scripts/lib/tmux.ts
@@ -42,6 +42,26 @@ export function tmuxSessionAlive(name: string, transport: Transport = HOST): boo
   return runTmux(transport, ['has-session', '-t', name]).status === 0;
 }
 
+/** Capture the visible pane as text, or null when tmux cannot read it. */
+export function capturePane(name: string, transport: Transport = HOST): string | null {
+  if (!name) return null;
+  const { cmd, argv } = tmuxArgv(transport, ['capture-pane', '-p', '-t', name]);
+  try {
+    const r = spawnSync(cmd, argv, { encoding: 'utf-8', timeout: 5000 });
+    if (r.error || r.status !== 0 || typeof r.stdout !== 'string') return null;
+    return r.stdout;
+  } catch {
+    return null;
+  }
+}
+
+/** Send a single Enter key, returning whether tmux accepted it. */
+export function sendEnter(sessionName: string, transport: Transport = HOST): boolean {
+  if (!sessionName) return false;
+  const submitted = runTmux(transport, ['send-keys', '-t', sessionName, 'Enter']);
+  return !submitted.error && submitted.status === 0;
+}
+
 /** Derive the tmux session name from config (CWD-relative project name). */
 export function getSessionName(config: Json): string {
   const name = config.tmux_session_name ?? 'hermit-{project_name}';
@@ -85,6 +105,5 @@ export function sendKeys(sessionName: string, text: string, transport: Transport
   const typed = runTmux(transport, ['send-keys', '-t', sessionName, '-l', '--', text]);
   if (typed.error || typed.status !== 0) return false;
   Bun.sleepSync(500);
-  const submitted = runTmux(transport, ['send-keys', '-t', sessionName, 'Enter']);
-  return !submitted.error && submitted.status === 0;
+  return sendEnter(sessionName, transport);
 }

--- a/plugins/claude-code-hermit/scripts/stop-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/stop-pipeline.ts
@@ -7,9 +7,15 @@ import { run as sessionDiff } from './session-diff';
 import { run as evaluateSession } from './evaluate-session';
 import { sessionCrons, backgroundTasks, ccVersion, hermitDir } from './lib/cc-compat';
 import { readRuntimeJson } from './lib/runtime';
-import { tmuxSessionAlive, sendKeys } from './lib/tmux';
+import { capturePane, sendEnter, sendKeys, tmuxSessionAlive } from './lib/tmux';
 import { applyContextReset } from './lib/context-reset';
-import { readPendingCommand, clearPendingCommand, renderCommand } from './lib/harness-command';
+import {
+  MODEL_CONFIRM_RENDER_MS,
+  clearPendingCommand,
+  isModelSwitchConfirmation,
+  readPendingCommand,
+  renderCommand,
+} from './lib/harness-command';
 import { currentHHMMOrUTC } from './lib/time';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -65,6 +71,23 @@ function drainHarnessCommand(): void {
     return;
   }
   clearPendingCommand(HERMIT_DIR);
+
+  // Claude Code applies a model switch immediately when the session has no context.
+  // With cached context it instead renders a confirmation whose selected default is
+  // "Yes". The trusted channel command already authorized that exact switch, so confirm
+  // only the model-specific dialog immediately caused by this delivery. A capture miss,
+  // wording drift, or failed Enter leaves the pane untouched and never reissues /model.
+  if (pending.command === '/model') {
+    Bun.sleepSync(MODEL_CONFIRM_RENDER_MS);
+    const pane = capturePane(sessionName);
+    if (pane !== null && isModelSwitchConfirmation(pane)) {
+      if (sendEnter(sessionName)) {
+        console.error(`[stop-pipeline] harness-command: confirmed cached-context switch for "${text}"`);
+      } else {
+        console.error(`[stop-pipeline] harness-command: tmux refused model-switch confirmation for "${text}"`);
+      }
+    }
+  }
 
   // Bookkeeping AFTER the confirmed send, not before: a refused send keeps the marker for
   // the next turn, and a pre-send stamp would have recorded a reset that never happened —

--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -103,7 +103,7 @@ This is how the agent learns the DM channel ID for proactive outbound notificati
 Before running any heavy sub-step — an archive traversal, a multi-file search, or a delegated execution step — apply the **Context-hygiene & delegation** rule: delegate when its criteria hold and keep only the verdict.
 
 - **Harness command** (exactly `/compact`, `/clear`, `/model <arg>`, or `/effort <arg>`)
-  - Intercepted by the `user-prompt-pipeline.ts` `UserPromptSubmit` hook's harness-command stage **before this skill runs** — the request is already recorded, and the `Stop` hook types it into the session when this turn ends. There is nothing for you to do; acknowledge briefly via the channel if you like.
+  - Intercepted by the `user-prompt-pipeline.ts` `UserPromptSubmit` hook's harness-command stage **before this skill runs** — the request is already recorded, and the `Stop` hook types it into the session when this turn ends. When `/model` opens Claude Code's cached-context warning, that same hook path confirms the already-authorized switch. There is nothing for you to do; acknowledge briefly via the channel if you like.
   - Do **not** try to run it yourself, and do not treat it as a skill invocation.
   - It applies to *this* session only: the next `hermit-start` re-asserts `config.model` / `config.effort`. If Claude Code rejects the argument, that shows in the terminal, not in chat — so don't promise it took effect.
   - A near-miss (`/model` with no argument, a bare `clear`, or prose mentioning one) is **not** intercepted — classify it under the categories below instead.

--- a/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
+++ b/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  isModelSwitchConfirmation,
+  writePendingCommand,
+} from '../scripts/lib/harness-command';
+import { runScript } from './helpers/run';
+import { withDir } from './helpers/workdir';
+
+const MODEL_SWITCH_PANE = `
+Switch model?
+Your next response will be slower and use more tokens
+
+This conversation is cached for the current model. Switching to Opus 5 means the full history gets
+re-read on your next message.
+
+❯ 1. Yes, switch to Opus 5
+  2. No, go back
+`;
+
+const hermit = (dir: string, ...parts: string[]) =>
+  path.join(dir, '.claude-code-hermit', ...parts);
+
+function seedPendingModel(dir: string): void {
+  fs.writeFileSync(hermit(dir, 'config.json'), JSON.stringify({ timezone: 'UTC' }));
+  fs.writeFileSync(hermit(dir, 'state', 'runtime.json'), JSON.stringify({
+    version: 1,
+    session_state: 'in_progress',
+    runtime_mode: 'headless',
+    tmux_session: 'hermit-test',
+    shutdown_requested_at: null,
+    shutdown_completed_at: null,
+  }));
+  writePendingCommand(hermit(dir), {
+    command: '/model',
+    arg: 'opus',
+    by: 'operator',
+    requested_at: new Date().toISOString(),
+  });
+}
+
+function installFakeTmux(
+  dir: string,
+  pane: string,
+  opts: { failLiteral?: boolean; failSecondEnter?: boolean } = {},
+): { bin: string; log: string } {
+  const bin = path.join(dir, 'fake-bin');
+  const log = path.join(dir, 'tmux-calls.log');
+  const paneFile = path.join(dir, 'pane.txt');
+  const enterCount = path.join(dir, 'enter-count');
+  fs.mkdirSync(bin);
+  fs.writeFileSync(paneFile, pane);
+  fs.writeFileSync(path.join(bin, 'tmux'), `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "${log}"
+case "$1" in
+  has-session) exit 0 ;;
+  capture-pane) cat "${paneFile}"; exit 0 ;;
+  send-keys)
+    if [[ "${opts.failLiteral ? '1' : '0'}" == "1" && "$*" == *" -l -- "* ]]; then exit 1; fi
+    if [[ "$*" == *" Enter" ]]; then
+      count=0
+      [[ -f "${enterCount}" ]] && count=$(cat "${enterCount}")
+      count=$((count + 1))
+      printf '%s' "$count" > "${enterCount}"
+      if [[ "${opts.failSecondEnter ? '1' : '0'}" == "1" && "$count" == "2" ]]; then exit 1; fi
+    fi
+    exit 0
+    ;;
+esac
+exit 1
+`);
+  fs.chmodSync(path.join(bin, 'tmux'), 0o755);
+  return { bin, log };
+}
+
+async function drain(dir: string, bin: string) {
+  return runScript('stop-pipeline.ts', {
+    stdin: '{}',
+    cwd: dir,
+    env: {
+      AGENT_HOOK_PROFILE: 'minimal',
+      PATH: `${bin}:${process.env.PATH}`,
+    },
+  });
+}
+
+describe('model-switch confirmation matcher', () => {
+  test('accepts the wrapped cached-context model prompt', () => {
+    expect(isModelSwitchConfirmation(MODEL_SWITCH_PANE)).toBe(true);
+  });
+
+  test('rejects unrelated or incomplete dialogs', () => {
+    expect(isModelSwitchConfirmation(`
+Permission required
+❯ 1. Yes, allow once
+  2. No, go back
+`)).toBe(false);
+    expect(isModelSwitchConfirmation(`
+Switch model?
+❯ 1. Yes, switch to Opus 5
+  2. No, go back
+`)).toBe(false);
+  });
+
+  test('looks only at the pane tail', () => {
+    expect(isModelSwitchConfirmation(`${MODEL_SWITCH_PANE}\n${'\n'.repeat(20)}ready`)).toBe(false);
+  });
+});
+
+describe('Stop hook model delivery', () => {
+  test('active context submits /model and confirms the selected Yes', withDir(async (dir) => {
+    seedPendingModel(dir);
+    const { bin, log } = installFakeTmux(dir, MODEL_SWITCH_PANE);
+
+    const result = await drain(dir, bin);
+
+    expect(result.exitCode).toBe(0);
+    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+    expect(calls.filter((line) => line.includes('-l -- /model opus'))).toHaveLength(1);
+    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(2);
+    expect(calls).toContain('capture-pane -p -t hermit-test');
+    expect(result.stderr).toContain('confirmed cached-context switch');
+    expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
+  }));
+
+  test('context-free switch does not receive an extra Enter', withDir(async (dir) => {
+    seedPendingModel(dir);
+    const { bin, log } = installFakeTmux(dir, 'Claude ready');
+
+    const result = await drain(dir, bin);
+
+    expect(result.exitCode).toBe(0);
+    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(1);
+    expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
+  }));
+
+  test('unrelated dialog is never answered', withDir(async (dir) => {
+    seedPendingModel(dir);
+    const { bin, log } = installFakeTmux(dir, `
+Permission required
+❯ 1. Yes, allow once
+  2. No, go back
+`);
+
+    const result = await drain(dir, bin);
+
+    expect(result.exitCode).toBe(0);
+    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(1);
+  }));
+
+  test('failed /model submission retains the marker for retry', withDir(async (dir) => {
+    seedPendingModel(dir);
+    const { bin } = installFakeTmux(dir, MODEL_SWITCH_PANE, { failLiteral: true });
+
+    const result = await drain(dir, bin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('marker kept for retry');
+    expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(true);
+  }));
+
+  test('failed confirmation does not reissue /model', withDir(async (dir) => {
+    seedPendingModel(dir);
+    const { bin, log } = installFakeTmux(dir, MODEL_SWITCH_PANE, { failSecondEnter: true });
+
+    const result = await drain(dir, bin);
+
+    expect(result.exitCode).toBe(0);
+    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+    expect(calls.filter((line) => line.includes('-l -- /model opus'))).toHaveLength(1);
+    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(2);
+    expect(result.stderr).toContain('refused model-switch confirmation');
+    expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
+  }));
+});


### PR DESCRIPTION
## Summary

- prevent trusted channel `/model <arg>` requests from stalling when Claude Code warns about re-reading an active cached context
- auto-confirm only the freshly-correlated model-switch dialog; unrelated native prompts remain untouched

## Changes

- add bounded pane capture and single-Enter support to the shared tmux adapter
- recognize the model-switch warning from model-specific anchors after normalizing wrapped pane text
- preserve the existing context-free no-op, initial-delivery retry, and no-reissue-on-confirmation-failure behavior
- document the narrow authorization exception and add focused delivery regressions

## Test plan

- [x] `cd plugins/claude-code-hermit && bun test` — 3,364 passed
- [x] `bunx tsc --noEmit`
- [x] `graphify update .`
- [x] Live Claude Code probe — blocked on this host because `/snap/bin/tmux` fails its snap/AppArmor preflight
