### PR TITLE
fix(claude-code-hermit): refuse a duplicate boot when lifecycle state is gone

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -12,7 +12,7 @@
 - The dashboard drops chrome that carried no information: the "Autonomous agent status" subtitle, the page footer, and the weekly card's empty state (the card is now omitted until there is a review).
 
 ### Fixed
-- `hermit-start` exits 1 with restart guidance when the session is already running but `state/runtime.json` is missing or unreadable, instead of reporting success and leaving `hermit-attach` stuck telling you to run start again. A healthy double-boot still exits 0.
+- `hermit-start` exits 1 with restart guidance when the session is already running but `state/runtime.json` is missing, unreadable, or holds no lifecycle record (no `runtime_mode`/`tmux_session` — what an interrupted `hermit-stop` leaves behind), instead of reporting success and leaving `hermit-attach` stuck telling you to run start again. A healthy double-boot still exits 0.
 - A failed `tmux new-session` no longer strands its temporary env file (mode 0600, holding the forwarded API key and setup token) in `/tmp`: cleanup previously only ran inside the session that failed to start.
 - Artifact pages paint their own `body` background instead of borrowing the viewer's, which left everything outside the centred column showing the host theme's ground.
 - An explicit viewer theme no longer leaves status chips resolved from the other theme — the two `[data-theme]` blocks had redefined 6 of the sheet's 19 tokens.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -12,6 +12,8 @@
 - The dashboard drops chrome that carried no information: the "Autonomous agent status" subtitle, the page footer, and the weekly card's empty state (the card is now omitted until there is a review).
 
 ### Fixed
+- `hermit-start` exits 1 with restart guidance when the session is already running but `state/runtime.json` is missing or unreadable, instead of reporting success and leaving `hermit-attach` stuck telling you to run start again. A healthy double-boot still exits 0.
+- A failed `tmux new-session` no longer strands its temporary env file (mode 0600, holding the forwarded API key and setup token) in `/tmp`: cleanup previously only ran inside the session that failed to start.
 - Artifact pages paint their own `body` background instead of borrowing the viewer's, which left everything outside the centred column showing the host theme's ground.
 - An explicit viewer theme no longer leaves status chips resolved from the other theme — the two `[data-theme]` blocks had redefined 6 of the sheet's 19 tokens.
 - Checklist alerts render the text stored alongside them instead of the raw dedup key. `alertMessage()` read only `message`, which the heartbeat writer never sets.

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -148,7 +148,7 @@ When idle and `idle_behavior` is `"discover"` (set via `/hermit-settings idle`),
 - **Crash during work:** SHELL.md persists. On restart, offers to resume.
 - **Crash during idle:** SHELL.md persists as `idle`. Asks what to work on next.
 - **Crash during waiting:** SHELL.md persists as `waiting`. On restart, re-enters waiting state and checks for operator response.
-- **hermit-start when already running:** Prints guidance, exits.
+- **hermit-start when already running:** Checks `state/runtime.json` before reporting health. Valid → prints attach guidance and exits 0. Missing or unreadable → exits 1 and tells you to restart the session: lifecycle state can't be rebuilt for a session already in flight, and inventing it would erase the `transition` / `last_error` markers session-start recovery reads. Until you restart, attach and the watchdog stay degraded.
 - **Docker SIGTERM:** The entrypoint traps SIGTERM and attempts a graceful session close (30s timeout) before the container exits. Sessions are archived even on raw `docker compose down`.
 
 ---

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -148,7 +148,7 @@ When idle and `idle_behavior` is `"discover"` (set via `/hermit-settings idle`),
 - **Crash during work:** SHELL.md persists. On restart, offers to resume.
 - **Crash during idle:** SHELL.md persists as `idle`. Asks what to work on next.
 - **Crash during waiting:** SHELL.md persists as `waiting`. On restart, re-enters waiting state and checks for operator response.
