### PR TITLE
feat(hermit): report outcomes in routine operator comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ You run on your own Claude subscription — no per-runtime-hour billing — and 
 - **Per-call** token usage logged to `.claude/cost-log.jsonl` (model, input/output/cache split, USD estimate, and what triggered the turn — `heartbeat`, `routine:<id>`, `routine:multi`, `channel:<name>`, or interactive/unattributed `other`).
 - **Per-session** running total in `.status.json`; carried into archived session reports as frontmatter `cost_usd`.
 - **Per-day** rollup in `cost-summary.md`, regenerated on every cost-tracker tick.
-- **Morning brief** (when scheduled as a routine) reads `cost-summary.md` and includes yesterday's spend.
+- **On demand** through `/cost-reflect`, `/hermit-doctor`, and the dashboard, plus a one-line spend summary in the weekly review. Routine briefs and status replies stay outcome-only; spend interrupts them only when a cap is approached or breached.
 
 Because idle always-on cost is effectively zero, one Claude subscription can run several hermits at once.
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- Routine operator messages report outcomes. `/brief` (every mode, including the single-line push fallback), the idle status reply, and the session-start resume line carry work status; the brief runner contract returns work fields only. Spend detail lives in `/cost-reflect`, `/hermit-doctor`, the dashboard, the weekly review's `Spend:` line, and budget alerts when a cap is configured.
+- Session-start injection carries operator, session, knowledge, and report context. Spend reaches the operator on request (`/cost-reflect`, the deterministic `status` reply) or when a budget cap fires.
+
 ## [1.2.39] - 2026-08-14
 
 ### Added

--- a/plugins/claude-code-hermit/README.md
+++ b/plugins/claude-code-hermit/README.md
@@ -209,7 +209,7 @@ You run on your own Claude subscription — no per-runtime-hour billing — and 
 - **Per-call** token usage logged to `.claude/cost-log.jsonl` (model, input/output/cache split, USD estimate, and what triggered the turn — `heartbeat`, `routine:<id>`, `routine:multi`, `channel:<name>`, or interactive/unattributed `other`).
 - **Per-session** running total in `.status.json`; carried into archived session reports as frontmatter `cost_usd`.
 - **Per-day** rollup in `cost-summary.md`, regenerated on every cost-tracker tick.
-- **Morning brief** (when scheduled as a routine) reads `cost-summary.md` and includes yesterday's spend.
+- **On demand** through `/cost-reflect`, `/hermit-doctor`, and the dashboard, plus a one-line spend summary in the weekly review. Routine briefs and status replies stay outcome-only; spend interrupts them only when a cap is approached or breached.
 
 Because idle always-on cost is effectively zero, one Claude subscription can run several hermits at once.
 

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -18,7 +18,6 @@ import { safe, safeForLLMMultiline, scanInjected } from './lib/sanitize';
 import { resolve as resolveOutboundChannel } from './resolve-outbound-channel';
 import { operatorLanguage as resolveOperatorLanguage } from './lib/operator-language';
 import { readSettledConfig } from './lib/config-read';
-import { formatTokens } from './lib/format';
 import { extractSection, firstContentLine, stripPlaceholders } from './lib/md-write';
 
 type Json = any;
@@ -37,7 +36,6 @@ const BUDGETS = {
   knowledge:     2500, // compiled/ artifacts — read from config, 2500 default
   schemaDrift:    400, // only emitted when compiled/ types are undeclared in knowledge-schema.md
   storageDrift:   500, // only emitted when misplaced files are found
-  cost:           500,
   report:        1500,
   upgrade:        500,
 };
@@ -426,24 +424,7 @@ function emitFullContext(source: string | null) {
   }
 
   // -------------------------------------------------------
