### PR TITLE
fix(claude-code-hermit): stop a ### sub-heading from hijacking SHELL.md section reads

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- One anchored parser in `scripts/lib/md-write.ts` now owns the `## <heading>` section grammar for SHELL.md — locating, reading, appending, replacing, and the placeholder-comment rule. The local parsers across `startup-context.ts`, `reflect-precheck.ts`, `lib/progress-log.ts`, `evaluate-session.ts`, `lib/alert-state.ts`, `cost-tracker.ts`, `session-archive.ts` and `archive-shell.ts` are deleted. Operator-added custom sections and hand edits still pass through untouched.
+
+### Fixed
+- A `###` sub-heading above a real section no longer hijacks that section's body. Most section reads used `indexOf('## Task')` or an unanchored `/## Blockers\n/`, and `'### Task'.indexOf('## Task') === 1`, so a sub-heading written anywhere above the section silently won — affecting session-start context injection, the `.status.json` task/blockers fields the channel status responder reads, Progress Log staleness detection, the Monitoring bloat check, and the `reflect --quick` content hash.
+
 ## [1.2.38] - 2026-08-12
 
 ### Added

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## [Unreleased]
 
 ### Changed
-- One anchored parser in `scripts/lib/md-write.ts` now owns the `## <heading>` section grammar for SHELL.md — locating, reading, appending, replacing, and the placeholder-comment rule. The local parsers across `startup-context.ts`, `reflect-precheck.ts`, `lib/progress-log.ts`, `evaluate-session.ts`, `lib/alert-state.ts`, `cost-tracker.ts`, `session-archive.ts` and `archive-shell.ts` are deleted. Operator-added custom sections and hand edits still pass through untouched.
+- `scripts/lib/md-write.ts` now owns the whole `## <heading>` grammar for SHELL.md (locate, read, append, replace, placeholder-stripping); the ten local parsers are gone. Operator-added custom sections still pass through untouched.
 
 ### Fixed
-- A `###` sub-heading above a real section no longer hijacks that section's body. Most section reads used `indexOf('## Task')` or an unanchored `/## Blockers\n/`, and `'### Task'.indexOf('## Task') === 1`, so a sub-heading written anywhere above the section silently won — affecting session-start context injection, the `.status.json` task/blockers fields the channel status responder reads, Progress Log staleness detection, the Monitoring bloat check, and the `reflect --quick` content hash.
+- A `###` sub-heading above a real section no longer hijacks that section's body — affects session-start injection, `.status.json` task/blockers, Progress Log staleness, the Monitoring bloat check, and the `reflect --quick` hash.
+- Session-start injection and the session quality score no longer read a section as empty when its content sits below a retained `<!-- ... -->` placeholder.
 
 ## [1.2.38] - 2026-08-12
 

--- a/plugins/claude-code-hermit/scripts/archive-shell.ts
+++ b/plugins/claude-code-hermit/scripts/archive-shell.ts
@@ -5,6 +5,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pinStateDirOrExit } from './lib/cc-compat';
+import { findSection } from './lib/md-write';
 
 type Json = any;
 
@@ -105,30 +106,19 @@ function main() {
   }
   try { fs.unlinkSync(snapshotTmp); } catch { /* tmp already gone */ }
 
-  const progressLogRe = /^## Progress Log[ \t]*$/m;
-  const startMatch = progressLogRe.exec(shell);
+  const progressLog = findSection(shell, 'Progress Log');
 
   let updatedShell = shell;
   let keptLineCount = archivedLineCount;
   let compacted = false;
 
