### PR TITLE
refactor(claude-code-hermit): make proposal.ts write verbs value-returning

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- `proposal.ts`'s write verbs (`create`, `patch`, `shell-append`, `next-task`, `routine`) return their stdout token instead of exiting, and are exported behind an `import.meta.main` guard, so the write-path grammar — header parsing, the id suffix walk, the `@now` decision-append guard — is testable in-process. Same argv, same stdout grammar, same exit codes.
+
 ## [1.2.38] - 2026-08-12
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/proposal.ts
+++ b/plugins/claude-code-hermit/scripts/proposal.ts
@@ -77,7 +77,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { readStdin, readJson, flagValue } from './lib/cli';
+import { emit, readStdin, readJson, flagValue } from './lib/cli';
 import { pinStateDirOrExit } from './lib/cc-compat';
 import { appendJsonlLine } from './lib/append-jsonl';
 import { writeFileAtomic, patchFrontmatter, appendToSection, appendShellLine, findSection, PATCH_KEY_RE } from './lib/md-write';
@@ -96,15 +96,12 @@ import { run as runQualityGate } from './lib/proposals/quality-gate';
 
 type Json = any;
 
-function fail(token: string): never {
-  process.stdout.write(`ERROR|${token}\n`);
-  process.exit(0);
-}
-
-function ok(token: string): never {
-  process.stdout.write(`${token}\n`);
-  process.exit(0);
-}
+// The write verbs return their complete stdout token — `ERROR|<reason>` or the
+// success line — rather than exiting, so the write-path grammar is callable
+// from a test without a subprocess. `main()`, via lib/cli's `emit`, is the only
+// exit adapter. An exported verb takes `stateDir` already pinned (see
+// requirePinnedStateDir): the pin is a property of the CLI entry, so an
+// in-process caller owns it.
 
 function warn(msg: string): void {
   console.error(`WARN: ${msg}`);
@@ -121,13 +118,13 @@ function regenTail(stateDir: string): void {
 
 const VALID_CATEGORIES = new Set(['improvement', 'routine', 'capability', 'constraint', 'bug']);
 
-function grabHeader(header: string, key: string): string | null {
+export function grabHeader(header: string, key: string): string | null {
   const m = new RegExp(`^${key}:[ \\t]*(.*)$`, 'm').exec(header);
   return m ? m[1].trim() : null;
 }
 
 // Returns [] for an absent/blank header, null to signal invalid JSON/shape.
-function parseStringArray(raw: string | null): string[] | null {
+export function parseStringArray(raw: string | null): string[] | null {
   if (raw == null || raw.trim() === '') return [];
   try {
     const parsed = JSON.parse(raw);
@@ -136,16 +133,15 @@ function parseStringArray(raw: string | null): string[] | null {
   return null;
 }
 
-async function verbCreate(stateDir: string): Promise<void> {
-  const stdin = await readStdin();
+export function verbCreate(stateDir: string, stdin: string): string {
   const sep = /^---[ \t]*$/m.exec(stdin);
-  if (!sep) fail('missing-separator');
+  if (!sep) return 'ERROR|missing-separator';
   const header = stdin.slice(0, sep.index);
   let body = stdin.slice(sep.index + sep[0].length).replace(/^\n+/, '').replace(/\s+$/, '');
-  if (!body) fail('empty-body');
+  if (!body) return 'ERROR|empty-body';
 
   const title = grabHeader(header, 'Title');
-  if (!title) fail('missing-title');
+  if (!title) return 'ERROR|missing-title';
 
   const source = grabHeader(header, 'Source') || 'manual';
   let session = grabHeader(header, 'Session');
@@ -157,23 +153,23 @@ async function verbCreate(stateDir: string): Promise<void> {
     session = runtime?.session_id ?? null;
   }
   const category = grabHeader(header, 'Category') || 'improvement';
-  if (!VALID_CATEGORIES.has(category)) fail('invalid-category');
+  if (!VALID_CATEGORIES.has(category)) return 'ERROR|invalid-category';
 
   const tags = parseStringArray(grabHeader(header, 'Tags'));
-  if (tags === null) fail('invalid-tags');
+  if (tags === null) return 'ERROR|invalid-tags';
   const relatedSessions = parseStringArray(grabHeader(header, 'Related-Sessions'));
-  if (relatedSessions === null) fail('invalid-related-sessions');
+  if (relatedSessions === null) return 'ERROR|invalid-related-sessions';
   const findingsSummary = grabHeader(header, 'Findings');
 
-  if (!fs.existsSync(stateDir)) fail('state-dir-not-found');
+  if (!fs.existsSync(stateDir)) return 'ERROR|state-dir-not-found';
 
   const templatePath = path.join(stateDir, 'templates', 'PROPOSAL.md.template');
   let templateContent: string;
   try { templateContent = fs.readFileSync(templatePath, 'utf-8'); }
-  catch { fail('template-missing'); }
-  if (!templateContent.startsWith('---')) fail('template-malformed');
+  catch { return 'ERROR|template-missing'; }
+  if (!templateContent.startsWith('---')) return 'ERROR|template-malformed';
   const fmEnd = templateContent.indexOf('\n---', 3);
-  if (fmEnd === -1) fail('template-malformed');
+  if (fmEnd === -1) return 'ERROR|template-malformed';
   const templateFrontmatterBlock = templateContent.slice(0, fmEnd + 4);
 
   if (!/^## Operator Decision[ \t]*$/m.test(body)) {
@@ -206,10 +202,10 @@ async function verbCreate(stateDir: string): Promise<void> {
       claimedId = candidateId;
       break;
     } catch (e: any) {
-      if (e.code !== 'EEXIST') fail('proposals-dir-unwritable');
+      if (e.code !== 'EEXIST') return 'ERROR|proposals-dir-unwritable';
     }
     suffixIdx++;
-    if (suffixIdx >= SUFFIX_LETTERS.length) fail('collision-suffixes-exhausted');
+    if (suffixIdx >= SUFFIX_LETTERS.length) return 'ERROR|collision-suffixes-exhausted';
     suffix = SUFFIX_LETTERS[suffixIdx];
   }
 
@@ -231,7 +227,7 @@ async function verbCreate(stateDir: string): Promise<void> {
 
   regenTail(stateDir);
 
-  ok(claimedId!);
+  return claimedId!;
 }
 
 // ----------------------------------------------------------------- patch ---
@@ -267,7 +263,7 @@ function escapeRe(s: string): string {
 // wildcard: every SKILL-documented Decision line is `... on @now.`, which
 // expands to a fresh stamp each second, so a byte-comparison against the
 // expanded line would never match on a retry and the guard would never fire.
-function sectionEndsWithLine(content: string, heading: string, rawLine: string): boolean {
+export function sectionEndsWithLine(content: string, heading: string, rawLine: string): boolean {
   const section = findSection(content, heading);
   if (!section) return false;
   const lines = content.slice(section.start, section.end).split('\n').map(l => l.trim()).filter(Boolean);
@@ -276,28 +272,24 @@ function sectionEndsWithLine(content: string, heading: string, rawLine: string):
   return new RegExp(`^${pattern}$`).test(lines[lines.length - 1]);
 }
 
-async function verbPatch(stateDir: string, args: string[]): Promise<void> {
+export function verbPatch(stateDir: string, stdin: string, args: string[]): string {
   const { filename, sets: rawSets, requestCompact } = parsePatchArgs(args);
-  if (!filename) fail('no-such-proposal');
+  if (!filename) return 'ERROR|no-such-proposal';
   // Direct-child basename only. The `path.join` below would otherwise let a
   // `../` prefix escape the proposals dir and patch any frontmatter-bearing
   // .md on disk; the state-dir pin in main() does not constrain this argument.
   // `startsWith('.')` covers `.`, `..`, and dotfiles in one predicate.
-  if (filename !== path.basename(filename) || filename.startsWith('.')) fail('no-such-proposal');
+  if (filename !== path.basename(filename) || filename.startsWith('.')) return 'ERROR|no-such-proposal';
 
   const sets: Record<string, string> = {};
   for (const kv of rawSets) {
     const eq = kv.indexOf('=');
-    if (eq === -1) fail('invalid-set');
+    if (eq === -1) return 'ERROR|invalid-set';
     const key = kv.slice(0, eq);
-    if (!PATCH_KEY_RE.test(key)) fail(`invalid-key:${key}`);
+    if (!PATCH_KEY_RE.test(key)) return `ERROR|invalid-key:${key}`;
     sets[key] = kv.slice(eq + 1);
   }
 
-  // patch is the one verb documented as stdin-optional (defer/dismiss with no
-  // note omit the heredoc) — skip the read on a TTY so an interactive invocation
-  // with no piped input doesn't hang waiting for EOF.
-  const stdin = process.stdin.isTTY ? '' : await readStdin();
   // `[ \t]*` not `\s*`: `\s` matches newlines, so a bare `Decision:` line
   // followed by a `Set:` line would capture the Set line as the decision text
   // (and then also apply it as a frontmatter set).
@@ -307,7 +299,7 @@ async function verbPatch(stateDir: string, args: string[]): Promise<void> {
   const setLineRe = /^Set:[ \t]*([^\s=]+)=(.*)$/gm;
   let m: RegExpExecArray | null;
   while ((m = setLineRe.exec(stdin))) {
-    if (!PATCH_KEY_RE.test(m[1])) fail(`invalid-key:${m[1]}`);
+    if (!PATCH_KEY_RE.test(m[1])) return `ERROR|invalid-key:${m[1]}`;
     stdinSets[m[1]] = m[2];
   }
 
@@ -318,11 +310,11 @@ async function verbPatch(stateDir: string, args: string[]): Promise<void> {
     const p = path.join(proposalsDir, name);
     if (fs.existsSync(p)) { targetPath = p; break; }
   }
-  if (!targetPath) fail('no-such-proposal');
+  if (!targetPath) return 'ERROR|no-such-proposal';
 
   let content: string;
   try { content = fs.readFileSync(targetPath, 'utf-8'); }
-  catch { fail('no-such-proposal'); }
+  catch { return 'ERROR|no-such-proposal'; }
 
   const now = new Date();
   const timezone = readTimezone(stateDir);
@@ -336,18 +328,18 @@ async function verbPatch(stateDir: string, args: string[]): Promise<void> {
   let patched = content;
   if (Object.keys(patch).length > 0) {
     try { patched = patchFrontmatter(content, patch); }
-    catch { fail('frontmatter-terminator-missing'); }
+    catch { return 'ERROR|frontmatter-terminator-missing'; }
   }
 
   if (decisionLine) {
     if (!sectionEndsWithLine(patched, 'Operator Decision', decisionLine)) {
       try { patched = appendToSection(patched, 'Operator Decision', expand(decisionLine)); }
-      catch { fail('no-operator-decision-section'); }
+      catch { return 'ERROR|no-operator-decision-section'; }
     }
   }
 
   try { writeFileAtomic(targetPath, patched); }
-  catch { fail('write-failed'); }
+  catch { return 'ERROR|write-failed'; }
 
   if (requestCompact) {
     try {
@@ -362,57 +354,55 @@ async function verbPatch(stateDir: string, args: string[]): Promise<void> {
 
   regenTail(stateDir);
 
-  ok(`OK|${path.basename(targetPath).replace(/\.md$/, '')}`);
+  return `OK|${path.basename(targetPath).replace(/\.md$/, '')}`;
 }
 
 // ----------------------------------------------------------- shell-append --
 
-async function verbShellAppend(stateDir: string, args: string[]): Promise<void> {
-  const line = (await readStdin()).trim();
+export function verbShellAppend(stateDir: string, stdin: string, args: string[]): string {
+  const line = stdin.trim();
   const section = flagValue(args, '--section');
-  if (section !== 'findings' && section !== 'progress') fail('unknown-section');
-  if (!line) fail('empty-line');
+  if (section !== 'findings' && section !== 'progress') return 'ERROR|unknown-section';
+  if (!line) return 'ERROR|empty-line';
   const heading = section === 'findings' ? 'Findings' : 'Progress Log';
   const err = appendShellLine(path.join(stateDir, 'sessions'), heading, line);
   if (err) {
-    if (err.startsWith('SHELL.md unreadable')) fail('shell-unreadable');
-    fail('shell-append-failed');
+    if (err.startsWith('SHELL.md unreadable')) return 'ERROR|shell-unreadable';
+    return 'ERROR|shell-append-failed';
   }
-  ok('OK');
+  return 'OK';
 }
 
 // --------------------------------------------------------------- next-task -
 
-async function verbNextTask(stateDir: string): Promise<void> {
-  const content = await readStdin();
-  if (!content.trim()) fail('empty-content');
+export function verbNextTask(stateDir: string, stdin: string): string {
+  if (!stdin.trim()) return 'ERROR|empty-content';
   const target = path.join(stateDir, 'sessions', 'NEXT-TASK.md');
   try {
-    fs.writeFileSync(target, content, { flag: 'wx' });
+    fs.writeFileSync(target, stdin, { flag: 'wx' });
   } catch (e: any) {
-    if (e.code === 'EEXIST') fail('next-task-exists');
-    fail('write-failed');
+    if (e.code === 'EEXIST') return 'ERROR|next-task-exists';
+    return 'ERROR|write-failed';
   }
-  ok('OK');
+  return 'OK';
 }
 
 // ------------------------------------------------------------------ routine
 
 const ROUTINE_REQUIRED_FIELDS = ['id', 'schedule', 'skill', 'enabled'];
 
-async function verbRoutine(stateDir: string): Promise<void> {
-  const stdin = await readStdin();
+export function verbRoutine(stateDir: string, stdin: string): string {
   let entry: Json;
-  try { entry = JSON.parse(stdin); } catch { fail('invalid-json'); }
-  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) fail('invalid-json');
+  try { entry = JSON.parse(stdin); } catch { return 'ERROR|invalid-json'; }
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return 'ERROR|invalid-json';
   for (const field of ROUTINE_REQUIRED_FIELDS) {
-    if (!(field in entry)) fail(`missing-field:${field}`);
+    if (!(field in entry)) return `ERROR|missing-field:${field}`;
   }
-  if (typeof entry.id !== 'string' || !entry.id) fail('missing-field:id');
+  if (typeof entry.id !== 'string' || !entry.id) return 'ERROR|missing-field:id';
 
   const configPath = path.join(stateDir, 'config.json');
   const config: Json = readJson(configPath);
-  if (!config) fail('config-unreadable');
+  if (!config) return 'ERROR|config-unreadable';
 
   if (!Array.isArray(config.routines)) config.routines = [];
   const idx = config.routines.findIndex((r: Json) => r && r.id === entry.id);
@@ -423,10 +413,10 @@ async function verbRoutine(stateDir: string): Promise<void> {
   try {
     writeFileAtomic(configPath, JSON.stringify(config, null, 2) + '\n');
   } catch {
-    fail('config-write-failed');
+    return 'ERROR|config-write-failed';
   }
 
-  ok(`OK|${verdict}`);
+  return `OK|${verdict}`;
 }
 
 // ------------------------------------------------------------------- main --
@@ -487,11 +477,17 @@ async function main(): Promise<void> {
 
   const rest = process.argv.slice(4);
   switch (verb) {
-    case 'create': return verbCreate(stateDir);
-    case 'patch': return verbPatch(stateDir, rest);
-    case 'shell-append': return verbShellAppend(stateDir, rest);
-    case 'next-task': return verbNextTask(stateDir);
-    case 'routine': return verbRoutine(stateDir);
+    case 'create': return emit(verbCreate(stateDir, await readStdin()));
+    case 'patch': {
+      // patch is the one verb documented as stdin-optional (defer/dismiss with
+      // no note omit the heredoc) — skip the read on a TTY so an interactive
+      // invocation with no piped input doesn't hang waiting for EOF.
+      const stdin = process.stdin.isTTY ? '' : await readStdin();
+      return emit(verbPatch(stateDir, stdin, rest));
+    }
+    case 'shell-append': return emit(verbShellAppend(stateDir, await readStdin(), rest));
+    case 'next-task': return emit(verbNextTask(stateDir, await readStdin()));
+    case 'routine': return emit(verbRoutine(stateDir, await readStdin()));
     case 'resolve-id': return runResolveId(stateDir, rest[0]);
     case 'gate': return runGate(stateDir, rest);
     case 'queue-micro': return runQueueMicro(stateDir);
@@ -500,18 +496,18 @@ async function main(): Promise<void> {
     // `event` is the writer; `metrics` above is the reader. Deliberately not named
     // `metric` — one character from `metrics` in a dispatcher whose default branch
     // exits 0 would make a typo a silent no-op in either direction.
-    case 'event': {
-      const verdict = runEvent(stateDir, rest);
-      return verdict === 'OK' ? ok('OK') : fail(verdict.replace(/^ERROR\|/, ''));
-    }
+    case 'event': return emit(runEvent(stateDir, rest));
     case 'quality-gate': return runQualityGate(stateDir, rest);
     default:
-      fail('unknown-verb');
+      emit('ERROR|unknown-verb');
   }
 }
 
-main().catch((e: any) => {
-  console.error('proposal.ts: unexpected error: ' + e.message);
-  process.stdout.write('ERROR|unexpected\n');
-  process.exit(0);
-});
+// Guarded so importing a verb for an in-process test does not run the CLI.
+if (import.meta.main) {
+  main().catch((e: any) => {
+    console.error('proposal.ts: unexpected error: ' + e.message);
+    process.stdout.write('ERROR|unexpected\n');
+    process.exit(0);
+  });
+}

--- a/plugins/claude-code-hermit/scripts/proposal.ts
+++ b/plugins/claude-code-hermit/scripts/proposal.ts
@@ -56,7 +56,7 @@
 //
 // The verbs below are the proposal-lifecycle *readers and satellites*, absorbed
 // from what used to be one top-level script each. They keep their own stdout
-// grammars and exit codes rather than being forced into `ok()`/`fail()` —
+// grammars and exit codes rather than being forced into `OK`/`ERROR|<token>` —
 // callers branch on those, and rewriting them would be a behavior change:
 //
 //   resolve-id <stateDir> <operator-input>       MATCH|… AMBIGUOUS|… NONE|…
@@ -427,11 +427,11 @@ const VERBS = 'create|patch|shell-append|next-task|routine|resolve-id|gate|queue
 // `.claude-code-hermit` from the project root; accepting an arbitrary root let
 // one pre-approved `Bash(bun */scripts/proposal.ts*)` call mutate — or read —
 // another project's proposal queue. Deliberately a usage error (stderr, exit 1)
-// rather than `fail()`: `fail()` writes `ERROR|<token>` to stdout, which would
-// corrupt the distinct stdout grammars several verbs own and callers branch on
-// (`gate` -> PROCEED|/DROP|/GATE_FAILED, `resolve-id` -> MATCH|/NONE|, `micro`
-// -> RESOLVED|). This also turns a drifted cwd into a loud failure instead of a
-// write against the wrong tree.
+// rather than an `ERROR|<token>` verdict line: that line goes to stdout, which
+// would corrupt the distinct stdout grammars several verbs own and callers
+// branch on (`gate` -> PROCEED|/DROP|/GATE_FAILED, `resolve-id` -> MATCH|/NONE|,
+// `micro` -> RESOLVED|). This also turns a drifted cwd into a loud failure
+// instead of a write against the wrong tree.
 function requirePinnedStateDir(dir: string): void {
   pinStateDirOrExit(dir, 'proposal.ts');
 }
@@ -499,7 +499,7 @@ async function main(): Promise<void> {
     case 'event': return emit(runEvent(stateDir, rest));
     case 'quality-gate': return runQualityGate(stateDir, rest);
     default:
-      emit('ERROR|unknown-verb');
+      return emit('ERROR|unknown-verb');
   }
 }
 

--- a/plugins/claude-code-hermit/tests/proposal-verbs.test.ts
+++ b/plugins/claude-code-hermit/tests/proposal-verbs.test.ts
@@ -1,0 +1,256 @@
+// In-process tests for the scripts/proposal.ts write verbs.
+//
+// The companion file (proposal-write.test.ts) spawns the CLI and owns the
+// process-boundary contract — argv, stdout grammar, exit codes. These call the
+// verbs directly, which is what makes the grammar itself (header parsing, the
+// EEXIST suffix walk, the `@now` idempotency guard) reachable per-case without
+// a subprocess or an AGENT_DIR override. Keep contract assertions there and
+// grammar assertions here.
+
+import { describe, test, expect, spyOn } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  verbCreate, verbPatch, verbShellAppend, verbNextTask, verbRoutine,
+  grabHeader, parseStringArray, sectionEndsWithLine,
+} from '../scripts/proposal';
+import { PLUGIN_ROOT } from './helpers/run';
+import { withDir } from './helpers/workdir';
+
+function stateDirOf(dir: string): string {
+  return path.join(dir, '.claude-code-hermit');
+}
+
+// withDir already makes sessions/ and state/; add what the create verb needs.
+function seed(dir: string, config: Record<string, unknown> = {}): string {
+  const base = stateDirOf(dir);
+  fs.mkdirSync(path.join(base, 'proposals'), { recursive: true });
+  fs.mkdirSync(path.join(base, 'templates'), { recursive: true });
+  fs.copyFileSync(
+    path.join(PLUGIN_ROOT, 'state-templates', 'PROPOSAL.md.template'),
+    path.join(base, 'templates', 'PROPOSAL.md.template'),
+  );
+  fs.writeFileSync(
+    path.join(base, 'config.json'),
+    JSON.stringify({ timezone: 'Europe/London', routines: [], ...config }),
+  );
+  return base;
+}
+
+const BODY = [
+  '## Context', 'ctx', '',
+  '## Problem', 'prob', '',
+  '## Operator Decision', '',
+].join('\n');
+
+function heredoc(header: Record<string, string>, body = BODY): string {
+  return Object.entries(header).map(([k, v]) => `${k}: ${v}`).join('\n') + '\n---\n' + body;
+}
+
+describe('verbCreate grammar', () => {
+  test('happy path returns the canonical id and writes the file it names', withDir(async (dir) => {
+    const base = seed(dir);
+    const id = verbCreate(base, heredoc({ Title: 'Ship the thing', Tags: '["architecture"]' }));
+
+    expect(id).toMatch(/^PROP-001-ship-thing-\d{6}$/);
+    const content = fs.readFileSync(path.join(base, 'proposals', `${id}.md`), 'utf-8');
+    expect(content).toContain(`id: ${id}`);
+    expect(content).toContain('status: proposed');
+    expect(content).toContain('tags: ["architecture"]');
+    expect(content).toContain(`# Proposal: ${id} — Ship the thing`);
+  }));
+
+  test.each([
+    ['no separator line', 'Title: x\nbody with no separator', 'ERROR|missing-separator'],
+    ['body is only whitespace', 'Title: x\n---\n   \n', 'ERROR|empty-body'],
+    ['no Title header', heredoc({ Source: 'manual' }), 'ERROR|missing-title'],
+    ['Title present but blank', heredoc({ Title: '   ' }), 'ERROR|missing-title'],
+    ['category outside the enum', heredoc({ Title: 'x', Category: 'wishlist' }), 'ERROR|invalid-category'],
+    ['Tags is not JSON', heredoc({ Title: 'x', Tags: 'architecture' }), 'ERROR|invalid-tags'],
+    ['Tags is JSON but not string[]', heredoc({ Title: 'x', Tags: '[1,2]' }), 'ERROR|invalid-tags'],
+    ['Related-Sessions is malformed', heredoc({ Title: 'x', 'Related-Sessions': '{}' }), 'ERROR|invalid-related-sessions'],
+  ])('%s', (_name, stdin, expected) => withDir(async (dir) => {
+    const base = seed(dir);
+    expect(verbCreate(base, stdin)).toBe(expected);
+    expect(fs.readdirSync(path.join(base, 'proposals'))).toEqual([]);
+  })());
+
+  test('a bare `Session:` header falls through to runtime.json, not an empty string', withDir(async (dir) => {
+    const base = seed(dir);
+    fs.writeFileSync(path.join(base, 'state', 'runtime.json'), JSON.stringify({ session_id: 'S-042' }));
+
+    const id = verbCreate(base, heredoc({ Title: 'x', Session: '' }));
+    expect(fs.readFileSync(path.join(base, 'proposals', `${id}.md`), 'utf-8')).toContain('session: S-042');
+  }));
+
+  test('an absent Operator Decision section is appended so patch has somewhere to write', withDir(async (dir) => {
+    const base = seed(dir);
+    const id = verbCreate(base, heredoc({ Title: 'x' }, '## Context\nctx'));
+    expect(fs.readFileSync(path.join(base, 'proposals', `${id}.md`), 'utf-8')).toContain('## Operator Decision');
+  }));
+
+  test('a missing template fails before any write', withDir(async (dir) => {
+    const base = seed(dir);
+    fs.rmSync(path.join(base, 'templates', 'PROPOSAL.md.template'));
+    expect(verbCreate(base, heredoc({ Title: 'x' }))).toBe('ERROR|template-missing');
+    expect(fs.readdirSync(path.join(base, 'proposals'))).toEqual([]);
+  }));
+
+  // Only reachable in production when two processes claim the same number at the
+  // same second — the race the exclusive-create loop exists to absorb. Forcing
+  // one EEXIST is what an in-process caller can do that a spawned CLI cannot.
+  test('an EEXIST on the first exclusive write walks to the -a suffix', withDir(async (dir) => {
+    const base = seed(dir);
+    const real = fs.writeFileSync;
+    let thrown = false;
+    const spy = spyOn(fs, 'writeFileSync').mockImplementation(((...args: any[]) => {
+      if (!thrown && args[2]?.flag === 'wx') {
+        thrown = true;
+        const e: any = new Error('EEXIST'); e.code = 'EEXIST'; throw e;
+      }
+      return (real as any)(...args);
+    }) as any);
+
+    try {
+      const id = verbCreate(base, heredoc({ Title: 'Racing create' }));
+      expect(thrown).toBe(true);
+      expect(id).toMatch(/^PROP-001-racing-create-\d{6}a$/);
+      expect(fs.existsSync(path.join(base, 'proposals', `${id}.md`))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  }));
+});
+
+describe('verbPatch grammar', () => {
+  function seedProposal(dir: string): { base: string; id: string } {
+    const base = seed(dir);
+    const id = verbCreate(base, heredoc({ Title: 'Patch me' }));
+    return { base, id };
+  }
+
+  test('frontmatter set and Operator Decision append land in one write', withDir(async (dir) => {
+    const { base, id } = seedProposal(dir);
+    const verdict = verbPatch(base, 'Decision: Accepted on @now.', [id, '--set', 'status=accepted']);
+
+    expect(verdict).toBe(`OK|${id}`);
+    const content = fs.readFileSync(path.join(base, 'proposals', `${id}.md`), 'utf-8');
+    expect(content).toContain('status: accepted');
+    expect(content).toMatch(/Accepted on \d{4}-\d{2}-\d{2}T[\d:]{8}[+-]\d{2}:\d{2}\./);
+  }));
+
+  test('re-applying the same @now decision line is idempotent', withDir(async (dir) => {
+    const { base, id } = seedProposal(dir);
+    const stdin = 'Decision: Accepted on @now.';
+    verbPatch(base, stdin, [id]);
+    verbPatch(base, stdin, [id]);
+
+    const content = fs.readFileSync(path.join(base, 'proposals', `${id}.md`), 'utf-8');
+    expect(content.match(/Accepted on /g)?.length).toBe(1);
+  }));
+
+  test.each([
+    ['a parent-dir escape', '../config.json'],
+    ['a nested path', 'sub/PROP-001.md'],
+    ['a dotfile', '.hidden.md'],
+    ['an absent proposal', 'PROP-999-nope.md'],
+  ])('%s is refused as no-such-proposal', (_name, filename) => withDir(async (dir) => {
+    const base = seed(dir);
+    const before = fs.readFileSync(path.join(base, 'config.json'), 'utf-8');
+    expect(verbPatch(base, '', [filename, '--set', 'status=accepted'])).toBe('ERROR|no-such-proposal');
+    expect(fs.readFileSync(path.join(base, 'config.json'), 'utf-8')).toBe(before);
+  })());
+
+  test('a --set with no `=` is rejected', withDir(async (dir) => {
+    const { base, id } = seedProposal(dir);
+    expect(verbPatch(base, '', [id, '--set', 'statusaccepted'])).toBe('ERROR|invalid-set');
+  }));
+
+  test('an invalid key is rejected before the file is touched, decision line included', withDir(async (dir) => {
+    const { base, id } = seedProposal(dir);
+    const propPath = path.join(base, 'proposals', `${id}.md`);
+    const before = fs.readFileSync(propPath, 'utf-8');
+
+    expect(verbPatch(base, 'Decision: Accepted on @now.', [id, '--set', 'sta tus=accepted']))
+      .toBe('ERROR|invalid-key:sta tus');
+    expect(fs.readFileSync(propPath, 'utf-8')).toBe(before);
+  }));
+
+  test('--request-compact writes the marker alongside the patch', withDir(async (dir) => {
+    const { base, id } = seedProposal(dir);
+    verbPatch(base, '', [id, '--set', 'status=resolved', '--request-compact']);
+
+    const marker = JSON.parse(fs.readFileSync(path.join(base, 'state', 'compact-requested.json'), 'utf-8'));
+    expect(marker.reason).toBe('proposal-resolve');
+  }));
+});
+
+describe('the remaining write verbs', () => {
+  test('shell-append routes each section to its own heading', withDir(async (dir) => {
+    const base = seed(dir);
+    expect(verbShellAppend(base, 'a finding\n', ['--section', 'findings'])).toBe('OK');
+    expect(verbShellAppend(base, 'a progress line\n', ['--section', 'progress'])).toBe('OK');
+
+    const shell = fs.readFileSync(path.join(base, 'sessions', 'SHELL.md'), 'utf-8');
+    expect(shell).toContain('a finding');
+    expect(shell).toContain('a progress line');
+  }));
+
+  test.each([
+    ['unknown section', 'line', ['--section', 'notes'], 'ERROR|unknown-section'],
+    ['blank line', '   \n', ['--section', 'findings'], 'ERROR|empty-line'],
+  ])('shell-append rejects %s', (_name, stdin, args, expected) => withDir(async (dir) => {
+    expect(verbShellAppend(seed(dir), stdin as string, args as string[])).toBe(expected);
+  })());
+
+  test('next-task is exclusive-create — an existing file is left untouched', withDir(async (dir) => {
+    const base = seed(dir);
+    expect(verbNextTask(base, 'first\n')).toBe('OK');
+    expect(verbNextTask(base, 'second\n')).toBe('ERROR|next-task-exists');
+    expect(fs.readFileSync(path.join(base, 'sessions', 'NEXT-TASK.md'), 'utf-8')).toBe('first\n');
+  }));
+
+  test('routine upserts by id', withDir(async (dir) => {
+    const base = seed(dir);
+    const entry = { id: 'daily-brief', schedule: '0 8 * * *', skill: 'brief', enabled: true };
+
+    expect(verbRoutine(base, JSON.stringify(entry))).toBe('OK|added');
+    expect(verbRoutine(base, JSON.stringify({ ...entry, enabled: false }))).toBe('OK|updated');
+
+    const config = JSON.parse(fs.readFileSync(path.join(base, 'config.json'), 'utf-8'));
+    expect(config.routines).toHaveLength(1);
+    expect(config.routines[0].enabled).toBe(false);
+  }));
+
+  test.each([
+    ['malformed JSON', 'not json', 'ERROR|invalid-json'],
+    ['a JSON array', '[]', 'ERROR|invalid-json'],
+    ['a missing field', '{"id":"x","schedule":"* * * * *","skill":"brief"}', 'ERROR|missing-field:enabled'],
+    ['a blank id', '{"id":"","schedule":"* * * * *","skill":"brief","enabled":true}', 'ERROR|missing-field:id'],
+  ])('routine rejects %s', (_name, stdin, expected) => withDir(async (dir) => {
+    expect(verbRoutine(seed(dir), stdin as string)).toBe(expected);
+  })());
+});
+
+describe('header and section helpers', () => {
+  test('grabHeader trims its value and matches only at line start', () => {
+    expect(grabHeader('Title:   spaced   \nSource: manual', 'Title')).toBe('spaced');
+    expect(grabHeader('Not-Title: x', 'Title')).toBe(null);
+  });
+
+  test('parseStringArray separates "absent" from "malformed"', () => {
+    expect(parseStringArray(null)).toEqual([]);
+    expect(parseStringArray('  ')).toEqual([]);
+    expect(parseStringArray('["a","b"]')).toEqual(['a', 'b']);
+    expect(parseStringArray('[1]')).toBe(null);
+    expect(parseStringArray('nope')).toBe(null);
+  });
+
+  test('sectionEndsWithLine treats @now as a timestamp wildcard', () => {
+    const doc = '## Operator Decision\n\nAccepted on 2026-08-13T23:45:01+01:00.\n';
+    expect(sectionEndsWithLine(doc, 'Operator Decision', 'Accepted on @now.')).toBe(true);
+    expect(sectionEndsWithLine(doc, 'Operator Decision', 'Deferred on @now.')).toBe(false);
+    expect(sectionEndsWithLine(doc, 'Missing Section', 'Accepted on @now.')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/proposal.ts` was a zero-export CLI: the five write verbs that own the proposal write-path grammar were reachable only by spawning a subprocess, so every assertion about that grammar paid a spawn plus an `AGENT_DIR` override (the reason `tests/helpers/run.ts:runProposal` exists at 74 call sites). The verbs now return their stdout token instead of exiting, and are exported behind an `import.meta.main` guard with `main()` as the sole exit adapter.

The CLI contract is unchanged: same argv, same stdout grammar, same exit codes. This extends a pattern the file already used in two places — `lib/proposals/event.ts` already returns `OK`/`ERROR|<reason>` for `main()` to map, and `lib/proposals/index-rebuild.ts` already splits a value-returning core from a thin exit adapter.

## Changes

- **`scripts/proposal.ts`** — `verbCreate`, `verbPatch`, `verbShellAppend`, `verbNextTask`, `verbRoutine` become exported, synchronous, value-returning functions taking `(stateDir, stdin[, args])`. `readStdin()` and the `patch` TTY guard move up into `main()`, which prints the returned token and exits 0. The grammar helpers `grabHeader`, `parseStringArray`, and `sectionEndsWithLine` are exported for direct tests. The local `fail()`/`ok()` pair is gone; the file now imports the existing shared `emit()` from `lib/cli` (it already imported three other symbols from that module).
- **`tests/proposal-verbs.test.ts`** (new, 34 tests) — in-process coverage of header-grammar edges, the `Session:` fallback, the traversal guard, `--request-compact`, routine upsert, and the `@now` idempotency guard, against a scratch state dir with no env injection. Also covers the EEXIST suffix walk, which is only reachable in production under a two-process race and previously had no test at all.
- **`tests/proposal-write.test.ts`** — untouched. It stays the process-boundary contract suite (its header explicitly says not to convert its callers to in-process imports); the new file is additive.

## Test plan

- `bun test` from `plugins/claude-code-hermit/` — **3587 pass, 0 fail** across 128 files, including all 62 pre-existing spawn-based proposal contract tests unchanged.
- `bunx tsc --noEmit` from the repo root — clean.
- Live CLI smoke against a scratch state dir: `create` returns the canonical id; `patch --set status=accepted` returns `OK|<id>` and writes the frontmatter; a second identical `patch` leaves exactly one decision line (idempotency holds); `patch ../config.json` still returns `ERROR|no-such-proposal`.
- Mutation-checked the new `test.each` blocks (deliberately wrong expectation → test failed) to confirm the table bodies are not vacuously passing.