### PR TITLE
fix(claude-code-hermit): route maintenance notices to maintainers

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - A trusted channel `/model <arg>` or `/effort <arg>` no longer stalls on Claude Code's cached-context confirmation. The Stop hook recognizes only the freshly-triggered, command-specific switch dialog and confirms its selected `Yes`; direct switches still complete without an extra keypress, and unrelated native prompts remain untouched.
+- Automated maintenance reports no longer duplicate into the primary operator chat when a maintainer channel is configured: the default doctor routine uses `--maintainer`, unattended evolve reports are maintainer-only, and manual doctor/evolve/cost-reflect invocations reply only where they were requested.
 
 ## [1.2.34] - 2026-07-26
 
@@ -91,6 +92,7 @@
 2. Run `bun <plugin_root>/scripts/apply-settings.ts <settings-file> permissions-sync` against the install's settings file (`.claude/settings.local.json` for a `local` hatch target, `.claude/settings.json` for `committed`). This is now the one step that reconciles permissions: it adds every sealed entry the install is missing — including `channel-send.ts`, new this version — and scrubs entries from retired plugin versions: `next-prop-id.ts`, `append-metrics.ts` (deleted this version; replaced by the narrower `observations.ts observe *` grant), the five proposal satellites absorbed into `proposal.ts` verbs, and the two pre-absorption `hermit-run` routes. It replaces the per-entry "re-run hatch so X lands in the allow-list" instructions.
 3. If `claude-code-dev-hermit` is installed and its CLAUDE.md/CLAUDE.local.md contains the literal string `<!-- mode:standard-only -->`, a prior version of `hermit-evolve` hit the marker-discovery bug above and appended the raw, un-rendered dev-hermit template. Remove the entire stray block (from the first `<!-- mode:standard-only -->` or `<!-- mode:safety-only -->` line it introduced through the end of that appended region) — the correctly-rendered `<!-- claude-code-dev-hermit: Development Workflow -->` block elsewhere in the file is unaffected and should be left in place.
 4. If an operator customized their CLAUDE-APPEND block in place (core, `hermit-scribe`, or `claude-code-dev-hermit`), note that the next version-gap sync for that plugin will replace it with the shipped template now that closing markers make the block bounds authoritative — re-apply any customization after that sync.
+5. In `.claude-code-hermit/config.json`, find the routine with `id: "doctor"`. If and only if its `skill` is exactly `"claude-code-hermit:hermit-doctor"`, replace it with `"claude-code-hermit:hermit-doctor --maintainer"`. Preserve its schedule, model, enabled state, and every other field. A skill string with any existing arguments is operator-customized — leave it untouched. The main evolve loop re-runs `/claude-code-hermit:hermit-routines load` after a successful always-on upgrade so fallback CronCreates pick up the changed invocation immediately; the boot-time doctor ratchet applies the same exact-match rewrite as a backstop.
 
 ## [1.2.33] - 2026-07-24
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Fixed
 - A trusted channel `/model <arg>` or `/effort <arg>` no longer stalls on Claude Code's cached-context confirmation. The Stop hook recognizes only the freshly-triggered, command-specific switch dialog and confirms its selected `Yes`; direct switches still complete without an extra keypress, and unrelated native prompts remain untouched.
-- Automated maintenance reports no longer duplicate into the primary operator chat when a maintainer channel is configured: the default doctor routine uses `--maintainer`, unattended evolve reports are maintainer-only, and manual doctor/evolve/cost-reflect invocations reply only where they were requested.
+- Automated doctor reports prefer the configured maintainer channel while legacy no-argument doctor invocations keep notifying the primary operator. Unattended evolve is maintainer-only, and direct evolve/cost-reflect requests reply where invoked.
+
+### Upgrade Instructions
+1. In `.claude-code-hermit/config.json`, find the routine with `id: "doctor"`. If and only if its `skill` is exactly `"claude-code-hermit:hermit-doctor"`, replace it with `"claude-code-hermit:hermit-doctor --maintainer"`. Preserve its schedule, model, enabled state, and every other field. Leave a skill string with any existing arguments untouched. The main evolve loop re-runs `/claude-code-hermit:hermit-routines load` after a successful always-on upgrade so fallback CronCreates pick up the changed invocation immediately; the boot-time doctor ratchet applies the same exact-match rewrite as a backstop.
 
 ## [1.2.34] - 2026-07-26
 
@@ -92,7 +95,6 @@
 2. Run `bun <plugin_root>/scripts/apply-settings.ts <settings-file> permissions-sync` against the install's settings file (`.claude/settings.local.json` for a `local` hatch target, `.claude/settings.json` for `committed`). This is now the one step that reconciles permissions: it adds every sealed entry the install is missing — including `channel-send.ts`, new this version — and scrubs entries from retired plugin versions: `next-prop-id.ts`, `append-metrics.ts` (deleted this version; replaced by the narrower `observations.ts observe *` grant), the five proposal satellites absorbed into `proposal.ts` verbs, and the two pre-absorption `hermit-run` routes. It replaces the per-entry "re-run hatch so X lands in the allow-list" instructions.
 3. If `claude-code-dev-hermit` is installed and its CLAUDE.md/CLAUDE.local.md contains the literal string `<!-- mode:standard-only -->`, a prior version of `hermit-evolve` hit the marker-discovery bug above and appended the raw, un-rendered dev-hermit template. Remove the entire stray block (from the first `<!-- mode:standard-only -->` or `<!-- mode:safety-only -->` line it introduced through the end of that appended region) — the correctly-rendered `<!-- claude-code-dev-hermit: Development Workflow -->` block elsewhere in the file is unaffected and should be left in place.
 4. If an operator customized their CLAUDE-APPEND block in place (core, `hermit-scribe`, or `claude-code-dev-hermit`), note that the next version-gap sync for that plugin will replace it with the shipped template now that closing markers make the block bounds authoritative — re-apply any customization after that sync.
