### PR TITLE
refactor(laravel-forge-hermit): export the write-confirm-gate classifier seam

### DIFF
--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Added
+- Inventory-sync test between `php/forge.php` and the write-confirm-gate hook: a subcommand added to the PHP dispatch chain without a matching entry in the hook's classifier now fails the test suite instead of silently falling through the hook's unknown-subcommand branch.
+
 ## [0.0.10] - 2026-07-30
 
 ### Added

--- a/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
+++ b/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
@@ -15,8 +15,60 @@
 // ONLY when we positively identify a write command lacking --confirm; if we
 // can't parse or classify the call, we pass through and let the authoritative
 // in-PHP gate handle it.
+//
+// classify() is the whole decision, exported so it can be tested as a function
+// and so the inventories below can be asserted against the subcommands
+// php/forge.php actually dispatches. main() owns only stdin, exit codes, and
+// the stderr message.
 
 import { readFileSync, writeSync } from 'node:fs';
+
+export const SAFE_SUBCOMMANDS: readonly string[] = [
+  'check', 'servers', 'server', 'sites', 'site', 'logs',
+  'server-log', 'site-log', 'background-process-log',
+  'deploy-history', 'deploy-log', 'deploy-status', 'deploy-watch',
+  'preview-deploy', 'preview-reboot',
+  'failed-deploys',
+  // Generic dispatch. `execute` mutates, but its authority is the plan hash
+  // plus the operator's channel approval — neither is visible in a Bash
+  // command string, so gating it here would be theatre. It stays in PHP.
+  'policy', 'call', 'preview', 'execute',
+  'help', '--help',
+];
+
+export const WRITE_SUBCOMMANDS: readonly string[] = ['deploy', 'server-reboot'];
+
+export type Classification =
+  | { gate: 'pass' }
+  | { gate: 'needs-confirm'; subcommand: string; preview: string };
+
+const PASS: Classification = { gate: 'pass' };
+
+export function classify(command: string): Classification {
+  if (!command.includes('forge.php')) return PASS;
+
+  const tokens = command.trim().split(/\s+/);
+  const idx = tokens.findIndex(t => t === 'forge.php' || t.endsWith('/forge.php'));
+
+  // forge.php is present but no subcommand token — pass through (e.g., --help).
+  if (idx === -1 || idx + 1 >= tokens.length) return PASS;
+
+  const subcommand = tokens[idx + 1]!;
+
+  if (SAFE_SUBCOMMANDS.includes(subcommand)) return PASS;
+
+  // Unknown subcommand — pass through (in-PHP gate handles it).
+  if (!WRITE_SUBCOMMANDS.includes(subcommand)) return PASS;
+
+  // Exact token, matching the in-PHP in_array() check.
+  if (tokens.includes('--confirm')) return PASS;
+
+  return {
+    gate: 'needs-confirm',
+    subcommand,
+    preview: subcommand === 'deploy' ? 'preview-deploy' : 'preview-reboot',
+  };
+}
 
 function block(message: string): never {
   try { writeSync(2, `${message}\n`); } catch {}
@@ -45,46 +97,10 @@ function main(): void {
   const command = (toolInput as Record<string, unknown>)['command'];
   if (typeof command !== 'string') process.exit(0);
 
-  if (!command.includes('forge.php')) process.exit(0);
+  const verdict = classify(command);
+  if (verdict.gate === 'pass') process.exit(0);
 
-  const tokens = command.trim().split(/\s+/);
-  const idx = tokens.findIndex(t => t === 'forge.php' || t.endsWith('/forge.php'));
-
-  if (idx === -1 || idx + 1 >= tokens.length) {
-    // forge.php is present but no subcommand token — pass through (e.g., --help).
-    process.exit(0);
-  }
-
-  const subcommand = tokens[idx + 1]!;
-
-  const SAFE_SUBCOMMANDS = [
-    'check', 'servers', 'server', 'sites', 'site', 'logs',
-    'server-log', 'site-log', 'background-process-log',
-    'deploy-history', 'deploy-log', 'deploy-status', 'deploy-watch',
-    'preview-deploy', 'preview-reboot',
-    'failed-deploys',
-    // Generic dispatch. `execute` mutates, but its authority is the plan hash
-    // plus the operator's channel approval — neither is visible in a Bash
-    // command string, so gating it here would be theatre. It stays in PHP.
-    'policy', 'call', 'preview', 'execute',
-    'help', '--help',
-  ];
-  if (SAFE_SUBCOMMANDS.includes(subcommand)) {
-    process.exit(0);
-  }
-
-  const WRITE_SUBCOMMANDS = ['deploy', 'server-reboot'];
-  if (!WRITE_SUBCOMMANDS.includes(subcommand)) {
-    // Unknown subcommand — pass through (in-PHP gate handles it).
-    process.exit(0);
-  }
-
-  if (tokens.includes('--confirm')) { // exact token, matching the in-PHP in_array() check
-    process.exit(0);
-  }
-
-  const preview = subcommand === 'deploy' ? 'preview-deploy' : 'preview-reboot';
-  block(`forge.php ${subcommand} requires --confirm. Run ${preview} first to review the canonical target, then re-run with --confirm.`);
+  block(`forge.php ${verdict.subcommand} requires --confirm. Run ${verdict.preview} first to review the canonical target, then re-run with --confirm.`);
 }
 
 if (import.meta.main) {

--- a/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
+++ b/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
@@ -36,7 +36,12 @@ export const SAFE_SUBCOMMANDS: readonly string[] = [
   'help', '--help',
 ];
 
-export const WRITE_SUBCOMMANDS: readonly string[] = ['deploy', 'server-reboot'];
+// subcommand -> the read-only command that previews it. A map rather than a
+// list so a new write subcommand cannot be added without naming its preview.
+export const WRITE_SUBCOMMANDS: Readonly<Record<string, string>> = {
+  'deploy': 'preview-deploy',
+  'server-reboot': 'preview-reboot',
+};
 
 export type Classification =
   | { gate: 'pass' }
@@ -58,16 +63,13 @@ export function classify(command: string): Classification {
   if (SAFE_SUBCOMMANDS.includes(subcommand)) return PASS;
 
   // Unknown subcommand — pass through (in-PHP gate handles it).
-  if (!WRITE_SUBCOMMANDS.includes(subcommand)) return PASS;
+  const preview = WRITE_SUBCOMMANDS[subcommand];
+  if (preview === undefined) return PASS;
 
   // Exact token, matching the in-PHP in_array() check.
   if (tokens.includes('--confirm')) return PASS;
 
-  return {
-    gate: 'needs-confirm',
-    subcommand,
-    preview: subcommand === 'deploy' ? 'preview-deploy' : 'preview-reboot',
-  };
+  return { gate: 'needs-confirm', subcommand, preview };
 }
 
 function block(message: string): never {

--- a/plugins/laravel-forge-hermit/tests/hook.test.ts
+++ b/plugins/laravel-forge-hermit/tests/hook.test.ts
@@ -1,11 +1,18 @@
 // Structural and behavioral tests for write-confirm-gate.ts
 // Run with: bun test tests/hook.test.ts
+//
+// Classification is tested as a function (classify); spawns are kept only for
+// the process edges the function cannot cover — stdin parsing, exit codes and
+// the stderr message.
 
 import { test, expect, describe } from 'bun:test';
 import { spawnSync } from 'child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { classify, SAFE_SUBCOMMANDS, WRITE_SUBCOMMANDS } from '../hooks/write-confirm-gate';
 
 const HOOK = path.join(import.meta.dir, '..', 'hooks', 'write-confirm-gate.ts');
+const FORGE_PHP = path.join(import.meta.dir, '..', 'php', 'forge.php');
 
 function runHook(payload: unknown): { exitCode: number; stderr: string; stdout: string } {
   const input = JSON.stringify(payload);
@@ -21,155 +28,101 @@ function runHook(payload: unknown): { exitCode: number; stderr: string; stdout: 
   };
 }
 
-describe('write-confirm-gate: pass-through cases', () => {
-  test('non-Bash tool always passes', () => {
-    const r = runHook({ tool_name: 'Read', tool_input: { file_path: '/some/file' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('Bash call not involving forge.php passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'ls -la' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('forge.php servers (read command) passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php servers' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('forge.php check passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php check' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('preview-deploy passes (read-only)', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php preview-deploy prod-web myapp.com' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('preview-reboot passes (read-only)', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php preview-reboot prod-web' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('failed-deploys passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php failed-deploys --json' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('deploy-status passes (read-only poll, not a write)', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy-status 12 34 8821' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('deploy-watch passes (read-only poll loop, not a write)', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy-watch 12 34 8821' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('call method passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'echo \'["s1"]\' | php /plugin/php/forge.php call servers' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('site-log (read command) passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php site-log web-1 example.com application' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('background-process-log (read command) passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php background-process-log web-1 123' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('policy passes (no credentials, no network)', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php policy' } });
-    expect(r.exitCode).toBe(0);
-  });
-
-  test('preview passes (captures a request, sends nothing)', () => {
-    const r = runHook({
-      tool_name: 'Bash',
-      tool_input: { command: 'echo \'[12, {"type":"cpu_load"}]\' | php /plugin/php/forge.php preview createMonitor' },
+describe('classify: every safe subcommand passes', () => {
+  for (const sub of SAFE_SUBCOMMANDS) {
+    test(`${sub} passes`, () => {
+      expect(classify(`php /plugin/php/forge.php ${sub}`).gate).toBe('pass');
     });
-    expect(r.exitCode).toBe(0);
-  });
+  }
+});
 
-  // `execute` does mutate. It is deliberately not gated here: its authority is
-  // the plan hash and the operator's channel approval, and neither is visible in
-  // a Bash command string. A hook that documents itself as fail-open must not
-  // pretend to own that decision.
-  test('execute passes — the PHP hash check owns this gate, not the hook', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php execute fp-3f9a1c7b' } });
-    expect(r.exitCode).toBe(0);
-  });
+describe('classify: pass-through cases', () => {
+  const PASS_CASES: Array<[string, string]> = [
+    ['a command not involving forge.php', 'ls -la'],
+    ['forge.php with no subcommand token', 'php /plugin/php/forge.php'],
+    ['a read command with arguments', 'php /plugin/php/forge.php site-log web-1 example.com application'],
+    ['deploy-status — a read-only poll, not a write', 'php /plugin/php/forge.php deploy-status 12 34 8821'],
+    ['deploy-watch — a read-only poll loop, not a write', 'php /plugin/php/forge.php deploy-watch 12 34 8821'],
+    ['a piped generic-dispatch read', 'echo \'["s1"]\' | php /plugin/php/forge.php call servers'],
+    // `execute` does mutate. It is deliberately not gated here: its authority is
+    // the plan hash and the operator's channel approval, and neither is visible
+    // in a Bash command string. A hook that documents itself as fail-open must
+    // not pretend to own that decision.
+    ['execute — the PHP hash check owns this gate, not the hook', 'php /plugin/php/forge.php execute fp-3f9a1c7b'],
+    ['an unknown subcommand — the in-PHP gate handles it', 'php /plugin/php/forge.php delete-site prod-web myapp.com'],
+    ['deploy with --confirm', 'php /plugin/php/forge.php deploy prod-web myapp.com --confirm'],
+    ['deploy with --confirm after another flag', 'php /plugin/php/forge.php deploy prod-web myapp.com --json --confirm'],
+    ['server-reboot with --confirm', 'php /plugin/php/forge.php server-reboot prod-web --confirm'],
+    ['${CLAUDE_PLUGIN_ROOT} deploy with --confirm', 'php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy srv site --confirm'],
+    ['an env-var prefix before a safe subcommand', 'FOO=bar php ${CLAUDE_PLUGIN_ROOT}/php/forge.php preview createMonitor'],
+  ];
 
-  test('the new verbs pass with ${CLAUDE_PLUGIN_ROOT} and an env prefix', () => {
-    for (const cmd of [
-      'php ${CLAUDE_PLUGIN_ROOT}/php/forge.php policy',
-      'FOO=bar php ${CLAUDE_PLUGIN_ROOT}/php/forge.php preview createMonitor',
-      'php ${CLAUDE_PLUGIN_ROOT}/php/forge.php execute fp-deadbeef',
-    ]) {
-      expect(runHook({ tool_name: 'Bash', tool_input: { command: cmd } }).exitCode).toBe(0);
-    }
+  for (const [label, command] of PASS_CASES) {
+    test(label, () => {
+      expect(classify(command).gate).toBe('pass');
+    });
+  }
+});
+
+describe('classify: writes lacking --confirm need confirmation', () => {
+  const BLOCK_CASES: Array<[string, string, string, string]> = [
+    ['deploy without --confirm', 'php /plugin/php/forge.php deploy prod-web myapp.com', 'deploy', 'preview-deploy'],
+    ['deploy with an unrelated trailing flag', 'php /plugin/php/forge.php deploy prod-web myapp.com --json', 'deploy', 'preview-deploy'],
+    // --confirm is matched as an exact token, mirroring the in-PHP in_array().
+    ['deploy with a --confirm substring flag', 'php /plugin/php/forge.php deploy prod-web myapp.com --confirm-later', 'deploy', 'preview-deploy'],
+    ['server-reboot without --confirm', 'php /plugin/php/forge.php server-reboot prod-web', 'server-reboot', 'preview-reboot'],
+    ['an env-var prefix does not confuse tokenization', 'FORGE_ORG=myorg php /plugin/php/forge.php deploy srv site', 'deploy', 'preview-deploy'],
+    // Under --plugin-dir the harness does not substitute ${CLAUDE_PLUGIN_ROOT},
+    // so the literal reaches the hook and must still resolve to forge.php.
+    ['${CLAUDE_PLUGIN_ROOT} as a literal path', 'php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy srv site', 'deploy', 'preview-deploy'],
+  ];
+
+  for (const [label, command, subcommand, preview] of BLOCK_CASES) {
+    test(label, () => {
+      expect(classify(command)).toEqual({ gate: 'needs-confirm', subcommand, preview });
+    });
+  }
+});
+
+describe('inventory sync: forge.php dispatch vs the hook classifier', () => {
+  // A subcommand added to forge.php but not classified here would fall through
+  // the hook's unknown-subcommand branch, silently reducing the documented
+  // two-layer write gate to the in-PHP check alone.
+  test('every forge.php subcommand is classified', () => {
+    const source = readFileSync(FORGE_PHP, 'utf8');
+    const dispatched = [...source.matchAll(/\$cmd === '([a-z-]+)'/g)].map(m => m[1]!);
+    const unique = [...new Set(dispatched)];
+
+    // Guards against the regex silently rotting into a vacuous pass if the
+    // dispatch style in forge.php ever changes.
+    expect(unique.length).toBeGreaterThanOrEqual(24);
+
+    const known = new Set([...SAFE_SUBCOMMANDS, ...WRITE_SUBCOMMANDS]);
+    const unclassified = unique.filter(sub => !known.has(sub));
+    expect(unclassified).toEqual([]);
   });
 });
 
-describe('write-confirm-gate: blocked cases', () => {
-  test('deploy without --confirm is blocked', () => {
+describe('write-confirm-gate: process contract', () => {
+  test('a write lacking --confirm exits 2 and names the preview command', () => {
     const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com' } });
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toContain('--confirm');
+    expect(r.stderr).toContain('preview-deploy');
   });
 
-  test('deploy with an unknown trailing flag but no --confirm is blocked', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --json' } });
-    expect(r.exitCode).toBe(2);
-  });
-
-  test('server-reboot without --confirm is blocked', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php server-reboot prod-web' } });
-    expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain('--confirm');
-  });
-
-  test('a --confirm substring (e.g. --confirm-later) does NOT satisfy the gate', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --confirm-later' } });
-    expect(r.exitCode).toBe(2);
-  });
-});
-
-describe('write-confirm-gate: allowed write cases', () => {
-  test('deploy with --confirm passes', () => {
+  test('a write with --confirm exits 0', () => {
     const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --confirm' } });
     expect(r.exitCode).toBe(0);
   });
 
-  test('deploy with --confirm anywhere in the args passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php deploy prod-web myapp.com --json --confirm' } });
+  test('non-Bash tool calls are never classified', () => {
+    const r = runHook({ tool_name: 'Read', tool_input: { file_path: '/some/file' } });
     expect(r.exitCode).toBe(0);
   });
 
-  test('server-reboot with --confirm passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php /plugin/php/forge.php server-reboot prod-web --confirm' } });
-    expect(r.exitCode).toBe(0);
-  });
-});
-
-describe('write-confirm-gate: env-var prefix + path variants', () => {
-  test('env-var prefix before php does not confuse tokenization', () => {
-    // The subcommand is still after forge.php
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'FORGE_ORG=myorg php /plugin/php/forge.php deploy srv site' } });
-    expect(r.exitCode).toBe(2);
-  });
-
-  test('${CLAUDE_PLUGIN_ROOT} as literal in command is handled (plugin-dir mode)', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy srv site' } });
-    expect(r.exitCode).toBe(2);
-  });
-
-  test('${CLAUDE_PLUGIN_ROOT} deploy with --confirm passes', () => {
-    const r = runHook({ tool_name: 'Bash', tool_input: { command: 'php ${CLAUDE_PLUGIN_ROOT}/php/forge.php deploy srv site --confirm' } });
+  test('a Bash payload without a command string passes through', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: {} });
     expect(r.exitCode).toBe(0);
   });
 });

--- a/plugins/laravel-forge-hermit/tests/hook.test.ts
+++ b/plugins/laravel-forge-hermit/tests/hook.test.ts
@@ -28,12 +28,20 @@ function runHook(payload: unknown): { exitCode: number; stderr: string; stdout: 
   };
 }
 
-describe('classify: every safe subcommand passes', () => {
-  for (const sub of SAFE_SUBCOMMANDS) {
-    test(`${sub} passes`, () => {
+describe('classify: the subcommand inventories', () => {
+  test('every safe subcommand passes', () => {
+    for (const sub of SAFE_SUBCOMMANDS) {
       expect(classify(`php /plugin/php/forge.php ${sub}`).gate).toBe('pass');
-    });
-  }
+    }
+  });
+
+  // The inventory-sync test below pushes new forge.php subcommands into one of
+  // these lists; a write landing in SAFE_SUBCOMMANDS would satisfy it while
+  // silently disarming the gate.
+  test('no subcommand is both safe and a write', () => {
+    const writes = Object.keys(WRITE_SUBCOMMANDS);
+    expect(SAFE_SUBCOMMANDS.filter(sub => writes.includes(sub))).toEqual([]);
+  });
 });
 
 describe('classify: pass-through cases', () => {
@@ -90,14 +98,16 @@ describe('inventory sync: forge.php dispatch vs the hook classifier', () => {
   // two-layer write gate to the in-PHP check alone.
   test('every forge.php subcommand is classified', () => {
     const source = readFileSync(FORGE_PHP, 'utf8');
-    const dispatched = [...source.matchAll(/\$cmd === '([a-z-]+)'/g)].map(m => m[1]!);
+    // Any non-empty quoted literal, so a subcommand with a digit or underscore
+    // is not silently invisible to this check.
+    const dispatched = [...source.matchAll(/\$cmd === '([^']+)'/g)].map(m => m[1]!);
     const unique = [...new Set(dispatched)];
 
     // Guards against the regex silently rotting into a vacuous pass if the
     // dispatch style in forge.php ever changes.
     expect(unique.length).toBeGreaterThanOrEqual(24);
 
-    const known = new Set([...SAFE_SUBCOMMANDS, ...WRITE_SUBCOMMANDS]);
+    const known = new Set([...SAFE_SUBCOMMANDS, ...Object.keys(WRITE_SUBCOMMANDS)]);
     const unclassified = unique.filter(sub => !known.has(sub));
     expect(unclassified).toEqual([]);
   });


### PR DESCRIPTION
## Summary

`forge.php`'s subcommand inventory was spelled twice in two languages: once as the `SAFE_SUBCOMMANDS`/`WRITE_SUBCOMMANDS` arrays buried inside the write-confirm-gate hook's `main()`, once as the `if ($cmd === '...')` dispatch chain in `php/forge.php`. Nothing pinned them together, and `php/forge.php` (891 loc) is loaded by no test — `php/tests/run.php` requires only `forge-lib.php` and `forge-operation.php`.

The consequence: a subcommand added to the PHP side fell through the hook's unknown-subcommand pass-through branch with nothing failing. For a write command that silently degrades the plugin's documented two-layer gate ("neither is optional") to the in-PHP `--confirm` check alone.

This exports the gating decision as a pure function and makes the drift mechanically detectable. Hook behavior is unchanged.

## Changes

- **`hooks/write-confirm-gate.ts`** — `classify(command)` is exported behind the existing `import.meta.main` shim, returning a discriminated `Classification` (`{gate:'pass'}` | `{gate:'needs-confirm', subcommand, preview}`). Both inventories are exported as importable data. `main()` is now only stdin parsing, exit codes, and the stderr message. The fail-open guards on unparseable/unexpected input stay in `main()`, unchanged.
- **`tests/hook.test.ts`** — classification cases become table tests over `classify()`, including a loop generated from the exported `SAFE_SUBCOMMANDS` (so it can't drift from the real inventory) and rows pinning the subtleties: `/x/forge.php` path-suffix matching, the literal `${CLAUDE_PLUGIN_ROOT}` seen under `--plugin-dir`, env-var prefixes, exact-token `--confirm` (so `--confirm-later` does not satisfy the gate), and an unknown subcommand asserting the pass-through branch.
- **New inventory-sync test** — scans `php/forge.php` for `$cmd === '<name>'` comparisons and asserts every one is classified by the hook, with a `>= 24` extraction floor so the test fails loudly rather than vacuously passing if the dispatch style changes.
- Six subprocess spawns remain (down from 27), pinning what a function call cannot: exit 2 + stderr on a blocked write, exit 0 on a confirmed one, non-Bash and command-less payloads, and fail-open on malformed/empty stdin.

`execute` stays classified as pass-through — its authority is the plan hash plus the operator's channel approval, neither visible in a Bash command string, so gating it in the hook would be theatre. That reasoning is preserved in the test comments.

## Test plan

- `bash tests/run-all.sh` from `plugins/laravel-forge-hermit/` — exit 0. PHP 112 passed (unchanged, this PR touches no PHP), hook suite 48 pass / 0 fail, structural lints 53 + 19 pass. Hook suite wall time dropped ~2.34s to ~0.89s.
- `bunx tsc --noEmit` from the repo root — exit 0.
- **Mutation check on the new guard**: appending `if ($cmd === 'delete-site') { exit(0); }` to `php/forge.php` turns the inventory-sync test red naming `delete-site`; reverted, green again.
- **Behavior preservation**: the refactored hook was run against the pre-existing 27-spawn test file *before* that file was rewritten — all passed unmodified.
- **Live process smoke**: `deploy` without `--confirm` exits 2 with the `preview-deploy` message; the same command with `--confirm` exits 0.