### PR TITLE
fix(claude-code-hermit): confirm cached-context effort switches

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- A trusted channel `/model <arg>` no longer stalls on Claude Code's cached-context confirmation. The Stop hook recognizes only that freshly-triggered model-switch dialog and confirms its selected `Yes`; context-free switches still complete without an extra keypress, and unrelated native prompts remain untouched.
+- A trusted channel `/model <arg>` or `/effort <arg>` no longer stalls on Claude Code's cached-context confirmation. The Stop hook recognizes only the freshly-triggered, command-specific switch dialog and confirms its selected `Yes`; direct switches still complete without an extra keypress, and unrelated native prompts remain untouched.
 
 ## [1.2.34] - 2026-07-26
 

--- a/plugins/claude-code-hermit/docs/security.md
+++ b/plugins/claude-code-hermit/docs/security.md
@@ -109,7 +109,7 @@ A channel-primary hermit (`always_on: true`, at least one reachable channel) has
 4. **Fail-loud** — when a prompt can't be redirected, notify the operator that something is stuck rather than silently hanging.
 5. **Native bridge** — defer to a first-party mirror/answer path once Anthropic ships one, and shrink custom machinery accordingly.
 
-Never bypass — no auto-answering a permission prompt, no sending Escape on the operator's behalf. Deciding what an unattended agent is allowed to do is always the operator's call, made in advance (config) or asynchronously (channel reply), never invented by the hermit in the moment. The narrow exception is Claude Code's cached-context warning immediately after a trusted sender requested an exact `/model <arg>`: that sender already made the model decision, so the Stop hook confirms only a model-specific, freshly-correlated dialog. Every other native dialog remains untouched.
+Never bypass — no auto-answering a permission prompt, no sending Escape on the operator's behalf. Deciding what an unattended agent is allowed to do is always the operator's call, made in advance (config) or asynchronously (channel reply), never invented by the hermit in the moment. The narrow exception is Claude Code's cached-context warning immediately after a trusted sender requested an exact `/model <arg>` or `/effort <arg>`: that sender already made the switch decision, so the Stop hook confirms only the command-specific, freshly-correlated dialog. Every other native dialog remains untouched.
 
 Two binding instances exist today:
 