-- **hermit-start when already running:** Checks `state/runtime.json` before reporting health. Valid → prints attach guidance and exits 0. Missing or unreadable → exits 1 and tells you to restart the session: lifecycle state can't be rebuilt for a session already in flight, and inventing it would erase the `transition` / `last_error` markers session-start recovery reads. Until you restart, attach and the watchdog stay degraded.
+- **hermit-start when already running:** Checks `state/runtime.json` before reporting health. Valid → prints attach guidance and exits 0. Missing, unreadable, or carrying no lifecycle record (`runtime_mode`/`tmux_session` empty) → exits 1 and tells you to restart the session: lifecycle state can't be rebuilt for a session already in flight, and inventing it would erase the `transition` / `last_error` markers session-start recovery reads. Until you restart, attach and the watchdog stay degraded.
 - **Docker SIGTERM:** The entrypoint traps SIGTERM and attempts a graceful session close (30s timeout) before the container exits. Sessions are archived even on raw `docker compose down`.
 
 ---

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -880,6 +880,13 @@ function refuseIfAnotherInstanceAlive(bootMode: 'tmux' | 'interactive'): void {
  * source of truth (skills/session-start/SKILL.md), so a synthesized record would
  * defeat the recovery branches that read it.
  *
+ * Parseable is not the same as usable: a stub record (no runtime_mode, or no
+ * tmux_session while a session of that name is demonstrably alive) dead-ends
+ * bin/hermit-attach exactly like a missing file does ("Unknown runtime mode" /
+ * "No tmux session recorded"). updateRuntimeField() seeds `{}` on a missing
+ * read, so an interrupted hermit-stop leaves precisely that stub behind —
+ * checking the fields, not just the JSON, is what keeps the loop broken.
+ *
  * Callers must also not mutate config on this path: no boot happened, so
  * always_on / applyAlwaysOnDoctorSchedule() must not fire — the doctor ratchet
  * only takes effect via a new session's `hermit-routines load`, so writing it
@@ -887,12 +894,17 @@ function refuseIfAnotherInstanceAlive(bootMode: 'tmux' | 'interactive'): void {
  */
 export function duplicateSessionRefusal(sessionName: string): string[] | null {
   const runtime = readRuntimeState();
-  if (runtime.kind === 'ok') return null;
+  let detail: string;
+  if (runtime.kind === 'missing') {
+    detail = 'state/runtime.json is missing';
+  } else if (runtime.kind === 'invalid') {
+    detail = `state/runtime.json is unusable: ${runtime.reason}`;
+  } else if (!pyTruthy(runtime.data.runtime_mode) || !pyTruthy(runtime.data.tmux_session)) {
+    detail = 'state/runtime.json records no live session (runtime_mode/tmux_session are empty)';
+  } else {
+    return null;
+  }
 
-  const detail =
-    runtime.kind === 'missing'
-      ? 'state/runtime.json is missing'
-      : `state/runtime.json is unusable: ${runtime.reason}`;
   return [
     `ERROR: session "${sessionName}" is running, but ${detail}.`,
     'Lifecycle state cannot be rebuilt from a session already in flight — attach,',
@@ -1144,6 +1156,11 @@ async function main(): Promise<void> {
     console.log('[hermit] Common causes: `claude` not in PATH, missing ANTHROPIC_API_KEY.');
     console.log('[hermit] To debug: tmux new-session -s hermit-debug then run `claude` manually.');
     console.log('[hermit] Falling back to interactive mode...');
+    // Same secret-hygiene reason as the spawn-failure branch above: tmux created
+    // the session, but a shell that died before reaching `rm -f` (a non-POSIX
+    // default shell, a failed `.`) leaves the 0600 env file behind — and execvp
+    // below never returns to clean it up.
+    fs.rmSync(envFile, { force: true });
     const stale = readRuntimeJson();
     stale.runtime_mode = 'interactive';
     stale.tmux_session = null;

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -15,7 +15,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { acquireLock, releaseLock } from './lib/lockfile';
-import { writeRuntimeJson, readRuntimeJson, STATE_DIR, RUNTIME_JSON, RUNTIME_TMP, LIFECYCLE_LOCK } from './lib/runtime';
+import { writeRuntimeJson, readRuntimeJson, readRuntimeState, STATE_DIR, RUNTIME_JSON, RUNTIME_TMP, LIFECYCLE_LOCK } from './lib/runtime';
 import { localISOStamp } from './lib/time';
 import { tmuxSessionAlive, getSessionName } from './lib/tmux';
 import { clearStatusCache } from './lib/context-reset';
@@ -865,6 +865,45 @@ function refuseIfAnotherInstanceAlive(bootMode: 'tmux' | 'interactive'): void {
   }
 }
 
+/**
+ * Decide what to do when tmux reports the session already exists: refusal lines,
+ * or null to report "already running" and exit 0. Pure of side effects so it's
+ * unit testable, like shouldRefuseBoot above.
+ *
+ * A duplicate means the session predates this invocation, so this process never
+ * observed its boot and cannot assume lifecycle state was written. A plain
+ * double-run has a healthy runtime.json and is waved through; a hermit whose
+ * state was lost underneath it (project dir recreated, state cleaned, a botched
+ * migration) is refused — 'invalid' as hard as 'missing', since a corrupt record
+ * may hold the only copy of state (see RuntimeRead in lib/runtime.ts).
+ * Deliberately rebuilds nothing either way: runtime.json is the declared single
+ * source of truth (skills/session-start/SKILL.md), so a synthesized record would
+ * defeat the recovery branches that read it.
+ *
+ * Callers must also not mutate config on this path: no boot happened, so
+ * always_on / applyAlwaysOnDoctorSchedule() must not fire — the doctor ratchet
+ * only takes effect via a new session's `hermit-routines load`, so writing it
+ * here would desync config from the scheduler actually running.
+ */
+export function duplicateSessionRefusal(sessionName: string): string[] | null {
+  const runtime = readRuntimeState();
+  if (runtime.kind === 'ok') return null;
+
+  const detail =
+    runtime.kind === 'missing'
+      ? 'state/runtime.json is missing'
+      : `state/runtime.json is unusable: ${runtime.reason}`;
+  return [
+    `ERROR: session "${sessionName}" is running, but ${detail}.`,
+    'Lifecycle state cannot be rebuilt from a session already in flight — attach,',
+    'the watchdog and session recovery stay degraded until the session restarts.',
+    'Recover:',
+    '  .claude-code-hermit/bin/hermit-stop',
+    '  .claude-code-hermit/bin/hermit-start',
+    `To inspect it first: tmux attach -t ${sessionName}`,
+  ];
+}
+
 async function main(): Promise<void> {
   const noTmuxFlag = process.argv.includes('--no-tmux');
 
@@ -1027,8 +1066,20 @@ async function main(): Promise<void> {
     encoding: 'utf-8',
   });
   if (result.status !== 0) {
+    // The env file's only cleanup is the `rm -f` inside shellCmd, which runs in
+    // the session tmux was asked to create. No session, no cleanup — so a failed
+    // launch would strand a 0600 file holding the forwarded API key / setup token
+    // on a predictable path in a world-writable tmpdir. Remove it on every
+    // failure path before deciding what to report.
+    fs.rmSync(envFile, { force: true });
+
     const stderrMsg = result.stderr ? result.stderr.trim() : '';
     if (stderrMsg.includes('duplicate session')) {
+      const refusal = duplicateSessionRefusal(sessionName);
+      if (refusal) {
+        for (const line of refusal) console.log(`[hermit] ${line}`);
+        process.exit(1);
+      }
       console.log(`[hermit] Session "${sessionName}" already running (always-on).`);
       console.log(`[hermit] Attach: .claude-code-hermit/bin/hermit-attach  (or: tmux attach -t ${sessionName})`);
       console.log('[hermit] Send tasks via channel, or run hermit-stop to shut down.');
@@ -1135,6 +1186,7 @@ export {
   isContainer,
   writeRuntimeJson,
   readRuntimeJson,
+  readRuntimeState,
   checkStaleRuntime,
   clearShutdownStampsOnBoot,
   clearStatusCacheOnBoot,

--- a/plugins/claude-code-hermit/scripts/lib/runtime.ts
+++ b/plugins/claude-code-hermit/scripts/lib/runtime.ts
@@ -34,6 +34,39 @@ function readRuntimeJson(stateDir?: string): Json | null {
   }
 }
 
+/**
+ * Outcome of a runtime.json read, keeping "absent" distinct from "unusable".
+ *
+ * readRuntimeJson() collapses both into null, which is fine for callers that
+ * only branch on "do I have state?" — but a caller deciding whether it may
+ * WRITE lifecycle state must not treat a corrupt or unreadable record as an
+ * empty slot: overwriting it destroys the only copy of transition/last_error
+ * markers that session-start recovery reads.
+ */
+type RuntimeRead =
+  | { kind: 'ok'; data: Json }
+  | { kind: 'missing' }
+  | { kind: 'invalid'; reason: string };
+
+/** Read state/runtime.json as a tri-state. See RuntimeRead. */
+function readRuntimeState(stateDir?: string): RuntimeRead {
+  const p = stateDir ? path.join(stateDir, 'runtime.json') : RUNTIME_JSON;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(p, 'utf-8');
+  } catch (err: any) {
+    // Only a genuine absence is 'missing'. EACCES/EISDIR/EIO mean the file may
+    // well hold live state we simply cannot see — that is 'invalid', not empty.
+    if (err?.code === 'ENOENT') return { kind: 'missing' };
+    return { kind: 'invalid', reason: err?.code ? `unreadable (${err.code})` : 'unreadable' };
+  }
+  try {
+    return { kind: 'ok', data: JSON.parse(raw) };
+  } catch (err: any) {
+    return { kind: 'invalid', reason: `malformed JSON (${err?.message ?? 'parse error'})` };
+  }
+}
+
 /** Read-modify-write runtime.json with atomic write. */
 function updateRuntimeField(updates: Json): void {
   const runtime = readRuntimeJson() || {};
@@ -41,4 +74,5 @@ function updateRuntimeField(updates: Json): void {
   writeRuntimeJson(runtime);
 }
 
-export { writeRuntimeJson, readRuntimeJson, updateRuntimeField, STATE_DIR, RUNTIME_JSON, RUNTIME_TMP, LIFECYCLE_LOCK };
+export { writeRuntimeJson, readRuntimeJson, readRuntimeState, updateRuntimeField, STATE_DIR, RUNTIME_JSON, RUNTIME_TMP, LIFECYCLE_LOCK };
+export type { RuntimeRead };

--- a/plugins/claude-code-hermit/scripts/lib/runtime.ts
+++ b/plugins/claude-code-hermit/scripts/lib/runtime.ts
@@ -60,11 +60,19 @@ function readRuntimeState(stateDir?: string): RuntimeRead {
     if (err?.code === 'ENOENT') return { kind: 'missing' };
     return { kind: 'invalid', reason: err?.code ? `unreadable (${err.code})` : 'unreadable' };
   }
+  let data: Json;
   try {
-    return { kind: 'ok', data: JSON.parse(raw) };
+    data = JSON.parse(raw);
   } catch (err: any) {
     return { kind: 'invalid', reason: `malformed JSON (${err?.message ?? 'parse error'})` };
   }
+  // `null`, arrays and scalars parse cleanly but carry no record. readRuntimeJson()
+  // hands the same bytes back as a bare null, so calling them 'ok' here would make
+  // the two readers disagree — and 'ok' promises `data` is dereferenceable.
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return { kind: 'invalid', reason: 'not a JSON object' };
+  }
+  return { kind: 'ok', data };
 }
 
 /** Read-modify-write runtime.json with atomic write. */

--- a/plugins/claude-code-hermit/tests/hermit-start.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-start.test.ts
@@ -38,7 +38,9 @@ import {
   hydrateSetupTokenEnv,
   shouldRefuseBoot,
   dockerHermitRunning,
+  duplicateSessionRefusal,
 } from '../scripts/hermit-start';
+import { readRuntimeState } from '../scripts/lib/runtime';
 import { TOKEN_ENV_VAR } from '../scripts/lib/setup-token';
 
 // The top-level beforeEach/afterEach below process.chdir()s into a fresh
@@ -291,6 +293,132 @@ describe.if(!IN_CONTAINER)('boot singleton guard', () => {
     fs.writeFileSync('.claude-code-hermit/state/runtime.json', JSON.stringify({ runtime_mode: 'docker', shutdown_completed_at: '2026-07-24T11:00:00Z' }));
     fs.writeFileSync('.claude-code-hermit/state/routine-monitor-liveness.json', '{}');
     expect(shouldRefuseBoot('tmux')).toBeNull();
+  });
+});
+
+// ============================================================
+// Duplicate-session handling + tri-state runtime read
+// ============================================================
+
+const RUNTIME_PATH = '.claude-code-hermit/state/runtime.json';
+
+// A realistic live record: a session mid-work, carrying the recovery markers
+// session-start reads. Used to prove nothing on the duplicate path rewrites it.
+const LIVE_RUNTIME = {
+  version: 1,
+  session_state: 'in_progress',
+  session_id: 'S-007',
+  runtime_mode: 'tmux',
+  tmux_session: 'hermit-proj',
+  transition: 'archiving',
+  last_error: 'unclean_shutdown',
+};
+
+describe('readRuntimeState tri-state', () => {
+  test('absent file reads as missing, not invalid', () => {
+    expect(readRuntimeState()).toEqual({ kind: 'missing' });
+  });
+
+  test('valid JSON reads as ok with parsed data', () => {
+    fs.writeFileSync(RUNTIME_PATH, JSON.stringify(LIVE_RUNTIME));
+    const read = readRuntimeState();
+    expect(read.kind).toBe('ok');
+    expect(read.kind === 'ok' && read.data.session_state).toBe('in_progress');
+  });
+
+  test('malformed JSON reads as invalid, not missing', () => {
+    fs.writeFileSync(RUNTIME_PATH, '{"session_state": "in_progr');
+    const read = readRuntimeState();
+    expect(read.kind).toBe('invalid');
+    expect(read.kind === 'invalid' && read.reason).toContain('malformed JSON');
+  });
+
+  // The distinction that matters: an unreadable file may hold live state we
+  // simply cannot see, so it must never be mistaken for an empty slot.
+  // Skipped as root, where the mode bits are ignored and the read would succeed.
+  // An in-test `if` would let this pass while asserting nothing; the skip makes
+  // the lost coverage visible in the report (same shape as IN_CONTAINER above).
+  test.skipIf(process.getuid?.() === 0)('unreadable file reads as invalid, not missing', () => {
+    fs.writeFileSync(RUNTIME_PATH, JSON.stringify(LIVE_RUNTIME));
+    fs.chmodSync(RUNTIME_PATH, 0o000);
+    try {
+      const read = readRuntimeState();
+      expect(read.kind).toBe('invalid');
+      expect(read.kind === 'invalid' && read.reason).toContain('unreadable');
+    } finally {
+      fs.chmodSync(RUNTIME_PATH, 0o644);
+    }
+  });
+
+  test('a directory in place of the file reads as invalid', () => {
+    fs.mkdirSync(RUNTIME_PATH);
+    const read = readRuntimeState();
+    expect(read.kind).toBe('invalid');
+  });
+});
+
+describe('duplicateSessionRefusal', () => {
+  test('healthy runtime → null (plain double-boot is waved through)', () => {
+    fs.writeFileSync(RUNTIME_PATH, JSON.stringify(LIVE_RUNTIME));
+    expect(duplicateSessionRefusal('hermit-proj')).toBeNull();
+  });
+
+  test('missing runtime → refuses, naming the session and the recovery steps', () => {
+    const lines = duplicateSessionRefusal('hermit-proj');
+    expect(lines).not.toBeNull();
+    const text = lines!.join('\n');
+    expect(text).toContain('hermit-proj');
+    expect(text).toContain('state/runtime.json is missing');
+    expect(text).toContain('.claude-code-hermit/bin/hermit-stop');
+    expect(text).toContain('.claude-code-hermit/bin/hermit-start');
+  });
+
+  test('corrupt runtime → refuses and surfaces the reason', () => {
+    fs.writeFileSync(RUNTIME_PATH, 'not json at all');
+    const text = duplicateSessionRefusal('hermit-proj')!.join('\n');
+    expect(text).toContain('unusable');
+    expect(text).toContain('malformed JSON');
+  });
+
+  // The whole point of refusing: reconstructing state would zero the transition
+  // and last_error markers that session-start recovery depends on.
+  test('never writes runtime.json — a corrupt record survives byte-identical', () => {
+    const corrupt = '{"session_state": "in_progr';
+    fs.writeFileSync(RUNTIME_PATH, corrupt);
+    duplicateSessionRefusal('hermit-proj');
+    expect(fs.readFileSync(RUNTIME_PATH, 'utf-8')).toBe(corrupt);
+  });
+
+  test('never creates runtime.json when it is missing', () => {
+    duplicateSessionRefusal('hermit-proj');
+    expect(fs.existsSync(RUNTIME_PATH)).toBe(false);
+  });
+
+  // No boot happened on this path, so no boot-time config mutation may either —
+  // the doctor ratchet only takes effect via a new session's `hermit-routines
+  // load`, so writing it here would desync config from the running scheduler.
+  test('never mutates config on any branch', () => {
+    const config = {
+      always_on: false,
+      routines: [{ id: 'doctor', schedule: '10 9 * * 1', skill: 'claude-code-hermit:hermit-doctor' }],
+    };
+    writeConfig(config);
+    const before = fs.readFileSync('.claude-code-hermit/config.json', 'utf-8');
+
+    duplicateSessionRefusal('hermit-proj'); // missing runtime
+    fs.writeFileSync(RUNTIME_PATH, JSON.stringify(LIVE_RUNTIME));
+    duplicateSessionRefusal('hermit-proj'); // healthy runtime
+
+    expect(fs.readFileSync('.claude-code-hermit/config.json', 'utf-8')).toBe(before);
+  });
+
+  test('leaves boot-only markers alone', () => {
+    fs.mkdirSync('.claude-code-hermit/sessions', { recursive: true });
+    fs.writeFileSync('.claude-code-hermit/state/.boot-id', 'boot-abc');
+    fs.writeFileSync('.claude-code-hermit/sessions/.status.json', '{"cached":true}');
+    duplicateSessionRefusal('hermit-proj');
+    expect(fs.readFileSync('.claude-code-hermit/state/.boot-id', 'utf-8')).toBe('boot-abc');
+    expect(fs.existsSync('.claude-code-hermit/sessions/.status.json')).toBe(true);
   });
 });
 

--- a/plugins/claude-code-hermit/tests/hermit-start.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-start.test.ts
@@ -355,6 +355,15 @@ describe('readRuntimeState tri-state', () => {
     const read = readRuntimeState();
     expect(read.kind).toBe('invalid');
   });
+
+  // 'ok' promises a dereferenceable record. JSON that parses to null/an array/a
+  // scalar carries none, and readRuntimeJson() reports the same bytes as absent.
+  test('parseable non-objects read as invalid, not ok', () => {
+    for (const raw of ['null', '[]', '"hermit"', '42']) {
+      fs.writeFileSync(RUNTIME_PATH, raw);
+      expect(readRuntimeState().kind).toBe('invalid');
+    }
+  });
 });
 
 describe('duplicateSessionRefusal', () => {
@@ -371,6 +380,21 @@ describe('duplicateSessionRefusal', () => {
     expect(text).toContain('state/runtime.json is missing');
     expect(text).toContain('.claude-code-hermit/bin/hermit-stop');
     expect(text).toContain('.claude-code-hermit/bin/hermit-start');
+  });
+
+  // The stub an interrupted hermit-stop leaves behind: updateRuntimeField() seeds
+  // `{}` on a missing read, so runtime.json comes back parseable but carrying no
+  // lifecycle record — and hermit-attach dead-ends on it exactly as it does on a
+  // missing file ("Unknown runtime mode" / "No tmux session recorded").
+  test('stub runtime with no lifecycle record → refuses', () => {
+    fs.writeFileSync(RUNTIME_PATH, JSON.stringify({ shutdown_requested_at: '2026-01-01T00:00:00+00:00' }));
+    const text = duplicateSessionRefusal('hermit-proj')!.join('\n');
+    expect(text).toContain('records no live session');
+  });
+
+  test('runtime with a mode but no tmux session → refuses', () => {
+    fs.writeFileSync(RUNTIME_PATH, JSON.stringify({ ...LIVE_RUNTIME, tmux_session: null }));
+    expect(duplicateSessionRefusal('hermit-proj')).not.toBeNull();
   });
 
   test('corrupt runtime → refuses and surfaces the reason', () => {


### PR DESCRIPTION
## Summary

`hermit-start`'s `duplicate session` branch exited **0** before writing `runtime.json` or flipping `always_on`, assuming a live session implies a previous boot already wrote lifecycle truth. That assumption breaks when state is lost underneath a running session — project directory recreated, state cleaned, a botched migration. The result is an operator-facing deadlock: start reports success, `hermit-attach` refuses with "run start first", and neither command can break the loop.

This makes the duplicate path consult `runtime.json` before claiming health, and **refuse rather than reconcile**.

Rebuilding the missing record was the tempting fix and is the wrong one. `runtime.json` is the declared single source of truth (`skills/session-start/SKILL.md`) and carries the `transition` / `last_error` / `context_cleared` markers session-start recovery reads — a synthesized record would zero them and silently defeat unclean-shutdown and interrupted-transition recovery. Refusing is both safer and a smaller diff; the operator's restart writes real state through the normal boot path.

## Changes

- **`scripts/lib/runtime.ts`** — `readRuntimeState()` returns a tri-state (`ok` / `missing` / `invalid`) so an absent file is distinguishable from a corrupt or unreadable one. `readRuntimeJson()` is untouched, so every existing caller keeps today's behavior. Follows the `AlertRead`/`readAlertState` pattern already in `lib/alert-state.ts:49-65`.
- **`scripts/hermit-start.ts`** — `duplicateSessionRefusal()` (pure, `string[] | null`, mirroring `shouldRefuseBoot`) decides the branch: `ok` keeps today's banner and exit 0; `missing`/`invalid` exits 1 with restart guidance. Nothing on this path mutates config — no boot happened, and the doctor ratchet only takes effect via a new session's `hermit-routines load`, so writing it here would desync config from the running scheduler.
- **Env-file leak (independent security fix)** — the temporary env file carrying the forwarded API key and setup token was only ever removed by the `rm -f` embedded in the *new session's* shell command, so **every** failed `tmux new-session` stranded a mode-0600 file in `/tmp`. Now cleaned on both failure branches.
- Docs (`always-on-ops.md`) and two `[Unreleased]` CHANGELOG entries.

## Test plan

`bun test` → **3495 pass, 0 fail** (123 files); `bunx tsc --noEmit` → exit 0.

New coverage in `tests/hermit-start.test.ts`: tri-state reader (absent / valid / malformed / unreadable / directory-in-place) and the refusal decision — healthy runtime waved through, missing and corrupt refused, corrupt record preserved byte-identical, no `runtime.json` created, config unmutated on both branches, boot-only markers untouched.

**Verified end-to-end against a real broken hermit, not a mock.** A session whose project directory had been deleted and recreated ~30 minutes earlier (`/proc/<pid>/cwd -> .../agent (deleted)`):

- before: `hermit-attach` → `No runtime found — run bin/hermit-start first`, exit 1
- after the fix: `hermit-start` → exit 1 naming the missing lifecycle state; `runtime.json` still absent, `always_on` still `false`, stranded `/tmp` env file removed
- after `hermit-stop` + `hermit-start`: `runtime.json` present, `always_on: true`, `hermit-attach` reaches the session
- regression: re-running `hermit-start` against the healthy session → unchanged banner, exit 0

## Notes

Related follow-up: #696 (session-ownership validation for `hermit-stop` / `hermit-watchdog`) — deliberately **not** addressed here. It is a pre-existing bug in a different layer, needs a tmux version floor the repo does not declare, and is not on the path to fixing attach. Leaving it open.