### PR TITLE
fix(claude-code-hermit): give doctor's dedup a ledger it actually writes

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -6,6 +6,9 @@
 - The `reflect` doctor check is informational and never warns. It reports run count, empty rate, output split into proposals and micro-proposals, and the judge suppress mix by code, instead of flagging a high empty rate as an "unproductive loop".
 ### Fixed
 - The `docker-security` doctor check no longer reports a permanent `warn` on dockerized hermits. `docker compose config` verification is skipped when the check runs inside the container, where the docker CLI does not exist; the presence cross-reference still applies.
+- `/hermit-doctor` no longer re-notifies the same standing finding on every run. Its escalation write had been silently discarded since v1.2.25, so no `doctor:<id>` key was ever recorded and every failing check read as new. Findings now live in `state/doctor-alerts.json`, derived by `doctor-check.ts` instead of authored by the model, and one whose delivery failed is re-offered on the next run rather than counted as sent.
+- Heartbeat retires leftover `doctor:*` entries written into `alert-state.json` by v1.2.17–v1.2.24. Those entries used to age out into a `Heartbeat: resolved — undefined` line in SHELL.md.
+- `state/doctor-report.json` is written through a PID-specific temp file, so two overlapping doctor runs cannot interleave into it.
 
 ## [1.2.36] - 2026-07-30
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `/hermit-doctor` no longer re-notifies the same standing finding on every run. Its escalation write had been silently discarded since v1.2.25, so no `doctor:<id>` key was ever recorded and every failing check read as new. Findings now live in `state/doctor-alerts.json`, derived by `doctor-check.ts` instead of authored by the model, and one whose delivery failed is re-offered on the next run rather than counted as sent.
 - Heartbeat retires leftover `doctor:*` entries written into `alert-state.json` by v1.2.17–v1.2.24. Those entries used to age out into a `Heartbeat: resolved — undefined` line in SHELL.md.
 - `state/doctor-report.json` is written through a PID-specific temp file, so two overlapping doctor runs cannot interleave into it.