--- a/plugins/claude-code-hermit/scripts/lib/harness-command.ts
+++ b/plugins/claude-code-hermit/scripts/lib/harness-command.ts
@@ -63,27 +63,40 @@ export type PendingCommand = {
  * wedged for an hour should not suddenly clear its context when it recovers.
  */
 export const COMMAND_MARKER_TTL_SECS = 3600;
-/** One render beat after submitting /model before inspecting the pane. */
-export const MODEL_CONFIRM_RENDER_MS = 500;
-const MODEL_CONFIRM_TAIL_LINES = 20;
+/** One render beat after submitting a confirmable harness switch before inspecting the pane. */
+export const HARNESS_CONFIRM_RENDER_MS = 500;
+const HARNESS_CONFIRM_TAIL_LINES = 20;
+
+const SWITCH_CONFIRMATION_ANCHORS: Record<string, readonly string[]> = {
+  '/model': [
+    'Switch model?',
+    'This conversation is cached for the current model.',
+  ],
+  '/effort': [
+    'Change effort level?',
+    'This conversation is cached for the current effort level.',
+  ],
+};
 
 /**
- * Match only Claude Code's cached-context model-switch confirmation.
+ * Match only Claude Code's cached-context confirmation for the delivered switch.
  *
  * Whitespace is collapsed because the warning wraps according to pane width. The
- * model label is deliberately not matched: a stable request alias such as `opus`
- * renders as a release display name such as "Opus 5".
+ * target label is deliberately not matched: a stable model alias such as `opus`
+ * renders as a release display name such as "Opus 5", and effort levels may expand.
  */
-export function isModelSwitchConfirmation(paneContent: string): boolean {
+export function isHarnessSwitchConfirmation(command: string, paneContent: string): boolean {
+  const commandAnchors = SWITCH_CONFIRMATION_ANCHORS[command];
+  if (!commandAnchors) return false;
+
   const tail = paneContent
     .split('\n')
-    .slice(-MODEL_CONFIRM_TAIL_LINES)
+    .slice(-HARNESS_CONFIRM_TAIL_LINES)
     .join(' ')
     .replace(/\s+/g, ' ');
 
-  return tail.includes('Switch model?')
+  return commandAnchors.every((anchor) => tail.includes(anchor))
     && tail.includes('Your next response will be slower and use more tokens')
-    && tail.includes('This conversation is cached for the current model.')
     && tail.includes('Yes, switch to')
     && tail.includes('No, go back');
 }

--- a/plugins/claude-code-hermit/scripts/stop-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/stop-pipeline.ts
@@ -10,9 +10,9 @@ import { readRuntimeJson } from './lib/runtime';
 import { capturePane, sendEnter, sendKeys, tmuxSessionAlive } from './lib/tmux';
 import { applyContextReset } from './lib/context-reset';
 import {
-  MODEL_CONFIRM_RENDER_MS,
+  HARNESS_CONFIRM_RENDER_MS,
   clearPendingCommand,
-  isModelSwitchConfirmation,
+  isHarnessSwitchConfirmation,
   readPendingCommand,
   renderCommand,
 } from './lib/harness-command';
@@ -72,19 +72,19 @@ function drainHarnessCommand(): void {
   }
   clearPendingCommand(HERMIT_DIR);
 
-  // Claude Code applies a model switch immediately when the session has no context.
-  // With cached context it instead renders a confirmation whose selected default is
-  // "Yes". The trusted channel command already authorized that exact switch, so confirm
-  // only the model-specific dialog immediately caused by this delivery. A capture miss,
-  // wording drift, or failed Enter leaves the pane untouched and never reissues /model.
-  if (pending.command === '/model') {
-    Bun.sleepSync(MODEL_CONFIRM_RENDER_MS);
+  // Claude Code may apply a model/effort switch immediately, or render a cached-context
+  // confirmation whose selected default is "Yes". The trusted channel command already
+  // authorized that exact switch, so confirm only the command-specific dialog immediately
+  // caused by this delivery. A capture miss, wording drift, or failed Enter leaves the pane
+  // untouched and never reissues the command.
+  if (pending.command === '/model' || pending.command === '/effort') {
+    Bun.sleepSync(HARNESS_CONFIRM_RENDER_MS);
     const pane = capturePane(sessionName);
-    if (pane !== null && isModelSwitchConfirmation(pane)) {
+    if (pane !== null && isHarnessSwitchConfirmation(pending.command, pane)) {
       if (sendEnter(sessionName)) {
         console.error(`[stop-pipeline] harness-command: confirmed cached-context switch for "${text}"`);
       } else {
-        console.error(`[stop-pipeline] harness-command: tmux refused model-switch confirmation for "${text}"`);
+        console.error(`[stop-pipeline] harness-command: tmux refused cached-context confirmation for "${text}"`);
       }
     }
   }

--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -103,7 +103,7 @@ This is how the agent learns the DM channel ID for proactive outbound notificati
 Before running any heavy sub-step — an archive traversal, a multi-file search, or a delegated execution step — apply the **Context-hygiene & delegation** rule: delegate when its criteria hold and keep only the verdict.
 
 - **Harness command** (exactly `/compact`, `/clear`, `/model <arg>`, or `/effort <arg>`)
-  - Intercepted by the `user-prompt-pipeline.ts` `UserPromptSubmit` hook's harness-command stage **before this skill runs** — the request is already recorded, and the `Stop` hook types it into the session when this turn ends. When `/model` opens Claude Code's cached-context warning, that same hook path confirms the already-authorized switch. There is nothing for you to do; acknowledge briefly via the channel if you like.
+  - Intercepted by the `user-prompt-pipeline.ts` `UserPromptSubmit` hook's harness-command stage **before this skill runs** — the request is already recorded, and the `Stop` hook types it into the session when this turn ends. When `/model` or `/effort` opens Claude Code's cached-context warning, that same hook path confirms the already-authorized switch. There is nothing for you to do; acknowledge briefly via the channel if you like.
   - Do **not** try to run it yourself, and do not treat it as a skill invocation.
   - It applies to *this* session only: the next `hermit-start` re-asserts `config.model` / `config.effort`. If Claude Code rejects the argument, that shows in the terminal, not in chat — so don't promise it took effect.
   - A near-miss (`/model` with no argument, a bare `clear`, or prose mentioning one) is **not** intercepted — classify it under the categories below instead.

--- a/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
+++ b/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import {
-  isModelSwitchConfirmation,
+  isHarnessSwitchConfirmation,
   writePendingCommand,
 } from '../scripts/lib/harness-command';
 import { runScript } from './helpers/run';
@@ -20,10 +20,26 @@ re-read on your next message.
   2. No, go back
 `;
 
+const EFFORT_SWITCH_PANE = `
+Change effort level?
+Your next response will be slower and use more tokens
+
+This conversation is cached for the current effort level. Switching to high means the full history gets
+re-read on your next message.
+
+❯ 1. Yes, switch to high
+  2. No, go back
+`;
+
+const SWITCH_CASES = [
+  { label: 'model', command: '/model', arg: 'opus', pane: MODEL_SWITCH_PANE },
+  { label: 'effort', command: '/effort', arg: 'high', pane: EFFORT_SWITCH_PANE },
+] as const;
+
 const hermit = (dir: string, ...parts: string[]) =>
   path.join(dir, '.claude-code-hermit', ...parts);
 
-function seedPendingModel(dir: string): void {
+function seedPendingSwitch(dir: string, command: string, arg: string): void {
   fs.writeFileSync(hermit(dir, 'config.json'), JSON.stringify({ timezone: 'UTC' }));
   fs.writeFileSync(hermit(dir, 'state', 'runtime.json'), JSON.stringify({
     version: 1,
@@ -34,8 +50,8 @@ function seedPendingModel(dir: string): void {
     shutdown_completed_at: null,
   }));
   writePendingCommand(hermit(dir), {
-    command: '/model',
-    arg: 'opus',
+    command,
+    arg,
     by: 'operator',
     requested_at: new Date().toISOString(),
   });
@@ -86,94 +102,107 @@ async function drain(dir: string, bin: string) {
   });
 }
 
-describe('model-switch confirmation matcher', () => {
-  test('accepts the wrapped cached-context model prompt', () => {
-    expect(isModelSwitchConfirmation(MODEL_SWITCH_PANE)).toBe(true);
+describe('harness-switch confirmation matcher', () => {
+  test('accepts wrapped cached-context model and effort prompts', () => {
+    expect(isHarnessSwitchConfirmation('/model', MODEL_SWITCH_PANE)).toBe(true);
+    expect(isHarnessSwitchConfirmation('/effort', EFFORT_SWITCH_PANE)).toBe(true);
   });
 
   test('rejects unrelated or incomplete dialogs', () => {
-    expect(isModelSwitchConfirmation(`
+    expect(isHarnessSwitchConfirmation('/model', `
 Permission required
 ❯ 1. Yes, allow once
   2. No, go back
 `)).toBe(false);
-    expect(isModelSwitchConfirmation(`
+    expect(isHarnessSwitchConfirmation('/model', `
 Switch model?
 ❯ 1. Yes, switch to Opus 5
   2. No, go back
 `)).toBe(false);
   });
 
+  test('requires anchors for the delivered command', () => {
+    expect(isHarnessSwitchConfirmation('/model', EFFORT_SWITCH_PANE)).toBe(false);
+    expect(isHarnessSwitchConfirmation('/effort', MODEL_SWITCH_PANE)).toBe(false);
+    expect(isHarnessSwitchConfirmation('/clear', MODEL_SWITCH_PANE)).toBe(false);
+  });
+
   test('looks only at the pane tail', () => {
-    expect(isModelSwitchConfirmation(`${MODEL_SWITCH_PANE}\n${'\n'.repeat(20)}ready`)).toBe(false);
+    for (const { command, pane } of SWITCH_CASES) {
+      expect(isHarnessSwitchConfirmation(command, `${pane}\n${'\n'.repeat(20)}ready`)).toBe(false);
+    }
   });
 });
 
-describe('Stop hook model delivery', () => {
-  test('active context submits /model and confirms the selected Yes', withDir(async (dir) => {
-    seedPendingModel(dir);
-    const { bin, log } = installFakeTmux(dir, MODEL_SWITCH_PANE);
+describe('Stop hook harness-switch delivery', () => {
+  for (const { label, command, arg, pane } of SWITCH_CASES) {
+    const text = `${command} ${arg}`;
 
-    const result = await drain(dir, bin);
+    test(`${label}: cached context submits once and confirms the selected Yes`, withDir(async (dir) => {
+      seedPendingSwitch(dir, command, arg);
+      const { bin, log } = installFakeTmux(dir, pane);
 
-    expect(result.exitCode).toBe(0);
-    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
-    expect(calls.filter((line) => line.includes('-l -- /model opus'))).toHaveLength(1);
-    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(2);
-    expect(calls).toContain('capture-pane -p -t hermit-test');
-    expect(result.stderr).toContain('confirmed cached-context switch');
-    expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
-  }));
+      const result = await drain(dir, bin);
 
-  test('context-free switch does not receive an extra Enter', withDir(async (dir) => {
-    seedPendingModel(dir);
-    const { bin, log } = installFakeTmux(dir, 'Claude ready');
+      expect(result.exitCode).toBe(0);
+      const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+      expect(calls.filter((line) => line.includes(`-l -- ${text}`))).toHaveLength(1);
+      expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(2);
+      expect(calls).toContain('capture-pane -p -t hermit-test');
+      expect(result.stderr).toContain('confirmed cached-context switch');
+      expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
+    }));
 
-    const result = await drain(dir, bin);
+    test(`${label}: direct switch does not receive an extra Enter`, withDir(async (dir) => {
+      seedPendingSwitch(dir, command, arg);
+      const { bin, log } = installFakeTmux(dir, 'Claude ready');
 
-    expect(result.exitCode).toBe(0);
-    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
-    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(1);
-    expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
-  }));
+      const result = await drain(dir, bin);
 
-  test('unrelated dialog is never answered', withDir(async (dir) => {
-    seedPendingModel(dir);
-    const { bin, log } = installFakeTmux(dir, `
+      expect(result.exitCode).toBe(0);
+      const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+      expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(1);
+      expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
+    }));
+
+    test(`${label}: unrelated dialog is never answered`, withDir(async (dir) => {
+      seedPendingSwitch(dir, command, arg);
+      const { bin, log } = installFakeTmux(dir, `
 Permission required
 ❯ 1. Yes, allow once
   2. No, go back
 `);
 
-    const result = await drain(dir, bin);
+      const result = await drain(dir, bin);
 
-    expect(result.exitCode).toBe(0);
-    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
-    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(1);
-  }));
+      expect(result.exitCode).toBe(0);
+      const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+      expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(1);
+    }));
 