-  if (startMatch) {
-    const bodyStart = startMatch.index + startMatch[0].length;
-    const after = shell.slice(bodyStart);
-    const nextHeadingMatch = /\n## /.exec(after);
-    const bodyEnd = nextHeadingMatch
-      ? bodyStart + nextHeadingMatch.index
-      : shell.length;
-
-    const before = shell.slice(0, bodyStart);
-    const tail = shell.slice(bodyEnd);
-
+  if (progressLog) {
     const newBody =
       `\n` +
       `<!-- snapshot @ ${nowIso} → snapshots/${snapshotName} (${archivedLineCount} lines) -->\n` +
       `- [archived] previous entries → snapshots/${snapshotName}\n`;
 
-    updatedShell = before + newBody + tail;
+    updatedShell = shell.slice(0, progressLog.start) + newBody + shell.slice(progressLog.end);
     keptLineCount = updatedShell.split('\n').length;
     compacted = true;
 

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -14,6 +14,7 @@ import { kStr, formatTokens } from './lib/format';
 import { sessionId as ccSessionId, transcriptPath as ccTranscriptPath, entryText, isToolResult, extractUsage, isCompactBoundary, turnPromptText, toolUseNames, costLogPath, hermitDir } from './lib/cc-compat';
 import { costIndexPath, updateCostIndex, readCostIndex, scanCostLogWarnings, SOURCE_ATTRIBUTION_VERSION } from './lib/cost-log';
 import { todayYMD, thisWeekKey, thisMonthYYYYMM, friendlyBoundary } from './lib/time';
+import { extractSection, stripPlaceholders } from './lib/md-write';
 import { mutateOwnedAlerts, budgetAlertsPath } from './lib/alert-state';
 import { setPause, isPaused } from './lib/pause';
 import { evaluateBudget, pauseBoundary } from './lib/budget';
@@ -514,11 +515,11 @@ function maintainOpenedAt(nowIso: string, transcriptId: string): void {
 
 function writeStatusJson(shellContent: string, cumulative: { cost: number; tokens: number; operatorTurns: number }, sessionId: string): void {
   const { cost: cumulativeCost, tokens: cumulativeTokens, operatorTurns: cumulativeOperatorTurns } = cumulative;
-  const taskMatch = shellContent.match(/## Task\n([\s\S]*?)(?=\n## |$)/);
-  const blockersMatch = shellContent.match(/## Blockers\n([\s\S]*?)(?=\n## |$)/);
+  const taskSection = extractSection(shellContent, 'Task');
+  const blockersSection = extractSection(shellContent, 'Blockers');
   const tasksMatch = shellContent.match(/\*\*Tasks Completed:\*\*\s*(\d+)/);
 
-  const task = taskMatch ? taskMatch[1].trim().replace(/<!--.*?-->/g, '').trim() : '';
+  const task = stripPlaceholders(taskSection ?? '');
 
   // Plan progress from native Claude Code Tasks
   const tasks = readTasks();
@@ -527,7 +528,7 @@ function writeStatusJson(shellContent: string, cumulative: { cost: number; token
   // Write tasks-snapshot.md
   writeTaskSnapshot(tasks, progress);
 
-  const blockersText = blockersMatch ? blockersMatch[1].trim().replace(/<!--.*?-->/g, '').trim() : '';
+  const blockersText = stripPlaceholders(blockersSection ?? '');
   const hasBlockers = blockersText.length > 0 && !/^none$/i.test(blockersText);
 
   const statusData = {

--- a/plugins/claude-code-hermit/scripts/evaluate-session.ts
+++ b/plugins/claude-code-hermit/scripts/evaluate-session.ts
@@ -11,7 +11,7 @@ import crypto from 'node:crypto';
 import { readTasks } from './lib/tasks';
 import { hermitDir } from './lib/cc-compat';
 import { currentHHMM, elapsedSinceHHMM, resolveHermitNowMs } from './lib/time';
-import { extractSection } from './lib/md-write';
+import { extractSection, stripPlaceholders } from './lib/md-write';
 
 type Json = any;
 
@@ -70,8 +70,8 @@ function evaluateSession(content: Json, tasks: Json[]): Json {
   // Helper: check if a markdown section exists and has non-comment content
   function checkSection(sectionName: string): { exists: boolean; hasContent: Json } {
     const section = extractSection(content, sectionName);
-    const text = section ? section.trim() : '';
-    return { exists: section !== null, hasContent: text && !text.startsWith('<!--') };
+    // stripPlaceholders, not startsWith('<!--') — see its doc comment in md-write.ts.
+    return { exists: section !== null, hasContent: stripPlaceholders(section ?? '').length > 0 };
   }
 
   // Criterion 3: Blockers section

--- a/plugins/claude-code-hermit/scripts/evaluate-session.ts
+++ b/plugins/claude-code-hermit/scripts/evaluate-session.ts
@@ -11,6 +11,7 @@ import crypto from 'node:crypto';
 import { readTasks } from './lib/tasks';
 import { hermitDir } from './lib/cc-compat';
 import { currentHHMM, elapsedSinceHHMM, resolveHermitNowMs } from './lib/time';
+import { extractSection } from './lib/md-write';
 
 type Json = any;
 
@@ -68,9 +69,9 @@ function evaluateSession(content: Json, tasks: Json[]): Json {
 
   // Helper: check if a markdown section exists and has non-comment content
   function checkSection(sectionName: string): { exists: boolean; hasContent: Json } {
-    const section = content.match(new RegExp(`## ${sectionName}\n([\\s\\S]*?)(?=\n## |$)`));
-    const text = section ? section[1].trim() : '';
-    return { exists: !!section, hasContent: text && !text.startsWith('<!--') };
+    const section = extractSection(content, sectionName);
+    const text = section ? section.trim() : '';
+    return { exists: section !== null, hasContent: text && !text.startsWith('<!--') };
   }
 
   // Criterion 3: Blockers section
@@ -175,8 +176,7 @@ async function _evaluate(): Promise<string | null> {
         // Progress Log timestamps are date-less [HH:MM]. Use the bottom-most entry
         // (append-ordered) and resolve it as its most recent past occurrence, so a
         // session spanning midnight doesn't backdate today's entries.
-        const progressSection = content.match(/## Progress Log\n([\s\S]*?)(?=\n## |$)/);
-        const progressText = progressSection ? progressSection[1].trim() : '';
+        const progressText = (extractSection(content, 'Progress Log') ?? '').trim();
         const timeEntries = progressText.match(/\[(\d{1,2}:\d{2})\]/g);
         if (timeEntries && timeEntries.length > 0) {
           const lastTime = timeEntries[timeEntries.length - 1].replace(/[\[\]]/g, '');
@@ -191,9 +191,9 @@ async function _evaluate(): Promise<string | null> {
     }
 
     // Monitoring bloat check (any status)
-    const monitoringSection = content.match(/## Monitoring\n([\s\S]*?)(?=\n## |$)/);
-    if (monitoringSection) {
-      const monitoringLines = (monitoringSection[1].match(/\n/g) || []).length;
+    const monitoringSection = extractSection(content, 'Monitoring');
+    if (monitoringSection !== null) {
+      const monitoringLines = (monitoringSection.match(/\n/g) || []).length;
       if (monitoringLines > 40) {
         console.error('Monitoring section too large. Alert dedup should prevent this — check if dedup is working.');
       }

--- a/plugins/claude-code-hermit/scripts/lib/alert-state.ts
+++ b/plugins/claude-code-hermit/scripts/lib/alert-state.ts
@@ -27,6 +27,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { parseFrontmatter, listProposalFiles } from './frontmatter';
 import { elapsedSinceHHMM } from './time';
+import { extractSection } from './md-write';
 
 type Json = any;
 
@@ -399,8 +400,8 @@ export function deriveStaleSession(
     return err?.code === 'ENOENT' ? { ok: true, items: [] } : { ok: false, items: [] };
   }
 
-  const section = shell.match(/## Progress Log\n([\s\S]*?)(?=\n## |$)/);
-  const entries = section ? section[1].match(/\[(\d{1,2}:\d{2})\]/g) : null;
+  const section = extractSection(shell, 'Progress Log');
+  const entries = section ? section.match(/\[(\d{1,2}:\d{2})\]/g) : null;
   if (!entries || entries.length === 0) return { ok: true, items: [] };
 
   const last = entries[entries.length - 1].replace(/[\[\]]/g, '');

--- a/plugins/claude-code-hermit/scripts/lib/md-write.ts
+++ b/plugins/claude-code-hermit/scripts/lib/md-write.ts
@@ -52,12 +52,19 @@ export function patchFrontmatter(content: string, patch: Record<string, Json>): 
   return '---\n' + lines.join('\n') + content.slice(end);
 }
 
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // Locates a `## <heading>` section's body — [start, end) bounded by the next
 // `## ` heading or EOF. Returns null when the heading is absent. Shared by
 // appendToSection and proposal.ts's read-only idempotency check so both agree
 // on where a section ends.
 export function findSection(content: string, heading: string): { start: number; end: number } | null {
-  const re = new RegExp(`^## ${heading}[ \\t]*$`, 'm');
+  // Escaped: the heading is a literal, and an operator-named section carrying a
+  // regex metacharacter (`## Notes (2026)`, `## v1.2.3`) would otherwise be read
+  // as a pattern and match the wrong line — or no line at all.
+  const re = new RegExp(`^## ${escapeRegExp(heading)}[ \\t]*$`, 'm');
   const m = re.exec(content);
   if (!m) return null;
   const start = m.index + m[0].length;
@@ -74,12 +81,18 @@ export function extractSection(content: string, heading: string): string | null 
   const section = findSection(content, heading);
   if (!section) return null;
   const body = content.slice(section.start, section.end);
-  return body.startsWith('\n') ? body.slice(1) : body;
+  // `\r?\n`, not `\n`: findSection's `$` matches before a CR too, so on a CRLF
+  // SHELL.md the span starts at the `\r` and a bare `\n` strip would leave it
+  // glued to the first body line.
+  return body.replace(/^\r?\n/, '');
 }
 
 // Drops placeholder comments (`<!-- ... -->`, possibly multi-line) and trims.
 // The single rule for "is this section really empty, or does it just still
-// carry its template placeholder?".
+// carry its template placeholder?". Use this rather than a whole-body
+// `startsWith('<!--')` check: the reset templates keep their placeholder
+// comments in place and real content is appended below them, so a whole-body
+// check reads a populated section as empty.
 export function stripPlaceholders(text: string): string {
   return text.replace(/<!--[\s\S]*?-->/g, '').trim();
 }

--- a/plugins/claude-code-hermit/scripts/lib/md-write.ts
+++ b/plugins/claude-code-hermit/scripts/lib/md-write.ts
@@ -1,6 +1,10 @@
 // lib/md-write.ts — transactional markdown/frontmatter write helpers, promoted
 // from apply-reflection-actions.ts so proposal.ts's create/patch/shell-append
 // verbs can reuse the same atomic-write and section-append primitives.
+//
+// Also the single home for the `## <heading>` section grammar (findSection and
+// the extract/replace/placeholder helpers built on it). Every SHELL.md reader
+// and writer goes through here so they agree on where a section starts and ends.
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -59,6 +63,45 @@ export function findSection(content: string, heading: string): { start: number; 
   const start = m.index + m[0].length;
   const nextHeading = content.indexOf('\n## ', start);
   return { start, end: nextHeading === -1 ? content.length : nextHeading };
+}
+
+// Reads a `## <heading>` section's body (heading line excluded, otherwise
+// verbatim — callers own their own trimming). Null when the heading is absent.
+// Anchored via findSection: `'### Task'.indexOf('## Task') === 1`, so the
+// unanchored substring/regex reads this replaces would let a `### Task`
+// sub-heading anywhere above the real section hijack the answer.
+export function extractSection(content: string, heading: string): string | null {
+  const section = findSection(content, heading);
+  if (!section) return null;
+  const body = content.slice(section.start, section.end);
+  return body.startsWith('\n') ? body.slice(1) : body;
+}
+
+// Drops placeholder comments (`<!-- ... -->`, possibly multi-line) and trims.
+// The single rule for "is this section really empty, or does it just still
+// carry its template placeholder?".
+export function stripPlaceholders(text: string): string {
+  return text.replace(/<!--[\s\S]*?-->/g, '').trim();
+}
+
+// First non-empty, non-placeholder line of a section body, optionally clipped.
+// '' when the section holds nothing but blanks and placeholders.
+export function firstContentLine(section: string, maxLen?: number): string {
+  for (const line of section.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('<!--')) continue;
+    return maxLen ? trimmed.slice(0, maxLen) : trimmed;
+  }
+  return '';
+}
+
+// Replaces a `## <heading>` section's body wholesale; content unchanged when the
+// heading is absent. `newBody` is inserted immediately after the heading line's
+// text, so it must carry its own leading newline.
+export function replaceSectionInPlace(content: string, heading: string, newBody: string): string {
+  const section = findSection(content, heading);
+  if (!section) return content;
+  return content.slice(0, section.start) + newBody + content.slice(section.end);
 }
 
 // Appends a pre-rendered line to a `## <heading>` section (inserted at section

--- a/plugins/claude-code-hermit/scripts/lib/progress-log.ts
+++ b/plugins/claude-code-hermit/scripts/lib/progress-log.ts
@@ -5,23 +5,22 @@
 // section-boundary logic instead of re-deriving it.
 
 import fs from 'node:fs';
+import { findSection } from './md-write';
 
-// Same boundary convention as startup-context.ts's extractSection and cost-tracker.ts's
-// ## Blockers regex: a section ends at the next `\n## ` or EOF.
+// Deliberately not md-write's appendToSection: this path must never throw on a
+// missing heading (it appends at EOF instead), and it inserts the raw line
+// without appendToSection's blank-line normalization, so an operator's SHELL.md
+// spacing survives an autonomous flush untouched.
 function appendToProgressLog(shellPath: string, line: string): void {
   try {
     let content = fs.readFileSync(shellPath, 'utf-8');
-    const marker = '## Progress Log';
-    const idx = content.indexOf(marker);
-    if (idx === -1) {
+    const section = findSection(content, 'Progress Log');
+    if (!section) {
       content = content.trimEnd() + '\n\n' + line + '\n';
+    } else if (section.end === content.length) {
+      content = content.trimEnd() + '\n' + line + '\n';
     } else {
-      const nextSection = content.indexOf('\n## ', idx + marker.length);
-      if (nextSection === -1) {
-        content = content.trimEnd() + '\n' + line + '\n';
-      } else {
-        content = content.slice(0, nextSection) + '\n' + line + content.slice(nextSection);
-      }
+      content = content.slice(0, section.end) + '\n' + line + content.slice(section.end);
     }
     fs.writeFileSync(shellPath, content, 'utf-8');
   } catch { /* fail-open */ }

--- a/plugins/claude-code-hermit/scripts/proposal.ts
+++ b/plugins/claude-code-hermit/scripts/proposal.ts
@@ -80,7 +80,7 @@ import path from 'node:path';
 import { readStdin, readJson, flagValue } from './lib/cli';
 import { pinStateDirOrExit } from './lib/cc-compat';
 import { appendJsonlLine } from './lib/append-jsonl';
-import { writeFileAtomic, patchFrontmatter, appendToSection, appendShellLine, findSection, PATCH_KEY_RE } from './lib/md-write';
+import { writeFileAtomic, patchFrontmatter, appendToSection, appendShellLine, findSection, escapeRegExp, PATCH_KEY_RE } from './lib/md-write';
 import { computeBase, readTimezone, SUFFIX_LETTERS } from './lib/prop-id';
 import { zonedISOStamp, utcISOStamp } from './lib/time';
 import { rebuildIndex, run as runIndex } from './lib/proposals/index-rebuild';
@@ -257,10 +257,6 @@ function parsePatchArgs(args: string[]): { filename: string | undefined; sets: s
 
 const TIMESTAMP_RE_SRC = '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:[+-]\\d{2}:\\d{2}|Z)';
 
-function escapeRe(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 // True when `heading`'s section already ends with `rawLine` — makes a re-run of
 // the same patch call idempotent instead of duplicating the Operator Decision
 // entry. Compares against the RAW (unexpanded) line with `@now` as a timestamp
@@ -272,7 +268,7 @@ function sectionEndsWithLine(content: string, heading: string, rawLine: string):
   if (!section) return false;
   const lines = content.slice(section.start, section.end).split('\n').map(l => l.trim()).filter(Boolean);
   if (lines.length === 0) return false;
-  const pattern = rawLine.trim().split('@now').map(escapeRe).join(TIMESTAMP_RE_SRC);
+  const pattern = rawLine.trim().split('@now').map(escapeRegExp).join(TIMESTAMP_RE_SRC);
   return new RegExp(`^${pattern}$`).test(lines[lines.length - 1]);
 }
 

--- a/plugins/claude-code-hermit/scripts/reflect-precheck.ts
+++ b/plugins/claude-code-hermit/scripts/reflect-precheck.ts
@@ -24,6 +24,7 @@ import { readFrontmatter, isEmptyAutoArchive } from './lib/frontmatter';
 import { findStorageDrift, findSchemaDrift } from './lib/drift';
 import { sha256 } from './lib/hash';
 import { appendToProgressLog } from './lib/progress-log';
+import { extractSection, stripPlaceholders } from './lib/md-write';
 import { pinStateDirOrExit, costLogPath as resolveCostLog, hermitDir as resolveHermitRoot } from './lib/cc-compat';
 
 type Json = any;
@@ -55,22 +56,15 @@ const readJSON = (p: string): Json => {
   catch { return null; }
 };
 
-// Extract a top-level ## Section from SHELL.md, dropping placeholder-comment and
-// blank lines so a real finding appended under a retained `<!-- ... -->` placeholder
-// still counts (per-line filter, same idiom as startup-context.ts's task scan — a
-// whole-body startsWith('<!--') check would mask content sitting below the comment).
-// Same boundary convention as startup-context.ts's extractSection and cost-tracker.ts's
-// ## Blockers regex: a section ends at the next `\n## ` or EOF.
+// A top-level ## Section of SHELL.md with placeholder comments and blank lines
+// dropped, so a real finding appended under a retained `<!-- ... -->` placeholder
+// still counts. Feeds the --quick content hash, so the normalization (trim each
+// line, drop empties) must stay stable — it decides whether the chain re-fires.
 function extractQuickSection(md: string, name: string): string {
-  const idx = md.indexOf(`## ${name}`);
-  if (idx === -1) return '';
-  const bodyStart = md.indexOf('\n', idx) + 1;
-  const nextSection = md.indexOf('\n## ', bodyStart);
-  const raw = nextSection !== -1 ? md.slice(bodyStart, nextSection) : md.slice(bodyStart);
-  return raw
+  return stripPlaceholders(extractSection(md, name) ?? '')
     .split('\n')
     .map(l => l.trim())
-    .filter(l => l && !l.startsWith('<!--'))
+    .filter(Boolean)
     .join('\n');
 }
 

--- a/plugins/claude-code-hermit/scripts/session-archive.ts
+++ b/plugins/claude-code-hermit/scripts/session-archive.ts
@@ -35,6 +35,7 @@ import { readAlertState as readRuntime, quarantineAlertState as quarantineRuntim
 import { costLogPath, pinStateDirOrExit } from './lib/cc-compat';
 import { computeSessionCost } from './lib/session-cost';
 import { AUTO_CLOSE_LULL_MINUTES } from './lib/auto-close';
+import { extractSection as sectionBody, firstContentLine, replaceSectionInPlace, stripPlaceholders } from './lib/md-write';
 
 type Json = any;
 
@@ -240,30 +241,16 @@ function readFileSafe(p: string): string | null {
   try { return fs.readFileSync(p, 'utf-8'); } catch { return null; }
 }
 
+// Trimmed, missing-section-is-empty flavour of md-write's section read — the
+// shape this file's callers expect.
 function extractSection(shell: string, heading: string): string {
-  const re = new RegExp(`^## ${heading}[ \\t]*$`, 'm');
-  const m = re.exec(shell);
-  if (!m) return '';
-  const bodyStart = m.index + m[0].length;
-  const after = shell.slice(bodyStart);
-  const next = /\n## /.exec(after);
-  const bodyEnd = next ? bodyStart + next.index : shell.length;
-  return shell.slice(bodyStart, bodyEnd).trim();
-}
-
-function firstContentLine(section: string, maxLen?: number): string {
-  for (const line of section.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('<!--')) continue;
-    return maxLen ? trimmed.slice(0, maxLen) : trimmed;
-  }
-  return '';
+  return (sectionBody(shell, heading) ?? '').trim();
 }
 
 function extractTags(shell: string): string[] {
   const m = /\*\*Tags:\*\*\s*(.*)/.exec(shell);
   if (!m) return [];
-  const raw = m[1].replace(/<!--.*?-->/g, '').trim();
+  const raw = stripPlaceholders(m[1]);
   if (!raw) return [];
   return raw.split(',').map(s => s.trim()).filter(Boolean);
 }
@@ -556,21 +543,6 @@ function buildReport(opts: {
 // ---------------------------------------------------------------------------
 // SHELL.md reset (mode-dependent).
 // ---------------------------------------------------------------------------
-
-function replaceSectionInPlace(shell: string, heading: string, newBody: string): string {
-  // Mirrors extractSection's index math exactly — a single regex with a `$`
-  // lookahead under the 'm' flag matches trivially at every line boundary,
-  // not just the next heading or end-of-string, which truncates the match
-  // after the first line and leaves old content behind. Manual slicing avoids it.
-  const re = new RegExp(`^## ${heading}[ \\t]*$`, 'm');
-  const m = re.exec(shell);
-  if (!m) return shell;
-  const headingLineEnd = m.index + m[0].length;
-  const after = shell.slice(headingLineEnd);
-  const next = /\n## /.exec(after);
-  const bodyEnd = next ? headingLineEnd + next.index : shell.length;
-  return shell.slice(0, headingLineEnd) + newBody + shell.slice(bodyEnd);
-}
 
 // `mode` isn't needed here — both call sites only invoke this when mode is
 // already known to be 'idle', so the cost the caller already has (computed once

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -19,7 +19,7 @@ import { loadConfig } from './lib/channel-auth';
 import { resolve as resolveOutboundChannel } from './resolve-outbound-channel';
 import { operatorLanguage as resolveOperatorLanguage } from './lib/operator-language';
 import { formatTokens } from './lib/format';
-import { extractSection, firstContentLine } from './lib/md-write';
+import { extractSection, firstContentLine, stripPlaceholders } from './lib/md-write';
 
 type Json = any;
 
@@ -264,24 +264,25 @@ function emitFullContext(source: string | null) {
   } else {
     const parts: string[] = [];
 
-    const task = extractSection(shellContent, 'Task');
-    if (task && task.trim() && !task.trim().startsWith('<!--')) {
-      parts.push(`## Task\n${task.trimEnd()}`);
+    // stripPlaceholders, not startsWith('<!--') — see its doc comment in md-write.ts.
+    const task = stripPlaceholders(extractSection(shellContent, 'Task') ?? '');
+    if (task) {
+      parts.push(`## Task\n${task}`);
     }
 
-    const progressRaw = extractSection(shellContent, 'Progress Log');
-    if (progressRaw && progressRaw.trim() && !progressRaw.trim().startsWith('<!--')) {
+    const progressRaw = stripPlaceholders(extractSection(shellContent, 'Progress Log') ?? '');
+    if (progressRaw) {
       const recent = lastLines(progressRaw, 10);
       parts.push(`## Progress Log (last 10)\n${recent}`);
     }
 
-    const blockers = extractSection(shellContent, 'Blockers');
-    if (blockers && blockers.trim() && !blockers.trim().startsWith('<!--')) {
-      parts.push(`## Blockers\n${blockers.trimEnd()}`);
+    const blockers = stripPlaceholders(extractSection(shellContent, 'Blockers') ?? '');
+    if (blockers) {
+      parts.push(`## Blockers\n${blockers}`);
     }
 
-    const monitoringRaw = extractSection(shellContent, 'Monitoring');
-    if (monitoringRaw && monitoringRaw.trim() && !monitoringRaw.trim().startsWith('<!--')) {
+    const monitoringRaw = stripPlaceholders(extractSection(shellContent, 'Monitoring') ?? '');
+    if (monitoringRaw) {
       const monLines = monitoringRaw.split('\n').filter(l => l.trim() && (l.startsWith('- ') || l.startsWith('[')));
       if (monLines.length > 0) {
         parts.push(`## Monitoring (last 5)\n${monLines.slice(-5).join('\n')}`);

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -19,6 +19,7 @@ import { loadConfig } from './lib/channel-auth';
 import { resolve as resolveOutboundChannel } from './resolve-outbound-channel';
 import { operatorLanguage as resolveOperatorLanguage } from './lib/operator-language';
 import { formatTokens } from './lib/format';
+import { extractSection, firstContentLine } from './lib/md-write';
 
 type Json = any;
 
@@ -88,16 +89,6 @@ function emitArtifacts(artifacts: Json[], budget: number, headerFn: (a: Json) =>
   }
 }
 
-// Extract a named ## Section from markdown content.
-// Returns the section body (without the header line), or null if not found.
-function extractSection(md: string, name: string): string | null {
-  const idx = md.indexOf(`## ${name}`);
-  if (idx === -1) return null;
-  const bodyStart = md.indexOf('\n', idx) + 1;
-  const nextSection = md.indexOf('\n## ', bodyStart);
-  return nextSection !== -1 ? md.slice(bodyStart, nextSection) : md.slice(bodyStart);
-}
-
 // Return last N non-empty lines from a string.
 function lastLines(text: string, n: number): string {
   const lines = text.split('\n').filter(l => l.trim());
@@ -142,11 +133,8 @@ function buildCompactionPointers(agentDir: string): string {
 
   try {
     const shellContent = fs.readFileSync(path.resolve(agentDir, 'sessions', 'SHELL.md'), 'utf-8');
-    const task = extractSection(shellContent, 'Task');
-    const firstLine = task
-      ? task.split('\n').map(l => l.trim()).find(l => l && !l.startsWith('<!--'))
-      : null;
-    if (firstLine) parts.push(`task: ${guarded('sessions/SHELL.md', firstLine.slice(0, 300))}`);
+    const firstLine = firstContentLine(extractSection(shellContent, 'Task') ?? '', 300);
+    if (firstLine) parts.push(`task: ${guarded('sessions/SHELL.md', firstLine)}`);
     const progress = extractSection(shellContent, 'Progress Log');
     const lastEntry = progress
       ? progress.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('<!--')).pop()

--- a/plugins/claude-code-hermit/tests/cost-tracker-status-writer.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-tracker-status-writer.test.ts
@@ -76,3 +76,64 @@ describe('cost-tracker: writeStatusJson populates status/task from real state', 
     expect(status.task).toBe('Test task for hook validation');
   });
 });
+
+// Regression: the section reads went through an unanchored `/## Blockers\n/`,
+// and a `### Blockers` sub-heading in a Progress Log entry matches that substring.
+// The status responder then reported a stale sub-heading's body as the live blocker.
+describe('cost-tracker: a ### sub-heading does not hijack the section read', () => {
+  let dir: string;
+  let statusPath: string;
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-cost-decoy-'));
+    const cchDir = path.join(dir, '.claude-code-hermit');
+    fs.mkdirSync(path.join(cchDir, 'state'), { recursive: true });
+    fs.mkdirSync(path.join(cchDir, 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(cchDir, 'state', 'runtime.json'),
+      JSON.stringify({ session_id: 'test-session', session_state: 'in_progress' })
+    );
+    fs.writeFileSync(path.join(cchDir, 'config.json'), JSON.stringify({ timezone: null }));
+    fs.writeFileSync(path.join(cchDir, 'sessions', 'SHELL.md'), [
+      '# Active Session',
+      '',
+      '## Session Info',
+      '- **ID:** S-001',
+      '',
+      '## Task',
+      'Real task',
+      '',
+      '## Progress Log',
+      '[09:00] Wrote up findings under a sub-heading:',
+      '### Blockers',
+      'decoy blocker from a sub-heading',
+      '',
+      '## Blockers',
+      'the real blocker',
+      '',
+      '## Session Summary',
+      '',
+    ].join('\n'));
+
+    const transcriptPath = path.join(dir, 'transcript.jsonl');
+    fs.writeFileSync(transcriptPath, [
+      triggerPrompt('[hermit-routine:demo] start'),
+      assistantEntry('claude-sonnet-4-6', 1000, 500),
+    ].join('\n') + '\n');
+    const stdin = JSON.stringify({ session_id: 'test-session', transcript_path: transcriptPath });
+    await runScript('cost-tracker.ts', { stdin, cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+
+    statusPath = path.join(cchDir, 'sessions', '.status.json');
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test('blockers reads the real ## Blockers section, not the ### decoy', () => {
+    const status = JSON.parse(fs.readFileSync(statusPath, 'utf-8'));
+    expect(status.blockers).toBe('the real blocker');
+  });
+});

--- a/plugins/claude-code-hermit/tests/shell-sections.test.ts
+++ b/plugins/claude-code-hermit/tests/shell-sections.test.ts
@@ -234,6 +234,56 @@ describe('startup-context injection is not hijackable by a ### sub-heading', () 
   });
 });
 
+// Content under a retained placeholder is the steady state after any idle
+// reset, not an edge case — see stripPlaceholders' doc comment in md-write.ts.
+describe('startup-context sees content below a retained placeholder', () => {
+  test('injects Task and Progress Log content written under the template comments', async () => {
+    const wd = setupWorkdir();
+    try {
+      fs.writeFileSync(path.join(wd.dir, '.claude-code-hermit', 'sessions', 'SHELL.md'), [
+        '# Active Session',
+        '',
+        '## Session Info',
+        '- **ID:** S-001',
+        '',
+        '## Task',
+        '<!-- Awaiting next task -->',
+        'REAL-TASK ship the thing',
+        '',
+        '## Progress Log',
+        '<!-- Primary record of work -->',
+        '<!-- Format: [HH:MM] Did X — result/outcome -->',
+        '[09:00] REAL-ENTRY started',
+        '',
+        '## Blockers',
+        '',
+        '## Session Summary',
+        '',
+      ].join('\n'));
+
+      const res = await runScript('startup-context.ts', {
+        stdin: '{}',
+        env: { AGENT_DIR: path.join(wd.dir, '.claude-code-hermit') },
+      });
+
+      expect(res.stdout).toContain('REAL-TASK ship the thing');
+      expect(res.stdout).toContain('[09:00] REAL-ENTRY started');
+      expect(res.stdout).not.toContain('Awaiting next task');
+      expect(res.stdout).not.toContain('has no actionable content');
+    } finally {
+      wd.cleanup();
+    }
+  });
+});
+
+describe('findSection escapes the heading', () => {
+  test('a metacharacter in the heading is matched literally', () => {
+    expect(extractSection('## Notes (2026)\nbody\n', 'Notes (2026)')?.trim()).toBe('body');
+    expect(extractSection('## Notes 2026\nbody\n', 'Notes (2026)')).toBeNull();
+    expect(extractSection('## AxB\nbody\n', 'A.B')).toBeNull();
+  });
+});
+
 describe('findSection agrees with extractSection', () => {
   test('the located span, minus its leading newline, is the extracted body', () => {
     for (const heading of ['Session Info', 'Task', 'Progress Log', 'Blockers', 'Session Summary']) {

--- a/plugins/claude-code-hermit/tests/shell-sections.test.ts
+++ b/plugins/claude-code-hermit/tests/shell-sections.test.ts
@@ -1,0 +1,244 @@
+// Tests for the `## <heading>` section grammar in lib/md-write.ts — the single
+// parser every SHELL.md reader and writer goes through. Pure functions, so
+// in-process import is safe (no load-time path resolution).
+//
+// The anchoring cases are the point: before consolidation, six sites located
+// sections with `indexOf('## Task')` or an unanchored `/## Task\n/`, and
+// `'### Task'.indexOf('## Task') === 1` — a `### Task` sub-heading anywhere
+// above the real section hijacked the read, including session-start injection.
+
+import { describe, test, expect } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { runScript } from './helpers/run';
+import { setupWorkdir } from './helpers/workdir';
+import {
+  findSection,
+  extractSection,
+  stripPlaceholders,
+  firstContentLine,
+  replaceSectionInPlace,
+  appendToSection,
+} from '../scripts/lib/md-write';
+
+const SHELL = [
+  '# Active Session',
+  '',
+  '## Session Info',
+  '- **ID:** S-001',
+  '',
+  '## Task',
+  'Real task body',
+  '',
+  '## Progress Log',
+  '[09:00] Did a thing',
+  '[10:30] Did another',
+  '',
+  '## Blockers',
+  '<!-- What is preventing progress? -->',
+  '',
+  '## Session Summary',
+  'Wrapped up.',
+  '',
+].join('\n');
+
+describe('extractSection anchoring', () => {
+  test('a ### sub-heading above the real section does not hijack the read', () => {
+    const md = '## Progress Log\n[09:00] ### Task decoy in a log line\n\n## Task\nReal task body\n';
+    expect(extractSection(md, 'Task')?.trim()).toBe('Real task body');
+  });
+
+  test('a ### heading with the same name is not the section', () => {
+    const md = '# Doc\n\n### Task\nSub-heading body\n\n## Task\nReal task body\n';
+    expect(extractSection(md, 'Task')?.trim()).toBe('Real task body');
+  });
+
+  test('a longer heading is not a prefix match', () => {
+    const md = '## Tasks Completed\nnot this\n\n## Task\nReal task body\n';
+    expect(extractSection(md, 'Task')?.trim()).toBe('Real task body');
+  });
+
+  test('heading with trailing text does not match', () => {
+    expect(extractSection('## Task now\nbody\n', 'Task')).toBeNull();
+  });
+
+  test('trailing spaces and tabs on the heading still match', () => {
+    expect(extractSection('## Task  \nbody\n', 'Task')?.trim()).toBe('body');
+    expect(extractSection('## Task\t\nbody\n', 'Task')?.trim()).toBe('body');
+  });
+
+  test('absent heading returns null', () => {
+    expect(extractSection(SHELL, 'Nonexistent')).toBeNull();
+  });
+});
+
+describe('extractSection boundaries', () => {
+  test('body stops at the next ## heading and excludes the heading line', () => {
+    expect(extractSection(SHELL, 'Task')).toBe('Real task body\n');
+  });
+
+  test('multi-line body is returned verbatim', () => {
+    expect(extractSection(SHELL, 'Progress Log')).toBe('[09:00] Did a thing\n[10:30] Did another\n');
+  });
+
+  test('last section runs to EOF', () => {
+    expect(extractSection(SHELL, 'Session Summary')).toBe('Wrapped up.\n');
+  });
+
+  test('last section without a trailing newline still terminates', () => {
+    expect(extractSection('## Task\nbody', 'Task')).toBe('body');
+  });
+
+  test('empty section body is empty, not the rest of the document', () => {
+    expect(extractSection('## Task\n\n## Blockers\nb\n', 'Task')).toBe('');
+  });
+
+  test('heading at EOF with no body returns empty', () => {
+    expect(extractSection('# Doc\n\n## Task', 'Task')).toBe('');
+  });
+
+  test('### sub-headings inside the body do not truncate it', () => {
+    const md = '## Task\nline one\n### detail\nline two\n\n## Blockers\nb\n';
+    expect(extractSection(md, 'Task')).toBe('line one\n### detail\nline two\n');
+  });
+});
+
+describe('operator-owned content passes through', () => {
+  test('an operator-added custom section is readable', () => {
+    const md = SHELL + '\n## Operator Notes\nhand-written\n';
+    expect(extractSection(md, 'Operator Notes')?.trim()).toBe('hand-written');
+  });
+
+  test('replacing one section leaves every other byte untouched', () => {
+    const md = SHELL + '\n## Operator Notes\nhand-written\n';
+    const out = replaceSectionInPlace(md, 'Task', '\nNew task\n\n');
+    expect(out).toContain('## Operator Notes\nhand-written\n');
+    expect(out).toContain('[09:00] Did a thing');
+    // The trailing blank line in newBody is preserved — it is what keeps the
+    // replaced section from gluing onto the next heading.
+    expect(extractSection(out, 'Task')).toBe('New task\n\n');
+  });
+
+  test('appending to one section leaves an operator section untouched', () => {
+    const md = SHELL + '\n## Operator Notes\nhand-written\n';
+    const out = appendToSection(md, 'Progress Log', '[11:00] Appended');
+    expect(out).toContain('## Operator Notes\nhand-written\n');
+    expect(extractSection(out, 'Progress Log')).toContain('[11:00] Appended');
+    expect(extractSection(out, 'Blockers')).toBe(extractSection(md, 'Blockers'));
+  });
+});
+
+describe('stripPlaceholders', () => {
+  test('drops a whole-line placeholder comment', () => {
+    expect(stripPlaceholders('<!-- What is preventing progress? -->\n')).toBe('');
+  });
+
+  test('drops a multi-line placeholder comment', () => {
+    expect(stripPlaceholders('<!-- line one\nline two -->\n')).toBe('');
+  });
+
+  test('drops an inline comment and keeps the surrounding text', () => {
+    expect(stripPlaceholders('Ship it <!-- note --> today')).toBe('Ship it  today');
+  });
+
+  test('keeps real content sitting below a retained placeholder', () => {
+    expect(stripPlaceholders('<!-- placeholder -->\nA real finding')).toBe('A real finding');
+  });
+
+  test('a placeholder-only Blockers section reads as empty', () => {
+    expect(stripPlaceholders(extractSection(SHELL, 'Blockers')!)).toBe('');
+  });
+});
+
+describe('firstContentLine', () => {
+  test('skips blanks and placeholders', () => {
+    expect(firstContentLine('\n<!-- hint -->\n  Real line  \nsecond\n')).toBe('Real line');
+  });
+
+  test('clips to maxLen', () => {
+    expect(firstContentLine('abcdef\n', 3)).toBe('abc');
+  });
+
+  test('placeholder-only section yields empty string', () => {
+    expect(firstContentLine('<!-- Awaiting next task -->\n')).toBe('');
+  });
+});
+
+describe('replaceSectionInPlace', () => {
+  test('replaces a middle section without touching its neighbours', () => {
+    const out = replaceSectionInPlace(SHELL, 'Progress Log', '\n[12:00] Only entry\n\n');
+    expect(extractSection(out, 'Progress Log')).toBe('[12:00] Only entry\n\n');
+    expect(extractSection(out, 'Task')).toBe('Real task body\n');
+    expect(extractSection(out, 'Blockers')).toBe(extractSection(SHELL, 'Blockers'));
+  });
+
+  test('replaces the last section at EOF', () => {
+    const out = replaceSectionInPlace(SHELL, 'Session Summary', '\nNew summary\n');
+    expect(extractSection(out, 'Session Summary')).toBe('New summary\n');
+  });
+
+  test('absent heading leaves content unchanged', () => {
+    expect(replaceSectionInPlace(SHELL, 'Nonexistent', '\nx\n')).toBe(SHELL);
+  });
+
+  test('does not target a ### sub-heading of the same name', () => {
+    const md = '### Task\nsub body\n\n## Task\nreal body\n';
+    const out = replaceSectionInPlace(md, 'Task', '\nreplaced\n');
+    expect(out).toContain('### Task\nsub body');
+    expect(extractSection(out, 'Task')).toBe('replaced\n');
+  });
+});
+
+// End-to-end on the surface that matters most: session-start injection. A model
+// writing a `### Blockers` sub-heading inside the Task body used to make the
+// injected "## Blockers" carry that sub-heading's text instead of the real one.
+describe('startup-context injection is not hijackable by a ### sub-heading', () => {
+  test('injects the real ## Blockers body, not the decoy above it', async () => {
+    const wd = setupWorkdir();
+    try {
+      fs.writeFileSync(path.join(wd.dir, '.claude-code-hermit', 'sessions', 'SHELL.md'), [
+        '# Active Session',
+        '',
+        '## Session Info',
+        '- **ID:** S-001',
+        '',
+        '## Task',
+        'Ship the parser consolidation.',
+        '### Blockers',
+        'DECOY-BLOCKER from a task sub-heading',
+        '',
+        '## Progress Log',
+        '[09:00] Started',
+        '',
+        '## Blockers',
+        'REAL-BLOCKER waiting on review',
+        '',
+        '## Session Summary',
+        '',
+      ].join('\n'));
+
+      const res = await runScript('startup-context.ts', {
+        stdin: '{}',
+        env: { AGENT_DIR: path.join(wd.dir, '.claude-code-hermit') },
+      });
+
+      // Anchored: the decoy legitimately appears inside the injected Task body,
+      // and `'### Blockers'` ends with the substring `'## Blockers'` — the very
+      // trap this consolidation removes. Only the emitted `## Blockers` heading
+      // (at a line start) is under test.
+      expect(res.stdout).toMatch(/^## Blockers\nREAL-BLOCKER waiting on review$/m);
+      expect(res.stdout).not.toMatch(/^## Blockers\nDECOY-BLOCKER/m);
+    } finally {
+      wd.cleanup();
+    }
+  });
+});
+
+describe('findSection agrees with extractSection', () => {
+  test('the located span, minus its leading newline, is the extracted body', () => {
+    for (const heading of ['Session Info', 'Task', 'Progress Log', 'Blockers', 'Session Summary']) {
+      const s = findSection(SHELL, heading)!;
+      expect(SHELL.slice(s.start, s.end).replace(/^\n/, '')).toBe(extractSection(SHELL, heading)!);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

"Get the body of `## <heading>`" was implemented independently at nine sites, in two families that disagreed on real input. The unanchored family located a section with `indexOf('## Task')` or `/## Blockers\n/`, and `'### Task'.indexOf('## Task') === 1` — so a `###` sub-heading written anywhere above the real section silently won. The anchored family (`/^## X[ \t]*$/m`) was immune. Same file, same heading, two answers.

That matters because SHELL.md bodies are model-written: a Task body or Progress Log entry containing a `### Blockers` sub-heading is ordinary, and the affected reads are load-bearing — session-start context injection, the `.status.json` task/blockers fields the channel status responder reports, Progress Log staleness detection, the Monitoring bloat check, the session quality score, and the `reflect --quick` content hash.

`lib/md-write.ts` already owned the anchored half of this grammar (`findSection`, `appendToSection`, `appendShellLine`, four call sites), so it becomes the single home rather than a new module.

## Changes

- `scripts/lib/md-write.ts` — `extractSection`, `stripPlaceholders`, `firstContentLine` and `replaceSectionInPlace`, all built on the existing anchored `findSection`.
- Migrated every reader/writer onto it: `startup-context.ts`, `reflect-precheck.ts`, `lib/progress-log.ts`, `evaluate-session.ts` (Progress Log, Monitoring, and the `checkSection` quality-score helper), `lib/alert-state.ts`, `cost-tracker.ts`, `session-archive.ts`, `archive-shell.ts`. Ten local parsers plus three inconsistent placeholder-stripping idioms are gone.
- `lib/progress-log.ts` keeps its append-at-EOF fallback and fail-open catch deliberately — it must not throw on a missing heading, and it skips `appendToSection`'s blank-line normalization so an operator's SHELL.md spacing survives an autonomous flush.
- No section-vocabulary registry: the grammar stays vocabulary-agnostic, which is what keeps operator-added custom sections and hand edits passing through untouched.

## Behavior change (intended)

On pathological input the previously-unanchored sites now return the real section instead of the hijacked one. Headings with trailing text (`## Task foo`) stop matching at those sites, matching the anchored family's long-standing behavior. `reflect --quick`'s hash normalization now strips multi-line placeholder comments correctly, so the first post-upgrade tick may see one content change.

## Test plan

- `bun test` — 3584 pass, 0 fail (128 files).
- `bunx tsc --noEmit` — exit 0.
- New `tests/shell-sections.test.ts`: table-driven over pathological bodies — `### Task` decoy above the real section, `## Tasks` prefix decoy, heading with trailing text/whitespace, EOF-terminated last section, empty body, `###` sub-headings inside a body, operator custom sections surviving read/replace/append untouched, plus a `findSection`/`extractSection` agreement invariant.
- End-to-end regressions on the surfaces that actually broke: `startup-context.ts` injecting the real `## Blockers` past a decoy, and `cost-tracker.ts` writing the real blocker into `.status.json`. Both are red against the old parsers by construction.
- Grep gate: no `indexOf('## ` or unanchored `## <heading>` regex section reads remain under `scripts/`.