-5. In `.claude-code-hermit/config.json`, find the routine with `id: "doctor"`. If and only if its `skill` is exactly `"claude-code-hermit:hermit-doctor"`, replace it with `"claude-code-hermit:hermit-doctor --maintainer"`. Preserve its schedule, model, enabled state, and every other field. A skill string with any existing arguments is operator-customized — leave it untouched. The main evolve loop re-runs `/claude-code-hermit:hermit-routines load` after a successful always-on upgrade so fallback CronCreates pick up the changed invocation immediately; the boot-time doctor ratchet applies the same exact-match rewrite as a backstop.
 
 ## [1.2.33] - 2026-07-24
 

--- a/plugins/claude-code-hermit/scripts/channel-send.ts
+++ b/plugins/claude-code-hermit/scripts/channel-send.ts
@@ -62,7 +62,7 @@ interface NoticePayload {
   client?: string;
   maintainer?: string;
   sensitive?: boolean;
-  fallback?: 'client' | 'findings';
+  fallback?: 'client' | 'primary' | 'findings';
 }
 
 const NOTICE_KEYS = new Set(['client', 'maintainer', 'sensitive', 'fallback']);
@@ -94,7 +94,7 @@ function parseNotice(raw: string): NoticePayload | { error: string } {
   if (sensitive !== undefined && typeof sensitive !== 'boolean') {
     return { error: 'sensitive must be a boolean' };
   }
-  if (fallback !== undefined && fallback !== 'client' && fallback !== 'findings') {
+  if (fallback !== undefined && fallback !== 'client' && fallback !== 'primary' && fallback !== 'findings') {
     return { error: `invalid fallback: ${fallback}` };
   }
   // Both modifiers apply to the maintainer leg only. Accepting them without one

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -55,7 +55,7 @@ const DEFAULT_CONFIG: Json = {
     { id: 'scheduled-checks', schedule: '5 9 * * *', skill: 'claude-code-hermit:reflect --scheduled-checks', run_during_waiting: true, enabled: true },
     { id: 'weekly-review', schedule: '0 23 * * 0', skill: 'claude-code-hermit:weekly-review', enabled: true },
     { id: 'daily-auto-close', schedule: '0 0 * * *', skill: 'claude-code-hermit:session-close --scheduled', model: 'haiku', run_during_waiting: true, enabled: true },
-    { id: 'doctor', schedule: '10 9 * * 1', skill: 'claude-code-hermit:hermit-doctor', model: 'haiku', run_during_waiting: true, enabled: true },
+    { id: 'doctor', schedule: '10 9 * * 1', skill: 'claude-code-hermit:hermit-doctor --maintainer', model: 'haiku', run_during_waiting: true, enabled: true },
   ],
   monitors: [],
   env: {
@@ -202,11 +202,10 @@ function loadConfig(): Json {
   return merged;
 }
 
-// One-way ratchet: an always-on boot upgrades a template-default weekly doctor
-// schedule to daily. Only touches the entry if it's still at a KNOWN default —
-// a custom schedule the operator set is left alone. Does not downgrade back to
-// weekly on stop; a box that reverts to interactive keeps daily doctor, which
-// is harmless.
+// One-way ratchet: an always-on boot upgrades template-default doctor fields.
+// Only exact known defaults move forward; operator-customized schedules and
+// skill arguments are left alone. Does not downgrade the schedule on stop; a
+// box that reverts to interactive keeps daily doctor, which is harmless.
 //
 // The set has three entries, not one, because it must recognize schedules from
 // every prior template generation: '0 10 * * 1' is the pre-clustering weekly
@@ -220,6 +219,8 @@ function loadConfig(): Json {
 // from interactive to always-on later).
 const KNOWN_DEFAULT_SCHEDULES = ['0 10 * * 1', '10 9 * * 1', '0 10 * * *'];
 const DOCTOR_DAILY_SCHEDULE = '10 9 * * *';
+const LEGACY_DOCTOR_SKILL = 'claude-code-hermit:hermit-doctor';
+const MAINTAINER_DOCTOR_SKILL = 'claude-code-hermit:hermit-doctor --maintainer';
 
 function applyAlwaysOnDoctorSchedule(config: Json): void {
   const routine = Array.isArray(config.routines)
@@ -227,6 +228,9 @@ function applyAlwaysOnDoctorSchedule(config: Json): void {
     : null;
   if (routine && KNOWN_DEFAULT_SCHEDULES.includes(routine.schedule)) {
     routine.schedule = DOCTOR_DAILY_SCHEDULE;
+  }
+  if (routine?.skill === LEGACY_DOCTOR_SKILL) {
+    routine.skill = MAINTAINER_DOCTOR_SKILL;
   }
 }
 

--- a/plugins/claude-code-hermit/scripts/lib/channel-send.ts
+++ b/plugins/claude-code-hermit/scripts/lib/channel-send.ts
@@ -169,13 +169,14 @@ export async function sendToChannel(hermitDir: string, text: string, opts: SendO
  * A two-audience operator notice. `client` is plain, localized copy for the
  * primary chat; `maintainer` carries technical/spend/ops detail whose `fallback`
  * decides where it goes when no `maintainer_channel_id` is configured
- * (`'client'` = the primary chat, today's behavior; `'findings'` = suppressed to
- * SHELL.md, fail-closed on disclosure). `sensitive` keeps the maintainer text
- * out of the episodic channel log.
+ * (`'client'` = the primary chat for technical profiles, `'primary'` = the
+ * primary chat for every profile, `'findings'` = suppressed to SHELL.md).
+ * A configured but unreachable maintainer destination always fails closed to
+ * Findings. `sensitive` keeps the maintainer text out of the episodic channel log.
  */
 export interface OperatorNotice {
   client?: string;
-  maintainer?: { text: string; fallback: 'client' | 'findings'; sensitive?: boolean };
+  maintainer?: { text: string; fallback: 'client' | 'primary' | 'findings'; sensitive?: boolean };
   timeoutMs?: number;
 }
 
@@ -229,11 +230,11 @@ export async function sendOperatorNotice(hermitDir: string, notice: OperatorNoti
       // over the fallback: a bad chat id must never spill technical/spend
       // detail into the client chat.
       out.maintainer = r.ok ? { ...r, route: 'maintainer_channel', delivered: true } : toFindings(true);
-    } else if (m.fallback === 'findings' || nonTechnical) {
+    } else if (m.fallback === 'findings' || (m.fallback === 'client' && nonTechnical)) {
       out.maintainer = toFindings(false);
     } else {
-      // fallback 'client' on a technical profile with no maintainer channel:
-      // today's behavior — the message goes to the primary chat.
+      // fallback 'client' on a technical profile, or explicit 'primary' on any
+      // profile, with no maintainer channel: send to the primary chat.
       const r = await sendToChannel(hermitDir, m.text, {
         target: clientTarget ?? undefined, timeoutMs: notice.timeoutMs, config,
       });

--- a/plugins/claude-code-hermit/skills/cost-reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/cost-reflect/SKILL.md
@@ -15,9 +15,8 @@ Runs a structural cost audit over the last 7 days of `cost-log.jsonl` and delive
 
 ## Step 0 — Channel reply
 
-Unless `$ARGUMENTS` contains `--maintainer`, if this skill was invoked from a channel-arrived message
-(the inbound prompt contains a `<channel source="...">` tag), reply via that channel's reply tool.
-Otherwise emit to conversation.
+On a channel-arrived message without `--maintainer` (the inbound prompt contains a `<channel source="...">` tag), reply via that channel's reply tool.
+Otherwise, do not send a channel reply in Step 0; proceed and deliver the result via Step 2 (terminal/manual) or Step 3 (maintainer notice).
 
 ## Step 1 — Run the analyzer
 

--- a/plugins/claude-code-hermit/skills/cost-reflect/SKILL.md
+++ b/plugins/claude-code-hermit/skills/cost-reflect/SKILL.md
@@ -6,19 +6,30 @@ description: "The 'why is my bill high' skill: audits where spend goes across to
 
 Runs a structural cost audit over the last 7 days of `cost-log.jsonl` and delivers the result to the operator. The math is done by a script — your job is to run it and deliver the output through the right channel.
 
+## Invocation mode
+
+- **Manual (no arguments):** reply only to the invoking terminal or channel conversation.
+- **Automated (`--maintainer`):** produce the full technical report and send it as a maintainer-tier
+  notice. Existing routine/proactive invocations without the flag retain this behavior for backward
+  compatibility, but new routine configuration should pass `--maintainer` explicitly.
+
 ## Step 0 — Channel reply
 
-If this skill was invoked from a channel-arrived message (the inbound prompt contains a `<channel source="...">` tag), reply via that channel's reply tool. Otherwise emit to conversation.
+Unless `$ARGUMENTS` contains `--maintainer`, if this skill was invoked from a channel-arrived message
+(the inbound prompt contains a `<channel source="...">` tag), reply via that channel's reply tool.
+Otherwise emit to conversation.
 
 ## Step 1 — Run the analyzer
 
-On a channel-tagged turn (Step 0 detected a `<channel source="...">` tag), run the plain-language mode instead of the full breakdown — a channel operator asking "why is my bill high" shouldn't get raw token-category jargon:
+On a channel-tagged turn without `--maintainer` (Step 0 detected a `<channel source="...">` tag), run
+the plain-language mode instead of the full breakdown — a channel operator asking "why is my bill
+high" shouldn't get raw token-category jargon:
 
 ```
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/cost-report.ts reflect .claude-code-hermit --plain
 ```
 
-Otherwise (terminal/dev use), run the full breakdown:
+Otherwise (terminal/dev use or `--maintainer`), run the full breakdown:
 
 ```
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/cost-report.ts reflect .claude-code-hermit
@@ -34,7 +45,10 @@ Capture stdout. If the output starts with "No cost data" or "No spend recorded y
 
 ## Step 3 — Channel delivery
 
-When this skill fires from a routine or proactively (i.e., not from a direct operator conversation), deliver the report through the operator's channel. Spend detail is maintainer-tier by definition, so send it as the `maintainer` leg only (no `client` leg):
+When `$ARGUMENTS` contains `--maintainer`, deliver the report through the operator's channel.
+For backward compatibility, do the same when the invocation is clearly from an existing routine or
+proactive prompt without the flag (i.e., not from a direct operator conversation). Spend detail is
+maintainer-tier by definition, so send it as the `maintainer` leg only (no `client` leg):
 
 ```
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/channel-send.ts .claude-code-hermit --notice
@@ -45,7 +59,9 @@ To set a preferred channel, add `"primary": "<channel-name>"` inside `channels` 
 
 ## Notes
 
-- **Scheduling:** this skill doesn't self-register a routine. To run it weekly, add it via `/claude-code-hermit:hermit-settings` — a Sunday 22:00 cadence (`0 22 * * 0`) before weekly-review works well.
+- **Scheduling:** this skill doesn't self-register a routine. To run it weekly, add
+  `claude-code-hermit:cost-reflect --maintainer` via `/claude-code-hermit:hermit-settings` — a
+  Sunday 22:00 cadence (`0 22 * * 0`) before weekly-review works well.
 - **What it measures:** token-type cost composition (cache_read / cache_write / output / input), per-model breakdown (shown when ≥2 models appear, e.g. Sonnet main + Haiku heartbeat), cold-start turns (context warm-ups with no prior cache hit), and per-session cost attribution. For week-over-week totals and autonomy trends, use `/claude-code-hermit:hermit-evolution` instead.
 - **`--plain` mode** (channel-tagged turns only): today's spend vs. a trailing-7-day typical day, drivers named by work (not token type), spend-cap status, and a one-line notional-dollars caveat. No token categories, session IDs, or internal IDs.
 - **Non-technical installs** (`config.operator_profile === 'non-technical'`): a client-chat spend question never reaches this skill, since `channel-responder` deflects it with a plain "handled by your provider" reply. Spend figures stay maintainer-side (terminal, maintainer chat, weekly review), so a channel-tagged run here is expected only from a maintainer-audience surface.

--- a/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
@@ -10,12 +10,18 @@ is the only one that performs outbound API calls — see Notes) and surfaces the
 to run at any time. Produces no side effects beyond writing
 `.claude-code-hermit/state/doctor-report.json` and appending a summary block to SHELL.md.
 
-## Invocation mode
+## Notification route
 
-- **Manual (no arguments):** return the report only to the invoking conversation. Do not send a
-  second proactive notification, even when a maintainer channel is configured.
-- **Automated (`--maintainer`):** run the same checks and persistence steps, but route newly-failing
-  findings as one maintainer-tier notification. This is the mode used by the default doctor routine.
+Every run with at least one newly-failing finding not already present in alert state sends exactly
+one notification.
+The optional flag changes its destination, not whether doctor notifies:
+
+- **Default (no arguments):** send the notification to the primary operator chat. This preserves
+  the legacy `hermit-doctor` behavior.
+- **Maintainer (`--maintainer`):** prefer the configured `maintainer_channel_id`. When no maintainer
+  destination is configured, fall back to the primary operator chat for every operator profile.
+  When a configured maintainer destination is unreachable, fail closed to SHELL.md Findings and
+  never spill the notification into the primary chat.
 
 ## Steps
 
@@ -58,29 +64,30 @@ to run at any time. Produces no side effects beyond writing
    HERMIT_ALERT_JSON
    ```
 
-   **Maintainer notification — only with `--maintainer` and non-empty `new_entries`.** Compose one
-   complete, concise technical summary covering every newly-failing check, its detail, and a named
-   next action, in the operator's configured language. Deliver it through the canonical notice path:
+   **Notification — when `new_entries` is non-empty.** Compose one complete, concise summary covering
+   every newly-failing check, its detail, and a named next action, in the operator's configured
+   language. Deliver it exactly once through the canonical notice path:
    ```bash
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/channel-send.ts .claude-code-hermit --notice
    ```
-   with `{"maintainer": "<complete technical summary>"}` on stdin. Never include a `client` leg.
-   The router owns fallback: no configured maintainer chat on a technical install falls back to the
-   primary chat; a non-technical install falls back to SHELL.md Findings. Follow § Operator
-   Notification if no channel is available or delivery degrades.
+   Choose one payload from the invocation:
+   - Without `--maintainer`, send `{"client": "<complete summary>"}`. Do not include a `maintainer` leg.
+   - With `--maintainer`, send
+     `{"maintainer": "<complete summary>", "fallback": "primary"}`. Do not include a `client` leg.
 
-   Without `--maintainer`, do not call `channel-send.ts` — step 4 is the requested reply. A check
-   already alerted (its `doctor:<id>` key still present) stays silent on subsequent automated runs
-   until it resolves. Resolving just deletes the key; there is no "recovered" ping in v1.
+   The router owns destination fallback and configured-destination failure handling. Follow
+   § Operator Notification if no channel is available or delivery degrades. A check already alerted
+   (its `doctor:<id>` key still present) stays silent on subsequent runs until it resolves.
+   Resolving just deletes the key; there is no "recovered" ping in v1.
 
 ## Silence policy
 
 - If every check is `ok`, return only: `All twenty-four checks passed.` Do not notify via
   channel (Tier 0). Still resolve any stale `doctor:*` alert-state keys (step 5) and still
   append to SHELL.md so the run is traceable.
-- If any check is `warn` or `fail`, return the full twenty-four-line summary. In `--maintainer`
-  mode, notification is governed by step 5's escalation-and-dedup logic, not a blanket per-run
-  ping: only newly appearing findings message the maintainer route, and only once until they resolve.
+- If any check is `warn` or `fail`, return the full twenty-four-line summary. Notification is
+  governed by step 5's escalation-and-dedup logic, not a blanket per-run ping: only newly appearing
+  findings notify the selected route, and only once until they resolve.
 
 ## What each check looks at
 

--- a/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
@@ -10,6 +10,13 @@ is the only one that performs outbound API calls — see Notes) and surfaces the
 to run at any time. Produces no side effects beyond writing
 `.claude-code-hermit/state/doctor-report.json` and appending a summary block to SHELL.md.
 
+## Invocation mode
+
+- **Manual (no arguments):** return the report only to the invoking conversation. Do not send a
+  second proactive notification, even when a maintainer channel is configured.
+- **Automated (`--maintainer`):** run the same checks and persistence steps, but route newly-failing
+  findings as one maintainer-tier notification. This is the mode used by the default doctor routine.
+
 ## Steps
 
 1. Run the check script:
@@ -51,22 +58,29 @@ to run at any time. Produces no side effects beyond writing
    HERMIT_ALERT_JSON
    ```
 
-   **Channel message — only when `new_entries` is non-empty.** Send one message covering all
-   newly-failing checks, in plain language with a named next action, no PROP-/S-NNN vocabulary,
-   no raw check ids, no slash commands (per the Channel voice rule in `CLAUDE-APPEND.md`). Example:
-   "I can't reach Telegram — the bot token was rejected. Regenerate it with @BotFather, then ask
-   your consultant to re-pair the channel." A check already alerted (its `doctor:<id>` key still
-   present) stays silent on subsequent runs until it resolves — resolving just deletes the key,
-   there is no "recovered" ping in v1.
+   **Maintainer notification — only with `--maintainer` and non-empty `new_entries`.** Compose one
+   complete, concise technical summary covering every newly-failing check, its detail, and a named
+   next action, in the operator's configured language. Deliver it through the canonical notice path:
+   ```bash
+   bun ${CLAUDE_PLUGIN_ROOT}/scripts/channel-send.ts .claude-code-hermit --notice
+   ```
+   with `{"maintainer": "<complete technical summary>"}` on stdin. Never include a `client` leg.
+   The router owns fallback: no configured maintainer chat on a technical install falls back to the
+   primary chat; a non-technical install falls back to SHELL.md Findings. Follow § Operator
+   Notification if no channel is available or delivery degrades.
+
+   Without `--maintainer`, do not call `channel-send.ts` — step 4 is the requested reply. A check
+   already alerted (its `doctor:<id>` key still present) stays silent on subsequent automated runs
+   until it resolves. Resolving just deletes the key; there is no "recovered" ping in v1.
 
 ## Silence policy
 
 - If every check is `ok`, return only: `All twenty-four checks passed.` Do not notify via
   channel (Tier 0). Still resolve any stale `doctor:*` alert-state keys (step 5) and still
   append to SHELL.md so the run is traceable.
-- If any check is `warn` or `fail`, return the full twenty-four-line summary. Channel notification
-  is governed by step 5's escalation-and-dedup logic, not a blanket per-run ping: only newly
-  appearing findings message the channel, and only once until they resolve.
+- If any check is `warn` or `fail`, return the full twenty-four-line summary. In `--maintainer`
+  mode, notification is governed by step 5's escalation-and-dedup logic, not a blanket per-run
+  ping: only newly appearing findings message the maintainer route, and only once until they resolve.
 
 ## What each check looks at
 

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -15,7 +15,13 @@ Every run of this skill (interactive or unattended) delegates steps 0–9 to the
 
 - **If you are running AS the `evolve-runner` subagent**, skip this section and execute steps 0–9 directly (you are the delegate — do not re-dispatch).
 - **Otherwise (main loop, any mode):**
-  1. **Determine the mode** and remember it for step 10: positional argument `unattended`, or running in an always-on session invoked via channel ⇒ *unattended*; else *interactive*.
+  1. **Determine execution and delivery separately** and remember both for step 10:
+     - Positional argument `unattended` ⇒ execution *unattended*, delivery *automated-maintainer*.
+     - No `unattended` argument + an inbound `<channel source="...">` tag ⇒ execution *unattended*
+       (never block on `AskUserQuestion`), delivery *direct-channel-reply*.
+     - Otherwise ⇒ execution *interactive*, delivery *inline*.
+     Only the explicit `unattended` argument authorizes a proactive maintainer notification. A
+     direct channel request must answer the channel that invoked it.
   2. **Bake the absolute plugin root** to thread to the subagent (it cannot resolve it itself — the bare env var `$CLAUDE_PLUGIN_ROOT` is **not** set at Bash runtime, and the value is empty inside subagents). Derive it from this skill's **Base directory**, which the harness injects in the skill invocation context as `<plugin_root>/skills/hermit-evolve`: strip the trailing `/skills/hermit-evolve` to get `plugin_root`. This works in both installed and `--plugin-dir` modes. (In installed mode this equals the harness's `${CLAUDE_PLUGIN_ROOT}` substitution, which step 1 relies on; the Base-directory derivation is the mode-independent source.) **Guard:** confirm both `test -f "<plugin_root>/skills/hermit-evolve/SKILL.md"` and `test -f "<plugin_root>/skills/hermit-evolve/reference.md"` — the subagent reads `reference.md` for steps 0–9, so a missing reference file is just as fatal as a missing SKILL.md. If either fails, **abort** — log `"hermit-evolve aborted: plugin root unresolved; cannot dispatch evolve-runner."` and stop. Do not dispatch with a broken path.
   3. **Dispatch** the `claude-code-hermit:evolve-runner` subagent via the Agent tool. Pass the baked absolute plugin root and the report contract (below). Do **not** execute steps 0–9 yourself.
   4. **Go to step 10** with the subagent's returned report.
@@ -25,7 +31,7 @@ Every run of this skill (interactive or unattended) delegates steps 0–9 to the
 Steps 0–9 (in `reference.md`, read only by the `evolve-runner` subagent) are executed with no `AskUserQuestion` — the subagent cannot pause to ask. Each step's **"Delegated mode:"** note states the non-interactive behavior. The rule in every case: never guess on a destructive choice, never block.
 
 - For any interactive choice with a safe non-destructive default (new settings, file deletions, `## Plan` strip, template conflicts), take the default silently and report it.
-- For a genuine either/or with **no safe default** (an `### Upgrade Instructions` migration step in 2b/7), **defer**: skip that step and record a verbatim deferred-migration block in the report (see the report contract in step 10). Never guess. Step 10 resolves it — interactive asks the operator, unattended relays it to the channel.
+- For a genuine either/or with **no safe default** (an `### Upgrade Instructions` migration step in 2b/7), **defer**: skip that step and record a verbatim deferred-migration block in the report (see the report contract in step 10). Never guess. Step 10 resolves it — interactive asks the operator; direct-channel and automated-maintainer execution relay it through their respective delivery routes.
 
 ### 10. Report
 
@@ -62,14 +68,18 @@ Deferred for operator: <none | one or more verbatim blocks, each:>
 
 **Sibling report integrity:** parse the finalizer JSON `siblings_confirmed` and `siblings_skipped`. Only names in `siblings_confirmed` may be reported as `vOLD->vNEW`. Any name in `siblings_skipped` must be reported as `SKIPPED-by-finalizer` — never as upgraded, even if Step 7 said it ran.
 
-**Failure fallback.** If the Agent call returned null/empty (subagent died — same partial-state risk as an in-loop failure), report "evolve delegation failed — run `/claude-code-hermit:hermit-evolve` manually" and fire that as the channel notification. Stop.
+**Failure fallback.** If the Agent call returned null/empty (subagent died — same partial-state risk
+as an in-loop failure), report "evolve delegation failed — run
+`/claude-code-hermit:hermit-evolve` manually". In automated-maintainer delivery, send that as a
+maintainer-only notice; in direct-channel or inline delivery, return it only to the invoking
+conversation. Stop.
 
 **Print the summary** from the report fields. Omit lines where nothing changed. End with "Run /claude-code-hermit:hermit-settings to adjust any settings." if settings were added.
 
-**Resolve deferrals by mode.** If "Deferred for operator" is non-empty:
-- **Interactive:** for each deferred-migration block, present its `instruction` + `options` to the operator via `AskUserQuestion`, then apply the chosen branch inline (this is the only place changelog/migration text re-enters the main loop, and only for the rare deferred step).
-- **Unattended:** relay each deferred block to the channel verbatim ("migration deferred for operator review: <source> — <instruction>"). **Do not apply — never run the migration's settings writes from this session.** If the deferred `instruction` text contains an explicit channel resolution stanza (a fenced `options: [...]` array and an `on_resolve: "..."` skill invocation with an `{answer}` placeholder — the CHANGELOG's artifact-publish-authorization migration is the current example), additionally queue a micro-proposal entry per `reflect` § Queuing procedure using that exact `options` and `on_resolve` (`tier: 1`, `"kind":"ask"` on the `micro-queued` event) and render the numbered options in the channel relay, so the operator's reply resolves it through `channel-responder` § Micro-approval response — the same bridge any other skill's bounded ask uses. An `on_resolve` reached this way may only alter hermit config/state, never `.claude/settings*.json` — a boot-time wrapper (e.g. `hermit-start`) applies any resulting permission grant out-of-session, never this session.
-- **Version-bump caveat (both modes):** the subagent already bumped `_hermit_versions` to `<to>` in step 9, having *skipped* the deferred migration. We keep that bump — withholding it would replay the whole oldest-first slice next evolve and double-apply non-idempotent migrations. So if an interactive apply **fails or the operator declines**, report loudly (summary + channel): "version already bumped to v`<to>`; migration `<source>` was NOT applied; apply manually: `<instruction>`" — otherwise a rerun-says-up-to-date would silently hide it. On success, report it applied.
+**Resolve deferrals by execution and delivery mode.** If "Deferred for operator" is non-empty:
+- **Interactive execution:** for each deferred-migration block, present its `instruction` + `options` to the operator via `AskUserQuestion`, then apply the chosen branch inline (this is the only place changelog/migration text re-enters the main loop, and only for the rare deferred step).
+- **Unattended execution:** relay each deferred block verbatim ("migration deferred for operator review: <source> — <instruction>") through the selected delivery route: direct reply for direct-channel delivery, maintainer-only notice for automated-maintainer delivery. **Do not apply — never run the migration's settings writes from this session.** If the deferred `instruction` text contains an explicit channel resolution stanza (a fenced `options: [...]` array and an `on_resolve: "..."` skill invocation with an `{answer}` placeholder — the CHANGELOG's artifact-publish-authorization migration is the current example), additionally queue a micro-proposal entry per `reflect` § Queuing procedure using that exact `options` and `on_resolve` (`tier: 1`, `"kind":"ask"` on the `micro-queued` event) and render the numbered options in the relay, so the operator's reply resolves it through `channel-responder` § Micro-approval response — the same bridge any other skill's bounded ask uses. An `on_resolve` reached this way may only alter hermit config/state, never `.claude/settings*.json` — a boot-time wrapper (e.g. `hermit-start`) applies any resulting permission grant out-of-session, never this session.
+- **Version-bump caveat (all delivery modes):** the subagent already bumped `_hermit_versions` to `<to>` in step 9, having *skipped* the deferred migration. We keep that bump — withholding it would replay the whole oldest-first slice next evolve and double-apply non-idempotent migrations. So if an interactive apply **fails or the operator declines**, report loudly through the selected delivery route: "version already bumped to v`<to>`; migration `<source>` was NOT applied; apply manually: `<instruction>`" — otherwise a rerun-says-up-to-date would silently hide it. On success, report it applied.
 
 **Docker rebuild notice.** From the report's `Docker entrypoint` / `Docker rebuild` fields, append a `Docker:` section when a rebuild is needed:
 - Entrypoint refreshed → "Docker entrypoint refreshed. Rebuild to apply: `.claude-code-hermit/bin/hermit-docker update`."
@@ -78,4 +88,20 @@ Deferred for operator: <none | one or more verbatim blocks, each:>
 - Baseline not recorded → "Docker template baseline not recorded. Run `/claude-code-hermit:docker-setup` once to arm the drift signal."
 - Never auto-rebuild.
 
-**Notify the operator** per CLAUDE-APPEND.md § Operator Notification with a condensed one-line message such as `"Hermit upgraded: vOLD → vNEW. N settings added, M templates refreshed."` Omit segments where nothing changed. **Append the deferred/auto-applied segments**: settings set to defaults (Step 4), permission entries added (Step 8), template conflicts parked as `.new` (Step 5), and any deferred migrations — so the operator can follow up via `/hermit-settings`.
+**Reconcile routines after a successful always-on upgrade.** If the report represents a completed
+upgrade (not blocked or already up to date) and the refreshed `config.json` has `always_on: true`,
+invoke `/claude-code-hermit:hermit-routines load`. This makes exact-match routine migrations active
+immediately in CronCreate fallback mode; Monitor mode is an idempotent re-arm. If reconciliation
+fails, append that failure and the manual `hermit-routines load` next action to the report.
+
+**Deliver the result.** Compose a condensed one-line message such as `"Hermit upgraded: vOLD → vNEW.
+N settings added, M templates refreshed."` Omit segments where nothing changed. **Append the
+deferred/auto-applied segments**: settings set to defaults (Step 4), permission entries added (Step
+8), template conflicts parked as `.new` (Step 5), and any deferred migrations — so the operator can
+follow up via `/hermit-settings`.
+
+- **Automated-maintainer:** deliver through `channel-send.ts --notice` with
+  `{"maintainer":"<complete condensed result>"}` on stdin and no `client` leg. Follow CLAUDE-APPEND.md
+  § Operator Notification fallback behavior.
+- **Direct-channel-reply or inline:** return the result only to the invoking conversation. Do not
+  send a second proactive notice.

--- a/plugins/claude-code-hermit/state-templates/config.json.template
+++ b/plugins/claude-code-hermit/state-templates/config.json.template
@@ -24,7 +24,7 @@
     {"id": "scheduled-checks",    "schedule": "5 9 * * *",  "skill": "claude-code-hermit:reflect --scheduled-checks",    "run_during_waiting": true, "enabled": true},
     {"id": "weekly-review",       "schedule": "0 23 * * 0", "skill": "claude-code-hermit:weekly-review",                "enabled": true},
     {"id": "daily-auto-close",    "schedule": "0 0 * * *",  "skill": "claude-code-hermit:session-close --scheduled", "model": "haiku", "run_during_waiting": true, "enabled": true},
-    {"id": "doctor",              "schedule": "10 9 * * 1", "skill": "claude-code-hermit:hermit-doctor",              "model": "haiku", "run_during_waiting": true, "enabled": true}
+    {"id": "doctor",              "schedule": "10 9 * * 1", "skill": "claude-code-hermit:hermit-doctor --maintainer", "model": "haiku", "run_during_waiting": true, "enabled": true}
   ],
   "monitors": [],
   "env": {

--- a/plugins/claude-code-hermit/tests/channel-send.test.ts
+++ b/plugins/claude-code-hermit/tests/channel-send.test.ts
@@ -242,16 +242,33 @@ describe('sendOperatorNotice tiering', () => {
   };
   const findings = (wd: Workdir) => fs.readFileSync(hermit(wd.dir, 'sessions', 'SHELL.md'), 'utf8');
 
-  test('maintainer target hit: same token, route maintainer_channel', async () => {
+  test('fallback:primary + maintainer target hit: same token, route maintainer_channel', async () => {
     const stub = startHttpStub();
     const wd = setupChannelWorkdir({ maintainer_channel_id: '99999' });
     try {
       const res = await withApi(stub.url, () =>
-        sendOperatorNotice(hermit(wd.dir), { maintainer: { text: 'MAINT', fallback: 'client' } }));
+        sendOperatorNotice(hermit(wd.dir), { maintainer: { text: 'MAINT', fallback: 'primary' } }));
       expect(res.maintainer).toMatchObject({ ok: true, route: 'maintainer_channel' });
       expect(stub.requests.length).toBe(1);
       expect(stub.requests[0].body.chat_id).toBe('99999');
       expect(stub.requests[0].path).toContain('bottest-token'); // same bot token as the client route
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
+  });
+
+  test('fallback:primary + non-technical + no maintainer channel -> primary chat', async () => {
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir({}, { operator_profile: 'non-technical' });
+    try {
+      const res = await withApi(stub.url, () =>
+        sendOperatorNotice(hermit(wd.dir), { maintainer: { text: 'DOCTOR ALERT', fallback: 'primary' } }));
+      expect(res.maintainer).toMatchObject({ ok: true, route: 'client', delivered: true });
+      expect(stub.requests.length).toBe(1);
+      expect(stub.requests[0].body.chat_id).toBe('12345');
+      expect(stub.requests[0].body.text).toBe('DOCTOR ALERT');
+      expect(findings(wd)).not.toContain('DOCTOR ALERT');
     } finally {
       stub.stop();
       wd.cleanup();
@@ -290,13 +307,13 @@ describe('sendOperatorNotice tiering', () => {
     }
   });
 
-  test('failed maintainer send -> Findings, never the client chat (fallback:client honored as intent)', async () => {
+  test('fallback:primary + failed maintainer send -> Findings, never the client chat', async () => {
     const stub = startHttpStub();
     stub.setStatus(500);
     const wd = setupChannelWorkdir({ maintainer_channel_id: '99999' });
     try {
       const res = await withApi(stub.url, () =>
-        sendOperatorNotice(hermit(wd.dir), { maintainer: { text: 'USD DETAIL', fallback: 'client' } }));
+        sendOperatorNotice(hermit(wd.dir), { maintainer: { text: 'USD DETAIL', fallback: 'primary' } }));
       // Degraded fallback: configured maintainer channel unreachable → delivered:false.
       expect(res.maintainer).toMatchObject({ ok: true, route: 'findings', suppressed: true, delivered: false });
       // Only the failed 500 to the maintainer chat — never a spill to the primary.
@@ -466,6 +483,24 @@ describe('channel-send CLI --notice', () => {
       expect(out.delivered).toBe(true);
       expect(stub.requests.length).toBe(0);
       expect(findings(wd)).toContain('SECRET DETAIL');
+    } finally {
+      stub.stop();
+      wd.cleanup();
+    }
+  });
+
+  test('fallback:primary, non-technical, no maintainer chat -> primary chat, exit 0', async () => {
+    const stub = startHttpStub();
+    const wd = setupChannelWorkdir({}, { operator_profile: 'non-technical' });
+    try {
+      const r = await runNotice(wd, { maintainer: 'DOCTOR ALERT', fallback: 'primary' }, stub);
+      expect(r.exitCode).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.delivered).toBe(true);
+      expect(stub.requests.length).toBe(1);
+      expect(stub.requests[0].body.chat_id).toBe('12345');
+      expect(stub.requests[0].body.text).toBe('DOCTOR ALERT');
+      expect(findings(wd)).not.toContain('DOCTOR ALERT');
     } finally {
       stub.stop();
       wd.cleanup();

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -2713,12 +2713,15 @@ describe('proactive-notify unification contract', () => {
     expect(step3).toContain('`maintainer` leg only (no `client` leg)');
   });
 
-  test('doctor manual and automated delivery modes stay distinct', () => {
+  test('doctor keeps legacy delivery while --maintainer changes only the route', () => {
     const doctor = read(path.join(SKILLS, 'hermit-doctor', 'SKILL.md'));
-    expect(doctor).toContain('Manual (no arguments)');
-    expect(doctor).toContain('Automated (`--maintainer`)');
-    expect(doctor).toContain('Never include a `client` leg');
-    expect(doctor).toContain('Without `--maintainer`, do not call `channel-send.ts`');
+    expect(doctor).toContain('Default (no arguments)');
+    expect(doctor).toContain('Maintainer (`--maintainer`)');
+    expect(doctor).toContain('The optional flag changes its destination, not whether doctor notifies');
+    expect(doctor).toContain('`{"client": "<complete summary>"}`');
+    expect(doctor).toContain('`{"maintainer": "<complete summary>", "fallback": "primary"}`');
+    expect(doctor).toContain('Deliver it exactly once');
+    expect(doctor).not.toContain('Without `--maintainer`, do not call `channel-send.ts`');
   });
 
   test('hermit-evolve uses explicit unattended as the maintainer delivery signal', () => {

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -2578,7 +2578,7 @@ describe('doctor routine template contract', () => {
     const routine = template.routines.find((r: any) => r.id === 'doctor');
     expect(routine).toBeDefined();
     expect(routine.schedule).toBe('10 9 * * 1');
-    expect(routine.skill).toBe('claude-code-hermit:hermit-doctor');
+    expect(routine.skill).toBe('claude-code-hermit:hermit-doctor --maintainer');
     expect(routine.enabled).toBe(true);
 
     const { errors, warnings } = validate(template);
@@ -2706,8 +2706,28 @@ describe('proactive-notify unification contract', () => {
   test('cost-reflect Step 3 (proactive) routes through --notice', () => {
     const costReflect = read(path.join(SKILLS, 'cost-reflect', 'SKILL.md'));
     const step3 = costReflect.slice(costReflect.indexOf('## Step 3'));
+    expect(costReflect).toContain('Automated (`--maintainer`)');
+    expect(costReflect).toContain('claude-code-hermit:cost-reflect --maintainer');
     expect(step3).toContain('channel-send.ts');
     expect(step3).toContain('--notice');
+    expect(step3).toContain('`maintainer` leg only (no `client` leg)');
+  });
+
+  test('doctor manual and automated delivery modes stay distinct', () => {
+    const doctor = read(path.join(SKILLS, 'hermit-doctor', 'SKILL.md'));
+    expect(doctor).toContain('Manual (no arguments)');
+    expect(doctor).toContain('Automated (`--maintainer`)');
+    expect(doctor).toContain('Never include a `client` leg');
+    expect(doctor).toContain('Without `--maintainer`, do not call `channel-send.ts`');
+  });
+
+  test('hermit-evolve uses explicit unattended as the maintainer delivery signal', () => {
+    const evolve = read(path.join(SKILLS, 'hermit-evolve', 'SKILL.md'));
+    expect(evolve).toContain('Only the explicit `unattended` argument authorizes a proactive maintainer notification');
+    expect(evolve).toContain('delivery *direct-channel-reply*');
+    expect(evolve).toContain('`{\"maintainer\":\"<complete condensed result>\"}`');
+    expect(evolve).toContain('no `client` leg');
+    expect(evolve).toContain('hermit-routines load');
   });
 
   test('weekly-review proactive delivery routes through --notice', () => {

--- a/plugins/claude-code-hermit/tests/hermit-start.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-start.test.ts
@@ -354,6 +354,12 @@ describe('config contract: template and DEFAULT_CONFIG must mirror', () => {
     expect(validTiers).toContain(template.quality_gate?.tier);
     expect(validTiers).toContain(DEFAULT_CONFIG.quality_gate?.tier);
   });
+
+  test('doctor routine uses explicit maintainer delivery in template and DEFAULT_CONFIG', () => {
+    const expected = 'claude-code-hermit:hermit-doctor --maintainer';
+    expect(template.routines.find((r: any) => r.id === 'doctor')?.skill).toBe(expected);
+    expect(DEFAULT_CONFIG.routines.find((r: any) => r.id === 'doctor')?.skill).toBe(expected);
+  });
 });
 
 // ============================================================
@@ -799,6 +805,53 @@ describe('applyAlwaysOnDoctorSchedule', () => {
     const config = { routines: [{ id: 'doctor', schedule: '10 9 * * *', enabled: true }] };
     applyAlwaysOnDoctorSchedule(config);
     expect(config.routines[0].schedule).toBe('10 9 * * *');
+  });
+
+  test('legacy default skill ratchets to explicit maintainer delivery', () => {
+    const config = {
+      routines: [{
+        id: 'doctor',
+        schedule: '10 9 * * *',
+        skill: 'claude-code-hermit:hermit-doctor',
+        model: 'haiku',
+        enabled: true,
+      }],
+    };
+    applyAlwaysOnDoctorSchedule(config);
+    expect(config.routines[0]).toEqual({
+      id: 'doctor',
+      schedule: '10 9 * * *',
+      skill: 'claude-code-hermit:hermit-doctor --maintainer',
+      model: 'haiku',
+      enabled: true,
+    });
+  });
+
+  test('maintainer skill ratchet is idempotent', () => {
+    const config = {
+      routines: [{
+        id: 'doctor',
+        schedule: '10 9 * * *',
+        skill: 'claude-code-hermit:hermit-doctor --maintainer',
+        enabled: true,
+      }],
+    };
+    applyAlwaysOnDoctorSchedule(config);
+    applyAlwaysOnDoctorSchedule(config);
+    expect(config.routines[0].skill).toBe('claude-code-hermit:hermit-doctor --maintainer');
+  });
+
+  test('custom doctor skill arguments are left untouched', () => {
+    const config = {
+      routines: [{
+        id: 'doctor',
+        schedule: '10 9 * * *',
+        skill: 'claude-code-hermit:hermit-doctor --custom',
+        enabled: true,
+      }],
+    };
+    applyAlwaysOnDoctorSchedule(config);
+    expect(config.routines[0].skill).toBe('claude-code-hermit:hermit-doctor --custom');
   });
 
   test('no doctor routine present does not throw', () => {


### PR DESCRIPTION
## Summary

- route automated doctor, evolve, and cost-reflect maintenance output through the maintainer notification tier
- keep manually invoked maintenance skills replying only in the conversation that requested them
- migrate only the untouched default doctor routine to `--maintainer` and re-arm routines after always-on upgrades

## Rationale

The doctor routine could send a plain-language health summary to the primary operator channel while also sending technical detail to the configured maintainer channel. Invocation origin should determine delivery: automated maintenance belongs on the maintainer route, while a person manually invoking a skill should receive its output where they asked for it. `operator_profile: technical` remains a fallback-routing choice, not a signal that manual output should be duplicated.

## Changes

- add explicit `--maintainer` behavior to `hermit-doctor` and `cost-reflect`
- distinguish automated unattended evolve delivery from direct channel and terminal invocation
- update the default doctor routine and exact-match boot migration without modifying customized skill arguments
- reload routines after successful always-on upgrades so migrated invocations take effect
- add contract and migration regression coverage

## Verification

- `bun test tests/hermit-start.test.ts tests/contracts.test.ts tests/channel-send.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `git diff --staged --check`
