### PR TITLE
fix(hermit): alert when an interactive dialog wedges the session

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- The watchdog alerts you when the session stops draining its queued notifications — a stale `enqueue` with no `dequeue` for 30 minutes while tmux is alive raises a `session-wedged` event and one deduped message. Catches any blocker, including dialog shapes the pane scanner doesn't recognise.
+
 ### Changed
 - Routine operator messages report outcomes. `/brief` (every mode, including the single-line push fallback), the idle status reply, and the session-start resume line carry work status; the brief runner contract returns work fields only. Spend detail lives in `/cost-reflect`, `/hermit-doctor`, the dashboard, the weekly review's `Spend:` line, and budget alerts when a cap is configured.
 - Session-start injection carries operator, session, knowledge, and report context. Spend reaches the operator on request (`/cost-reflect`, the deterministic `status` reply) or when a budget cap fires.
@@ -20,6 +23,7 @@
 4. **Report leftovers** — any `~/.claude/tasks/hermit-*` directory is now inert. Name it in the step-10 report so the operator can delete it by hand; do not delete it automatically.
 
 ### Fixed
+- Stalled-dialog detection recognises selector-style prompts. It required a numbered option (`❯ 1.`), so Claude Code 2.1.233's `❯ Continue` setup wizard went unseen and left a hermit blocked for days with no alert; a dialog whose only footer is `Enter to continue` is now caught too.
 - Generated watchdog units no longer crash-loop on a missing `bun`. `bin/hermit-watchdog install` bakes the installing shell's own PATH into the systemd unit, launchd plist, and cron line, so `bun`, `claude`, and `tmux` all resolve on every tick.
 - The cron fallback line applies its PATH to the watchdog rather than to `cd`, which left cron installs running on cron's default PATH.
 - `scripts/hermit-exec.sh` resolves `bun` from `$BUN_INSTALL`, `~/.bun/bin`, `/usr/local/bin`, or `/opt/homebrew/bin` when it is off PATH, repairing units baked before this fix without operator action.

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -341,7 +341,9 @@ const QUEUE_TAIL_BYTES = 64 * 1024;
 /**
  * Verdict on the newest queue-operation in a transcript tail.
  * 'wedged' — the last queue record is an enqueue older than the threshold.
- * 'draining' — the last queue record is a dequeue, or a newer non-queue record exists.
+ * 'draining' — the last queue record is a dequeue/remove, or an enqueue still inside
+ *   the threshold. Only queue records are read: measured enqueue→drain gaps top out
+ *   around 5 minutes, so the 30-minute threshold already absorbs a long turn.
  * 'unknown' — no queue records at all (fail-open: a fresh or quiet session).
  */
 export function classifyQueueTail(tailText: string, nowMs: number, staleSecs = WEDGE_QUEUE_STALE_SECS): 'wedged' | 'draining' | 'unknown' {
@@ -361,14 +363,16 @@ export function classifyQueueTail(tailText: string, nowMs: number, staleSecs = W
 }
 
 /** Tail of the active session's transcript, or null when it can't be located/read.
- *  The session id is passed in from the runtime.json main() already read this tick —
- *  re-deriving it here would re-read the same file a second time on every tick. */
-function readTranscriptTail(sessionId: string | null, world: World = REAL_WORLD): string | null {
-  if (!sessionId) return null; // no session between runs — nothing to judge
+ *  Takes the CC transcript UUID (runtime.json's `opened_transcript`, maintained by
+ *  cost-tracker.ts:maintainOpenedAt) — NOT `session_id`, which is the logical S-NNN
+ *  arc id and never names a transcript file. It is passed in from the runtime.json
+ *  main() already read this tick, so this doesn't re-read the same file every tick. */
+function readTranscriptTail(transcriptId: string | null, world: World = REAL_WORLD): string | null {
+  if (!transcriptId) return null; // no transcript recorded yet — nothing to judge
   // hermitRoot is repo-relative ('.claude-code-hermit'), and CC keys transcript dirs by
   // ABSOLUTE project path — resolve against cwd rather than path.dirname (which yields '.').
   const projectRoot = path.resolve(world.paths.hermitRoot, '..');
-  const file = path.join(transcriptDirFor(projectRoot), `${sessionId}.jsonl`);
+  const file = path.join(transcriptDirFor(projectRoot), `${transcriptId}.jsonl`);
   try {
     const size = fs.statSync(file).size;
     const fd = fs.openSync(file, 'r');
@@ -1427,8 +1431,10 @@ async function main(): Promise<void> {
   // Alert-only, deduped like 3b: the operator decides how to clear it, and sending keys
   // into an unknown blocker is exactly the auto-answer 3b refuses to do.
   {
-    const sessionId = typeof runtime.session_id === 'string' ? runtime.session_id : null;
-    const tail = readTranscriptTail(sessionId);
+    // `opened_transcript` — the CC transcript UUID that names the .jsonl file.
+    // `session_id` is the logical S-NNN arc id and resolves to a path that never exists.
+    const transcriptId = typeof runtime.opened_transcript === 'string' ? runtime.opened_transcript : null;
+    const tail = readTranscriptTail(transcriptId);
     const verdict = tail === null ? 'unknown' : classifyQueueTail(tail, Date.now());
     const watchdogState = readWatchdogState();
     if (verdict === 'wedged') {

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -32,7 +32,7 @@ import { writeRuntimeJson, readRuntimeJson, STATE_DIR, LIFECYCLE_LOCK } from './
 import { anchoredPaneTail, tmuxSessionAlive, getSessionName as deriveSessionName, sendKeys } from './lib/tmux';
 import { paneRootPids, collectTree, terminateSurvivors } from './lib/proc';
 import { sharedLivenessAgeSecs, LIVENESS_FRESH_SECS } from './lib/liveness';
-import { costLogPath } from './lib/cc-compat';
+import { costLogPath, transcriptDirFor } from './lib/cc-compat';
 import { readSettledConfig } from './lib/config-read';
 import { wallMinutes } from './lib/cron-shift';
 import { isPaused, pauseReasonLabel } from './lib/pause';
@@ -202,6 +202,11 @@ export function composeStallQuestionMessage(timezone: string, locale: Locale = O
   return WATCHDOG[locale].stallQuestion(nowHHMM(timezone));
 }
 
+/** Operator-language message for a session that stopped consuming its queued notifications. */
+export function composeSessionWedgedMessage(timezone: string, locale: Locale = OPERATOR_LOCALE): string {
+  return WATCHDOG[locale].sessionWedged(nowHHMM(timezone));
+}
+
 /** Operator-language message for a likely orphan (tmux gone, state still fresh). */
 export function composeOrphanMessage(timezone: string, locale: Locale = OPERATOR_LOCALE): string {
   return WATCHDOG[locale].orphan(nowHHMM(timezone));
@@ -287,14 +292,25 @@ function getPaneHash(sessionName: string, world: World = REAL_WORLD): string | n
   return content === null ? null : crypto.createHash('sha256').update(content).digest('hex');
 }
 
-// A blocking modal (AskUserQuestion widget or a native permission prompt) renders
-// a pointer-marked numbered option plus an "Esc to cancel" footer — verified against
-// real captures in compiled/spike-ask-gate-probe-2026-07-05.md. Neither token appears
-// in ordinary session output (tool calls, prose, status bar), so requiring both is a
-// conservative, low-false-positive signal that the pane is stalled on an unanswerable
-// dialog. Over-detection costs one deduped push; under-detection is a silent stall.
-const PENDING_OPTION_RE = /❯\s*\d+\./;
-const PENDING_FOOTER = 'Esc to cancel';
+// A blocking modal (AskUserQuestion widget, a native permission prompt, or a
+// harness-shipped setup wizard) renders a pointer-marked option plus a dialog footer
+// — verified against real captures in compiled/spike-ask-gate-probe-2026-07-05.md and
+// against the CC 2.1.233 "Set up auto mode for your environment?" wizard that wedged a
+// live hermit for ~2.5 days. Neither token appears in ordinary session output (tool
+// calls, prose, status bar), so requiring both is a conservative, low-false-positive
+// signal that the pane is stalled on an unanswerable dialog. Over-detection costs one
+// deduped push; under-detection is a silent stall.
+//
+// The option label is deliberately NOT constrained to a number: the wizard's selector
+// reads "❯ Continue", and requiring `\d+\.` is exactly why the live wedge went
+// undetected. The pointer glyph also starts the composer prompt ("❯ Try ..."), but a
+// modal replaces the composer rather than rendering above it, so the footer anchor
+// below keeps the composer out of every match.
+const PENDING_OPTION_RE = /❯\s+\S/;
+// A dialog footer must terminate the visible pane. Both spellings are load-bearing:
+// AskUserQuestion and permission prompts end "· Esc to cancel", while a wizard step
+// that cannot be cancelled offers only "Enter to continue".
+const PENDING_FOOTERS = ['Esc to cancel', 'Enter to continue'];
 
 // Only the pane TAIL counts: a live blocking modal renders at the bottom of the
 // pane, whereas the same tokens appearing in scrollback or quoted tool output
@@ -307,8 +323,68 @@ const PENDING_TAIL_LINES = 15;
 
 /** True when the pane TAIL looks stalled on an interactive dialog nobody can answer. */
 export function hasPendingQuestion(paneContent: string): boolean {
-  const tail = anchoredPaneTail(paneContent, PENDING_TAIL_LINES, PENDING_FOOTER);
-  return tail !== null && PENDING_OPTION_RE.test(tail);
+  return PENDING_FOOTERS.some((footer) => {
+    const tail = anchoredPaneTail(paneContent, PENDING_TAIL_LINES, footer);
+    return tail !== null && PENDING_OPTION_RE.test(tail);
+  });
+}
+
+// A wedged session is shape-independent: whatever holds stdin (a dialog the pane
+// scanner above doesn't recognise, a modal from a future CC release, a hung render),
+// the harness keeps ENQUEUEING monitor notifications it never DEQUEUES. On the live
+// 2026-08-17 incident that signal ran for ~2.5 days — 16 straight enqueues, zero
+// dequeues — while every pane-shaped check stayed silent. Reading only the tail of
+// the transcript keeps this cheap; transcripts reach megabytes.
+const WEDGE_QUEUE_STALE_SECS = 30 * 60;
+const QUEUE_TAIL_BYTES = 64 * 1024;
+
+/**
+ * Verdict on the newest queue-operation in a transcript tail.
+ * 'wedged' — the last queue record is an enqueue older than the threshold.
+ * 'draining' — the last queue record is a dequeue, or a newer non-queue record exists.
+ * 'unknown' — no queue records at all (fail-open: a fresh or quiet session).
+ */
+export function classifyQueueTail(tailText: string, nowMs: number, staleSecs = WEDGE_QUEUE_STALE_SECS): 'wedged' | 'draining' | 'unknown' {
+  let last: { op: string; ts: number } | null = null;
+  for (const line of tailText.split('\n')) {
+    if (!line.includes('"queue-operation"')) continue;
+    let rec: Json;
+    try { rec = JSON.parse(line); } catch { continue; } // a truncated first line is expected
+    if (rec?.type !== 'queue-operation' || typeof rec.operation !== 'string') continue;
+    const ts = Date.parse(String(rec.timestamp ?? ''));
+    if (Number.isNaN(ts)) continue;
+    if (last === null || ts >= last.ts) last = { op: rec.operation, ts };
+  }
+  if (last === null) return 'unknown';
+  if (last.op !== 'enqueue') return 'draining';
+  return nowMs - last.ts > staleSecs * 1000 ? 'wedged' : 'draining';
+}
+
+/** Tail of the active session's transcript, or null when it can't be located/read.
+ *  The session id is passed in from the runtime.json main() already read this tick —
+ *  re-deriving it here would re-read the same file a second time on every tick. */
+function readTranscriptTail(sessionId: string | null, world: World = REAL_WORLD): string | null {
+  if (!sessionId) return null; // no session between runs — nothing to judge
+  // hermitRoot is repo-relative ('.claude-code-hermit'), and CC keys transcript dirs by
+  // ABSOLUTE project path — resolve against cwd rather than path.dirname (which yields '.').
+  const projectRoot = path.resolve(world.paths.hermitRoot, '..');
+  const file = path.join(transcriptDirFor(projectRoot), `${sessionId}.jsonl`);
+  try {
+    const size = fs.statSync(file).size;
+    const fd = fs.openSync(file, 'r');
+    try {
+      const start = Math.max(0, size - QUEUE_TAIL_BYTES);
+      const len = size - start;
+      const buf = Buffer.alloc(len);
+      // readSync may return a short read; slice to what was actually read so a
+      // zero-filled remainder can't inject NUL bytes into the newest lines — the
+      // same guard report-export.ts's bounded tail read carries.
+      const bytesRead = fs.readSync(fd, buf, 0, len, start);
+      return buf.subarray(0, bytesRead).toString('utf-8');
+    } finally { fs.closeSync(fd); }
+  } catch {
+    return null; // absent/unreadable transcript is not evidence of a wedge
+  }
 }
 
 // sendKeys now lives in lib/tmux.ts so the harness-command drain shares one
@@ -1341,6 +1417,32 @@ async function main(): Promise<void> {
       }
     } else if (watchdogState.stall_question_notified) {
       watchdogState.stall_question_notified = false;
+      writeWatchdogState(watchdogState);
+    }
+  }
+
+  // 3c. Queue-liveness wedge detection — the shape-independent net behind 3b. Whatever
+  // holds stdin (a dialog 3b's pane scanner doesn't recognise, a modal from a future CC
+  // release), the harness keeps enqueueing monitor notifications it never dequeues.
+  // Alert-only, deduped like 3b: the operator decides how to clear it, and sending keys
+  // into an unknown blocker is exactly the auto-answer 3b refuses to do.
+  {
+    const sessionId = typeof runtime.session_id === 'string' ? runtime.session_id : null;
+    const tail = readTranscriptTail(sessionId);
+    const verdict = tail === null ? 'unknown' : classifyQueueTail(tail, Date.now());
+    const watchdogState = readWatchdogState();
+    if (verdict === 'wedged') {
+      if (!watchdogState.session_wedged_notified) {
+        pushOperatorMessage(composeSessionWedgedMessage(timezone));
+        appendEvent('session-wedged', 'queued notifications not draining, session alive');
+        watchdogState.session_wedged_notified = true;
+        writeWatchdogState(watchdogState);
+      }
+    } else if (watchdogState.session_wedged_notified) {
+      // Re-arm on ANY non-wedged verdict, 'unknown' included: a restart starts a fresh
+      // transcript with no queue records yet, and holding the flag through that would
+      // suppress the NEXT genuine wedge — the silent stall this check exists to prevent.
+      watchdogState.session_wedged_notified = false;
       writeWatchdogState(watchdogState);
     }
   }

--- a/plugins/claude-code-hermit/scripts/lib/messages.ts
+++ b/plugins/claude-code-hermit/scripts/lib/messages.ts
@@ -237,6 +237,7 @@ export interface WatchdogMessages {
   pauseUntilResume(label: string): string;
   pauseUntilDate(label: string, boundary: string): string;
   stallQuestion(hhmm: string): string;
+  sessionWedged(hhmm: string): string;
   orphan(hhmm: string): string;
 }
 
@@ -250,6 +251,8 @@ export const WATCHDOG: Localized<WatchdogMessages> = {
     pauseUntilDate: (label, boundary) => `Your hermit is paused (${label}) until ${boundary}.`,
     stallQuestion: (hhmm) =>
       `Your hermit is waiting on a question it can't ask over chat — open the terminal or Claude app to answer (${hhmm}).`,
+    sessionWedged: (hhmm) =>
+      `Your hermit has stopped picking up its scheduled work — something on screen is holding it. Open the terminal or Claude app and clear whatever is waiting there (${hhmm}).`,
     orphan: (hhmm) =>
       `Your hermit's session ended but a process may still be running (${hhmm}). If it keeps replying, stop it from the terminal: run \`pgrep -af "claude --channels"\` and kill that PID.`,
   },
@@ -262,6 +265,8 @@ export const WATCHDOG: Localized<WatchdogMessages> = {
     pauseUntilDate: (label, boundary) => `O seu hermit está em pausa (${label}) até ${boundary}.`,
     stallQuestion: (hhmm) =>
       `O seu hermit está à espera de uma pergunta que não pode fazer pelo chat — abra o terminal ou a app Claude para responder (${hhmm}).`,
+    sessionWedged: (hhmm) =>
+      `O seu hermit deixou de executar o trabalho agendado — algo no ecrã está a bloqueá-lo. Abra o terminal ou a app Claude e resolva o que está à espera (${hhmm}).`,
     orphan: (hhmm) =>
       `A sessão do seu hermit terminou mas pode haver um processo ainda a correr (${hhmm}). Se continuar a responder, pare-o no terminal: corra \`pgrep -af "claude --channels"\` e faça kill desse PID.`,
   },

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -14,7 +14,7 @@ import path from 'node:path';
 
 import { runScript, SCRIPTS_DIR } from './helpers/run';
 import {
-  inActiveHours, isNearDailyAutoClose, composeRestartMessage, composeWedgeMessage, composeStallQuestionMessage, composePauseMessage, hasPendingQuestion, composeCompactSteeringMessage,
+  inActiveHours, isNearDailyAutoClose, composeRestartMessage, composeWedgeMessage, composeStallQuestionMessage, composeSessionWedgedMessage, composePauseMessage, hasPendingQuestion, classifyQueueTail, composeCompactSteeringMessage,
   rearmDamperOpen, passesLifecycleGuards, setHygieneEval, stampHygieneEval,
   maybeContextClear, maybeContextCompact, MONITOR_REARM_DAMPER_SECS, type World,
 } from '../scripts/hermit-watchdog';
@@ -461,9 +461,46 @@ describe('dead session with channel configured', () => {
 const PENDING_QUESTION_PANE =
   ' Which color do you prefer?\n\n❯ 1. Red\n  2. Green\n  3. Blue\n\nEnter to select · Esc to cancel';
 
+// Verbatim from the live capture of claude-code-paulinho-hermit on 2026-08-17, wedged
+// ~2.5 days by CC 2.1.233's first-run wizard. The selector is "❯ Continue" — no digit,
+// which is precisely what the old numbered-option regex could not see.
+const AUTO_MODE_WIZARD_PANE = [
+  '   Set up auto mode for your environment?',
+  '',
+  '   Claude Code reads this project, your recent Claude sessions, and optionally your shell history and other repositories.',
+  '',
+  '     How you use Claude here    ◀ Mixed ▶',
+  '     Also scan shell history    [✔]',
+  '     Also scan your other repos [ ]',
+  '',
+  '   ❯ Continue',
+  '',
+  '   ←/→ to change usage · Enter to continue · Esc to cancel',
+].join('\n');
+
 describe('hasPendingQuestion tail-scan (#8 false-positive guard)', () => {
   test('a genuine modal at the bottom of the pane matches', () => {
     expect(hasPendingQuestion(PENDING_QUESTION_PANE)).toBe(true);
+  });
+
+  test('the CC 2.1.233 auto-mode setup wizard matches (live wedge regression)', () => {
+    expect(hasPendingQuestion(AUTO_MODE_WIZARD_PANE)).toBe(true);
+  });
+
+  test('the wizard still matches with blank terminal rows below it', () => {
+    expect(hasPendingQuestion(`${AUTO_MODE_WIZARD_PANE}${'\n'.repeat(20)}`)).toBe(true);
+  });
+
+  test('a dialog whose only footer is "Enter to continue" matches', () => {
+    // A wizard step that cannot be cancelled omits the Esc affordance entirely.
+    expect(hasPendingQuestion('   Set up something?\n\n   ❯ Continue\n\n   Enter to continue')).toBe(true);
+  });
+
+  test('an idle composer prompt does NOT match', () => {
+    // The pointer glyph also opens the composer; the status bar, not a dialog footer,
+    // terminates the pane there.
+    const idle = 'Boot summary\n  - Session: idle\n\n❯ Try "how does <filepath> work?"\n\n  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents';
+    expect(hasPendingQuestion(idle)).toBe(false);
   });
 
   test('a genuine modal still matches with blank terminal rows below it', () => {
@@ -487,6 +524,151 @@ describe('hasPendingQuestion tail-scan (#8 false-positive guard)', () => {
     expect(hasPendingQuestion('the docs say to press Esc to cancel a running task\nall done')).toBe(false);
   });
 });
+
+// -------------------------------------------------------
+// 3c. Queue-liveness wedge detection — the shape-independent net behind 3b.
+//     Fixture shape is the live 2026-08-17 incident: monitor notifications
+//     enqueued and never dequeued while the session sat behind a dialog.
+// -------------------------------------------------------
+
+const NOW = Date.parse('2026-08-17T14:00:00Z');
+const queueRec = (operation: string, iso: string) =>
+  JSON.stringify({ type: 'queue-operation', operation, timestamp: iso, sessionId: 'sess-1' });
+
+describe('classifyQueueTail', () => {
+  test('enqueue older than the threshold with no dequeue → wedged', () => {
+    const tail = [
+      queueRec('enqueue', '2026-08-17T07:30:00Z'),
+      queueRec('enqueue', '2026-08-17T08:00:00Z'),
+    ].join('\n');
+    expect(classifyQueueTail(tail, NOW)).toBe('wedged');
+  });
+
+  test('a dequeue after the last enqueue → draining', () => {
+    const tail = [
+      queueRec('enqueue', '2026-08-17T07:30:00Z'),
+      queueRec('dequeue', '2026-08-17T07:30:01Z'),
+    ].join('\n');
+    expect(classifyQueueTail(tail, NOW)).toBe('draining');
+  });
+
+  test('a recent enqueue still within the threshold → draining (not yet a wedge)', () => {
+    expect(classifyQueueTail(queueRec('enqueue', '2026-08-17T13:50:00Z'), NOW)).toBe('draining');
+  });
+
+  test('a transcript with no queue records → unknown (fail-open)', () => {
+    const tail = '{"type":"assistant","timestamp":"2026-08-17T13:00:00Z"}\n{"type":"mode","mode":"normal"}';
+    expect(classifyQueueTail(tail, NOW)).toBe('unknown');
+  });
+
+  test('a truncated leading line (byte-offset tail read) is skipped, not fatal', () => {
+    const tail = `p":"2026-08-17T06:00:00Z"}\n${queueRec('enqueue', '2026-08-17T08:00:00Z')}`;
+    expect(classifyQueueTail(tail, NOW)).toBe('wedged');
+  });
+});
+
+/** Seed a transcript for `sessionId` under a sandboxed HOME, and point runtime.json at it. */
+function seedTranscript(h: Hermit, sessionId: string, lines: string[]): Record<string, string> {
+  const home = path.join(h.dir, 'fake-home');
+  const dir = path.join(home, '.claude', 'projects', h.dir.replace(/[^a-zA-Z0-9]/g, '-'));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
+  const runtimePath = state(h, 'runtime.json');
+  fs.writeFileSync(runtimePath, JSON.stringify({ ...readJson(runtimePath), session_id: sessionId }, null, 2) + '\n');
+  return { HOME: home };
+}
+
+describe('session-wedged detection (queued notifications not draining)', () => {
+  let h: Hermit;
+  let stub: Stub;
+  let exitCode: number;
+
+  beforeAll(async () => {
+    h = setupHermit();
+    writeConfig(h);
+    configureChannel(h);
+    writeFakeTmux(h, 0, 'ordinary pane output\nno dialog here');
+    writeFakePgrep(h, 1);
+    stub = startHttpStub();
+    const env = seedTranscript(h, 'sess-wedged', [
+      queueRec('enqueue', isoAgoSeconds(50)),
+      queueRec('enqueue', isoAgoSeconds(2)),
+    ]);
+    ({ exitCode } = await watchdog(h, 'run', { env: { ...env, HERMIT_TELEGRAM_API_URL: stub.url } }));
+  });
+
+  afterAll(() => { stub.stop(); h.cleanup(); });
+
+  test('stale enqueue tail → session-wedged event', () => {
+    expect(exitCode).toBe(0);
+    expect(fs.readFileSync(eventsFile(h), 'utf-8')).toContain('session-wedged');
+  });
+
+  test('stale enqueue tail → watchdog-state flags session_wedged_notified', () => {
+    expect(readJson(state(h, 'watchdog-state.json')).session_wedged_notified).toBe(true);
+  });
+
+  test('stale enqueue tail → exactly one operator push', () => {
+    expect(stub.requests.length).toBe(1);
+    expect(stub.requests[0].body.text).toContain('scheduled work');
+  });
+
+  test('alert-only: no keystrokes and no kill were sent to the pane', () => {
+    const calls = fs.existsSync(path.join(h.dir, 'tmux-calls.log'))
+      ? fs.readFileSync(path.join(h.dir, 'tmux-calls.log'), 'utf-8')
+      : '';
+    expect(calls).not.toContain('send-keys');
+    expect(calls).not.toContain('kill-session');
+  });
+});
+
+test('draining transcript → no wedge event, sticky flag clears', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0, 'ordinary pane output');
+  writeFakePgrep(h, 1);
+  fs.writeFileSync(state(h, 'watchdog-state.json'), JSON.stringify({ session_wedged_notified: true }) + '\n');
+  const stub = startHttpStub();
+  try {
+    const env = seedTranscript(h, 'sess-ok', [
+      queueRec('enqueue', isoAgoSeconds(50)),
+      queueRec('dequeue', isoAgoSeconds(49)),
+    ]);
+    await watchdog(h, 'run', { env: { ...env, HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(readJson(state(h, 'watchdog-state.json')).session_wedged_notified).toBe(false);
+    const events = fs.existsSync(eventsFile(h)) ? fs.readFileSync(eventsFile(h), 'utf-8') : '';
+    expect(events).not.toContain('session-wedged');
+  } finally { stub.stop(); }
+}));
+
+test('unknown verdict (fresh transcript after restart) re-arms the sticky flag', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0, 'ordinary pane output');
+  writeFakePgrep(h, 1);
+  fs.writeFileSync(state(h, 'watchdog-state.json'), JSON.stringify({ session_wedged_notified: true }) + '\n');
+  const stub = startHttpStub();
+  try {
+    // A brand-new session's transcript carries no queue records yet → 'unknown'.
+    // Holding the flag through that would mute the NEXT real wedge.
+    const env = seedTranscript(h, 'sess-fresh', ['{"type":"mode","mode":"normal"}']);
+    await watchdog(h, 'run', { env: { ...env, HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(readJson(state(h, 'watchdog-state.json')).session_wedged_notified).toBe(false);
+  } finally { stub.stop(); }
+}));
+
+test('missing transcript → no wedge event (fail-open)', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0, 'ordinary pane output');
+  writeFakePgrep(h, 1);
+  const stub = startHttpStub();
+  try {
+    await watchdog(h, 'run', { env: { HOME: path.join(h.dir, 'empty-home'), HERMIT_TELEGRAM_API_URL: stub.url } });
+    const events = fs.existsSync(eventsFile(h)) ? fs.readFileSync(eventsFile(h), 'utf-8') : '';
+    expect(events).not.toContain('session-wedged');
+  } finally { stub.stop(); }
+}));
 
 describe('stall-question detection', () => {
   let h: Hermit;
@@ -2449,6 +2631,13 @@ describe('watchdog message localization', () => {
       /^Your hermit is waiting on a question it can't ask over chat — open the terminal or Claude app to answer \(\d{2}:\d{2}\)\.$/);
     expect(composeStallQuestionMessage('UTC', 'pt-PT')).toMatch(
       /^O seu hermit está à espera de uma pergunta que não pode fazer pelo chat — abra o terminal ou a app Claude para responder \(\d{2}:\d{2}\)\.$/);
+  });
+
+  test('composeSessionWedgedMessage en / pt-PT', () => {
+    expect(composeSessionWedgedMessage('UTC', 'en')).toMatch(
+      /^Your hermit has stopped picking up its scheduled work — something on screen is holding it\. Open the terminal or Claude app and clear whatever is waiting there \(\d{2}:\d{2}\)\.$/);
+    expect(composeSessionWedgedMessage('UTC', 'pt-PT')).toMatch(
+      /^O seu hermit deixou de executar o trabalho agendado — algo no ecrã está a bloqueá-lo\. Abra o terminal ou a app Claude e resolva o que está à espera \(\d{2}:\d{2}\)\.$/);
   });
 
   test('composePauseMessage indefinite form is deterministic and localized', () => {

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -567,14 +567,17 @@ describe('classifyQueueTail', () => {
   });
 });
 
-/** Seed a transcript for `sessionId` under a sandboxed HOME, and point runtime.json at it. */
-function seedTranscript(h: Hermit, sessionId: string, lines: string[]): Record<string, string> {
+/** Seed a transcript for CC transcript id `transcriptId` under a sandboxed HOME, and point
+ *  runtime.json's `opened_transcript` at it. That field — not `session_id`, which holds the
+ *  logical S-NNN arc id — is what names the `<uuid>.jsonl` file CC writes. */
+function seedTranscript(h: Hermit, transcriptId: string, lines: string[]): Record<string, string> {
   const home = path.join(h.dir, 'fake-home');
   const dir = path.join(home, '.claude', 'projects', h.dir.replace(/[^a-zA-Z0-9]/g, '-'));
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(dir, `${transcriptId}.jsonl`), lines.join('\n') + '\n');
   const runtimePath = state(h, 'runtime.json');
-  fs.writeFileSync(runtimePath, JSON.stringify({ ...readJson(runtimePath), session_id: sessionId }, null, 2) + '\n');
+  fs.writeFileSync(runtimePath, JSON.stringify(
+    { ...readJson(runtimePath), session_id: 'S-001', opened_transcript: transcriptId }, null, 2) + '\n');
   return { HOME: home };
 }
 


### PR DESCRIPTION
## Summary

A live hermit sat blocked for ~2.5 days behind Claude Code 2.1.233's **"Set up auto mode for your environment?"** first-run wizard, silently losing 16 scheduled routines. The watchdog kept ticking the whole time but had no way to see it — and kept typing `/clear` and `/compact` into the modal, which swallowed them.

Two layers, both detection-only.

**The specific miss.** `hasPendingQuestion` required a pointer-marked *numbered* option (`❯ 1.`). The wizard's selector reads `❯ Continue` — no digit — so the pane scanner returned false and the tick fell straight through to the nudge tier. The pointer match now accepts any selector label; the footer anchor (not the digit) is what keeps the ordinary composer prompt out of a match, since a modal replaces the composer rather than rendering above it. A wizard step offering only `Enter to continue` with no Esc affordance is now caught too.

**The general miss.** Pattern-matching pane shapes loses to the next dialog Claude Code ships. The signal that *was* screaming for 2.5 days is shape-independent: whatever holds stdin, the harness keeps **enqueueing** monitor notifications it never **dequeues**. A new watchdog step reads a bounded 64KB tail of the active transcript and raises one deduped `session-wedged` alert when the newest queue record is a stale enqueue while tmux is alive.

Both paths are **alert-only** — the watchdog never answers, dismisses, or restarts on these signals. Clearing a dialog stays the operator's call; the sticky flag re-arms on any non-wedged verdict so a restart can't mute the next real wedge.

## Changes

- `hermit-watchdog.ts` — pointer regex accepts selector labels; footer anchors extended to `Enter to continue`; new `classifyQueueTail` + bounded `readTranscriptTail`; step 3c raises `session-wedged` with sticky dedup
- `lib/messages.ts` — `sessionWedged` operator message, `en` + `pt-PT`
- `tests/watchdog.test.ts` — the wedging wizard pane captured verbatim as a regression fixture, an idle-composer negative guarding the widened regex, queue-classifier unit tests, and spawn tests asserting one alert and **no** `send-keys`/`kill-session`

## Not included: prevention

The original plan also called for pre-seeding a config key to stop the wizard appearing at all. **Dropped on evidence.** Probed against local CC 2.1.233 (`--model sonnet`; haiku has no auto mode and falls back to manual, so it cannot exercise this):

- user settings `defaultMode: auto` with **no** `autoMode.environment` anywhere → auto mode engages, documented notice shows, **no wizard**
- same plus `autoMode.environment` seeded → identical, **no wizard**
- the blocked hermit's **exact** `.claude.json` + user `settings.json`, copied off the container → **no wizard**

Every top-level and per-project key was diffed between a wizard-answered install and the wizard-pending one; nothing names this wizard. It appears to be environment- or rollout-gated, so there is no durable local key to seed and any "prevention" commit would have been speculative. Worth reporting upstream separately: an upgrade-triggered interactive wizard permanently blocks unattended sessions.

Incidental finding, deliberately **not** acted on: `automode-seed` only runs when `artifacts.publish_authorized === true` (`hermit-start.ts:768-772`), so most hermits never get `autoMode.environment`. Probe run A shows its absence does not cause the wizard, so decoupling it isn't justified by this evidence.

## Test plan

- `cd plugins/claude-code-hermit && bun test` → **3820 pass / 0 fail**
- `bunx tsc --noEmit` from repo root → exit 0
- New coverage: wizard fixture matches; idle composer does not; stale-enqueue tail → exactly one alert and zero keystrokes to the pane; dequeue tail and fresh-transcript (`unknown`) both re-arm the flag; missing transcript stays silent (fail-open)
