### PR TITLE
fix(claude-code-hermit): report Docker preflight failures

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- `hermit-docker` no longer exits silently when its running-container probe finds no `hermit` service or Docker Compose itself fails; stopped stacks get start guidance, while probe failures surface a bounded Docker error.
 - A trusted channel `/model <arg>` or `/effort <arg>` no longer stalls on Claude Code's cached-context confirmation. A bounded check runs after the Stop hook returns, tolerates blank renderer rows, and confirms only the command-specific dialog still active at the bottom of the pane; direct switches and stale confirmations in scrollback never receive an extra keypress.
 - The watchdog now recognizes a live native permission/Ask modal even when `tmux capture-pane` includes blank terminal rows below it, while stale modal text followed by even a few lines of progress no longer suppresses recovery.
 - Routine Monitor registration now carries the narrow `routine-monitor.sh` permission grant and passes an absolute state path, avoiding Claude Code's `simple_expansion` approval so configured monitors can start unattended.

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -52,9 +52,13 @@ _oauth_hint() {
 }
 
 _require_running() {
-  local running
-  running="$(cd "$PROJECT_DIR" && "${DC[@]}" ps --status running --format '{{.Service}}' 2>/dev/null | grep -x "$SERVICE")"
-  if [ -z "$running" ]; then
+  local services
+  if ! services="$(cd "$PROJECT_DIR" && "${DC[@]}" ps --status running --format '{{.Service}}' 2>&1)"; then
+    echo "[hermit] Could not query Docker Compose for running services." >&2
+    printf '%s\n' "$services" | awk 'NR <= 5 { print substr($0, 1, 300) }' >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$services" | grep -qx "$SERVICE"; then
     echo "[hermit] Container is not running. Start it first:" >&2
     echo "  .claude-code-hermit/bin/hermit-docker up" >&2
     exit 1

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -215,6 +215,126 @@ describe('static file checks', () => {
 });
 
 // -------------------------------------------------------
+// hermit-docker running-container gate (stubbed Docker)
+// -------------------------------------------------------
+
+describe('hermit-docker running-container gate', () => {
+  function fixture(mode: 'running' | 'stopped' | 'failed') {
+    const wd = setupWorkdir();
+    const proj = wd.dir;
+    const binDir = hermit(proj, 'bin');
+    const stateDir = hermit(proj, 'state');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    for (const name of ['hermit-docker', 'hermit-attach']) {
+      const dest = path.join(binDir, name);
+      fs.copyFileSync(path.join(PLUGIN_ROOT, 'state-templates', 'bin', name), dest);
+      fs.chmodSync(dest, 0o755);
+    }
+
+    write(hermit(proj, 'config.json'), JSON.stringify({
+      tmux_session_name: 'hermit-{project_name}',
+    }));
+    write(path.join(stateDir, 'runtime.json'), JSON.stringify({
+      runtime_mode: 'docker',
+      tmux_session: `hermit-${path.basename(proj)}`,
+    }));
+    write(path.join(proj, 'docker-compose.hermit.yml'), 'services:\n  hermit:\n    image: test\n');
+    write(path.join(proj, 'docker-compose.security.yml'), 'services:\n  hermit:\n    environment: []\n');
+
+    const stubDir = path.join(proj, '.stub');
+    const callsFile = path.join(stubDir, 'docker-calls.txt');
+    fs.mkdirSync(stubDir, { recursive: true });
+    write(path.join(stubDir, 'docker'), `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_STUB_CALLS"
+if [[ " $* " == *" ps --status running "* ]]; then
+  case "$DOCKER_STUB_MODE" in
+    running) printf 'hermit\n'; exit 0 ;;
+    stopped) printf 'hermit-netguard\n'; exit 0 ;;
+    failed)
+      for i in 1 2 3 4 5 6 7; do
+        printf 'probe-line-%s:%0400d\n' "$i" 0 >&2
+      done
+      exit 23
+      ;;
+  esac
+fi
+exit 0
+`);
+    fs.chmodSync(path.join(stubDir, 'docker'), 0o755);
+
+    return {
+      wd,
+      proj,
+      callsFile,
+      env: {
+        PATH: `${stubDir}:${process.env.PATH}`,
+        DOCKER_STUB_CALLS: callsFile,
+        DOCKER_STUB_MODE: mode,
+      },
+    };
+  }
+
+  test('running service reaches the configured tmux session', async () => {
+    const f = fixture('running');
+    try {
+      const r = await runBash(hermit(f.proj, 'bin', 'hermit-docker'), {
+        args: ['attach'],
+        cwd: f.proj,
+        env: f.env,
+      });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain(`[hermit] Attaching to tmux session: hermit-${path.basename(f.proj)}`);
+      const calls = fs.readFileSync(f.callsFile, 'utf8');
+      expect(calls).toContain('ps --status running --format {{.Service}}');
+      expect(calls).toContain(`exec hermit tmux attach -t hermit-${path.basename(f.proj)}`);
+    } finally {
+      f.wd.cleanup();
+    }
+  });
+
+  test('stopped service prints start guidance through both attach entrypoints', async () => {
+    const f = fixture('stopped');
+    try {
+      for (const name of ['hermit-docker', 'hermit-attach']) {
+        const r = await runBash(hermit(f.proj, 'bin', name), {
+          args: name === 'hermit-docker' ? ['attach'] : [],
+          cwd: f.proj,
+          env: f.env,
+        });
+        expect(r.exitCode).toBe(1);
+        expect(r.stderr).toContain('[hermit] Container is not running. Start it first:');
+        expect(r.stderr).toContain('.claude-code-hermit/bin/hermit-docker up');
+        expect(r.stderr).not.toContain('Could not query Docker Compose');
+      }
+    } finally {
+      f.wd.cleanup();
+    }
+  });
+
+  test('failed Compose probe prints a bounded underlying cause', async () => {
+    const f = fixture('failed');
+    try {
+      const r = await runBash(hermit(f.proj, 'bin', 'hermit-docker'), {
+        args: ['attach'],
+        cwd: f.proj,
+        env: f.env,
+      });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toContain('[hermit] Could not query Docker Compose for running services.');
+      expect(r.stderr).not.toContain('Container is not running');
+      const diagnosticLines = r.stderr.split('\n').filter(line => line.startsWith('probe-line-'));
+      expect(diagnosticLines).toHaveLength(5);
+      expect(diagnosticLines.every(line => line.length <= 300)).toBe(true);
+      expect(r.stderr).not.toContain('probe-line-6:');
+    } finally {
+      f.wd.cleanup();
+    }
+  });
+});
+
+// -------------------------------------------------------
 // hermit-update (host path, stubbed claude/tmux)
 // -------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Prevent `hermit-docker` from exiting silently when its running-container preflight finds no `hermit` service or Docker Compose itself fails.

## Changes

- handle the Compose service query explicitly under `set -euo pipefail`
- retain the existing start guidance for stopped containers
- surface a bounded five-line, 300-character-per-line diagnostic for Compose failures
- cover running, stopped, failed-probe, and Docker-mode `hermit-attach` delegation paths

## Test plan

- `bun test tests/scripts.test.ts` — 375 passed
- `bun test` — 3,390 passed across 120 files
- `bunx tsc --noEmit`
- `bash -n plugins/claude-code-hermit/state-templates/bin/hermit-docker`
