### PR TITLE
feat(claude-code-hermit): rebuild the artifact page theme around one palette

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -7,7 +7,9 @@
 
 ### Changed
 - The dashboard and proposals pages are laid out for scanning: a 1100px column, a type scale with headings above body text, monospace for machine values (ids, dates, costs, token counts), severity rails, and summary tiles before the lists. Proposal rows lead with the title; the full id moves to a hover attribute and the row shows `PROP-NNN`.
-- Status alerts group by kind. Twenty `proposal-pending:*` entries render as one row carrying the count, with the proposal titles behind a disclosure, instead of twenty identical dedup keys.
+- Both artifact pages lead their `<title>` with the hermit's own name — `<agent_name> — Dashboard` and `<agent_name> — Proposals` — so two hermits' tabs are distinguishable. The dashboard `<h1>` matches its title instead of reading "Hermit — Hermit Dashboard".
+- `proposal-pending` alerts no longer render rows in the status card; the proposals card is the one surface for them, and they still count in the "Needs you" tile. A 20-proposal backlog no longer buries every other alert.
+- The dashboard drops chrome that carried no information: the "Autonomous agent status" subtitle, the page footer, and the weekly card's empty state (the card is now omitted until there is a review).
 
 ### Fixed
 - Artifact pages paint their own `body` background instead of borrowing the viewer's, which left everything outside the centred column showing the host theme's ground.
@@ -17,7 +19,7 @@
 ### Upgrade Instructions
 
 1. Both artifact pages change shape, so the next publish re-mints each one once. Steady state returns to hash-gated no-op republishes; nothing to do.
-2. **Only if `.claude-code-hermit/state/artifact-strings.json` exists** (a hermit with a translation overlay): regenerate the scaffold with `bun ${CLAUDE_PLUGIN_ROOT}/scripts/artifact.ts scaffold-strings <language>`, carry the existing translated values across, and translate the ten new keys — `dashboard_dek`, `status_tokens`, `session_in_progress`, `session_idle`, `session_paused`, `session_closed`, `alert_group_proposals`, `common_show_all`, `proposals_pill_open`, `proposals_pill_decided`. Untranslated keys fall back to English per key, so the page renders correctly either way. Also re-check `status_today` and `status_alerts`: their English defaults changed to "Spent today" and "Needs you", so an existing overlay may now read oddly next to the new tiles.
+2. **Only if `.claude-code-hermit/state/artifact-strings.json` exists** (a hermit with a translation overlay): regenerate the scaffold with `bun ${CLAUDE_PLUGIN_ROOT}/scripts/artifact.ts scaffold-strings <language>`, carry the existing translated values across, and translate the eight new keys — `status_tokens`, `session_in_progress`, `session_idle`, `session_waiting`, `session_dead_process`, `session_suspect_process`, `proposals_pill_open`, `proposals_pill_decided`. Untranslated keys fall back to English per key, so the page renders correctly either way. Two more need a second look: `dashboard_title` and `proposals_page_title` now take a `{name}` placeholder (`{name} — Dashboard`), and `status_today`/`status_alerts` changed to "Spent today"/"Needs you". The scaffold drops `dashboard_header`, `dashboard_dek`, `footer`, `weekly_heading`, `weekly_none`, `alert_group_proposals`, `common_show_all`, `session_paused` and `session_closed` — those strings no longer render anywhere; stale entries are ignored, so nothing breaks if they are left behind.
 3. Hermits with no `artifact-strings.json` need no action.
 
 ## [1.2.37] - 2026-08-08

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `scripts/lib/artifact-theme.ts` owns the visual system for the dashboard and proposals pages — one `PALETTE` generating all four theme blocks, the type scale, and the shared markup helpers. `tests/artifact-theme.test.ts` pins the invariants a hand edit could break.
+
+### Changed
+- The dashboard and proposals pages are laid out for scanning: a 1100px column, a type scale with headings above body text, monospace for machine values (ids, dates, costs, token counts), severity rails, and summary tiles before the lists. Proposal rows lead with the title; the full id moves to a hover attribute and the row shows `PROP-NNN`.
+- Status alerts group by kind. Twenty `proposal-pending:*` entries render as one row carrying the count, with the proposal titles behind a disclosure, instead of twenty identical dedup keys.
+
+### Fixed
+- Artifact pages paint their own `body` background instead of borrowing the viewer's, which left everything outside the centred column showing the host theme's ground.
+- An explicit viewer theme no longer leaves status chips resolved from the other theme — the two `[data-theme]` blocks had redefined 6 of the sheet's 19 tokens.
+- Checklist alerts render the text stored alongside them instead of the raw dedup key. `alertMessage()` read only `message`, which the heartbeat writer never sets.
+
+### Upgrade Instructions
+
+1. Both artifact pages change shape, so the next publish re-mints each one once. Steady state returns to hash-gated no-op republishes; nothing to do.
+2. **Only if `.claude-code-hermit/state/artifact-strings.json` exists** (a hermit with a translation overlay): regenerate the scaffold with `bun ${CLAUDE_PLUGIN_ROOT}/scripts/artifact.ts scaffold-strings <language>`, carry the existing translated values across, and translate the ten new keys — `dashboard_dek`, `status_tokens`, `session_in_progress`, `session_idle`, `session_paused`, `session_closed`, `alert_group_proposals`, `common_show_all`, `proposals_pill_open`, `proposals_pill_decided`. Untranslated keys fall back to English per key, so the page renders correctly either way. Also re-check `status_today` and `status_alerts`: their English defaults changed to "Spent today" and "Needs you", so an existing overlay may now read oddly next to the new tiles.
+3. Hermits with no `artifact-strings.json` need no action.
+
 ## [1.2.37] - 2026-08-08
 
 ### Added

--- a/plugins/claude-code-hermit/docs/artifacts.md
+++ b/plugins/claude-code-hermit/docs/artifacts.md
@@ -119,6 +119,46 @@ and steady state stays no-op-gated. Weekly-review has no chrome (pure frontmatte
 model markdown), so it needs no string table. Number/date formatting (`$`, ISO timestamps)
 is not localized — format, not language.
 
+## Design contract
+
+The two HTML pages share one stylesheet and one set of markup helpers, both in
+`scripts/lib/artifact-theme.ts`. That file is the **only** place a re-sync against
+Claude Code's `artifact-design` skill needs to touch — `dashboard.ts` and
+`proposals-page.ts` contribute content, not styling. `artifact-design` is prose
+guidance with nothing importable, so the sync mechanism is deliberate: keep every
+decision in one module, and encode the checkable rules as
+`tests/artifact-theme.test.ts`. When that skill gains a mechanically-checkable
+rule, add an assertion there rather than trusting a re-read.
+
+Implemented from `artifact-design`:
+
+- **One palette, four theme blocks.** `PALETTE` declares light and dark once, and
+  `:root`, the `prefers-color-scheme` media query (guarded with
+  `:not([data-theme="light"])`), `:root[data-theme="dark"]`, and
+  `:root[data-theme="light"]` are all generated from it. Partial-override drift is
+  unrepresentable, not merely fixed.
+- **`body` paints its own background** from a token, so the page never composites
+  over the viewer's ground.
+- **Two type roles.** System sans for prose; `ui-monospace` for every
+  machine-emitted value (ids, dates, costs, token counts, state enums). Scale runs
+  title > stat > body > meta, with eyebrows small because they are labels.
+- **State encoded as form**, not only as text: severity rails on alert and
+  proposal rows, status chips derived from the semantic trio.
+- **Summary before detail**: stat tiles and count pills precede the lists.
+- Chosen neutrals (a cool cast, deliberately off stock greys), `tabular-nums`,
+  `overflow-x: auto` on wide children, visible focus rings, reduced-motion honored.
+
+Deliberately declined:
+
+- **No inlined webfont.** `artifact-design` suggests a `@font-face` data URI, but
+  the plugin bans build steps and runtime dependencies, subsetting needs tooling
+  the repo does not have, and it would vendor a font plus its license into a
+  public plugin. Two system faces used as distinct roles carry the hierarchy.
+- **No per-publish model authorship.** These pages are script-rendered on purpose
+  (a publish costs a render, not a generation, and publishes fire several times a
+  day) — so the design work is done once, by hand, into the renderer. Never call
+  `artifact-design` on the publish path.
+
 ## Weekly review
 
 `config.artifacts.weekly_review`, state key `weekly_review`. The latest compiled