-  // 6. Session cost (priority 3, budget 500) — was 5
-  // -------------------------------------------------------
-  try {
-    const statusPath = path.resolve(AGENT_DIR, 'sessions', '.status.json');
-    let out = 'No cost data';
-    try {
-      const d = JSON.parse(fs.readFileSync(statusPath, 'utf-8'));
-      out = `$${d.cost_usd.toFixed(4)} (${formatTokens(d.tokens)})`;
-    } catch {
-      // missing/malformed status — keep the placeholder, same as read-cost.py did
-    }
-    emit('Session Cost', out.slice(0, BUDGETS.cost));
-  } catch {
-    // Non-fatal
-  }
-
-  // -------------------------------------------------------
-  // 7. Last report (priority 4, budget 1500) — skipped on resume with an
+  // 6. Last report (priority 4, budget 1500) — skipped on resume with an
   //    active SHELL.md: the resumed transcript already contains the report.
   // -------------------------------------------------------
   if (totalChars < HARD_CAP && !(source === 'resume' && hasActiveSession)) {
@@ -492,7 +473,7 @@ function emitFullContext(source: string | null) {
   }
 
   // -------------------------------------------------------
-  // 8. Upgrade check (priority 5, budget 500)
+  // 7. Upgrade check (priority 5, budget 500)
   // -------------------------------------------------------
   if (totalChars < HARD_CAP) {
     try {

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -93,7 +93,7 @@ Current behavior — general purpose summary as described below.
      ```
      [Brief] YYYY-MM-DD | idle | N tasks completed
      Session: since [start date]
-     Last: [latest Session Summary entry] — [status]
+     Last: [latest Session Summary entry, with the trailing `($X.XX)` spend figure stripped] — [status]
      Status: Idle — ready for what's next (run /claude-code-hermit:session-start to begin)
      ```
      Then check for auto-detected proposals (step after Output Format) and return.

--- a/plugins/claude-code-hermit/skills/brief/SKILL.md
+++ b/plugins/claude-code-hermit/skills/brief/SKILL.md
@@ -8,7 +8,7 @@ Provide a concise executive summary of recent session activity. Designed for mor
 
 ## Always-On Delivery Rule
 
-If `config.always_on` is `true`, deliver all operator-facing output per `CLAUDE-APPEND.md § Operator Notification`. The terminal is unmonitored in always-on mode. For the push-fallback branch, condense the brief to a single line (per § Operator Notification push format): include whichever of yesterday's/today's cost, open proposal count, and active heartbeat alerts are present and non-zero; omit zero or unavailable fields. Example: `Brief: 16 proposals open, yesterday $0.42, 1 alert — open CC to view`. In interactive mode, output to terminal. This applies to all flags below.
+If `config.always_on` is `true`, deliver all operator-facing output per `CLAUDE-APPEND.md § Operator Notification`. The terminal is unmonitored in always-on mode. For the push-fallback branch, condense the brief to a single line (per § Operator Notification push format): include whichever of open proposal count and active heartbeat alerts are present and non-zero; omit zero or unavailable fields. Example: `Brief: 16 proposals open, 1 alert — open CC to view`. In interactive mode, output to terminal. This applies to all flags below.
 
 ## Dispatch
 
@@ -27,9 +27,9 @@ Before composing any brief, determine the dispatch mode:
 
 For dispatching modes: invoke `claude-code-hermit:skill-eval-runner` pointed at `${CLAUDE_PLUGIN_ROOT}/skills/brief/reference.md`. Pass in the dispatch prompt: `mode` (one of the values above), `today` (current ISO date), and for `morning` only: `context_recovery` (set to `true` if auto-memory seems sparse — new instance, fresh machine — `false` otherwise).
 
-**Boundary rule:** `sessions/SHELL.md` is the live session document — it stays in main, never goes to the runner. Archived `sessions/S-*-REPORT.md` bodies, `cost-summary.md`, `proposals/*.md` frontmatter, `OPERATOR.md`, and `NEXT-TASK.md` go to the runner.
+**Boundary rule:** `sessions/SHELL.md` is the live session document — it stays in main, never goes to the runner. Archived `sessions/S-*-REPORT.md` bodies, `proposals/*.md` frontmatter, `OPERATOR.md`, and `NEXT-TASK.md` go to the runner.
 
-**Failure policy:** if the runner returns null or malformed JSON, fail-open — compose the brief from whatever live data main holds (TaskList, SHELL.md, `cost-report.ts today` output) and skip the runner-derived lines. Note nothing fatal to the operator.
+**Failure policy:** if the runner returns null or malformed JSON, fail-open — compose the brief from whatever live data main holds (TaskList, SHELL.md) and skip the runner-derived lines. Note nothing fatal to the operator.
 
 **Eval runner return schema** — the runner returns a JSON object conforming to this block. The schema is byte-identical in `reference.md` (producer) and here (consumer); a contract test asserts this.
 
@@ -37,12 +37,10 @@ For dispatching modes: invoke `claude-code-hermit:skill-eval-runner` pointed at 
 ```json
 {
   "report_summary": { "date": "<ISO>", "tags": ["<tag>"], "working_on": "<one-line>",
-                       "status": "<completed|partial|blocked>", "cost_line": "<$X.XX (N tokens)>",
-                       "next_start_point": "<text>" }|null,
+                       "status": "<completed|partial|blocked>", "next_start_point": "<text>" }|null,
   "sessions_today": [ { "session": "S-NNN", "summary": "<one-line>" } ],
   "findings": ["<text>"],
   "tomorrow": ["<text>"],
-  "cost_context": { "yesterday": "<text>"|null, "week": "<text>"|null, "all_time": "<text>"|null }|null,
   "pending_proposals": ["<PROP-NNN: title>"],
   "operator_priorities": ["<text>"],
   "queued_work": ["<text>"]
@@ -57,7 +55,6 @@ For dispatching modes: invoke `claude-code-hermit:skill-eval-runner` pointed at 
 **Delivery:** Write the full composed brief text (before any push-fallback single-line condensing) to `.claude-code-hermit/state/last-brief.json` as `{"kind":"morning","text":"<brief text>","generated_at":"<now, ISO>"}`, so the dashboard's "latest brief" section can pick it up. Then refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md`; if it returns a URL, append a final line `📎 <url>`. Then deliver the brief to the operator (see Always-On Delivery Rule above).
 
 Emphasize forward-looking content. Compose from runner JSON (see Dispatch above) and live main-session data:
-- **Cost context:** use `runner.cost_context.yesterday`
 - **Pending proposals:** use `runner.pending_proposals`
 - **Operator priorities:** use `runner.operator_priorities`
 - **Queued work:** use `runner.queued_work`
@@ -80,7 +77,6 @@ After composing the morning brief, age the micro-proposal queue in one pass: run
 
 Emphasize backward-looking content. Compose from runner JSON (see Dispatch above) and live main-session data:
 - **Sessions today:** use `runner.sessions_today`; also note any progress in the current SHELL.md progress log (read SHELL.md in main **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**).
-- **Today's cost:** run `bun "${CLAUDE_PLUGIN_ROOT}/scripts/cost-report.ts today"` (live, in main) — do not use `cost-summary.md` for today's figure; it is only updated once per day and will be stale in always-on deployments.
 - **Key findings:** use `runner.findings`
 - **Tomorrow:** use `runner.tomorrow`
 - After generating summary: if `runtime.json session_state` is `in_progress` or SHELL.md has progress entries since last report, note it in the brief (e.g., "Session still open — run /session-close to archive.") and let the operator close explicitly. Exception: if `config.always_on` is `true` AND `config.routines` contains an enabled entry with `id` `daily-auto-close` (the midnight routine, which invokes `/claude-code-hermit:session-close --scheduled`), suppress the note — the auto-close routine archives it at midnight. Idle transitions are owned by the `session` skill and `scripts/session-archive.ts`; brief does not trigger them.
@@ -92,13 +88,12 @@ Current behavior — general purpose summary as described below.
 ## Plan
 
 1. Use `session_state` already read in the Dispatch step:
-   - **1a. `in_progress` (no dispatch):** read `.claude-code-hermit/sessions/SHELL.md` **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. Summarize the active task using TaskList for Done/Next lines; produce the standard 5-line output. For the cost line, read `cost_usd` and `tokens` from `.claude-code-hermit/sessions/.status.json` (live per-session totals; fall back to `0`/`0` if missing) rather than the once-daily `cost-summary.md`. Scale the token suffix by magnitude — the same K/M/B convention as `scripts/lib/format.ts`'s `formatTokens` (raw integer under 1K, `K` under 1M, `M` under 1B, `B` beyond, promoting to the next tier when rounding would otherwise overflow to 1000 — e.g. 999999 tokens is `1.0M`, not `1000K`; one decimal place if the scaled value is under 100, otherwise round) — never assume `K`. Then read `.claude-code-hermit/state/alert-state.json`; if its `active` array is non-empty, append one line: `⚠ N alert(s) active — run /claude-code-hermit:hermit-health`.
-   - **1b. `idle` (no dispatch):** read SHELL.md **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. For the `Cumulative:` line, read `total_cost_usd` and `total_tokens` from `.claude-code-hermit/cost-summary.md` frontmatter (fall back to `0`/`0` if missing), scaling the token suffix by magnitude as above. Format as:
+   - **1a. `in_progress` (no dispatch):** read `.claude-code-hermit/sessions/SHELL.md` **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. Summarize the active task using TaskList for Done/Next lines; produce the standard 5-line output. Then read `.claude-code-hermit/state/alert-state.json`; if its `active` array is non-empty, append one line: `⚠ N alert(s) active — run /claude-code-hermit:hermit-health`.
+   - **1b. `idle` (no dispatch):** read SHELL.md **(fresh read — re-read the file(s) now; do not reuse a value cached in context from before compaction)**. Format as:
      ```
      [Brief] YYYY-MM-DD | idle | N tasks completed
      Session: since [start date]
      Last: [latest Session Summary entry] — [status]
-     Cumulative: $X.XX (N tokens) across N tasks
      Status: Idle — ready for what's next (run /claude-code-hermit:session-start to begin)
      ```
      Then check for auto-detected proposals (step after Output Format) and return.
@@ -112,7 +107,7 @@ Keep the output to 5 lines, plus an optional 6th line for pending proposals (see
 ```
 [Brief] YYYY-MM-DD | [tags if present]
 Working on: one-line description
-Status: completed/partial/blocked (X/Y tasks) | $cost spent (N tokens)
+Status: completed/partial/blocked (X/Y tasks)
 Done: step1, step2, step3
 Next: description of next action (or "Session complete" if all done)
 ```
@@ -131,4 +126,4 @@ Next: description of next action (or "Session complete" if all done)
 
 When invoked with "brief today", "daily summary", or "what happened today":
 
-Compose from runner JSON (mode: `daily`). For today's cost and token total, run `bun "${CLAUDE_PLUGIN_ROOT}/scripts/cost-report.ts today"` (live, in main). Use `runner.cost_context.week` and `runner.cost_context.all_time` for aggregates from `cost-summary.md`. Use `runner.sessions_today`, `runner.findings`, and `runner.tomorrow` for the day narrative. Format as a day-level summary covering: work done, cost, and proposals created/resolved.
+Compose from runner JSON (mode: `daily`). Use `runner.sessions_today`, `runner.findings`, and `runner.tomorrow` for the day narrative. Format as a day-level summary covering: work done and proposals created/resolved.

--- a/plugins/claude-code-hermit/skills/brief/reference.md
+++ b/plugins/claude-code-hermit/skills/brief/reference.md
@@ -7,7 +7,6 @@ below; the calling main session composes and delivers the brief.
 ## Inputs (read fresh — do not reuse cached values)
 
 - `.claude-code-hermit/sessions/S-*-REPORT.md` — archived session reports (today's or latest, depending on mode)
-- `.claude-code-hermit/cost-summary.md` — yesterday, week, and all-time cost aggregates
 - `.claude-code-hermit/proposals/PROP-*.md` — frontmatter only (leading `---` YAML block); for pending-review scan
 - `.claude-code-hermit/OPERATOR.md` — operator priorities (morning only; skip silently if absent)
 - `.claude-code-hermit/NEXT-TASK.md` — queued work (morning only; skip silently if absent)
@@ -22,27 +21,21 @@ The calling skill passes the following scalars in the dispatch prompt (do not re
 
 ### morning
 
-1. Read `.claude-code-hermit/cost-summary.md`. Find the trend table row whose Date column matches
-   the day before `today`. Populate `cost_context.yesterday` as
-   `"Yesterday: <Cost> (<Tokens>) across <Sessions> sessions"`, copying the Cost, Tokens, and
-   Sessions cells from that row **verbatim** (e.g. `"Yesterday: $1189.14 (532M tokens) across
-   44 sessions"`) — do not reformat the token count. Set `cost_context.week` and
-   `cost_context.all_time` to `null`.
-2. Scan `.claude-code-hermit/proposals/PROP-*.md` — read the leading `---` YAML block only for
+1. Scan `.claude-code-hermit/proposals/PROP-*.md` — read the leading `---` YAML block only for
    each file. Collect files where `status: proposed` AND `source: auto-detected`. Populate
    `pending_proposals` as `["PROP-NNN: <title>", ...]`. Empty list if none.
-3. Read `.claude-code-hermit/OPERATOR.md` if it exists. Extract actionable priority items
+2. Read `.claude-code-hermit/OPERATOR.md` if it exists. Extract actionable priority items
    (bullet points, numbered items, any section labelled "Priorities", "TODO", or "Current Focus").
    Populate `operator_priorities` as a list of strings. Empty list if absent or no priorities found.
-4. Read `.claude-code-hermit/NEXT-TASK.md` if it exists. Extract the queued items. Populate
+3. Read `.claude-code-hermit/NEXT-TASK.md` if it exists. Extract the queued items. Populate
    `queued_work` as a list of strings. Empty list if absent.
-5. If `context_recovery` is `true`: find the most recent `.claude-code-hermit/sessions/S-*-REPORT.md`
+4. If `context_recovery` is `true`: find the most recent `.claude-code-hermit/sessions/S-*-REPORT.md`
    (highest numbered) and read its YAML frontmatter: `date`, `tags`, `task` (Working-on/Goal), `status`,
-   `cost_usd`/`tokens` (session cost), and `next_start` (Next Start Point). Populate `report_summary`
-   from those fields. A report whose frontmatter lacks the `next_start` key is legacy — read it in full
-   instead and extract the same fields from `## Summary`/`## Overview` and the session-cost line, as
-   before. Set `report_summary: null` if `context_recovery` is `false`.
-6. Set `sessions_today: []`, `findings: []`, `tomorrow: []`.
+   and `next_start` (Next Start Point). Populate `report_summary` from those fields. A report whose
+   frontmatter lacks the `next_start` key is legacy — read it in full instead and extract the same
+   fields from `## Summary`/`## Overview`, as before. Set `report_summary: null` if
+   `context_recovery` is `false`.
+5. Set `sessions_today: []`, `findings: []`, `tomorrow: []`.
 
 ### evening
 
@@ -60,28 +53,22 @@ The calling skill passes the following scalars in the dispatch prompt (do not re
 4. Aggregate `tomorrow`: collect the `next_start` field from each collected report; for a legacy
    report, collect items from its `## Next Steps`, `## Tomorrow`, or equivalent future-looking
    section instead. Populate as a list of strings.
-5. Set `report_summary: null`, `cost_context: null`, `pending_proposals: []`, `operator_priorities: []`, `queued_work: []`.
+5. Set `report_summary: null`, `pending_proposals: []`, `operator_priorities: []`, `queued_work: []`.
 
 ### daily
 
 1. Same report collection as evening (steps 1–4): collect reports with `date:` matching `today`,
    frontmatter first (legacy reports in full), populate `sessions_today`, `findings`, `tomorrow`.
-2. Read `.claude-code-hermit/cost-summary.md`. Populate `cost_context.week` and
-   `cost_context.all_time` as `"$X.XX (<Tokens> tokens) across N sessions"`, copying the Cost and
-   Sessions values and the already magnitude-suffixed Tokens figure from the `## This Week` and
-   `## All Time` sections **verbatim** (e.g. `"$1189.14 (532M tokens) across 44 sessions"`) — do
-   not reformat or rescale the token count. Set `cost_context.yesterday` to `null` (today's live
-   cost runs in the calling main session via `cost-report.ts today`).
-3. Set `report_summary: null`, `pending_proposals: []`, `operator_priorities: []`, `queued_work: []`.
+2. Set `report_summary: null`, `pending_proposals: []`, `operator_priorities: []`, `queued_work: []`.
 
 ### default-no-session
 
 1. Find the most recent `.claude-code-hermit/sessions/S-*-REPORT.md` (highest numbered). Read its
-   YAML frontmatter: `date`, `tags`, `task` (Working-on/Goal), `status`, `cost_usd`/`tokens`
-   (session cost), `next_start` (Next Start Point). Populate `report_summary` from those fields.
+   YAML frontmatter: `date`, `tags`, `task` (Working-on/Goal), `status`, `next_start` (Next Start
+   Point). Populate `report_summary` from those fields.
 2. A report whose frontmatter lacks the `next_start` key is legacy — read it in full instead and
-   extract the same fields from `## Summary`/`## Overview` and the session-cost line, as before.
-3. Set `sessions_today: []`, `findings: []`, `tomorrow: []`, `cost_context: null`,
+   extract the same fields from `## Summary`/`## Overview`, as before.
+3. Set `sessions_today: []`, `findings: []`, `tomorrow: []`,
    `pending_proposals: []`, `operator_priorities: []`, `queued_work: []`.
 
 ## Return Value
@@ -93,12 +80,10 @@ Return a single JSON object — no prose, no markdown wrapping. Every field is r
 ```json
 {
   "report_summary": { "date": "<ISO>", "tags": ["<tag>"], "working_on": "<one-line>",
-                       "status": "<completed|partial|blocked>", "cost_line": "<$X.XX (N tokens)>",
-                       "next_start_point": "<text>" }|null,
+                       "status": "<completed|partial|blocked>", "next_start_point": "<text>" }|null,
   "sessions_today": [ { "session": "S-NNN", "summary": "<one-line>" } ],
   "findings": ["<text>"],
   "tomorrow": ["<text>"],
-  "cost_context": { "yesterday": "<text>"|null, "week": "<text>"|null, "all_time": "<text>"|null }|null,
   "pending_proposals": ["<PROP-NNN: title>"],
   "operator_priorities": ["<text>"],
   "queued_work": ["<text>"]

--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -115,7 +115,7 @@ Before running any heavy sub-step — an archive traversal, a multi-file search,
   - If nothing matches, say so briefly.
 
 - **Status request** ("what are you working on?", "status", "progress")
-  - If `session_state` (runtime.json) is `idle`: respond with session summary — tasks completed, cumulative cost, "ready for what's next"
+  - If `session_state` (runtime.json) is `idle`: respond with session summary — tasks completed, "ready for what's next"
   - If `session_state` is `in_progress`: respond with a concise summary of SHELL.md: task, current step, blockers
   - Keep it short — channel messages should be brief
 

--- a/plugins/claude-code-hermit/skills/session-start/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-start/SKILL.md
@@ -132,7 +132,7 @@ All state lives under `.claude-code-hermit/` in the project root.
    - If the session status is `blocked`: suggest running `/debug` to diagnose tool/hook failures before re-attempting the blocked work
    - Ask the operator if they want to continue the current task or start a new one
 9b. If resuming an idle session (runtime.json `session_state` is `idle`):
-   - Show session continuity info: tasks completed, session duration, cumulative cost
+   - Show session continuity info: tasks completed, session duration
    - Ask: "What should I work on next?" (unless a NEXT-TASK.md was accepted in step 6)
    - Once provided, pipe `Task: <text>` on stdin to `bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts open --state-dir=.claude-code-hermit` to fill Task and update runtime.json `session_state` to `in_progress`. After confirming the plan, create native Tasks for each step.
 10. If starting a new session:

--- a/plugins/claude-code-hermit/skills/session-start/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-start/SKILL.md
@@ -66,7 +66,7 @@ All state lives under `.claude-code-hermit/` in the project root.
    On the slow path: run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts open --state-dir=.claude-code-hermit` (empty `Task:` payload if no task is known yet) to create/update SHELL.md and pre-compute the session ID. Gate on the returned `ok`; if `false`, surface the `reason` to the operator before proceeding.
 4b. If `runtime.json` `session_state` is `idle` (session between tasks — SHELL.md exists but no active task):
    - This is a session between tasks — do NOT create a new session or SHELL.md
-   - Present: session start date, tasks completed count, latest entry from Session Summary
+   - Present: session start date, tasks completed count, latest entry from Session Summary (strip its trailing `($X.XX)` spend figure — spend is on request via `/cost-reflect`)
    - Skip to step 5 (NEXT-TASK.md check) to determine the task source
    - When a task is provided: pipe `Task: <text>` on stdin to `bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts open --state-dir=.claude-code-hermit` to update runtime.json `session_state` to `in_progress` and fill in Task. After confirming the plan with the operator, create native Tasks (`TaskCreate`) for each step.
    - The session ID is pre-computed in runtime.json (set by the previous idle transition's `archive --mode=idle`)

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -1083,7 +1083,7 @@ Rota body.
     expect(r.stdout.length).toBeLessThanOrEqual(1200);
     expect(r.stdout).toContain('---Compaction Pointers---');
     for (const banned of ['---Operator Context (OPERATOR.md)---', '---Active Session---', '---Compiled Knowledge---',
-      '---Schema Drift---', '---Storage Drift---', '---Session Cost---', '---Last Report---', '---Upgrade Check---']) {
+      '---Schema Drift---', '---Storage Drift---', '---Last Report---', '---Upgrade Check---']) {
       expect(r.stdout).not.toContain(banned);
     }
   }));
@@ -1185,7 +1185,22 @@ Rota body.
     expect(r.exitCode).toBe(0);
     expect(r.stdout).not.toContain('---Last Report---');
     expect(r.stdout).toContain('---Active Session---');
-    expect(r.stdout).toContain('---Session Cost---');
+  }));
+
+  // Spend telemetry stays out of the injected context on every source: routine
+  // comms report outcomes, and cost detail is on-demand (cost-reflect, doctor,
+  // dashboard) or exception-driven (budget alerts).
+  test('startup-context (live .status.json → no Session Cost section, any source)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', '.status.json'),
+      '{"session_id":"S-001","cost_usd":698.78,"tokens":300000000,"operator_turns":3}');
+    for (const source of ['startup', 'resume']) {
+      const r = await runScript('startup-context.ts', {
+        cwd: dir, env: ENV, stdin: JSON.stringify({ source, session_id: 'x' }),
+      });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).not.toContain('---Session Cost---');
+      expect(r.stdout).not.toContain('698.78');
+    }
   }));
 
   test('startup-context (source=resume, no actionable SHELL.md → Last Report still emitted)', withDir(async (dir) => {

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- `ha-morning-brief` renders its `Cost:` section only when `reflect` flags a cost spike, and omits it otherwise.
+
 ## [0.4.9] - 2026-08-14
 
 ### Changed

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
-- `ha-morning-brief` renders its `Cost:` section only when `reflect` flags a cost spike, and omits it otherwise.
+- `ha-morning-brief` renders its `Cost:` section only when `reflect` flags a cost spike, and omits it otherwise. The spike line is no longer droppable under the 25-line cap.
 
 ## [0.4.9] - 2026-08-14
 

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md
@@ -52,7 +52,6 @@ When both `claude-code-hermit` and `claude-code-homeassistant-hermit` are instal
 9. **Pending work** — Scan for:
    - `Glob` `.claude-code-hermit/proposals/PROP-*.md` (reuse step 8a's glob result if its `Otherwise` branch already ran it; otherwise run the `Glob` here) — read status from each, list any `pending` proposals. Exclude a `pending` proposal whose title starts with `[ha-update]` **only when the `Updates:` section is present** (it surfaces there instead); when step 8a omitted the `Updates:` section (skipped fetch or no updates pending), keep `[ha-update]` proposals in this list so they are not lost
    - Check if `.claude-code-hermit/sessions/NEXT-TASK.md` exists (queued task)
-   - Read `.claude-code-hermit/cost-summary.md` if it exists — include yesterday's cost
 
 <!-- keep in sync with plugins/claude-code-hermit/skills/brief/SKILL.md — same MP lifecycle protocol -->
 9a. **Micro-proposals lifecycle** — age the queue in one call: `.claude-code-hermit/bin/hermit-run proposal micro .claude-code-hermit brief-cycle`. This runs core's writer through the project-resident `bin/hermit-run`, which resolves core's plugin root (a static `../claude-code-hermit/…` path can't — HA's `${CLAUDE_PLUGIN_ROOT}` is `<cache>/<marketplace>/claude-code-homeassistant-hermit/<version>/` and the version segment isn't knowable from skill text). It performs the whole `follow_up_count` 0/1/2+ lifecycle atomically (re-nudges count-1 entries, expires count-2+ entries, records each expiry, prunes any entry whose `status` isn't `"pending"`) and prints one JSON line `{"new":[…],"renudged":[…],"expired":[…],"dropped":[…]}`. Never hand-edit `state/micro-proposals.json`. Render from that verdict:
@@ -109,13 +108,14 @@ Awaiting decision:
 - [Omit section entirely when the step-9a verdict's `new` and `renudged` are both empty.]
 
 Cost:
-- [yesterday's cost if available; cost-spike alert if flagged by reflect]
+- [cost-spike alert if flagged by reflect]
+- [Omit section entirely when no spike is flagged.]
 
 Today's priorities:
 - [from OPERATOR.md Current Priority, filtered to actionable items]
 ```
 
-Adapt the greeting and section headers to the operator's configured language. Keep the entire brief under 25 lines — strip lower-priority lines (e.g., Cost when no spike) if the Overnight section pushes over the cap. **`Awaiting decision:` lines are final and non-droppable** — strip from `Energy`, `Cost`, `Today's priorities`, and `Updates` (in that order) before touching MP lines.
+Adapt the greeting and section headers to the operator's configured language. Keep the entire brief under 25 lines — strip lower-priority lines if the Overnight section pushes over the cap. **`Awaiting decision:` lines are final and non-droppable** — strip from `Energy`, `Cost`, `Today's priorities`, and `Updates` (in that order) before touching MP lines.
 
 ## Delivery
 

--- a/plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/ha-morning-brief/SKILL.md
@@ -115,7 +115,7 @@ Today's priorities:
 - [from OPERATOR.md Current Priority, filtered to actionable items]
 ```
 
-Adapt the greeting and section headers to the operator's configured language. Keep the entire brief under 25 lines — strip lower-priority lines if the Overnight section pushes over the cap. **`Awaiting decision:` lines are final and non-droppable** — strip from `Energy`, `Cost`, `Today's priorities`, and `Updates` (in that order) before touching MP lines.
+Adapt the greeting and section headers to the operator's configured language. Keep the entire brief under 25 lines — strip lower-priority lines if the Overnight section pushes over the cap. **`Awaiting decision:` lines are final and non-droppable, and so is `Cost:`** (it only renders on a flagged spike, so its presence is itself the alert) — strip from `Energy`, `Today's priorities`, and `Updates` (in that order) before touching MP lines.
 
 ## Delivery
 


### PR DESCRIPTION
## Summary

Routine operator messages now report outcomes, not telemetry. Token counts and cost estimates are removed from `/brief` (all modes), the idle status reply, the session-start resume line, the SessionStart context injection, and the HA morning brief. Spend stays fully available where it is actionable: on request (`/cost-reflect`, `/hermit-doctor`, dashboard), as the weekly review's `Spend:` line, and as budget alerts when a cap is configured.

Two motivations. First, raw token counts are misleading in this cost model — cache reads are the large majority of an always-on hermit's spend, so a token figure in a brief doesn't map to anything the operator can act on. Second, the channel-voice rule already bans token counts from channel messages; the brief skill was the surface still emitting them, so part of this is closing a compliance gap rather than introducing a new policy.

Deliberately scoped as a deletion-only change: no new config knob, no baseline/spike detection, no cold-start taper. Those were considered and left out pending evidence that operators want them.

## Changes

- **`skills/brief/`** — `SKILL.md` and `reference.md`: removed the `cost_line`/`cost_context` runner-contract fields (schema block kept byte-identical across both files, as the contract test requires), the `Cumulative:` line, the status-line cost suffix, the push-fallback cost mention, and the `cost-report.ts today` / `cost-summary.md` reads. Morning steps renumbered 1–6 → 1–5, daily 1–3 → 1–2.
- **`scripts/startup-context.ts`** — dropped the `---Session Cost---` section, its `BUDGETS.cost` entry, and the now-unused `formatTokens` import. This was the only hard gate available: with the figure in context, freehand replies volunteered it.
- **`skills/channel-responder/SKILL.md`, `skills/session-start/SKILL.md`** — idle status and resume continuity lines no longer include cumulative cost. The explicit spend-request branch (routing to `/cost-reflect`) is untouched.
- **`ha-morning-brief/SKILL.md`** — the `Cost:` section renders only when `reflect` flags a cost spike.
- **READMEs** — corrected the cost bullet, which claimed the morning brief includes yesterday's spend.
- **Tests** — the resume-source assertion for `---Session Cost---` is replaced by a regression guard that seeds a live `.status.json` and asserts neither the section nor the figure appears on either source; the compact banned-sections list drops the now-nonexistent name.

## Test plan

- `bun test` in `plugins/claude-code-hermit` — 3791 pass, 0 fail.
- `bun test` in `plugins/claude-code-homeassistant-hermit` — 676 pass, 1 todo, 0 fail.
- `bunx tsc --noEmit` — clean (exit 0).
- Live smoke: ran `startup-context.ts` with `source=startup` and `source=resume` against a scratch state dir holding a `.status.json` of `$698.78 / 300M tokens`; neither the section nor the figure appears in stdout.
- Grep gates clean: no `cost_line`/`cost_context`/`Cumulative:` in `skills/brief/`, no `Session Cost`/`formatTokens` in `startup-context.ts`, no `yesterday's cost` in the HA brief.

## Notes for the reviewer

- `cost-report.ts today` no longer has a skill-level caller (brief was its only one). Left in place as a CLI entry point with its own tests rather than deleted as out-of-scope; worth a second opinion.
- No `### Upgrade Instructions` needed — the change is entirely in plugin-shipped skill/script files, with no operator state or config migration.