+- The alert-state files (`alert-state.json`, `budget-alerts.json`, `telemetry-alert.json`, `doctor-alerts.json`) are written `0600` instead of inheriting the umask, so the `permissions` doctor check no longer reports a `warn` that a `chmod` cannot fix.
 
 ## [1.2.36] - 2026-07-30
 

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -1734,6 +1734,10 @@ const NO_ESCALATION = (prior_state_known: boolean): DoctorEscalation =>
 function escalate(checks: Json[], nowIso: string, dir: string = hermitDir): DoctorEscalation {
   try {
     const p = doctorAlertsPath(dir);
+    // writeReport creates state/ too, but it runs *after* this — without the mkdir a hermit
+    // whose state dir is missing gets persisted:false and the skill suppresses the whole
+    // notification, exactly on the broken install where the findings matter most.
+    try { fs.mkdirSync(path.dirname(p), { recursive: true }); } catch { /* write below reports the failure */ }
     const failing = new Map<string, Json>();
     for (const c of checks) {
       if (c?.status === 'warn' || c?.status === 'fail') failing.set(DOCTOR_PREFIX + c.id, c);
@@ -1787,7 +1791,12 @@ function escalate(checks: Json[], nowIso: string, dir: string = hermitDir): Doct
 // Flip `notified` on findings the caller confirmed reached the operator. Mirrors
 // cost-tracker.ts's `--mark-budget-notified` verb. Unknown ids are ignored.
 function markNotified(ids: string[], dir: string = hermitDir): boolean {
-  return mutateOwnedAlerts(doctorAlertsPath(dir), (alerts) => {
+  const p = doctorAlertsPath(dir);
+  // Only confirm against a ledger we could actually read. mutateOwnedAlerts would happily
+  // quarantine a corrupt file, rebuild it empty and report success — dropping the episodes
+  // just announced, so the next run reads them as new and re-notifies. Report false instead.
+  if (readAlertState(p).kind !== 'ok') return false;
+  return mutateOwnedAlerts(p, (alerts) => {
     for (const id of ids) {
       const entry = alerts[DOCTOR_PREFIX + id];
       if (entry && entry.notified !== true) entry.notified = true;

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -16,6 +16,7 @@ import { getEnabledChannels, isContainer } from './hermit-start';
 import { readChannelToken } from './lib/channel-token';
 import { siblingPluginDirs, versionedCacheCoreDir, readHermitMeta, readCoreName } from './lib/plugin-siblings';
 import { tokenModeActive, defaultConfigDir, credentialsFilePath, parkedCredentialsFilePath, CREDENTIALS_FILENAME } from './lib/setup-token';
+import { doctorAlertsPath, readAlertState, mutateOwnedAlerts, DOCTOR_PREFIX } from './lib/alert-state';
 
 type Json = any;
 
@@ -1706,17 +1707,107 @@ async function runAllChecks() {
   ];
 }
 
-function writeReport(checks: Json[]) {
+// ----------------- Escalation ledger (issue #690) -----------------
+//
+// Per-finding dedup lives in state/doctor-alerts.json, this script's own file.
+// It is NOT in alert-state.json: heartbeat's classifyTick rebuilds alerts{} from
+// prevAlerts ∪ firing, so a doctor key parked there ages out after two clean ticks.
+//
+// Deriving the transition here (rather than in SKILL.md prose, as before) is the
+// same correction #594 applied to heartbeat: the model renders and sends, it does
+// not decide what is new. `notified` is the two-phase flag from cost-tracker.ts —
+// set false on write, flipped true only once the send is confirmed, so a finding
+// raised while the channel is down is re-offered on the next run instead of lost.
+
+export interface DoctorEscalation {
+  persisted: boolean;
+  prior_state_known: boolean;
+  new: { id: string; status: string; detail: string }[];
+  resolved: string[];
+}
+
+const NO_ESCALATION = (prior_state_known: boolean): DoctorEscalation =>
+  ({ persisted: false, prior_state_known, new: [], resolved: [] });
+
+// `dir` defaults to the argv-derived hermitDir; tests pass their own so cases
+// stay isolated without reloading this module.
+function escalate(checks: Json[], nowIso: string, dir: string = hermitDir): DoctorEscalation {
+  try {
+    const p = doctorAlertsPath(dir);
+    const failing = new Map<string, Json>();
+    for (const c of checks) {
+      if (c?.status === 'warn' || c?.status === 'fail') failing.set(DOCTOR_PREFIX + c.id, c);
+    }
+
+    // Classify the prior ledger BEFORE mutating — mutateOwnedAlerts quarantines a
+    // corrupt file and rebuilds from empty, which is indistinguishable downstream
+    // from a first run and would re-notify every standing finding. `missing` is a
+    // genuine first run: an empty ledger is a trustworthy prior (nothing was sent).
+    const prior = readAlertState(p);
+    if (prior.kind === 'ioerror') return NO_ESCALATION(false); // healthy file we couldn't read — touch nothing
+    const priorStateKnown = prior.kind !== 'corrupt';
+
+    const pending: { id: string; status: string; detail: string }[] = [];
+    const resolved: string[] = [];
+    const applied = mutateOwnedAlerts(p, (alerts) => {
+      for (const [key, c] of failing) {
+        const prev = alerts[key];
+        alerts[key] = prev
+          ? { ...prev, status: c.status, message: c.detail, last_seen: nowIso,
+              count: (typeof prev.count === 'number' ? prev.count : 0) + 1 }
+          : { first_seen: nowIso, last_seen: nowIso, status: c.status, message: c.detail,
+              suppressed: false, notified: false, count: 1 };
+        // Anything not yet confirmed delivered is still owed to the operator.
+        if (alerts[key].notified !== true) pending.push({ id: c.id, status: c.status, detail: c.detail });
+      }
+      for (const key of Object.keys(alerts)) {
+        if (key.startsWith(DOCTOR_PREFIX) && !failing.has(key)) {
+          delete alerts[key];
+          resolved.push(key.slice(DOCTOR_PREFIX.length));
+        }
+      }
+    });
+    if (!applied) return NO_ESCALATION(priorStateKnown);
+
+    // On a rebuilt-from-corrupt ledger the entries were re-seeded above (so the
+    // next run dedups normally), but this run stays silent — we cannot know what
+    // the lost ledger had already announced.
+    return {
+      persisted: true,
+      prior_state_known: priorStateKnown,
+      new: priorStateKnown ? pending : [],
+      resolved: priorStateKnown ? resolved : [],
+    };
+  } catch (e: any) {
+    process.stderr.write(`[doctor-check] escalation failed: ${e.message}\n`);
+    return NO_ESCALATION(false);
+  }
+}
+
+// Flip `notified` on findings the caller confirmed reached the operator. Mirrors
+// cost-tracker.ts's `--mark-budget-notified` verb. Unknown ids are ignored.
+function markNotified(ids: string[], dir: string = hermitDir): boolean {
+  return mutateOwnedAlerts(doctorAlertsPath(dir), (alerts) => {
+    for (const id of ids) {
+      const entry = alerts[DOCTOR_PREFIX + id];
+      if (entry && entry.notified !== true) entry.notified = true;
+    }
+  });
+}
+
+function writeReport(checks: Json[], escalation?: DoctorEscalation) {
   try {
     if (!fs.existsSync(stateDir)) fs.mkdirSync(stateDir, { recursive: true });
-    const report = { ts: new Date().toISOString(), checks };
-    const tmp = reportPath + '.tmp';
+    const report = { ts: new Date().toISOString(), checks, ...(escalation ? { escalation } : {}) };
+    // PID-specific tmp so two overlapping runs can't interleave into one file
+    // (matches lib/alert-state.ts's writeAlertState).
+    const tmp = `${reportPath}.${process.pid}.tmp`;
     fs.writeFileSync(tmp, JSON.stringify(report, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
     fs.renameSync(tmp, reportPath);
     return report;
   } catch (e: any) {
     process.stderr.write(`[doctor-check] write failed: ${e.message}\n`);
-    return { ts: new Date().toISOString(), checks };
+    return { ts: new Date().toISOString(), checks, ...(escalation ? { escalation } : {}) };
   }
 }
 
@@ -1728,13 +1819,21 @@ export {
   checkCredentialExpiry, checkModelPricingKnown, checkContextScan, checkChannelLiveness,
   satisfiesRange, cidrOverlap,
   // runAllChecks is async (checkChannelLiveness performs network I/O) — callers must await it.
-  runAllChecks, writeReport,
+  runAllChecks, writeReport, escalate, markNotified,
 };
 
 if (import.meta.main) {
   try {
+    // `doctor-check.ts <dir> --mark-notified <id>…` — confirm delivery of findings
+    // the caller already sent, so they stop being re-offered. No checks are run.
+    if (process.argv[3] === '--mark-notified') {
+      const ok = markNotified(process.argv.slice(4));
+      process.stdout.write(JSON.stringify({ marked: ok }) + '\n');
+      process.exit(0);
+    }
     const checks = await runAllChecks();
-    const report = writeReport(checks);
+    const escalation = escalate(checks, new Date().toISOString());
+    const report = writeReport(checks, escalation);
     // Print the report JSON so skills/tests can capture it without re-reading.
     process.stdout.write(JSON.stringify(report, null, 2) + '\n');
   } catch (e: any) {

--- a/plugins/claude-code-hermit/scripts/lib/alert-state.ts
+++ b/plugins/claude-code-hermit/scripts/lib/alert-state.ts
@@ -75,7 +75,11 @@ export function quarantineAlertState(p: string, stamp: number): void {
 export function writeAlertState(p: string, obj: Json): boolean {
   try {
     const tmp = `${p}.${process.pid}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + '\n', 'utf-8');
+    // 0600 like doctor-check's writeReport: doctor's own `permissions` check warns on any
+    // world-readable state/*.json, and these files are rewritten on every tick — a default
+    // 0644 creation makes that warn permanent and un-chmod-able.
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
+    fs.chmodSync(tmp, 0o600); // mode is only honored on create; a reused tmp path would keep its old bits
     fs.renameSync(tmp, p);
     return true;
   } catch { return false; /* fail-open */ }

--- a/plugins/claude-code-hermit/scripts/lib/alert-state.ts
+++ b/plugins/claude-code-hermit/scripts/lib/alert-state.ts
@@ -13,10 +13,15 @@
 //   - budget-alerts.json   — budget-* alerts (cost-tracker, Stop hook — sole writer)
 //   - telemetry-alert.json — the telemetry export-failed alert (report-export,
 //                            watchdog tick — sole writer)
-// Each of the latter two has exactly one writer process, so the plain atomic
+//   - doctor-alerts.json   — doctor:* finding episodes (doctor-check — sole writer).
+//                            Split out because heartbeat's classifyTick rebuilds
+//                            alerts{} from prevAlerts ∪ firing, so a doctor key
+//                            parked in alert-state.json ages out after two clean
+//                            ticks (issue #690).
+// Each of the latter three has exactly one writer process, so the plain atomic
 // tmp+rename write needs no lock. Generic readers that want "all alerts" call
-// readMergedAlerts() to union the three files (keyspaces are disjoint by
-// construction: checklist / budget-* / telemetry:*).
+// readMergedAlerts() to union the four files (keyspaces are disjoint by
+// construction: checklist / budget-* / telemetry:* / doctor:*).
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -33,6 +38,9 @@ export function budgetAlertsPath(stateDir: string): string {
 }
 export function telemetryAlertPath(stateDir: string): string {
   return path.join(stateDir, 'state', 'telemetry-alert.json');
+}
+export function doctorAlertsPath(stateDir: string): string {
+  return path.join(stateDir, 'state', 'doctor-alerts.json');
 }
 
 export const defaultAlertState = (): Json =>
@@ -74,14 +82,14 @@ export function writeAlertState(p: string, obj: Json): boolean {
 }
 
 /**
- * Union of alert entries across the three per-writer files, for generic readers
+ * Union of alert entries across the four per-writer files, for generic readers
  * (dashboard, cost-summary, telemetry bundle, the heartbeat budget scan) that
  * want the full alert view. Later files win on a key collision, but the keyspaces
  * are disjoint by construction. Unreadable/corrupt/missing files contribute nothing.
  */
 export function readMergedAlerts(stateDir: string): Json {
   const merged: Json = {};
-  for (const p of [alertStatePath(stateDir), budgetAlertsPath(stateDir), telemetryAlertPath(stateDir)]) {
+  for (const p of [alertStatePath(stateDir), budgetAlertsPath(stateDir), telemetryAlertPath(stateDir), doctorAlertsPath(stateDir)]) {
     const r = readAlertState(p);
     if (r.kind === 'ok' && r.value?.alerts && typeof r.value.alerts === 'object') {
       Object.assign(merged, r.value.alerts);
@@ -144,6 +152,13 @@ export const isStructuredKey = (key: string): boolean =>
 // no channel-silencing). Its model-phantom-drop is a separate exact-match check
 // in lib/heartbeat/alert-update.ts.
 export const STALE_KEY = 'stale-session';
+
+// doctor:* episodes live in doctor-alerts.json, written by doctor-check.ts alone.
+// Deliberately NOT in STRUCTURED_PREFIXES: those get id-scrubbing and first-fire
+// channel silencing, neither of which applies here. Heartbeat's only relationship
+// to this prefix is to purge v1.2.17–v1.2.24 residue out of alert-state.json
+// (see lib/heartbeat/alert-update.ts) — it never fires or resolves a doctor key.
+export const DOCTOR_PREFIX = 'doctor:';
 
 // Strip internal ids that must never reach the operator channel. The banned set
 // is the closed list in state-templates/CLAUDE-APPEND.md § Channel voice:

--- a/plugins/claude-code-hermit/scripts/lib/heartbeat/alert-update.ts
+++ b/plugins/claude-code-hermit/scripts/lib/heartbeat/alert-update.ts
@@ -24,7 +24,7 @@ import path from 'node:path';
 import {
   readAlertState, defaultAlertState, quarantineAlertState, writeAlertState,
   classifyTick, deriveMicroPendingKeys, deriveProposalPendingKeys, deriveStaleSession, FiringItem,
-  MICRO_PREFIX, PROPOSAL_PREFIX, STALE_KEY, isStructuredKey,
+  MICRO_PREFIX, PROPOSAL_PREFIX, STALE_KEY, DOCTOR_PREFIX, isStructuredKey,
 } from '../alert-state';
 import { currentHHMM, todayYMD, resolveHermitNowMs, parseDuration } from '../time';
 
@@ -79,7 +79,9 @@ function apply(payloadJson: string): void {
 
   const validated = validateFiring(payload.firing);
   if (validated === null) process.exit(0); // malformed firing shape — reject the tick, no write
-  const modelFiring = validated.filter(f => !isStructuredKey(f.key) && f.key !== STALE_KEY);
+  const modelFiring = validated.filter(
+    f => !isStructuredKey(f.key) && f.key !== STALE_KEY && !f.key.startsWith(DOCTOR_PREFIX),
+  );
 
   const selfEvalUpdates: Json =
     payload.self_eval_updates && typeof payload.self_eval_updates === 'object' && !Array.isArray(payload.self_eval_updates)
@@ -124,6 +126,16 @@ function apply(payloadJson: string): void {
   // refactor exists to prevent) — freeze them untouched instead.
   const frozen: Json = {};
   const classifiable: Json = { ...prevAlerts };
+
+  // Retire doctor:* residue left in alert-state.json by v1.2.17–v1.2.24, when
+  // doctor's escalation payload was still honoured by this writer (issue #690).
+  // Dropped silently — no monitoring line, no notification, no resolution ping:
+  // those entries carry `detail` but neither `text` nor `suppressed`, so aging
+  // them through classifyTick emits a literal "resolved — undefined" into
+  // SHELL.md. doctor-check.ts owns this prefix now, in its own file.
+  for (const k of Object.keys(classifiable)) {
+    if (k.startsWith(DOCTOR_PREFIX)) delete classifiable[k];
+  }
   const freezePrefix = (prefix: string) => {
     for (const k of Object.keys(classifiable)) {
       if (k.startsWith(prefix)) { frozen[k] = classifiable[k]; delete classifiable[k]; }

--- a/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
@@ -8,12 +8,14 @@ description: Returns a twenty-four-check health report on the hermit installatio
 Runs twenty-four read-only health checks against the current hermit install (`channel-liveness`
 is the only one that performs outbound API calls — see Notes) and surfaces the summary. Safe
 to run at any time. Produces no side effects beyond writing
-`.claude-code-hermit/state/doctor-report.json` and appending a summary block to SHELL.md.
+`.claude-code-hermit/state/doctor-report.json` and `.claude-code-hermit/state/doctor-alerts.json`,
+and appending a summary block to SHELL.md.
 
 ## Notification route
 
-Every run with at least one newly-failing finding not already present in alert state sends exactly
-one notification.
+A finding gets one notification per unresolved episode: the check script records it, you send it
+once, and it stays silent until it resolves. A send that never reached the operator is re-offered
+on the next run rather than counted as delivered.
 The optional flag changes its destination, not whether doctor notifies:
 
 - **Default (no arguments):** send the notification to the primary operator chat. This preserves
@@ -47,26 +49,21 @@ The optional flag changes its destination, not whether doctor notifies:
 
 4. Return the twenty-four lines to the caller. Cap total output at 30 lines.
 
-5. **Escalation & dedup.** Build the failing set: every JSON check from step 2 with
-   `status: warn|fail`.
+5. **Escalation.** The script already computed this — do not recompute it, and do not write alert
+   state yourself. Read the `escalation` object from the step-1 JSON:
 
-   Read `.claude-code-hermit/state/alert-state.json` `alerts{}` and compute:
-   - `new_entries`: for each failing check whose `doctor:<id>` key is absent from `alerts{}` —
-     `{"doctor:<id>": {"first_seen": "<ISO now>", "status": "<warn|fail>", "detail": "<check detail>"}}`.
-   - `resolved_keys`: every existing `doctor:*` key in `alerts{}` whose check is now `ok` or no
-     longer present in the failing set.
+   - `escalation.new` — findings owed to the operator, each `{id, status, detail}`. Empty means
+     everything currently failing has already been announced; say nothing.
+   - `escalation.resolved` — check ids whose finding cleared. Recorded, never announced: there is
+     no "recovered" ping.
+   - `escalation.persisted: false` — the ledger could not be written. `prior_state_known: false` —
+     the ledger was unreadable and had to be rebuilt, so what was already announced is unknown.
+     **On either, send nothing** and record the findings under `## Findings` in SHELL.md instead;
+     a notification you cannot dedup would repeat every run.
 
-   Do not touch heartbeat-owned fields (`self_eval_updates`, `last_clean_eval_at`). If either
-   `new_entries` or `resolved_keys` is non-empty, persist via the same stdin API heartbeat uses:
-   ```bash
-   bun ${CLAUDE_PLUGIN_ROOT}/scripts/heartbeat.ts alert-state .claude-code-hermit/state/alert-state.json <<'HERMIT_ALERT_JSON'
-   {"new_entries": {...}, "updated_entries": {}, "resolved_keys": [...]}
-   HERMIT_ALERT_JSON
-   ```
-
-   **Notification — when `new_entries` is non-empty.** Compose one complete, concise summary covering
-   every newly-failing check, its detail, and a named next action, in the operator's configured
-   language. Deliver it exactly once through the canonical notice path:
+   **When `escalation.new` is non-empty.** Compose one complete, concise summary covering every
+   listed check, its detail, and a named next action, in the operator's configured language.
+   Deliver it once through the canonical notice path:
    ```bash
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/channel-send.ts .claude-code-hermit --notice
    ```
@@ -75,19 +72,24 @@ The optional flag changes its destination, not whether doctor notifies:
    - With `--maintainer`, send
      `{"maintainer": "<complete summary>", "fallback": "primary"}`. Do not include a `client` leg.
 
-   The router owns destination fallback and configured-destination failure handling. Follow
-   § Operator Notification if no channel is available or delivery degrades. A check already alerted
-   (its `doctor:<id>` key still present) stays silent on subsequent runs until it resolves.
-   Resolving just deletes the key; there is no "recovered" ping in v1.
+   **Then confirm delivery**, so those findings stop being re-offered — only when the send actually
+   landed (exit 0):
+   ```bash
+   bun ${CLAUDE_PLUGIN_ROOT}/scripts/doctor-check.ts .claude-code-hermit --mark-notified <id> [<id>…]
+   ```
+   Pass the `escalation.new[].id` values you just announced. If the send failed or degraded, skip
+   this step — leaving them unconfirmed is what makes the next run retry instead of dropping them.
+   For exit-code handling and the Findings fallback, follow
+   `/claude-code-hermit:channel-responder` § Outbound notification protocol.
 
 ## Silence policy
 
 - If every check is `ok`, return only: `All twenty-four checks passed.` Do not notify via
-  channel (Tier 0). Still resolve any stale `doctor:*` alert-state keys (step 5) and still
-  append to SHELL.md so the run is traceable.
+  channel (Tier 0). Still append to SHELL.md so the run is traceable. Clearing the stale
+  `doctor:*` entries is the script's job, not yours — it happens on every run.
 - If any check is `warn` or `fail`, return the full twenty-four-line summary. Notification is
-  governed by step 5's escalation-and-dedup logic, not a blanket per-run ping: only newly appearing
-  findings notify the selected route, and only once until they resolve.
+  governed by `escalation.new` (step 5), not a blanket per-run ping: only findings not yet
+  confirmed delivered notify the selected route.
 
 ## What each check looks at
 

--- a/plugins/claude-code-hermit/tests/alert-state-split.test.ts
+++ b/plugins/claude-code-hermit/tests/alert-state-split.test.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 
 import {
   mutateOwnedAlerts, readMergedAlerts, writeAlertState,
-  alertStatePath, budgetAlertsPath, telemetryAlertPath,
+  alertStatePath, budgetAlertsPath, telemetryAlertPath, doctorAlertsPath,
 } from '../scripts/lib/alert-state';
 
 function withRoot(fn: (dir: string) => void) {
@@ -22,18 +22,29 @@ function withRoot(fn: (dir: string) => void) {
 }
 
 describe('alert-state file split', () => {
-  test('budget, telemetry, and skill alerts coexist and merge', withRoot((dir) => {
+  test('budget, telemetry, doctor, and skill alerts coexist and merge', withRoot((dir) => {
     // skill alert in alert-state.json (heartbeat/update-alert-state territory)
     writeAlertState(alertStatePath(dir), { alerts: { 'stale-session': { suppressed: false } }, total_ticks: 7 });
     // budget alert in its own file (cost-tracker)
     mutateOwnedAlerts(budgetAlertsPath(dir), (a) => { a['budget-breach:daily:2026-07-05'] = { kind: 'budget', notified: false }; });
     // telemetry alert in its own file (report-export)
     mutateOwnedAlerts(telemetryAlertPath(dir), (a) => { a['telemetry:export-failed'] = { count: 3 }; });
+    // doctor finding episode in its own file (doctor-check — issue #690)
+    mutateOwnedAlerts(doctorAlertsPath(dir), (a) => { a['doctor:permissions'] = { status: 'warn', notified: false }; });
 
     const merged = readMergedAlerts(dir);
     expect(Object.keys(merged).sort()).toEqual([
-      'budget-breach:daily:2026-07-05', 'stale-session', 'telemetry:export-failed',
+      'budget-breach:daily:2026-07-05', 'doctor:permissions', 'stale-session', 'telemetry:export-failed',
     ]);
+  }));
+
+  test('a doctor write leaves the heartbeat-owned alert file untouched', withRoot((dir) => {
+    writeAlertState(alertStatePath(dir), { alerts: { 'stale-session': { suppressed: false } }, total_ticks: 7 });
+    const before = fs.readFileSync(alertStatePath(dir), 'utf-8');
+
+    mutateOwnedAlerts(doctorAlertsPath(dir), (a) => { a['doctor:permissions'] = { status: 'warn' }; });
+
+    expect(fs.readFileSync(alertStatePath(dir), 'utf-8')).toBe(before); // byte-identical
   }));
 
   test('writing the budget file never touches the telemetry file (no cross-clobber)', withRoot((dir) => {

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -2720,7 +2720,10 @@ describe('proactive-notify unification contract', () => {
     expect(doctor).toContain('The optional flag changes its destination, not whether doctor notifies');
     expect(doctor).toContain('`{"client": "<complete summary>"}`');
     expect(doctor).toContain('`{"maintainer": "<complete summary>", "fallback": "primary"}`');
-    expect(doctor).toContain('Deliver it exactly once');
+    // "exactly once" was an overclaim: dedup was persisted before the send, so a
+    // failed send was counted as delivered (issue #690). One attempt per episode,
+    // retried until confirmed, is the guarantee doctor can actually keep.
+    expect(doctor).toContain('Deliver it once through the canonical notice path');
     expect(doctor).not.toContain('Without `--maintainer`, do not call `channel-send.ts`');
   });
 
@@ -2795,6 +2798,37 @@ describe('heartbeat eval-runner return contract', () => {
   test('SKILL.md reads monitoring_lines/notifications/heartbeat_result from the script, not the subagent', () => {
     expect(skill).toContain('"monitoring_lines": [...], "notifications": [...], "heartbeat_result"');
     expect(skill).toContain("per the **script's** `heartbeat_result`");
+  });
+
+  // Issue #690: this guard used to read only heartbeat's two files, so when
+  // #594 stopped the writer accepting `new_entries`/`resolved_keys`,
+  // hermit-doctor kept sending exactly that payload — accepted, discarded,
+  // exit 0 — and doctor's dedup was dead for eleven releases. The invariant is
+  // ownership: alert-state.json has exactly one writer skill.
+  test('only skills/heartbeat/SKILL.md invokes heartbeat.ts alert-state', () => {
+    // Match the invocation form, not the bare phrase — heartbeat/reference.md
+    // mentions the verb in prose three times and must not trip this.
+    const INVOCATION = 'scripts/heartbeat.ts alert-state';
+    const offenders = fs.readdirSync(SKILLS)
+      .flatMap((d) => {
+        const skillDir = path.join(SKILLS, d);
+        if (!fs.statSync(skillDir).isDirectory()) return [];
+        return fs.readdirSync(skillDir)
+          .filter((f) => f.endsWith('.md'))
+          .filter((f) => read(path.join(skillDir, f)).includes(INVOCATION))
+          .map((f) => `${d}/${f}`);
+      });
+    expect(offenders).toEqual(['heartbeat/SKILL.md']);
+  });
+
+  test('hermit-doctor authors no alert-state bookkeeping fields', () => {
+    const doctor = read(path.join(SKILLS, 'hermit-doctor', 'SKILL.md'));
+    for (const field of ['new_entries', 'updated_entries', 'resolved_keys']) {
+      expect(doctor).not.toContain(field);
+    }
+    // …and consumes the script-derived verdict instead.
+    expect(doctor).toContain('escalation.new');
+    expect(doctor).toContain('--mark-notified');
   });
 });
 

--- a/plugins/claude-code-hermit/tests/doctor-escalation.test.ts
+++ b/plugins/claude-code-hermit/tests/doctor-escalation.test.ts
@@ -1,0 +1,219 @@
+// Doctor escalation ledger (issue #690).
+//
+// Before this, hermit-doctor's SKILL.md sent `{new_entries, updated_entries,
+// resolved_keys}` to `heartbeat.ts alert-state`, which has read only `firing`
+// since #594 — so the payload was silently discarded, no doctor:* key was ever
+// persisted, and every run re-notified every standing finding.
+//
+// The ledger now lives in doctor-alerts.json and is computed by doctor-check.ts.
+// These tests drive escalate()/markNotified() directly (the check suite itself is
+// covered elsewhere) plus one end-to-end pass through the CLI.
+
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { runScript, PLUGIN_ROOT } from './helpers/run';
+
+let dir: string;
+let hermit: string;
+let ledger: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-esc-'));
+  hermit = path.join(dir, '.claude-code-hermit');
+  fs.mkdirSync(path.join(hermit, 'state'), { recursive: true });
+  ledger = path.join(hermit, 'state', 'doctor-alerts.json');
+});
+
+afterEach(() => {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+// escalate()/markNotified() take an explicit hermit dir (defaulting to the
+// argv-derived one) so each case is isolated in its own tmpdir.
+const { escalate: escalateIn, markNotified: markNotifiedIn } =
+  await import(`${PLUGIN_ROOT}/scripts/doctor-check.ts`);
+const escalate = (checks: any[], nowIso: string) => escalateIn(checks, nowIso, hermit);
+const markNotified = (ids: string[]) => markNotifiedIn(ids, hermit);
+
+const check = (id: string, status: string, detail = `${id} detail`) => ({ id, status, detail });
+const readLedger = () => JSON.parse(fs.readFileSync(ledger, 'utf-8')).alerts;
+
+describe('escalate — episode lifecycle', () => {
+  test('first warn is new; unchanged second run is silent and preserves first_seen', async () => {
+
+    const checks = [check('permissions', 'warn'), check('runtime', 'ok')];
+
+    const first = escalate(checks, '2026-08-01T10:00:00Z');
+    expect(first.persisted).toBe(true);
+    expect(first.prior_state_known).toBe(true);
+    expect(first.new.map((n: any) => n.id)).toEqual(['permissions']);
+    expect(readLedger()['doctor:permissions'].first_seen).toBe('2026-08-01T10:00:00Z');
+
+    // Announced — confirm delivery, which is what makes the next run silent.
+    expect(markNotified(['permissions'])).toBe(true);
+
+    const second = escalate(checks, '2026-08-02T10:00:00Z');
+    expect(second.new).toEqual([]);
+    const entry = readLedger()['doctor:permissions'];
+    expect(entry.first_seen).toBe('2026-08-01T10:00:00Z'); // episode start preserved
+    expect(entry.last_seen).toBe('2026-08-02T10:00:00Z');
+    expect(entry.count).toBe(2);
+  });
+
+  test('an unconfirmed finding is re-offered until delivery is confirmed', async () => {
+
+    const checks = [check('permissions', 'warn')];
+
+    expect(escalate(checks, '2026-08-01T10:00:00Z').new).toHaveLength(1);
+    // No markNotified — the send failed or degraded.
+    expect(escalate(checks, '2026-08-02T10:00:00Z').new.map((n: any) => n.id)).toEqual(['permissions']);
+    expect(escalate(checks, '2026-08-03T10:00:00Z').new).toHaveLength(1);
+
+    markNotified(['permissions']);
+    expect(escalate(checks, '2026-08-04T10:00:00Z').new).toEqual([]);
+  });
+
+  test('detail change and warn->fail stay one episode, not a re-notification', async () => {
+
+    escalate([check('docker-security', 'warn', 'overlay missing')], '2026-08-01T10:00:00Z');
+    markNotified(['docker-security']);
+
+    const escalated = escalate([check('docker-security', 'fail', 'ports published')], '2026-08-02T10:00:00Z');
+    expect(escalated.new).toEqual([]); // same unresolved episode
+
+    const entry = readLedger()['doctor:docker-security'];
+    expect(entry.status).toBe('fail');          // status refreshed
+    expect(entry.message).toBe('ports published'); // detail refreshed
+    expect(entry.first_seen).toBe('2026-08-01T10:00:00Z');
+  });
+
+  test('resolution deletes the key and reports it; recurrence is new again', async () => {
+
+    escalate([check('permissions', 'warn')], '2026-08-01T10:00:00Z');
+    markNotified(['permissions']);
+
+    const cleared = escalate([check('permissions', 'ok')], '2026-08-02T10:00:00Z');
+    expect(cleared.resolved).toEqual(['permissions']);
+    expect(readLedger()['doctor:permissions']).toBeUndefined();
+
+    const again = escalate([check('permissions', 'warn')], '2026-08-03T10:00:00Z');
+    expect(again.new.map((n: any) => n.id)).toEqual(['permissions']);
+    expect(readLedger()['doctor:permissions'].first_seen).toBe('2026-08-03T10:00:00Z');
+  });
+
+  test('a check absent from the report entirely resolves its episode', async () => {
+
+    escalate([check('reflect', 'warn')], '2026-08-01T10:00:00Z');
+    markNotified(['reflect']);
+
+    // `reflect` became informational upstream and no longer reports warn.
+    const out = escalate([check('runtime', 'ok')], '2026-08-02T10:00:00Z');
+    expect(out.resolved).toEqual(['reflect']);
+    expect(readLedger()['doctor:reflect']).toBeUndefined();
+  });
+
+  test('markNotified ignores unknown ids without corrupting the ledger', async () => {
+
+    escalate([check('permissions', 'warn')], '2026-08-01T10:00:00Z');
+    expect(markNotified(['nonexistent-check'])).toBe(true);
+    expect(readLedger()['doctor:permissions'].notified).toBe(false);
+  });
+});
+
+describe('escalate — degraded prior state', () => {
+  test('missing ledger is a trustworthy prior: first run notifies', async () => {
+
+    expect(fs.existsSync(ledger)).toBe(false);
+    const out = escalate([check('permissions', 'warn')], '2026-08-01T10:00:00Z');
+    expect(out.prior_state_known).toBe(true);
+    expect(out.new).toHaveLength(1);
+  });
+
+  test('corrupt ledger re-seeds but emits nothing — it cannot know what was already sent', async () => {
+    fs.writeFileSync(ledger, '{ this is not json', 'utf-8');
+
+
+    const out = escalate([check('permissions', 'warn')], '2026-08-01T10:00:00Z');
+    expect(out.persisted).toBe(true);
+    expect(out.prior_state_known).toBe(false);
+    expect(out.new).toEqual([]); // silent this run
+    expect(out.resolved).toEqual([]);
+
+    // But the entry was re-seeded, so the NEXT run dedups normally rather than
+    // re-notifying forever.
+    expect(readLedger()['doctor:permissions']).toBeDefined();
+    const next = escalate([check('permissions', 'warn')], '2026-08-02T10:00:00Z');
+    expect(next.prior_state_known).toBe(true);
+    expect(next.new).toHaveLength(1); // owed: never confirmed delivered
+  });
+
+  test('unreadable ledger touches nothing and reports persisted:false', async () => {
+    fs.writeFileSync(ledger, JSON.stringify({ alerts: {} }), 'utf-8');
+    fs.chmodSync(ledger, 0o000);
+
+
+    try {
+      const out = escalate([check('permissions', 'warn')], '2026-08-01T10:00:00Z');
+      // Root ignores the mode bit; only assert when the read genuinely failed.
+      if (out.persisted === false) {
+        expect(out.new).toEqual([]);
+        expect(out.resolved).toEqual([]);
+      }
+    } finally {
+      fs.chmodSync(ledger, 0o600);
+    }
+  });
+});
+
+describe('escalate — file boundaries', () => {
+  test('doctor findings never touch alert-state.json', async () => {
+    const alertState = path.join(hermit, 'state', 'alert-state.json');
+    const seeded = JSON.stringify({ alerts: {}, last_digest_date: null, self_eval: {}, total_ticks: 3 }, null, 2) + '\n';
+    fs.writeFileSync(alertState, seeded, 'utf-8');
+
+
+    escalate([check('permissions', 'warn')], '2026-08-01T10:00:00Z');
+
+    expect(fs.readFileSync(alertState, 'utf-8')).toBe(seeded); // byte-identical
+    expect(readLedger()['doctor:permissions']).toBeDefined();
+  });
+
+  test('readMergedAlerts unions doctor entries with the other alert files', async () => {
+    const { readMergedAlerts } = await import(`${PLUGIN_ROOT}/scripts/lib/alert-state.ts`);
+    fs.writeFileSync(
+      path.join(hermit, 'state', 'alert-state.json'),
+      JSON.stringify({ alerts: { 'checklist-thing': { text: 'x' } } }),
+      'utf-8',
+    );
+    fs.writeFileSync(ledger, JSON.stringify({ alerts: { 'doctor:permissions': { message: 'world-readable' } } }), 'utf-8');
+
+    const merged = readMergedAlerts(hermit);
+    expect(Object.keys(merged).sort()).toEqual(['checklist-thing', 'doctor:permissions']);
+    expect(merged['doctor:permissions'].message).toBe('world-readable');
+  });
+});
+
+describe('doctor-check CLI', () => {
+  test('emits escalation in the report and --mark-notified silences the next run', async () => {
+    fs.writeFileSync(path.join(hermit, 'config.json'), JSON.stringify({ timezone: 'UTC' }), 'utf-8');
+    const run = async (...args: string[]) =>
+      await runScript('doctor-check.ts', { args: [hermit, ...args], cwd: dir });
+
+    const first = JSON.parse((await run()).stdout);
+    expect(Array.isArray(first.checks)).toBe(true);
+    expect(first.escalation).toBeDefined();
+    expect(first.escalation.persisted).toBe(true);
+
+    const firstIds = first.escalation.new.map((n: any) => n.id);
+    if (firstIds.length === 0) return; // a fully-green scratch install has nothing to assert
+
+    await run('--mark-notified', ...firstIds);
+    const second = JSON.parse((await run()).stdout);
+    // Everything announced and confirmed above must now be silent.
+    for (const id of firstIds) {
+      expect(second.escalation.new.map((n: any) => n.id)).not.toContain(id);
+    }
+  }, 60_000);
+});

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -827,6 +827,36 @@ describe('update-alert-state', () => {
     expect(stdout.notifications).toEqual(['Session idle 3h']); // first observation notifies
   }));
 
+  // Issue #690: v1.2.17–v1.2.24 persisted doctor:* keys here, when this writer
+  // still honoured doctor's new_entries payload. Those entries carry `detail`
+  // but neither `text` nor `suppressed`, so aging them through classifyTick
+  // emitted a literal "resolved — undefined" line. doctor-check.ts owns the
+  // prefix now (state/doctor-alerts.json); heartbeat just retires the residue.
+  test('update-alert-state (legacy doctor:* residue is dropped silently in one tick)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'), JSON.stringify({
+      alerts: {
+        'doctor:permissions': { first_seen: '2026-08-04', status: 'warn', detail: 'world-readable' },
+        'checklist:keepme': { count: 1, consecutive_clean: 0, suppressed: false, first_seen: '2026-07-10', last_seen: '2026-07-10', text: 'keep me' },
+      },
+      self_eval: {}, total_ticks: 2,
+    }));
+    const { state, stdout } = await updateAlertState(dir, firingPayload([{ key: 'checklist:keepme', text: 'keep me' }]));
+
+    expect(state.alerts['doctor:permissions']).toBeUndefined();       // gone in ONE tick, not aged over two
+    expect(state.alerts['checklist:keepme']).toBeDefined();           // unrelated keys untouched
+    expect(stdout.monitoring_lines.join('\n')).not.toContain('undefined');
+    expect(stdout.monitoring_lines.join('\n')).not.toContain('doctor:');
+    expect(stdout.notifications.join('\n')).not.toContain('doctor:'); // silent — no resolution ping
+  }));
+
+  test('update-alert-state (a model-authored doctor:* firing key is ignored)', withDir(async (dir) => {
+    write(hermit(dir, 'state', 'alert-state.json'), '{"alerts":{},"self_eval":{},"total_ticks":0}');
+    const { state } = await updateAlertState(dir, firingPayload([
+      { key: 'doctor:permissions', text: 'model tried to author a doctor finding' },
+    ]));
+    expect(state.alerts['doctor:permissions']).toBeUndefined();
+  }));
+
   test('update-alert-state (repeat fire increments count, no notification on ticks 2-4)', withDir(async (dir) => {
     write(hermit(dir, 'state', 'alert-state.json'),
       '{"alerts":{"checklist:idle0001":{"count":1,"consecutive_clean":0,"suppressed":false,"first_seen":"2026-07-08","last_seen":"2026-07-08","text":"old text"}},"self_eval":{},"total_ticks":10}');


### PR DESCRIPTION
## Summary

`/hermit-doctor` re-notified the same standing finding on every run. The dedup contract its own docs advertise — "a check already alerted stays silent on subsequent runs until it resolves" — has been unenforceable since **v1.2.25**.

The issue theorized that heartbeat clobbers doctor's dedup keys. That isn't what happens. `3248ea0` (the #594 fix) removed `new_entries` / `updated_entries` / `resolved_keys` support from the alert-state writer and updated `heartbeat/SKILL.md` and `heartbeat/reference.md` — but not `hermit-doctor/SKILL.md`, which kept sending exactly that payload. With `payload.firing` absent, `validateFiring` returns `null` and the script `process.exit(0)`s before reading or writing anything. **The write was accepted and discarded**: exit 0, no stdout, no state change. No `doctor:<id>` key was ever recorded, so every failing check read as new, forever.

Reproduced directly: running doctor's exact payload against a scratch state dir leaves `alert-state.json` byte-identical.

Closes #690.

## Changes

**The ledger moves to its own file.** `state/doctor-alerts.json`, single-owner, alongside the existing `budget-alerts.json` / `telemetry-alert.json` split. It cannot live in `alert-state.json`: `classifyTick` rebuilds `alerts{}` from `prevAlerts ∪ firing`, so a `doctor:*` key not re-asserted by heartbeat ages out after two clean ticks — verified live, along with the `Heartbeat: resolved — undefined` line it emitted (doctor's entry shape carries `detail`, never `text`).

**The transition is derived, not authored.** `doctor-check.ts` computes `escalation.{new,resolved}` and emits it in the report; the skill renders and sends. Same correction #594 applied to heartbeat — the model can no longer garble or omit the bookkeeping.

**Delivery is two-phase.** Entries are written `notified: false` and flipped only by an explicit `--mark-notified` after a confirmed send, mirroring `cost-tracker.ts`'s budget-alert pattern. A finding whose send failed is re-offered next run rather than counted as delivered. The old "deliver it exactly once" wording was an overclaim — dedup persisted *before* the send, so a crash or a dead channel silently consumed the notification.

**Degraded state fails closed.** A corrupt ledger is quarantined and re-seeded but emits nothing that run, since it cannot know what was already announced. `mutateOwnedAlerts` returns false only on ioerror; corrupt is quarantine-and-rebuild, which would otherwise make every finding look new.

**Legacy cleanup.** v1.2.17–v1.2.24 genuinely persisted `doctor:*` keys (the writer honoured the payload then; `CHANGELOG.md` for 1.2.17 names them). Heartbeat now drops that residue silently in one tick, since it owns that file. No operator action, no `### Upgrade Instructions`.

**Also folded in:** `doctor-report.json` gets a PID-specific temp file (matching `alert-state.ts`), and `hermit-doctor/SKILL.md`'s pointer to "§ Operator Notification" — a section that does not exist in that document — now resolves to `channel-responder` § Outbound notification protocol.

## Test plan

- `bun test` in `plugins/claude-code-hermit` → **3425 pass, 0 fail**
- `bunx tsc --noEmit` from repo root → clean
- Grep gate: no `new_entries` / `resolved_keys` / `updated_entries` remain in any skill doc
- New `tests/doctor-escalation.test.ts` (12 cases): episode lifecycle, unconfirmed re-offer, warn→fail staying one episode, resolution + recurrence, missing vs corrupt vs unreadable prior state, cross-file isolation, CLI round trip
- New regression guard in `contracts.test.ts`: only `skills/heartbeat/SKILL.md` may invoke `scripts/heartbeat.ts alert-state`. This is the check that would have caught the original drift — the existing #594 guard listed the right field names but only ever read heartbeat's two files
- Six live smoke paths on a scratch hatch dir: first-notify → unconfirmed re-offer → `--mark-notified` → silence → resolution → corrupt-ledger fail-closed; plus a seeded v1.2.17-shaped legacy key purged in one heartbeat tick with no `resolved — undefined` line

## Note on live impact

`#683` and `#684` already fixed `docker-security` and `reflect` at source, so two of the checks that were re-firing no longer warn at all. The dedup bug is independent and still live on `main`, but the standing-warning volume this suppresses is smaller than the issue implies.