--- a/plugins/claude-code-hermit/docs/artifacts.md
+++ b/plugins/claude-code-hermit/docs/artifacts.md
@@ -63,7 +63,11 @@ differ per type (called out in each subsection below):
 latest brief, proposal queue, weekly evolution, and a compiled-docs index — rendered by
 `scripts/lib/dashboard.ts` (deterministic; no model authorship, except the embedded
 "latest brief" text, which is itself model-composed by the `brief` skill and written to
-`state/last-brief.json` — see the file's header comment). `<title>` is `Hermit Dashboard`.
+`state/last-brief.json` — see the file's header comment). `<title>` and the `<h1>` are
+both `<agent_name> — Dashboard` (`agent_name` falls back to `Hermit`), so a fleet
+operator can tell two hermits' tabs apart. The weekly and alert sections are omitted
+rather than rendered empty; pending-proposal alerts are left to the proposals card,
+which owns that surface, and still count in the "Needs you" tile.
 
 Refresh triggers: `brief` (`--morning`/`--evening`), `weekly-review`, `proposal-create`,
 `proposal-act`. `brief` and `weekly-review` append a `📎 <url>` line to their channel
@@ -84,7 +88,8 @@ count (e.g. "3 Open"); deferred/resolved/dismissed proposals stay one-line histo
 — the same "other" bucket the dashboard already computes. Rendered by
 `scripts/lib/proposals-page.ts` (reuses the dashboard's proposal loader, markdown
 converter, and CSS — no CSS changes were needed since `.proposal`/`.proposal-body` already
-existed for the dashboard's own `<details>`). `<title>` is `Hermit Proposals`. Deliberately
+existed for the dashboard's own `<details>`). `<title>` is `<agent_name> — Proposals`,
+matching the dashboard's tab convention. Deliberately
 omits proposal age-in-days (unlike the dashboard) — age is `Date.now()`-derived and would
 otherwise mint a new artifact version once a day even with zero activity; created-date
 is shown instead, keeping the hash purely activity-driven (the open count is likewise
@@ -106,8 +111,8 @@ text unconditionally so the link is useful either way.
 
 ## Localization
 
-The dashboard and proposals renderers read their fixed UI chrome (section headers, stat
-labels, empty states, age labels, the footer, the synthesized budget-alert line) from
+The dashboard and proposals renderers read their fixed UI chrome (page titles, section
+headers, stat labels, empty states, age labels, the synthesized budget-alert line) from
 `scripts/lib/artifact-strings.ts` (`DEFAULT_STRINGS`, English). When
 `.claude-code-hermit/state/artifact-strings.json` is present, `loadStrings()` overlays it
 **per key** over those defaults — a missing key or an absent file falls back to English,

--- a/plugins/claude-code-hermit/scripts/lib/artifact-strings.ts
+++ b/plugins/claude-code-hermit/scripts/lib/artifact-strings.ts
@@ -20,6 +20,7 @@ export const DEFAULT_STRINGS = {
   // Page shell / shared chrome
   dashboard_title: 'Hermit Dashboard',
   dashboard_header: '{name} — Hermit Dashboard',
+  dashboard_dek: 'Autonomous agent status',
   proposals_page_title: 'Hermit Proposals',
   proposals_page_header: 'Proposals',
   label_updated: 'updated',
@@ -28,9 +29,20 @@ export const DEFAULT_STRINGS = {
   // Status card
   status_heading: 'Status',
   status_session: 'Session',
-  status_today: 'Today',
-  status_alerts: 'Alerts',
+  status_today: 'Spent today',
+  status_tokens: 'Tokens',
+  status_alerts: 'Needs you',
   status_no_alerts: 'No active alerts.',
+
+  // Session-state labels. runtime.json stores machine enums; an unmapped value
+  // falls back to the raw string rather than rendering blank.
+  session_in_progress: 'Working',
+  session_idle: 'Idle',
+  session_paused: 'Paused',
+  session_closed: 'Closed',
+
+  // Alert grouping — one row per alert *kind*, not per dedup key.
+  alert_group_proposals: '{n} proposals are waiting on your decision',
 
   // Budget-alert synthesis (message-less budget alerts)
   budget_text: '{period} budget {state}{amounts}',
@@ -55,6 +67,8 @@ export const DEFAULT_STRINGS = {
   // Proposals page
   proposals_history: 'History',
   proposals_open_count: '{n} Open',
+  proposals_pill_open: 'open',
+  proposals_pill_decided: 'decided',
 
   // Weekly card
   weekly_heading: "This week's evolution",
@@ -75,6 +89,7 @@ export const DEFAULT_STRINGS = {
 
   // Shared
   common_more_not_shown: '+{n} more not shown',
+  common_show_all: 'Show all {n}',
 };
 
 export type ArtifactStrings = typeof DEFAULT_STRINGS;

--- a/plugins/claude-code-hermit/scripts/lib/artifact-strings.ts
+++ b/plugins/claude-code-hermit/scripts/lib/artifact-strings.ts
@@ -17,14 +17,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 export const DEFAULT_STRINGS = {
-  // Page shell / shared chrome
-  dashboard_title: 'Hermit Dashboard',
-  dashboard_header: '{name} — Hermit Dashboard',
-  dashboard_dek: 'Autonomous agent status',
-  proposals_page_title: 'Hermit Proposals',
+  // Page shell / shared chrome. Both page titles lead with the hermit's own name
+  // ({name} = config.agent_name, "Hermit" when unset) so an operator running
+  // several hermits can tell two tabs apart — and so a hermit that *is* named
+  // "Hermit" reads "Hermit — Dashboard", not "Hermit — Hermit Dashboard".
+  dashboard_title: '{name} — Dashboard',
+  proposals_page_title: '{name} — Proposals',
   proposals_page_header: 'Proposals',
   label_updated: 'updated',
-  footer: 'Rendered by claude-code-hermit — script-generated, not model-authored.',
 
   // Status card
   status_heading: 'Status',
@@ -34,15 +34,13 @@ export const DEFAULT_STRINGS = {
   status_alerts: 'Needs you',
   status_no_alerts: 'No active alerts.',
 
-  // Session-state labels. runtime.json stores machine enums; an unmapped value
-  // falls back to the raw string rather than rendering blank.
+  // One label per enum runtime.json actually stores — invented states render as
+  // dead keys, and a real state with no key falls back to the raw enum.
   session_in_progress: 'Working',
   session_idle: 'Idle',
-  session_paused: 'Paused',
-  session_closed: 'Closed',
-
-  // Alert grouping — one row per alert *kind*, not per dedup key.
-  alert_group_proposals: '{n} proposals are waiting on your decision',
+  session_waiting: 'Waiting on you',
+  session_dead_process: 'Process died',
+  session_suspect_process: 'Process suspect',
 
   // Budget-alert synthesis (message-less budget alerts)
   budget_text: '{period} budget {state}{amounts}',
@@ -70,9 +68,8 @@ export const DEFAULT_STRINGS = {
   proposals_pill_open: 'open',
   proposals_pill_decided: 'decided',
 
-  // Weekly card
-  weekly_heading: "This week's evolution",
-  weekly_none: 'No weekly review yet.',
+  // Weekly card. No empty state: the card is omitted entirely when there is no
+  // review, rather than spending a section on saying so.
   weekly_week: 'Week {week}',
   weekly_cost: 'Cost: {amount}{delta}',
   weekly_autonomy: 'Autonomy: {pct} self-directed{delta}',
@@ -89,7 +86,6 @@ export const DEFAULT_STRINGS = {
 
   // Shared
   common_more_not_shown: '+{n} more not shown',
-  common_show_all: 'Show all {n}',
 };
 
 export type ArtifactStrings = typeof DEFAULT_STRINGS;

--- a/plugins/claude-code-hermit/scripts/lib/artifact-theme.ts
+++ b/plugins/claude-code-hermit/scripts/lib/artifact-theme.ts
@@ -98,7 +98,6 @@ body { margin: 0; background: var(--bg); color: var(--fg); }
 .hermit-page header { display: flex; justify-content: space-between; align-items: baseline; gap: 16px; flex-wrap: wrap; }
 .hermit-page header h1 { font-size: 26px; font-weight: 600; letter-spacing: -0.015em; margin: 0; text-wrap: balance; }
 .hermit-page header .updated { font-family: var(--mono); font-size: 12px; color: var(--muted); }
-.dek { color: var(--muted); font-size: 14px; margin: 6px 0 0; }
 .summary { display: flex; flex-wrap: wrap; gap: 8px; margin: 20px 0; }
 .pill { display: inline-flex; align-items: baseline; gap: 7px; border-radius: 999px; padding: 5px 13px; font-size: 13px; border: 1px solid transparent; }
 .pill b { font-family: var(--mono); font-weight: 600; font-size: 13.5px; }
@@ -106,7 +105,11 @@ body { margin: 0; background: var(--bg); color: var(--fg); }
 .pill-good { background: var(--chip-good-bg); color: var(--chip-good-fg); }
 .pill-acc { background: var(--chip-acc-bg); color: var(--chip-acc-fg); }
 .pill-mute { background: transparent; color: var(--muted); border-color: var(--border); }
-.card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; margin-bottom: 14px; }
+/* The card is the scroll container for wide content: proposal bodies and the
+   weekly review are model-authored markdown, so a long unbroken token (a file
+   path in inline code, a URL) has to scroll here rather than push the page into
+   a horizontal scroll. */
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; margin-bottom: 14px; overflow-x: auto; }
 .card h2 { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.09em; color: var(--muted); margin: 0 0 14px; }
 .stat-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 18px; margin-bottom: 4px; }
 .stat { display: flex; flex-direction: column; }
@@ -150,19 +153,13 @@ body { margin: 0; background: var(--bg); color: var(--fg); }
 .proposal-history li:first-child { border-top: none; }
 .evolution { list-style: none; margin: 0 0 12px; padding: 0; }
 .evolution li { padding: 3px 0; }
-.weekly-body summary, details.disc > summary { cursor: pointer; color: var(--accent); font-size: 13px; width: fit-content; }
-details.disc { margin-top: 10px; }
-details.disc ul { list-style: none; margin: 10px 0 0; padding: 0; font-family: var(--mono); font-size: 12.5px; color: var(--muted); }
-details.disc li { padding: 3px 0; }
-details.disc li b { color: var(--fg); font-weight: 600; }
+.weekly-body summary { cursor: pointer; color: var(--accent); font-size: 13px; width: fit-content; }
 summary:focus-visible, a:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 3px; }
-.scroller { overflow-x: auto; }
 code { background: var(--code-bg); border-radius: 4px; padding: 1px 5px; font-family: var(--mono); font-size: 13px; }
 pre { background: var(--code-bg); border-radius: 6px; padding: 10px 12px; overflow-x: auto; }
 pre code { background: none; padding: 0; }
 table { border-collapse: collapse; }
 a { color: var(--accent); }
-footer.hermit-footer { color: var(--muted); font-size: 12px; margin-top: 20px; }
 @media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
 `;
 
@@ -212,12 +209,6 @@ export function railRow(opts: { tone: Tone; title: string; meta?: string[]; extr
   return `<div class="rail rail-${opts.tone}"><p class="rail-title">${opts.title}</p>${meta}${opts.extra ?? ''}</div>`;
 }
 
-/** Collapsed list used for the "show the rest" tails. */
-export function disclosure(summary: string, items: string[]): string {
-  if (!items.length) return '';
-  return `<details class="disc"><summary>${summary}</summary><ul>${items.map(i => `<li>${i}</li>`).join('')}</ul></details>`;
-}
-
 /** Pill strip: the summary-before-detail layer at the top of a page. There is no
  *  `.pill-crit` on purpose — a rail has room for a distinct critical colour, a
  *  compact pill does not, so `crit` borrows `warn`'s here. */
@@ -234,13 +225,10 @@ export function pills(entries: { tone: Tone; value: string; label: string }[]): 
 export function pageShell(opts: {
   title: string;
   heading: string;
-  dek?: string;
   updatedLabel: string;
   updatedToken: string;
   body: string;
-  footer: string;
 }): string {
-  const dek = opts.dek ? `<p class="dek">${opts.dek}</p>` : '';
   return `<title>${opts.title}</title>
 <style>${CSS}</style>
 <div class="hermit-page">
@@ -248,9 +236,7 @@ export function pageShell(opts: {
     <h1>${opts.heading}</h1>
     <span class="updated">${opts.updatedLabel} ${opts.updatedToken}</span>
   </header>
-  ${dek}
   ${opts.body}
-  <footer class="hermit-footer">${opts.footer}</footer>
 </div>
 `;
 }

--- a/plugins/claude-code-hermit/scripts/lib/artifact-theme.ts
+++ b/plugins/claude-code-hermit/scripts/lib/artifact-theme.ts
@@ -1,0 +1,256 @@
+// Single source of visual truth for the script-rendered Artifact pages
+// (dashboard, proposals). Everything a re-sync against Claude Code's
+// `artifact-design` skill needs to touch lives in this file: the palette, the
+// type scale, the layout, and the small markup helpers the renderers compose.
+// `dashboard.ts` and `proposals-page.ts` contribute content, not styling.
+//
+// Why a module and not a CSS const inside dashboard.ts: the previous sheet
+// hand-wrote its token set four times (bare :root, the dark media query, and
+// both [data-theme] blocks), and the two [data-theme] blocks silently drifted
+// to 6 of 19 tokens — so a viewer with an explicit theme choice got base
+// colours from one block and chip colours from another. Here PALETTE is
+// declared once and every block is generated from it, which makes that class
+// of drift unrepresentable rather than merely fixed. tests/artifact-theme.test.ts
+// pins the invariants that a hand edit could still break.
+//
+// Helpers take **already-escaped** HTML, matching the convention the renderers
+// already use (see dashboard.ts alertMessage/proposalLabel): callers escape
+// file-derived values, chrome strings arrive pre-escaped from loadStrings().
+
+/** Token set, declared once per theme. Both objects must carry identical keys —
+ *  a missing key is what produced the chip-drift bug this module replaces. */
+export const PALETTE = {
+  light: {
+    bg: '#fbfbfa',
+    surface: '#f4f5f4',
+    raised: '#ffffff',
+    fg: '#171a1c',
+    muted: '#5f6b6b',
+    border: '#e0e4e3',
+    accent: '#116b63',
+    good: '#2f6f4a',
+    warn: '#8a5a10',
+    crit: '#a33a32',
+    'chip-warn-bg': '#f7ead3',
+    'chip-warn-fg': '#7a4f0c',
+    'chip-good-bg': '#dcece2',
+    'chip-good-fg': '#2a6042',
+    'chip-acc-bg': '#d9ecea',
+    'chip-acc-fg': '#0e5f58',
+    'chip-mute-bg': '#e9ecec',
+    'chip-mute-fg': '#55605f',
+    'code-bg': '#eef0ef',
+  },
+  dark: {
+    bg: '#14171a',
+    surface: '#1c2024',
+    raised: '#20262a',
+    fg: '#e6e9e8',
+    muted: '#93a0a0',
+    border: '#2b3236',
+    accent: '#63d9c9',
+    good: '#6fca92',
+    warn: '#e3ae53',
+    crit: '#f08b80',
+    'chip-warn-bg': '#3a2a10',
+    'chip-warn-fg': '#e3ae53',
+    'chip-good-bg': '#17301f',
+    'chip-good-fg': '#6fca92',
+    'chip-acc-bg': '#10302d',
+    'chip-acc-fg': '#63d9c9',
+    'chip-mute-bg': '#232a2c',
+    'chip-mute-fg': '#93a0a0',
+    'code-bg': '#232a2c',
+  },
+} as const;
+
+export type Tone = 'warn' | 'good' | 'acc' | 'mute' | 'crit';
+
+function vars(theme: Record<string, string>): string {
+  return Object.entries(theme).map(([k, v]) => `--${k}:${v};`).join(' ');
+}
+
+// Four blocks, because the viewer has three states and an explicit choice must
+// win in both directions: bare :root is the light default; the media query is
+// guarded with :not([data-theme="light"]) so an explicit light choice beats a
+// dark OS; and each [data-theme] block restates the *full* set so a toggle can
+// never leave half the tokens resolved from the other theme.
+const THEME_BLOCKS = [
+  `:root { color-scheme: light dark; ${vars(PALETTE.light)} }`,
+  `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) { ${vars(PALETTE.dark)} } }`,
+  `:root[data-theme="dark"] { ${vars(PALETTE.dark)} }`,
+  `:root[data-theme="light"] { ${vars(PALETTE.light)} }`,
+].join('\n');
+
+// Type scale runs title > stat > body > meta > eyebrow-as-label. The previous
+// sheet set h2 at 14px under 15px body, so section headings read as smaller
+// than the text they introduced; eyebrows are small here on purpose (they are
+// labels) and hierarchy comes from the content beneath them.
+const RULES = `
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--fg); }
+.hermit-page {
+  background: var(--bg); color: var(--fg);
+  font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-variant-numeric: tabular-nums;
+  max-width: 1100px; margin: 0 auto; padding: 32px 24px 64px;
+}
+.hermit-page header { display: flex; justify-content: space-between; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+.hermit-page header h1 { font-size: 26px; font-weight: 600; letter-spacing: -0.015em; margin: 0; text-wrap: balance; }
+.hermit-page header .updated { font-family: var(--mono); font-size: 12px; color: var(--muted); }
+.dek { color: var(--muted); font-size: 14px; margin: 6px 0 0; }
+.summary { display: flex; flex-wrap: wrap; gap: 8px; margin: 20px 0; }
+.pill { display: inline-flex; align-items: baseline; gap: 7px; border-radius: 999px; padding: 5px 13px; font-size: 13px; border: 1px solid transparent; }
+.pill b { font-family: var(--mono); font-weight: 600; font-size: 13.5px; }
+.pill-warn { background: var(--chip-warn-bg); color: var(--chip-warn-fg); }
+.pill-good { background: var(--chip-good-bg); color: var(--chip-good-fg); }
+.pill-acc { background: var(--chip-acc-bg); color: var(--chip-acc-fg); }
+.pill-mute { background: transparent; color: var(--muted); border-color: var(--border); }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; margin-bottom: 14px; }
+.card h2 { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.09em; color: var(--muted); margin: 0 0 14px; }
+.stat-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 18px; margin-bottom: 4px; }
+.stat { display: flex; flex-direction: column; }
+.stat-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); margin-bottom: 4px; }
+.stat-value { font-family: var(--mono); font-size: 21px; font-weight: 600; letter-spacing: -0.02em; }
+.stat-value.tone-acc { color: var(--accent); }
+.stat-value.tone-warn { color: var(--warn); }
+.stat-value.tone-crit { color: var(--crit); }
+.muted { color: var(--muted); font-size: 13.5px; }
+.chip { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+.chip-proposed { background: var(--chip-warn-bg); color: var(--chip-warn-fg); }
+.chip-accepted { background: var(--chip-acc-bg); color: var(--chip-acc-fg); }
+.chip-resolved { background: var(--chip-good-bg); color: var(--chip-good-fg); }
+.chip-deferred { background: var(--chip-mute-bg); color: var(--chip-mute-fg); }
+.chip-dismissed { background: var(--chip-mute-bg); color: var(--chip-mute-fg); }
+.chip-unknown { background: var(--chip-mute-bg); color: var(--chip-mute-fg); }
+.rail { border-left: 3px solid var(--border); padding: 9px 0 9px 13px; }
+.rail + .rail { border-top: 1px solid var(--border); }
+.rail-warn { border-left-color: var(--warn); }
+.rail-good { border-left-color: var(--good); }
+.rail-crit { border-left-color: var(--crit); }
+.rail-acc { border-left-color: var(--accent); }
+.rail-mute { border-left-color: var(--border); }
+.rail-title { font-size: 15px; font-weight: 600; margin: 0; text-wrap: pretty; }
+.rail-meta { font-family: var(--mono); font-size: 12.5px; color: var(--muted); margin: 3px 0 0; display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 9px; }
+.alerts { list-style: none; margin: 0; padding: 0; }
+.proposal { border-left: 3px solid var(--warn); padding: 9px 0 9px 13px; }
+.proposal + .proposal { border-top: 1px solid var(--border); }
+.proposal summary { cursor: pointer; }
+/* The row template is two block-level paragraphs, so the native disclosure
+   marker would sit on its own line above the title. Hide it and draw the caret
+   inline at the head of the title instead, which keeps the affordance on the
+   thing you actually click. */
+.proposal summary { list-style: none; }
+.proposal summary::-webkit-details-marker { display: none; }
+.proposal summary .rail-title::before { content: "\\25B8"; color: var(--muted); margin-right: 8px; font-size: 11px; vertical-align: 1px; }
+.proposal[open] summary .rail-title::before { content: "\\25BE"; }
+.proposal-body { margin-top: 10px; padding-left: 2px; }
+.proposal-history { list-style: none; margin: 0; padding: 0; }
+.proposal-history li { padding: 7px 0; border-top: 1px solid var(--border); font-size: 14px; }
+.proposal-history li:first-child { border-top: none; }
+.evolution { list-style: none; margin: 0 0 12px; padding: 0; }
+.evolution li { padding: 3px 0; }
+.weekly-body summary, details.disc > summary { cursor: pointer; color: var(--accent); font-size: 13px; width: fit-content; }
+details.disc { margin-top: 10px; }
+details.disc ul { list-style: none; margin: 10px 0 0; padding: 0; font-family: var(--mono); font-size: 12.5px; color: var(--muted); }
+details.disc li { padding: 3px 0; }
+details.disc li b { color: var(--fg); font-weight: 600; }
+summary:focus-visible, a:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 3px; }
+.scroller { overflow-x: auto; }
+code { background: var(--code-bg); border-radius: 4px; padding: 1px 5px; font-family: var(--mono); font-size: 13px; }
+pre { background: var(--code-bg); border-radius: 6px; padding: 10px 12px; overflow-x: auto; }
+pre code { background: none; padding: 0; }
+table { border-collapse: collapse; }
+a { color: var(--accent); }
+footer.hermit-footer { color: var(--muted); font-size: 12px; margin-top: 20px; }
+@media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
+`;
+
+// --mono is a plain constant rather than a themed token — it does not vary by
+// theme, but routing it through a custom property keeps every font-family
+// declaration below to one name.
+export const CSS = `${THEME_BLOCKS}
+:root { --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+${RULES}`;
+
+// ---------- markup helpers (inputs must be pre-escaped) ----------
+
+const CHIP_STATUSES = ['proposed', 'accepted', 'resolved', 'dismissed', 'deferred'];
+
+/** Status chip. `status` is escaped by the caller-facing wrapper in dashboard.ts. */
+export function chipHtml(status: string, escapedLabel: string): string {
+  const cls = CHIP_STATUSES.includes(status) ? status : 'unknown';
+  return `<span class="chip chip-${cls}">${escapedLabel}</span>`;
+}
+
+/** Section card with an uppercase eyebrow heading. */
+export function card(heading: string, body: string): string {
+  return `
+    <section class="card">
+      <h2>${heading}</h2>
+      ${body}
+    </section>`;
+}
+
+/** One stat tile inside a `.stat-row` grid. */
+export function statTile(label: string, value: string, tone?: 'acc' | 'warn' | 'crit'): string {
+  const cls = tone ? ` tone-${tone}` : '';
+  return `<div class="stat"><span class="stat-label">${label}</span><span class="stat-value${cls}">${value}</span></div>`;
+}
+
+/** Separator between meta parts. Shared with dashboard.ts's proposal rows so the
+ *  markup — including the `aria-hidden` that keeps it out of the accessible name —
+ *  has one definition rather than a copy per call site. */
+export const META_SEP = '<span aria-hidden="true">·</span>';
+
+/** A row whose left rail encodes state as form, not just as text. `meta` parts
+ *  are joined with a separator so callers never hand-build the dot list. */
+export function railRow(opts: { tone: Tone; title: string; meta?: string[]; extra?: string }): string {
+  const meta = opts.meta && opts.meta.length
+    ? `<p class="rail-meta">${opts.meta.join(META_SEP)}</p>`
+    : '';
+  return `<div class="rail rail-${opts.tone}"><p class="rail-title">${opts.title}</p>${meta}${opts.extra ?? ''}</div>`;
+}
+
+/** Collapsed list used for the "show the rest" tails. */
+export function disclosure(summary: string, items: string[]): string {
+  if (!items.length) return '';
+  return `<details class="disc"><summary>${summary}</summary><ul>${items.map(i => `<li>${i}</li>`).join('')}</ul></details>`;
+}
+
+/** Pill strip: the summary-before-detail layer at the top of a page. There is no
+ *  `.pill-crit` on purpose — a rail has room for a distinct critical colour, a
+ *  compact pill does not, so `crit` borrows `warn`'s here. */
+export function pills(entries: { tone: Tone; value: string; label: string }[]): string {
+  if (!entries.length) return '';
+  const items = entries
+    .map(e => `<span class="pill pill-${e.tone === 'crit' ? 'warn' : e.tone}"><b>${e.value}</b> ${e.label}</span>`)
+    .join('');
+  return `<div class="summary">${items}</div>`;
+}
+
+/** Page shell shared by both renderers. `updated` is the placeholder token the
+ *  callers swap post-hash, so the "last updated" stamp stays out of the hash. */
+export function pageShell(opts: {
+  title: string;
+  heading: string;
+  dek?: string;
+  updatedLabel: string;
+  updatedToken: string;
+  body: string;
+  footer: string;
+}): string {
+  const dek = opts.dek ? `<p class="dek">${opts.dek}</p>` : '';
+  return `<title>${opts.title}</title>
+<style>${CSS}</style>
+<div class="hermit-page">
+  <header>
+    <h1>${opts.heading}</h1>
+    <span class="updated">${opts.updatedLabel} ${opts.updatedToken}</span>
+  </header>
+  ${dek}
+  ${opts.body}
+  <footer class="hermit-footer">${opts.footer}</footer>
+</div>
+`;
+}

--- a/plugins/claude-code-hermit/scripts/lib/dashboard.ts
+++ b/plugins/claude-code-hermit/scripts/lib/dashboard.ts
@@ -15,12 +15,12 @@ import path from 'node:path';
 import { readFileWithFrontmatter, globDir } from './frontmatter';
 import { formatTokens } from './format';
 import { sha256 } from './hash';
-import { readMergedAlerts } from './alert-state';
+import { readMergedAlerts, PROPOSAL_PREFIX } from './alert-state';
 import { todayYMD } from './time';
 import { costIndexPath, readCostIndex } from './cost-log';
 import { rebuildIndex, type ProposalsIndex } from './proposals/index-rebuild';
 import { loadStrings, fmt, type ArtifactStrings } from './artifact-strings';
-import { chipHtml, card, statTile, railRow, disclosure, pageShell, META_SEP } from './artifact-theme';
+import { chipHtml, card, statTile, railRow, pageShell, META_SEP } from './artifact-theme';
 
 type Json = any;
 
@@ -275,6 +275,16 @@ function alertMessage(key: string, v: Json, s: ArtifactStrings): string {
   return escapeHtml(key);
 }
 
+function agentNameFromConfig(config: Json): string {
+  return typeof config?.agent_name === 'string' && config.agent_name.trim() ? config.agent_name : 'Hermit';
+}
+
+/** The hermit's own name, used to lead both page titles. Shared with
+ *  proposals-page.ts, which has no other reason to read config.json. */
+export function loadAgentName(hermitDir: string): string {
+  return agentNameFromConfig(readJsonSafe(path.join(hermitDir, 'config.json')));
+}
+
 export function loadDashboardState(hermitDir: string): DashboardState {
   const config = readJsonSafe(path.join(hermitDir, 'config.json')) ?? {};
   const timezone = typeof config.timezone === 'string' && config.timezone ? config.timezone : 'UTC';
@@ -293,7 +303,7 @@ export function loadDashboardState(hermitDir: string): DashboardState {
   }
 
   return {
-    agentName: typeof config.agent_name === 'string' && config.agent_name.trim() ? config.agent_name : 'Hermit',
+    agentName: agentNameFromConfig(config),
     sessionState: typeof runtime?.session_state === 'string' ? runtime.session_state : null,
     todayCostUsd: today.costUsd,
     todayTokens: today.tokens,
@@ -451,45 +461,21 @@ function delta(current: number | null, prior: number | null, unit: 'pp' | '$', s
   return fmt(s.weekly_delta_pp, { prior: Math.round(prior), sign, diff: Math.round(diff) });
 }
 
-// Alert keys are `<kind>:<instance>` (e.g. `proposal-pending:PROP-012`). One row
-// per key turned a 20-proposal backlog into twenty near-identical lines, so kinds
-// listed here state the situation once and keep the instances behind a
-// disclosure. Anything not listed still renders a row each — a new alert kind is
-// never silently collapsed into a count.
-const GROUPED_ALERT_KINDS: Record<string, keyof ArtifactStrings> = {
-  'proposal-pending': 'alert_group_proposals',
-};
-
-function alertKind(key: string): string {
-  const i = key.indexOf(':');
-  return i === -1 ? key : key.slice(0, i);
-}
-
+// The proposals card below is the canonical surface for pending proposals — it
+// carries titles, chips and full bodies, which an alert row cannot. Rendering
+// them here too turned a 20-proposal backlog into twenty near-identical lines
+// that buried every other alert. They still count toward the "Needs you" tile,
+// so the number stays honest and the card explains it.
 function renderAlerts(state: DashboardState): string {
   const s = state.strings;
   if (!state.alerts.length) return `<p class="muted">${s.status_no_alerts}</p>`;
 
-  const groups = new Map<string, AlertRow[]>();
-  for (const a of state.alerts) {
-    const kind = alertKind(a.key);
-    const bucket = groups.get(kind);
-    if (bucket) bucket.push(a);
-    else groups.set(kind, [a]);
-  }
+  const shown = state.alerts.filter(a => !a.key.startsWith(PROPOSAL_PREFIX));
+  // Every alert was card-owned. That is not "no alerts" — the tile says 20 — so
+  // render nothing rather than contradicting it.
+  if (!shown.length) return '';
 
-  const rows: string[] = [];
-  for (const [kind, members] of groups) {
-    const key = GROUPED_ALERT_KINDS[kind];
-    if (key && members.length > 1) {
-      rows.push(railRow({
-        tone: 'warn',
-        title: fmt(s[key], { n: members.length }),
-        extra: disclosure(fmt(s.common_show_all, { n: members.length }), members.map(m => m.message)),
-      }));
-    } else {
-      for (const m of members) rows.push(railRow({ tone: 'warn', title: m.message }));
-    }
-  }
+  const rows = shown.map(a => railRow({ tone: 'warn', title: a.message }));
   return `<div class="alerts">${rows.join('')}</div>`;
 }
 
@@ -561,10 +547,12 @@ function renderProposals(state: DashboardState): string {
   return card(s.proposals_heading, `${oldestLine}${openHtml}${otherHtml}`);
 }
 
+// Omits the card entirely when there is no review yet — an empty section costs a
+// heading and a line of prose to say nothing.
 function renderWeekly(state: DashboardState): string {
   const s = state.strings;
   const w = state.weekly;
-  if (!w) return card(s.weekly_heading, `<p class="muted">${s.weekly_none}</p>`);
+  if (!w) return '';
 
   const costLine = w.costUsd != null
     ? fmt(s.weekly_cost, { amount: `$${w.costUsd.toFixed(2)}`, delta: w.hasPrior ? delta(w.costUsd, w.priorCostUsd, '$', s) : '' })
@@ -612,10 +600,10 @@ function renderCompiledIndex(state: DashboardState): string {
  *  via a placeholder token, so the publish gate can skip no-op republishes). */
 export function renderDashboard(state: DashboardState, opts?: { now?: string }): { html: string; hash: string } {
   const s = state.strings;
+  const title = fmt(s.dashboard_title, { name: escapeHtml(state.agentName) });
   const templated = pageShell({
-    title: s.dashboard_title,
-    heading: fmt(s.dashboard_header, { name: escapeHtml(state.agentName) }),
-    dek: s.dashboard_dek,
+    title,
+    heading: title,
     updatedLabel: s.label_updated,
     updatedToken: UPDATED_TOKEN,
     body: [
@@ -624,8 +612,7 @@ export function renderDashboard(state: DashboardState, opts?: { now?: string }):
       renderProposals(state),
       renderWeekly(state),
       renderCompiledIndex(state),
-    ].join('\n  '),
-    footer: s.footer,
+    ].filter(Boolean).join('\n  '),
   });
 
   const hash = sha256(templated);

--- a/plugins/claude-code-hermit/scripts/lib/dashboard.ts
+++ b/plugins/claude-code-hermit/scripts/lib/dashboard.ts
@@ -20,6 +20,7 @@ import { todayYMD } from './time';
 import { costIndexPath, readCostIndex } from './cost-log';
 import { rebuildIndex, type ProposalsIndex } from './proposals/index-rebuild';
 import { loadStrings, fmt, type ArtifactStrings } from './artifact-strings';
+import { chipHtml, card, statTile, railRow, disclosure, pageShell, META_SEP } from './artifact-theme';
 
 type Json = any;
 
@@ -249,15 +250,20 @@ function loadCompiledIndex(hermitDir: string): { docs: CompiledDocRow[]; omitted
   return { docs, omitted };
 }
 
-// Alert entries have no single schema: telemetry/checklist alerts carry a `message`
-// string, but budget alerts (the dominant type) store structured fields and no message.
-// Synthesize a readable line for those instead of falling back to the raw dedup key.
+// Alert entries have no single schema. Telemetry alerts carry `message`; the
+// heartbeat checklist writer stores its human sentence under `text` (with a
+// `channelText` variant for chat); budget alerts store structured fields and no
+// prose at all. Read both prose fields before synthesizing or giving up —
+// checking only `message` sent every checklist alert to the raw-dedup-key
+// fallback below, so a page of proposal alerts rendered as
+// "proposal-pending:PROP-012" while the proposal title sat unused on disk.
 // Returns an already-escaped, safe-to-inject-raw string: file-derived parts (message,
 // period, dedup key) are escaped here; the chrome templates are pre-escaped by
 // loadStrings(). renderStatus injects the result without re-escaping, so a translated
 // budget-alert string isn't double-escaped.
 function alertMessage(key: string, v: Json, s: ArtifactStrings): string {
   if (typeof v?.message === 'string') return escapeHtml(v.message);
+  if (typeof v?.text === 'string') return escapeHtml(v.text);
   if (v?.kind === 'budget') {
     const period = escapeHtml(typeof v.period === 'string' ? v.period : 'budget');
     const state = v.level === 'breach' ? s.budget_state_breached : s.budget_state_warning;
@@ -402,10 +408,16 @@ export function mdToHtml(md: string): string {
 // ---------- rendering ----------
 
 export function chip(status: string): string {
-  const cls = ['proposed', 'accepted', 'resolved', 'dismissed', 'deferred'].includes(status)
-    ? status
-    : 'unknown';
-  return `<span class="chip chip-${cls}">${escapeHtml(status)}</span>`;
+  return chipHtml(status, escapeHtml(status));
+}
+
+/** "PROP-012-graphify-optional-recall-source-094353" -> "PROP-012". The slug
+ *  restates the title it sits next to and the trailing HHMMSS is noise; the
+ *  short form is also the handle the operator uses in chat ("accept PROP-012").
+ *  Callers keep the full id in a `title=` attribute. */
+export function shortPropId(id: string): string {
+  const m = id.match(/^(PROP-\d+)/i);
+  return m ? m[1] : id;
 }
 
 function ageLabel(days: number | null, s: ArtifactStrings): string {
@@ -414,11 +426,11 @@ function ageLabel(days: number | null, s: ArtifactStrings): string {
   return fmt(s.age_days, { n: days });
 }
 
-// Renders " (Nd)" (leading space included) or '' when age is unknown, so callers
-// never emit an empty "()" placeholder.
-function ageParen(days: number | null, s: ArtifactStrings): string {
+// Age as a meta part, or nothing at all when unknown — callers spread this into
+// the monospace meta line, so an absent age contributes no separator.
+function ageMeta(days: number | null, s: ArtifactStrings): string[] {
   const label = ageLabel(days, s);
-  return label ? ` <span class="muted">(${label})</span>` : '';
+  return label ? [label] : [];
 }
 
 function pct(n: number | null): string {
@@ -439,31 +451,81 @@ function delta(current: number | null, prior: number | null, unit: 'pp' | '$', s
   return fmt(s.weekly_delta_pp, { prior: Math.round(prior), sign, diff: Math.round(diff) });
 }
 
-function renderStatus(state: DashboardState): string {
-  const s = state.strings;
-  const alertsHtml = state.alerts.length
-    ? `<ul class="alerts">${state.alerts
-        .map(a => `<li>⚠ ${a.message}</li>`)
-        .join('')}</ul>`
-    : `<p class="muted">${s.status_no_alerts}</p>`;
+// Alert keys are `<kind>:<instance>` (e.g. `proposal-pending:PROP-012`). One row
+// per key turned a 20-proposal backlog into twenty near-identical lines, so kinds
+// listed here state the situation once and keep the instances behind a
+// disclosure. Anything not listed still renders a row each — a new alert kind is
+// never silently collapsed into a count.
+const GROUPED_ALERT_KINDS: Record<string, keyof ArtifactStrings> = {
+  'proposal-pending': 'alert_group_proposals',
+};
 
-  return `
-    <section class="card">
-      <h2>${s.status_heading}</h2>
-      <div class="stat-row">
-        <div class="stat"><span class="stat-label">${s.status_session}</span><span class="stat-value">${escapeHtml(state.sessionState ?? 'idle')}</span></div>
-        <div class="stat"><span class="stat-label">${s.status_today}</span><span class="stat-value">$${state.todayCostUsd.toFixed(2)} · ${escapeHtml(formatTokens(state.todayTokens))}</span></div>
-        <div class="stat"><span class="stat-label">${s.status_alerts}</span><span class="stat-value">${state.alerts.length}</span></div>
-      </div>
-      ${alertsHtml}
-    </section>`;
+function alertKind(key: string): string {
+  const i = key.indexOf(':');
+  return i === -1 ? key : key.slice(0, i);
 }
 
-// Shared label for a proposal row: status chip, id, title, plus a caller-supplied
-// suffix (age paren here; proposals-page.ts passes a created-date paren instead).
+function renderAlerts(state: DashboardState): string {
+  const s = state.strings;
+  if (!state.alerts.length) return `<p class="muted">${s.status_no_alerts}</p>`;
+
+  const groups = new Map<string, AlertRow[]>();
+  for (const a of state.alerts) {
+    const kind = alertKind(a.key);
+    const bucket = groups.get(kind);
+    if (bucket) bucket.push(a);
+    else groups.set(kind, [a]);
+  }
+
+  const rows: string[] = [];
+  for (const [kind, members] of groups) {
+    const key = GROUPED_ALERT_KINDS[kind];
+    if (key && members.length > 1) {
+      rows.push(railRow({
+        tone: 'warn',
+        title: fmt(s[key], { n: members.length }),
+        extra: disclosure(fmt(s.common_show_all, { n: members.length }), members.map(m => m.message)),
+      }));
+    } else {
+      for (const m of members) rows.push(railRow({ tone: 'warn', title: m.message }));
+    }
+  }
+  return `<div class="alerts">${rows.join('')}</div>`;
+}
+
+// runtime.json stores a machine enum (`in_progress`); show the operator-facing
+// label when one exists, and the raw value rather than a blank when it doesn't.
+function sessionLabel(state: DashboardState): string {
+  const raw = state.sessionState ?? 'idle';
+  const label = state.strings[`session_${raw}` as keyof ArtifactStrings];
+  return typeof label === 'string' ? label : escapeHtml(raw);
+}
+
+function renderStatus(state: DashboardState): string {
+  const s = state.strings;
+  const tiles = [
+    statTile(s.status_session, sessionLabel(state), 'acc'),
+    statTile(s.status_today, `$${state.todayCostUsd.toFixed(2)}`),
+    statTile(s.status_tokens, escapeHtml(formatTokens(state.todayTokens))),
+    statTile(s.status_alerts, String(state.alerts.length), state.alerts.length ? 'warn' : undefined),
+  ].join('');
+  return card(s.status_heading, `<div class="stat-row">${tiles}</div>${renderAlerts(state)}`);
+}
+
+// Shared two-line template for a proposal row: the title carries the scan, and
+// the machine values (status chip, short id, plus caller-supplied meta — age
+// here, created date on the proposals page) drop to a monospace second line.
+// The full id rides along in `title=` so it stays copyable and searchable
+// without being the loudest thing in the row.
 // Exported so proposals-page.ts's open/history rows reuse the same template.
-export function proposalLabel(p: ProposalRow, suffix: string): string {
-  return `${chip(p.status)} <strong>${escapeHtml(p.id)}</strong> — ${escapeHtml(p.title)}${suffix}`;
+export function proposalLabel(p: ProposalRow, meta: string[]): string {
+  const parts = [
+    chip(p.status),
+    `<span title="${escapeHtml(p.id)}">${escapeHtml(shortPropId(p.id))}</span>`,
+    ...meta,
+  ];
+  return `<p class="rail-title">${escapeHtml(p.title)}</p>` +
+    `<p class="rail-meta">${parts.join(META_SEP)}</p>`;
 }
 
 function renderProposals(state: DashboardState): string {
@@ -474,7 +536,7 @@ function renderProposals(state: DashboardState): string {
     ? open
         .map(
           p => `<details class="proposal">
-            <summary>${proposalLabel(p, ageParen(p.ageDays, s))}</summary>
+            <summary>${proposalLabel(p, ageMeta(p.ageDays, s))}</summary>
             <div class="proposal-body">${mdToHtml(p.body)}</div>
           </details>`
         )
@@ -483,7 +545,7 @@ function renderProposals(state: DashboardState): string {
 
   const otherHtml = other.length
     ? `<ul class="proposal-history">${other
-        .map(p => `<li>${proposalLabel(p, ageParen(p.ageDays, s))}</li>`)
+        .map(p => `<li>${proposalLabel(p, ageMeta(p.ageDays, s))}</li>`)
         .join('')}${otherOmitted > 0 ? `<li class="muted">${fmt(s.common_more_not_shown, { n: otherOmitted })}</li>` : ''}</ul>`
     : '';
 
@@ -496,21 +558,13 @@ function renderProposals(state: DashboardState): string {
       })}</p>`
     : '';
 
-  return `
-    <section class="card">
-      <h2>${s.proposals_heading}</h2>
-      ${oldestLine}
-      ${openHtml}
-      ${otherHtml}
-    </section>`;
+  return card(s.proposals_heading, `${oldestLine}${openHtml}${otherHtml}`);
 }
 
 function renderWeekly(state: DashboardState): string {
   const s = state.strings;
   const w = state.weekly;
-  if (!w) {
-    return `<section class="card"><h2>${s.weekly_heading}</h2><p class="muted">${s.weekly_none}</p></section>`;
-  }
+  if (!w) return card(s.weekly_heading, `<p class="muted">${s.weekly_none}</p>`);
 
   const costLine = w.costUsd != null
     ? fmt(s.weekly_cost, { amount: `$${w.costUsd.toFixed(2)}`, delta: w.hasPrior ? delta(w.costUsd, w.priorCostUsd, '$', s) : '' })
@@ -524,139 +578,55 @@ function renderWeekly(state: DashboardState): string {
 
   const summary = [costLine, autonomyLine, proposalsLine].filter(Boolean) as string[];
 
-  return `
-    <section class="card">
-      <h2>${fmt(s.weekly_week, { week: escapeHtml(w.week) })}</h2>
+  return card(fmt(s.weekly_week, { week: escapeHtml(w.week) }), `
       <ul class="evolution">${summary.map(l => `<li>${l}</li>`).join('')}</ul>
       <details class="weekly-body">
         <summary>${s.weekly_full_review}</summary>
         <div>${w.bodyHtml}</div>
-      </details>
-    </section>`;
+      </details>`);
 }
 
 function renderBrief(state: DashboardState): string {
   const s = state.strings;
   const b = state.lastBrief;
-  if (!b) {
-    return `<section class="card"><h2>${s.brief_heading}</h2><p class="muted">${s.brief_none}</p></section>`;
-  }
+  if (!b) return card(s.brief_heading, `<p class="muted">${s.brief_none}</p>`);
   const when = b.generatedAt ? ` <span class="muted">· ${escapeHtml(b.generatedAt)}</span>` : '';
-  return `
-    <section class="card">
-      <h2>${s.brief_heading} <span class="muted">(${escapeHtml(b.kind)})</span>${when}</h2>
-      ${mdToHtml(b.text)}
-    </section>`;
+  return card(`${s.brief_heading} <span class="muted">(${escapeHtml(b.kind)})</span>${when}`, mdToHtml(b.text));
 }
 
 function renderCompiledIndex(state: DashboardState): string {
   const s = state.strings;
   const { docs, omitted } = state.compiledIndex;
-  if (!docs.length) {
-    return `<section class="card"><h2>${s.compiled_heading}</h2><p class="muted">${s.compiled_none}</p></section>`;
-  }
-  const items = docs.map(d => `<li>${escapeHtml(d.title)} <span class="muted">(${escapeHtml(d.name)})</span></li>`).join('');
+  if (!docs.length) return card(s.compiled_heading, `<p class="muted">${s.compiled_none}</p>`);
+  const items = docs
+    .map(d => `<li>${escapeHtml(d.title)}<span class="rail-meta">${escapeHtml(d.name)}</span></li>`)
+    .join('');
   const omittedLine = omitted > 0 ? `<li class="muted">${fmt(s.common_more_not_shown, { n: omitted })}</li>` : '';
-  return `
-    <section class="card">
-      <h2>${s.compiled_heading}</h2>
+  return card(s.compiled_heading, `
       <p class="muted">${s.compiled_hint}</p>
-      <ul class="proposal-history">${items}${omittedLine}</ul>
-    </section>`;
+      <ul class="proposal-history">${items}${omittedLine}</ul>`);
 }