-  test('failed /model submission retains the marker for retry', withDir(async (dir) => {
-    seedPendingModel(dir);
-    const { bin } = installFakeTmux(dir, MODEL_SWITCH_PANE, { failLiteral: true });
+    test(`${label}: failed submission retains the marker for retry`, withDir(async (dir) => {
+      seedPendingSwitch(dir, command, arg);
+      const { bin } = installFakeTmux(dir, pane, { failLiteral: true });
 
-    const result = await drain(dir, bin);
+      const result = await drain(dir, bin);
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toContain('marker kept for retry');
-    expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(true);
-  }));
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('marker kept for retry');
+      expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(true);
+    }));
 
-  test('failed confirmation does not reissue /model', withDir(async (dir) => {
-    seedPendingModel(dir);
-    const { bin, log } = installFakeTmux(dir, MODEL_SWITCH_PANE, { failSecondEnter: true });
+    test(`${label}: failed confirmation does not reissue the command`, withDir(async (dir) => {
+      seedPendingSwitch(dir, command, arg);
+      const { bin, log } = installFakeTmux(dir, pane, { failSecondEnter: true });
 
-    const result = await drain(dir, bin);
+      const result = await drain(dir, bin);
 
-    expect(result.exitCode).toBe(0);
-    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
-    expect(calls.filter((line) => line.includes('-l -- /model opus'))).toHaveLength(1);
-    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(2);
-    expect(result.stderr).toContain('refused model-switch confirmation');
-    expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
-  }));
+      expect(result.exitCode).toBe(0);
+      const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+      expect(calls.filter((line) => line.includes(`-l -- ${text}`))).toHaveLength(1);
+      expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(2);
+      expect(result.stderr).toContain('refused cached-context confirmation');
+      expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
+    }));
+  }
 });


### PR DESCRIPTION
## Summary

- prevent trusted channel `/effort <arg>` requests from stalling on Claude Code's cached-context confirmation
- extend PR 669's freshly-correlated confirmation path without auto-answering direct switches or unrelated native prompts

## Changes

- generalize the bounded pane-tail matcher with command-specific model and effort anchors
- let the Stop hook confirm `/model` and `/effort` dialogs through the same one-capture, one-Enter path
- expand delivery regressions across cached context, direct application, unrelated prompts, and send failures
- align the channel responder, security contract, and Unreleased changelog wording

## Test plan

- [x] `cd plugins/claude-code-hermit && bun test tests/harness-command-delivery.test.ts` — 14 passed
- [x] `cd plugins/claude-code-hermit && bun test` — 3,370 passed
- [x] `cd plugins/claude-code-hermit && bunx tsc --noEmit`
- [x] `graphify update .`
- [x] Live Claude Code 2.1.220 Sonnet probe — reproduced the cached-effort dialog and confirmed the selected `Yes` with one Enter; Haiku's direct-application path required no extra keypress