-
-export const CSS = `
-:root {
-  color-scheme: light dark;
-  --bg: #ffffff; --fg: #1a1a1a; --muted: #6b7280; --border: #e5e7eb; --card-bg: #fafafa;
-  --chip-proposed-bg: #fef3c7; --chip-proposed-fg: #92400e;
-  --chip-accepted-bg: #dbeafe; --chip-accepted-fg: #1e40af;
-  --chip-resolved-bg: #dcfce7; --chip-resolved-fg: #166534;
-  --chip-dismissed-bg: #f3f4f6; --chip-dismissed-fg: #4b5563;
-  --chip-deferred-bg: #ede9fe; --chip-deferred-fg: #5b21b6;
-  --chip-unknown-bg: #f3f4f6; --chip-unknown-fg: #6b7280;
-  --code-bg: #f3f4f6;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0f1115; --fg: #e5e7eb; --muted: #9ca3af; --border: #2a2e37; --card-bg: #171a20;
-    --chip-proposed-bg: #422006; --chip-proposed-fg: #fbbf24;
-    --chip-accepted-bg: #1e3a5f; --chip-accepted-fg: #93c5fd;
-    --chip-resolved-bg: #14321f; --chip-resolved-fg: #86efac;
-    --chip-dismissed-bg: #1f2229; --chip-dismissed-fg: #9ca3af;
-    --chip-deferred-bg: #2e1f4d; --chip-deferred-fg: #c4b5fd;
-    --chip-unknown-bg: #1f2229; --chip-unknown-fg: #9ca3af;
-    --code-bg: #1f2229;
-  }
-}
-:root[data-theme="light"] {
-  --bg: #ffffff; --fg: #1a1a1a; --muted: #6b7280; --border: #e5e7eb; --card-bg: #fafafa; --code-bg: #f3f4f6;
-}
-:root[data-theme="dark"] {
-  --bg: #0f1115; --fg: #e5e7eb; --muted: #9ca3af; --border: #2a2e37; --card-bg: #171a20; --code-bg: #1f2229;
-}
-* { box-sizing: border-box; }
-body, .hermit-page { margin: 0; }
-.hermit-page {
-  background: var(--bg); color: var(--fg);
-  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  font-variant-numeric: tabular-nums;
-  max-width: 720px; margin: 0 auto; padding: 24px 20px 48px;
-}
-.hermit-page header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 20px; }
-.hermit-page header h1 { font-size: 18px; margin: 0; }
-.hermit-page header .updated { color: var(--muted); font-size: 13px; }
-.card { border: 1px solid var(--border); background: var(--card-bg); border-radius: 8px; padding: 16px 18px; margin-bottom: 16px; overflow-x: auto; }
-.card h2 { font-size: 14px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); margin: 0 0 12px; }
-.stat-row { display: flex; gap: 24px; flex-wrap: wrap; margin-bottom: 8px; }
-.stat { display: flex; flex-direction: column; }
-.stat-label { font-size: 12px; color: var(--muted); }
-.stat-value { font-size: 16px; font-weight: 600; }
-.muted { color: var(--muted); font-size: 13px; }
-.chip { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 12px; font-weight: 600; }
-.chip-proposed { background: var(--chip-proposed-bg); color: var(--chip-proposed-fg); }
-.chip-accepted { background: var(--chip-accepted-bg); color: var(--chip-accepted-fg); }
-.chip-resolved { background: var(--chip-resolved-bg); color: var(--chip-resolved-fg); }
-.chip-dismissed { background: var(--chip-dismissed-bg); color: var(--chip-dismissed-fg); }
-.chip-deferred { background: var(--chip-deferred-bg); color: var(--chip-deferred-fg); }
-.chip-unknown { background: var(--chip-unknown-bg); color: var(--chip-unknown-fg); }
-.alerts { margin: 8px 0 0; padding-left: 18px; }
-.proposal { border-top: 1px solid var(--border); padding: 8px 0; }
-.proposal:first-of-type { border-top: none; }
-.proposal summary { cursor: pointer; }
-.proposal-body { margin-top: 8px; padding-left: 4px; }
-.proposal-history { list-style: none; margin: 8px 0 0; padding: 0; }
-.proposal-history li { padding: 4px 0; border-top: 1px solid var(--border); }
-.proposal-history li:first-child { border-top: none; }
-.evolution { margin: 0 0 12px; padding-left: 18px; }
-.weekly-body summary { cursor: pointer; color: var(--muted); }
-code { background: var(--code-bg); border-radius: 4px; padding: 1px 5px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
-pre { background: var(--code-bg); border-radius: 6px; padding: 10px 12px; overflow-x: auto; }
-pre code { background: none; padding: 0; }
-a { color: inherit; }
-footer.hermit-footer { color: var(--muted); font-size: 12px; margin-top: 8px; }
-`;
 
 /** Renders the full artifact fragment plus a content hash stable across
  *  identical underlying state (the "last updated" stamp is excluded from the hash
  *  via a placeholder token, so the publish gate can skip no-op republishes). */
 export function renderDashboard(state: DashboardState, opts?: { now?: string }): { html: string; hash: string } {
   const s = state.strings;
-  const templated = `<title>${s.dashboard_title}</title>
-<style>${CSS}</style>
-<div class="hermit-page">
-  <header>
-    <h1>${fmt(s.dashboard_header, { name: escapeHtml(state.agentName) })}</h1>
-    <span class="updated">${s.label_updated} ${UPDATED_TOKEN}</span>
-  </header>
-  ${renderStatus(state)}
-  ${renderBrief(state)}
-  ${renderProposals(state)}
-  ${renderWeekly(state)}
-  ${renderCompiledIndex(state)}
-  <footer class="hermit-footer">${s.footer}</footer>
-</div>
-`;
+  const templated = pageShell({
+    title: s.dashboard_title,
+    heading: fmt(s.dashboard_header, { name: escapeHtml(state.agentName) }),
+    dek: s.dashboard_dek,
+    updatedLabel: s.label_updated,
+    updatedToken: UPDATED_TOKEN,
+    body: [
+      renderStatus(state),
+      renderBrief(state),
+      renderProposals(state),
+      renderWeekly(state),
+      renderCompiledIndex(state),
+    ].join('\n  '),
+    footer: s.footer,
+  });
 
   const hash = sha256(templated);
   const now = opts?.now ?? new Date().toISOString();

--- a/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
+++ b/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
@@ -7,7 +7,7 @@
 // dashboard already computes. Self-contained fragment — no
 // <!DOCTYPE>/<html>/<head>/<body> (Artifact tool wraps it).
 
-import { loadProposals, mdToHtml, escapeHtml, proposalLabel, shortPropId, type ProposalRow, type OpenProposalRow } from './dashboard';
+import { loadProposals, loadAgentName, mdToHtml, escapeHtml, proposalLabel, shortPropId, type ProposalRow, type OpenProposalRow } from './dashboard';
 import { sha256 } from './hash';
 import { loadStrings, fmt, type ArtifactStrings } from './artifact-strings';
 import { card, pills, pageShell } from './artifact-theme';
@@ -15,6 +15,7 @@ import { card, pills, pageShell } from './artifact-theme';
 const UPDATED_TOKEN = '__PROPOSALS_PAGE_UPDATED__';
 
 export interface ProposalsPageState {
+  agentName: string;
   open: OpenProposalRow[];
   other: ProposalRow[];
   otherOmitted: number;
@@ -23,7 +24,7 @@ export interface ProposalsPageState {
 
 export function loadProposalsPageState(hermitDir: string): ProposalsPageState {
   const { open, other, otherOmitted } = loadProposals(hermitDir);
-  return { open, other, otherOmitted, strings: loadStrings(hermitDir) };
+  return { agentName: loadAgentName(hermitDir), open, other, otherOmitted, strings: loadStrings(hermitDir) };
 }
 
 // "PROP-025-some-slug-123243" -> "prop-025". Falls back to a full slugified id
@@ -79,14 +80,13 @@ export function renderProposalsPage(state: ProposalsPageState, opts?: { now?: st
   ]);
 
   const templated = pageShell({
-    title: s.proposals_page_title,
+    title: fmt(s.proposals_page_title, { name: escapeHtml(state.agentName) }),
     heading: s.proposals_page_header,
     updatedLabel: s.label_updated,
     updatedToken: UPDATED_TOKEN,
     body: `${summary}
   ${renderOpen(state.open, s)}
   ${renderOther(state.other, state.otherOmitted, s)}`,
-    footer: s.footer,
   });
 
   const hash = sha256(templated);

--- a/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
+++ b/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
@@ -7,9 +7,10 @@
 // dashboard already computes. Self-contained fragment — no
 // <!DOCTYPE>/<html>/<head>/<body> (Artifact tool wraps it).
 
-import { loadProposals, mdToHtml, escapeHtml, CSS, proposalLabel, type ProposalRow, type OpenProposalRow } from './dashboard';
+import { loadProposals, mdToHtml, escapeHtml, proposalLabel, shortPropId, type ProposalRow, type OpenProposalRow } from './dashboard';
 import { sha256 } from './hash';
 import { loadStrings, fmt, type ArtifactStrings } from './artifact-strings';
+import { card, pills, pageShell } from './artifact-theme';
 
 const UPDATED_TOKEN = '__PROPOSALS_PAGE_UPDATED__';
 
@@ -28,41 +29,36 @@ export function loadProposalsPageState(hermitDir: string): ProposalsPageState {
 // "PROP-025-some-slug-123243" -> "prop-025". Falls back to a full slugified id
 // for legacy rows with no PROP-NNN prefix.
 export function proposalAnchorId(id: string): string {
-  const m = id.match(/^(PROP-\d+)/i);
-  const base = m ? m[1] : id;
-  return base.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return shortPropId(id).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
-function createdLabel(created: string | null): string {
-  if (!created) return '';
-  return ` <span class="muted">(${escapeHtml(created)})</span>`;
+// Calendar date only. The stored value is a full ISO stamp with an offset, which
+// is noise in a scan line — and the date alone stays activity-driven, so the
+// hash-gate rationale in this file's header still holds.
+function createdMeta(created: string | null): string[] {
+  if (!created) return [];
+  const day = created.slice(0, 10);
+  return [`<span title="${escapeHtml(created)}">${escapeHtml(day)}</span>`];
 }
 
 function renderOpen(open: OpenProposalRow[], s: ArtifactStrings): string {
   if (!open.length) return `<p class="muted">${s.proposals_none_open}</p>`;
   const items = open
     .map(p => `<details class="proposal" id="${proposalAnchorId(p.id)}">
-      <summary>${proposalLabel(p, createdLabel(p.created))}</summary>
+      <summary>${proposalLabel(p, createdMeta(p.created))}</summary>
       <div class="proposal-body">${mdToHtml(p.body)}</div>
     </details>`)
     .join('');
-  return `<section class="card">
-    <h2>${fmt(s.proposals_open_count, { n: open.length })}</h2>
-    ${items}
-  </section>`;
+  return card(fmt(s.proposals_open_count, { n: open.length }), items);
 }
 
 function renderOther(other: ProposalRow[], otherOmitted: number, s: ArtifactStrings): string {
   if (!other.length) return '';
   const items = other
-    .map(p => `<li>${proposalLabel(p, createdLabel(p.created))}</li>`)
+    .map(p => `<li>${proposalLabel(p, createdMeta(p.created))}</li>`)
     .join('');
   const omittedLine = otherOmitted > 0 ? `<li class="muted">${fmt(s.common_more_not_shown, { n: otherOmitted })}</li>` : '';
-  return `
-    <section class="card">
-      <h2>${s.proposals_history}</h2>
-      <ul class="proposal-history">${items}${omittedLine}</ul>
-    </section>`;
+  return card(s.proposals_history, `<ul class="proposal-history">${items}${omittedLine}</ul>`);
 }
 
 /** Renders the full artifact fragment plus a content hash stable across
@@ -73,18 +69,25 @@ function renderOther(other: ProposalRow[], otherOmitted: number, s: ArtifactStri
  *  day even with zero proposal activity; created-date is shown instead. */
 export function renderProposalsPage(state: ProposalsPageState, opts?: { now?: string }): { html: string; hash: string } {
   const s = state.strings;
-  const templated = `<title>${s.proposals_page_title}</title>
-<style>${CSS}</style>
-<div class="hermit-page">
-  <header>
-    <h1>${s.proposals_page_header}</h1>
-    <span class="updated">${s.label_updated} ${UPDATED_TOKEN}</span>
-  </header>
+  // Counts before the list: how many need a decision vs. how many are already
+  // settled is the question this page answers, and it should not require
+  // counting rows. `decided` includes the capped tail, so the total stays true.
+  const decided = state.other.length + state.otherOmitted;
+  const summary = pills([
+    ...(state.open.length ? [{ tone: 'warn' as const, value: String(state.open.length), label: s.proposals_pill_open }] : []),
+    ...(decided ? [{ tone: 'good' as const, value: String(decided), label: s.proposals_pill_decided }] : []),
+  ]);
+
+  const templated = pageShell({
+    title: s.proposals_page_title,
+    heading: s.proposals_page_header,
+    updatedLabel: s.label_updated,
+    updatedToken: UPDATED_TOKEN,
+    body: `${summary}
   ${renderOpen(state.open, s)}
-  ${renderOther(state.other, state.otherOmitted, s)}
-  <footer class="hermit-footer">${s.footer}</footer>
-</div>
-`;
+  ${renderOther(state.other, state.otherOmitted, s)}`,
+    footer: s.footer,
+  });
 
   const hash = sha256(templated);
   const now = opts?.now ?? new Date().toISOString();

--- a/plugins/claude-code-hermit/tests/artifact-strings.test.ts
+++ b/plugins/claude-code-hermit/tests/artifact-strings.test.ts
@@ -95,9 +95,9 @@ describe('loadStrings', () => {
   }));
 
   test('{placeholder} tokens in an overlay value survive escaping and still fill via fmt()', withHermitDir((hermitDir) => {
-    writeStrings(hermitDir, { dashboard_header: '{name} — O Painel do Eremita' });
+    writeStrings(hermitDir, { dashboard_title: '{name} — O Painel' });
     const s = loadStrings(hermitDir);
-    expect(fmt(s.dashboard_header, { name: 'Atlas' })).toBe('Atlas — O Painel do Eremita');
+    expect(fmt(s.dashboard_title, { name: 'Atlas' })).toBe('Atlas — O Painel');
   }));
 
   test('every DEFAULT_STRINGS value is a non-empty string', () => {
@@ -118,8 +118,7 @@ describe('renderers honor the overlay', () => {
 
     // English chrome must be gone (all masked to x-runs)...
     for (const phrase of ['Status', 'No active alerts.', 'No open proposals.', 'Latest brief',
-                          'No brief yet.', 'Compiled docs', "This week's evolution", 'No weekly review yet.',
-                          'Hermit Dashboard', 'Rendered by claude-code-hermit']) {
+                          'No brief yet.', 'Compiled docs', 'Dashboard']) {
       expect(html, phrase).not.toContain(phrase);
     }
     // ...replaced by the masked chrome, with the {name} placeholder still filled from config.
@@ -130,7 +129,7 @@ describe('renderers honor the overlay', () => {
   test('proposals page chrome is fully table-sourced', withHermitDir((hermitDir) => {
     writeStrings(hermitDir, fullMaskedOverlay());
     const { html } = renderProposalsPage(loadProposalsPageState(hermitDir), { now: '2026-07-05T09:00:00Z' });
-    for (const phrase of ['Hermit Proposals', 'No open proposals.', 'Rendered by claude-code-hermit']) {
+    for (const phrase of ['Proposals', 'No open proposals.']) {
       expect(html, phrase).not.toContain(phrase);
     }
   }));

--- a/plugins/claude-code-hermit/tests/artifact-theme.test.ts
+++ b/plugins/claude-code-hermit/tests/artifact-theme.test.ts
@@ -10,7 +10,7 @@
 // resolved from the other theme).
 
 import { describe, test, expect } from 'bun:test';
-import { PALETTE, CSS, chipHtml, railRow, disclosure, pills } from '../scripts/lib/artifact-theme';
+import { PALETTE, CSS, chipHtml, railRow, pills } from '../scripts/lib/artifact-theme';
 
 const TOKENS = Object.keys(PALETTE.light);
 
@@ -78,7 +78,9 @@ describe('page-level rules', () => {
   });
 
   test('wide content can scroll inside its own container', () => {
-    expect(CSS).toContain('.scroller { overflow-x: auto; }');
+    // Every rendered section is a `.card`, and its body can be model-authored
+    // markdown — without this the page itself scrolls horizontally.
+    expect(CSS).toMatch(/\.card\s*\{[^}]*overflow-x:\s*auto/);
     expect(CSS).toMatch(/pre\s*\{[^}]*overflow-x:\s*auto/);
   });
 
@@ -129,8 +131,7 @@ describe('markup helpers', () => {
     expect(railRow({ tone: 'mute', title: 'x', meta: ['a', 'b'] })).toContain('rail-meta');
   });
 
-  test('disclosure and pills collapse to nothing when empty', () => {
-    expect(disclosure('Show all', [])).toBe('');
+  test('pills collapse to nothing when empty', () => {
     expect(pills([])).toBe('');
   });
 });

--- a/plugins/claude-code-hermit/tests/artifact-theme.test.ts
+++ b/plugins/claude-code-hermit/tests/artifact-theme.test.ts
@@ -1,0 +1,136 @@
+// Invariants for the shared Artifact stylesheet. These are the rules from Claude
+// Code's `artifact-design` skill that can be checked mechanically — the sync
+// mechanism for a prose skill that offers nothing importable. When that skill
+// gains a checkable rule, add an assertion here rather than trusting a re-read.
+//
+// The regressions these pin are real, not hypothetical: the sheet this module
+// replaced painted no background on `body` (so the page borrowed the viewer's
+// ground outside its centred column) and declared only 6 of its 19 tokens in the
+// two [data-theme] blocks (so an explicit theme choice left chip colours
+// resolved from the other theme).
+
+import { describe, test, expect } from 'bun:test';
+import { PALETTE, CSS, chipHtml, railRow, disclosure, pills } from '../scripts/lib/artifact-theme';
+
+const TOKENS = Object.keys(PALETTE.light);
+
+/** The four blocks that must each carry the full token set. */
+const THEME_BLOCK_SELECTORS = [
+  ':root {',
+  ':root:not([data-theme="light"]) {',
+  ':root[data-theme="dark"] {',
+  ':root[data-theme="light"] {',
+];
+
+function blockBody(selector: string): string {
+  const start = CSS.indexOf(selector);
+  expect(start).toBeGreaterThan(-1);
+  const open = start + selector.length;
+  const end = CSS.indexOf('}', open);
+  return CSS.slice(open, end);
+}
+
+describe('palette', () => {
+  test('both themes declare identical token sets', () => {
+    expect(Object.keys(PALETTE.dark).sort()).toEqual(TOKENS.slice().sort());
+  });
+
+  test('every token resolves to a literal colour, not another var()', () => {
+    for (const theme of [PALETTE.light, PALETTE.dark]) {
+      for (const [name, value] of Object.entries(theme)) {
+        expect(value, `${name} must be a hex literal`).toMatch(/^#[0-9a-f]{3,8}$/i);
+      }
+    }
+  });
+});
+
+describe('theme blocks', () => {
+  // The bug this replaces: [data-theme] blocks that redefine only part of the
+  // set leave the rest resolved from whichever earlier block won, so a viewer
+  // who picks a theme gets half of each.
+  for (const selector of THEME_BLOCK_SELECTORS) {
+    test(`${selector} declares all ${TOKENS.length} tokens`, () => {
+      const body = blockBody(selector);
+      const missing = TOKENS.filter(t => !body.includes(`--${t}:`));
+      expect(missing).toEqual([]);
+    });
+  }
+
+  test('the dark media query is guarded so an explicit light choice wins', () => {
+    expect(CSS).toContain('@media (prefers-color-scheme: dark) { :root:not([data-theme="light"])');
+  });
+
+  test('both explicit-theme blocks exist, so the toggle wins in both directions', () => {
+    expect(CSS).toContain(':root[data-theme="dark"]');
+    expect(CSS).toContain(':root[data-theme="light"]');
+  });
+});
+
+describe('page-level rules', () => {
+  test('body paints its own background from a token', () => {
+    // Without this the artifact composites over the host's ground and the page
+    // renders one theme's text on the other theme's background.
+    expect(CSS).toMatch(/body\s*\{[^}]*background:\s*var\(--bg\)/);
+  });
+
+  test('digits that line up in columns use tabular figures', () => {
+    expect(CSS).toContain('tabular-nums');
+  });
+
+  test('wide content can scroll inside its own container', () => {
+    expect(CSS).toContain('.scroller { overflow-x: auto; }');
+    expect(CSS).toMatch(/pre\s*\{[^}]*overflow-x:\s*auto/);
+  });
+
+  test('reduced-motion is respected', () => {
+    expect(CSS).toContain('prefers-reduced-motion');
+  });
+});
+
+describe('CSP and token discipline', () => {
+  test('no external references — a published artifact blocks every other host', () => {
+    expect(CSS).not.toMatch(/https?:\/\//);
+    expect(CSS).not.toMatch(/url\(/);
+    expect(CSS).not.toMatch(/@import/);
+  });
+
+  test('colours are only ever declared in the generated theme blocks', () => {
+    // Every hex literal in the sheet must come from a `--token:` declaration.
+    // A raw hex on a component rule is the failure mode that makes one theme
+    // unreadable, and it is invisible until someone opens the other theme.
+    const stray = CSS.split('\n')
+      .filter(line => /#[0-9a-f]{3,8}\b/i.test(line))
+      .filter(line => !/--[a-z-]+:\s*#/i.test(line));
+    expect(stray).toEqual([]);
+  });
+});
+
+describe('markup helpers', () => {
+  test('known statuses map to their own chip class, unknown ones fall back', () => {
+    expect(chipHtml('proposed', 'proposed')).toContain('chip-proposed');
+    expect(chipHtml('resolved', 'resolved')).toContain('chip-resolved');
+    expect(chipHtml('banana', 'banana')).toContain('chip-unknown');
+  });
+
+  test('every chip class the helper can emit is styled', () => {
+    for (const status of ['proposed', 'accepted', 'resolved', 'dismissed', 'deferred', 'unknown']) {
+      expect(CSS).toContain(`.chip-${status} {`);
+    }
+  });
+
+  test('railRow emits a tone class that the sheet styles', () => {
+    const html = railRow({ tone: 'warn', title: 'Something needs you' });
+    expect(html).toContain('rail rail-warn');
+    expect(CSS).toContain('.rail-warn {');
+  });
+
+  test('railRow omits the meta line rather than emitting an empty one', () => {
+    expect(railRow({ tone: 'mute', title: 'x' })).not.toContain('rail-meta');
+    expect(railRow({ tone: 'mute', title: 'x', meta: ['a', 'b'] })).toContain('rail-meta');
+  });
+
+  test('disclosure and pills collapse to nothing when empty', () => {
+    expect(disclosure('Show all', [])).toBe('');
+    expect(pills([])).toBe('');
+  });
+});

--- a/plugins/claude-code-hermit/tests/dashboard.test.ts
+++ b/plugins/claude-code-hermit/tests/dashboard.test.ts
@@ -361,7 +361,15 @@ describe('renderDashboard', () => {
     expect(html).not.toMatch(/<html/i);
     expect(html).not.toMatch(/<head>/i);
     expect(html).not.toMatch(/<body>/i);
-    expect(html).toContain('<title>Hermit Dashboard</title>');
+    expect(html).toContain('<title>Hermit — Dashboard</title>');
+  }));
+
+  test('both page titles lead with the hermit name, never doubling it', withHermitDir((hermitDir) => {
+    writeJson(hermitDir, 'config.json', { agent_name: 'Atlas' });
+    const { html } = renderDashboard(loadDashboardState(hermitDir), { now: '2026-07-05T09:00:00Z' });
+    expect(html).toContain('<title>Atlas — Dashboard</title>');
+    expect(html).toContain('<h1>Atlas — Dashboard</h1>');
+    expect(html).not.toContain('Hermit Dashboard');
   }));
 
   test('hash is stable across identical state regardless of the "now" timestamp', withHermitDir((hermitDir) => {
@@ -442,10 +450,40 @@ describe('renderDashboard', () => {
     expect(html).toContain('PROP-002-resolved-100000');
   }));
 
-  test('shows placeholder copy for empty proposals and missing weekly review', withHermitDir((hermitDir) => {
+  test('shows placeholder copy for empty proposals and alerts', withHermitDir((hermitDir) => {
     const { html } = renderDashboard(loadDashboardState(hermitDir));
     expect(html).toContain('No open proposals.');
-    expect(html).toContain('No weekly review yet.');
     expect(html).toContain('No active alerts.');
+  }));
+
+  test('proposal-pending alerts stay out of the alert list but keep counting in the tile', withHermitDir((hermitDir) => {
+    writeJson(hermitDir, 'state/alert-state.json', {
+      alerts: {
+        'proposal-pending:PROP-001': { message: 'PROP-001 awaiting decision' },
+        'proposal-pending:PROP-002': { message: 'PROP-002 awaiting decision' },
+        'budget-daily': { message: 'Daily budget at 92%' },
+      },
+      self_eval: {}, total_ticks: 1, last_digest_date: null,
+    });
+    const { html } = renderDashboard(loadDashboardState(hermitDir));
+    expect(html).not.toContain('PROP-001 awaiting decision');
+    expect(html).toContain('Daily budget at 92%');          // other kinds still render
+    expect(html).toContain('>3<');                          // tile still counts all three
+  }));
+
+  test('renders no alert list rather than "No active alerts." when every alert is card-owned', withHermitDir((hermitDir) => {
+    writeJson(hermitDir, 'state/alert-state.json', {
+      alerts: { 'proposal-pending:PROP-001': { message: 'PROP-001 awaiting decision' } },
+      self_eval: {}, total_ticks: 1, last_digest_date: null,
+    });
+    const { html } = renderDashboard(loadDashboardState(hermitDir));
+    expect(html).not.toContain('No active alerts.');        // would contradict the tile
+    expect(html).not.toContain('PROP-001 awaiting decision');
+  }));
+
+  test('omits the weekly card entirely when there is no review yet', withHermitDir((hermitDir) => {
+    const { html } = renderDashboard(loadDashboardState(hermitDir));
+    expect(html).not.toContain('<h2>Week ');
+    expect(html).not.toContain('<details class="weekly-body">');
   }));
 });

--- a/plugins/claude-code-hermit/tests/proposals-page.test.ts
+++ b/plugins/claude-code-hermit/tests/proposals-page.test.ts
@@ -84,7 +84,7 @@ describe('renderProposalsPage', () => {
     expect(html).not.toMatch(/<html/i);
     expect(html).not.toMatch(/<head>/i);
     expect(html).not.toMatch(/<body>/i);
-    expect(html).toContain('<title>Hermit Proposals</title>');
+    expect(html).toContain('<title>Hermit — Proposals</title>');
   }));
 
   test('renders each open proposal as a collapsed <details> anchored for deep-linking', withHermitDir((hermitDir) => {


### PR DESCRIPTION
## Summary

The dashboard and proposals Artifact pages shared a hand-rolled 71-line stylesheet that had drifted. This consolidates the whole visual system into `scripts/lib/artifact-theme.ts`, fixes three real defects it was hiding, and lays the pages out for scanning instead of reading.

The motivation was a comparison against a page built through Claude Code's `artifact-design` skill. That skill is prose with nothing importable, so "stay in sync with it" cannot mean depending on it — the mechanism here is: concentrate every decision in one module, and encode the mechanically-checkable rules as a test. When the skill gains a checkable rule, you add an assertion rather than trusting a re-read.

**`artifact-design` is deliberately NOT on the publish path.** These renderers are scripts on purpose (`dashboard.ts:1-3` — a publish costs a render, not a generation, and publishes fire several times a day from `brief`, `proposal-create`, and `proposal-act`). The design work is done once, by hand, into the renderer.

## Bugs fixed

1. **The page borrowed the viewer's background.** `body` never painted one; only `.hermit-page` did, and it is a centred column — so everything outside it showed the host theme's ground. Observed live as cream gutters framing a dark card column.
2. **An explicit theme choice broke the chips.** Bare `:root` and the dark media query each defined 19 tokens; both `[data-theme]` blocks defined **6**. All 12 chip tokens went missing when a viewer picked a theme, so base colours resolved from one block and chips from another.
3. **Readable alert text was discarded.** `alertMessage()` read only `v.message`, but the heartbeat checklist writer stores its sentence under `text`. Verified against live state: **0 of 20** active alerts carried a `message` field, so every one fell through to `escapeHtml(key)` and rendered as `proposal-pending:PROP-012` while the proposal title sat unused on disk.

Bugs 1 and 2 both trace to the same cause: the token set was hand-duplicated four times. `PALETTE` is now declared once and all four theme blocks are generated from it, which makes that class of drift unrepresentable rather than merely fixed.

## Changes

- **New `scripts/lib/artifact-theme.ts`** — `PALETTE`, the generated theme blocks, the type scale, and shared markup helpers (`card`, `statTile`, `railRow`, `disclosure`, `pills`, `pageShell`, `chipHtml`). The single file a future re-sync edits.
- **Layout and hierarchy** — 1100px column (was 720px); a type scale where headings sit above body text (they were 14px under 15px body, so nothing read as a heading); `ui-monospace` promoted from "inside `<code>`" to a real role for every machine value; severity rails; summary tiles and count pills before the lists.
- **Status alerts group by kind** — twenty `proposal-pending:*` entries become one row with the count and the recovered titles behind a disclosure. Unlisted kinds still render a row each, so a new alert kind is never silently collapsed into a number.
- **Proposal rows lead with the title**; the full slug moves to a `title=` attribute and the row shows `PROP-NNN`. Deep-link anchors (`#prop-012`) are unchanged.
- **New `tests/artifact-theme.test.ts`** — 19 invariant tests. The strongest is "no hex literal outside the generated token blocks", which mechanically enforces styling through tokens.
- **`docs/artifacts.md` § Design contract** — what is implemented from `artifact-design`, and what is declined (no inlined webfont: the plugin bans build steps and runtime deps, subsetting needs absent tooling, and it would vendor a font plus licence into a public plugin).

## Test plan

- `bun test` from `plugins/claude-code-hermit/` — **3479 pass, 0 fail** across 123 files. The 639 lines of pre-existing render tests assert content and escaping only and passed **unchanged**; no existing assertion was edited or relaxed.
- `bunx tsc --noEmit` from repo root — clean.
- Rendered both pages from real state and published the dashboard output to inspect it in a browser: verified the grouped alert row, mono meta lines, inline disclosure caret, and that zero raw `proposal-pending:PROP-NNN` keys survive.
- **Hash gate holds** — two renders of identical state produce a byte-identical hash (`67ce8250…` twice), so steady-state republishes stay no-ops.
- **Deep links intact** — re-rendered proposals page still emits `id="prop-012"`, `id="prop-027"`, …
- Theme states were checked visually across system-light, system-dark, and an explicit `data-theme` toggle (the state that exposed bug 2).

## Notes for the reviewer

- `[Unreleased]` carries `### Upgrade Instructions` for ten new string keys. They matter only for hermits that have a `state/artifact-strings.json` translation overlay; missing keys fall back to English per key, so an untranslated hermit renders correctly either way.
- Both pages change shape, so the next publish re-mints each once. That is expected, not a gate failure.