### PR TITLE
fix(claude-code-hermit): let channel-setup add the channel it was asked to activate

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `/claude-code-hermit:channel-setup` adds the channel entry itself when `channels` is empty, instead of stopping and pointing at `/claude-code-hermit:hermit-settings` — that skill carries `disable-model-invocation`, so nothing could reach it and the operator was left to type the command.
+- `/claude-code-hermit:channel-setup` now treats a channel with `enabled: false` as disabled rather than configured, and offers to re-enable it instead of proceeding as though it were live.
+
 ## [1.2.42] - 2026-08-19
 
 ### Added

--- a/plugins/claude-code-hermit/docs/always-on.md
+++ b/plugins/claude-code-hermit/docs/always-on.md
@@ -146,13 +146,13 @@ The docker-setup wizard walks you through token setup, state dir configuration, 
 
 ### Local / tmux
 
-After `hatch` configures your channel preference, run the guided activation wizard:
+Run the guided activation wizard — it picks up the channel preference from `hatch`, or adds one if you skipped that step:
 
 ```
 /claude-code-hermit:channel-setup
 ```
 
-It installs the plugin (requires [Bun](https://bun.sh)), writes the bot token to `.claude.local/channels/<plugin>/.env`, and walks through pairing. `hermit-start` passes `--channels` automatically — no manual flag needed. If bun is missing or the token file isn't present, `hermit-start` prints a clear warning and skips the channel.
+It installs the plugin (requires [Bun](https://bun.sh)), writes the bot token to `.claude.local/channels/<plugin>/.env`, and walks through pairing. It can also re-enable a channel you previously turned off. `hermit-start` passes `--channels` automatically — no manual flag needed. If bun is missing or the token file isn't present, `hermit-start` prints a clear warning and skips the channel.
 
 ---
 

--- a/plugins/claude-code-hermit/docs/how-to-use.md
+++ b/plugins/claude-code-hermit/docs/how-to-use.md
@@ -127,7 +127,7 @@ See [Always-On Setup](always-on.md) for the full guide — auth, channels, pausi
 .claude-code-hermit/bin/hermit-stop
 ```
 
-To activate a channel in tmux mode, run `/claude-code-hermit:channel-setup` — it installs the plugin, configures the token, and guides pairing. `hermit-start` passes `--channels` automatically on boot.
+To activate a channel in tmux mode, run `/claude-code-hermit:channel-setup` — it adds the channel to `config.json` if you skipped that at hatch, installs the plugin, configures the token, and guides pairing. `hermit-start` passes `--channels` automatically on boot.
 
 See [Always-On Operations](always-on-ops.md) for tmux setup and operational details.
 

--- a/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: channel-setup
-description: Guided channel activation for local/tmux users — installs the plugin, configures the bot token in the project-local state dir, and walks through pairing. Run after hatch or hermit-settings to activate a configured channel.
+description: Guided channel activation for local/tmux users — adds a channel entry when none is configured, installs the plugin, configures the bot token in the project-local state dir, and walks through pairing. Run after hatch, or any time to add or re-enable a channel.
 ---
 # Channel Setup
 
-Activate a channel configured in `config.json` for local/tmux operation. This mirrors what `docker-setup` does for Docker users but targets the local environment.
+Activate a channel for local/tmux operation, adding the `config.json` entry first when there isn't one. This mirrors what `docker-setup` does for Docker users but targets the local environment.
 
 ## Plan
 
@@ -19,11 +19,20 @@ Activate a channel configured in `config.json` for local/tmux operation. This mi
 - If `runtime.json` is missing AND `.claude-code-hermit/docker/Dockerfile.hermit` exists (Docker scaffolded but not yet booted): same redirect.
 - Otherwise: proceed.
 
-Read `.claude-code-hermit/config.json`. Collect all entries under `channels` that are valid objects.
+Read `.claude-code-hermit/config.json`. Collect all entries under `channels` that are valid objects, tracking which are disabled (`enabled: false`).
 
-- If no channels configured: tell the operator — "No channels in config.json. Run `/claude-code-hermit:hatch` or `/claude-code-hermit:hermit-settings channels` to add one first." Stop.
-- If exactly one channel: use it automatically.
-- If multiple channels: ask with `AskUserQuestion` (header: "Channel") — list channel names as options plus **All** — which to set up.
+**Adding an entry.** Where a branch below says *create the entry*, run:
+
+```
+echo '{"channels":{"<name>":{"enabled":true}}}' | bun ${CLAUDE_PLUGIN_ROOT}/scripts/hatch-config.ts "$(pwd)" --reinit >/dev/null
+```
+
+The script fills `enabled`, `dm_channel_id: null`, and `state_dir` (`.claude.local/channels/<name>`), validates the whole config, preserves every other key, and merges onto an existing entry rather than replacing it. Discard stdout — it prints the full config.
+
+- If no channels configured: offer to add one — `AskUserQuestion` (header: "Channel") with options **Discord**, **Telegram**, **Cancel**. On **Cancel**, stop without writing. Otherwise create the entry and continue with that channel selected. Do not offer iMessage here: step 4 defines token vars for Discord and Telegram only.
+- If entries exist but all are disabled: name them, then ask with `AskUserQuestion` (header: "Channel") — the disabled channel names plus **Cancel** — which to re-enable. On **Cancel**, stop without writing. Otherwise create the entry for the chosen name (this flips `enabled` and leaves `dm_channel_id`, `state_dir`, and `allowed_users` intact) and continue with it selected.
+- If exactly one enabled channel: use it automatically.
+- If multiple enabled channels: ask with `AskUserQuestion` (header: "Channel") — list the enabled channel names as options plus **All** — which to set up.
 
 Run steps 2–6 for each selected channel.
 

--- a/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
@@ -21,18 +21,18 @@ Activate a channel for local/tmux operation, adding the `config.json` entry firs
 
 Read `.claude-code-hermit/config.json`. Collect all entries under `channels` that are valid objects, tracking which are disabled (`enabled: false`).
 
-**Adding an entry.** Where a branch below says *create the entry*, run:
+**Adding an entry.** Where a branch below says *create the entry*, run (`<name>` is the lowercase channel key — `discord`, `telegram` — never the capitalized option label):
 
 ```
 echo '{"channels":{"<name>":{"enabled":true}}}' | bun ${CLAUDE_PLUGIN_ROOT}/scripts/hatch-config.ts "$(pwd)" --reinit >/dev/null
 ```
 
-The script fills `enabled`, `dm_channel_id: null`, and `state_dir` (`.claude.local/channels/<name>`), validates the whole config, preserves every other key, and merges onto an existing entry rather than replacing it. Discard stdout — it prints the full config.
+The script fills `enabled`, `dm_channel_id: null`, and `state_dir` (`.claude.local/channels/<name>`), validates the whole config, preserves every other key, and merges onto an existing entry rather than replacing it. Discard stdout — it prints the full config. A non-zero exit means nothing was written: report the `hatch-config:` line it printed on stderr and stop — never fall through into steps 2–6 against a channel that isn't in `config.json`.
 
 - If no channels configured: offer to add one — `AskUserQuestion` (header: "Channel") with options **Discord**, **Telegram**, **Cancel**. On **Cancel**, stop without writing. Otherwise create the entry and continue with that channel selected. Do not offer iMessage here: step 4 defines token vars for Discord and Telegram only.
 - If entries exist but all are disabled: name them, then ask with `AskUserQuestion` (header: "Channel") — the disabled channel names plus **Cancel** — which to re-enable. On **Cancel**, stop without writing. Otherwise create the entry for the chosen name (this flips `enabled` and leaves `dm_channel_id`, `state_dir`, and `allowed_users` intact) and continue with it selected.
-- If exactly one enabled channel: use it automatically.
-- If multiple enabled channels: ask with `AskUserQuestion` (header: "Channel") — list the enabled channel names as options plus **All** — which to set up.
+- If exactly one enabled channel and nothing disabled: use it automatically.
+- Otherwise (several enabled, or enabled and disabled side by side): ask with `AskUserQuestion` (header: "Channel") — every channel name as an option, disabled ones labelled `<name> — disabled`, plus **All** (enabled channels only) — which to set up. If a disabled name is chosen, create the entry for it first (re-enabling it), then continue with it selected.
 
 Run steps 2–6 for each selected channel.
 

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -1202,6 +1202,48 @@ describe('bootstrap skills', () => {
 });
 
 // ============================================================
+// channel-setup empty-channels branch (TestChannelSetupEmptyChannels)
+//
+// channel-setup used to hard-stop on `channels: {}` and point at
+// /hermit-settings, which carries disable-model-invocation and therefore
+// cannot be reached from a skill — leaving the operator to type it. The
+// skill now creates the entry itself via hatch-config.ts --reinit.
+//
+// Coverage note: this is a static text scan of SKILL.md. It proves the
+// dead-end prose is gone and the writer is named, not that the model
+// follows the branch — that needs a live probe.
+// ============================================================
+
+describe('channel-setup empty-channels branch', () => {
+  const text = read(path.join(SKILLS, 'channel-setup', 'SKILL.md'));
+
+  test('does not send the operator to hermit-settings to add a channel', () => {
+    expect(text).not.toContain('to add one first');
+    expect(text).not.toContain('hermit-settings channels');
+  });
+
+  test('creates the entry through hatch-config.ts --reinit, discarding stdout', () => {
+    expect(text).toContain('hatch-config.ts');
+    expect(text).toContain('--reinit');
+    // hatch-config prints the whole config on success; skills must not ingest it.
+    expect(text).toContain('--reinit >/dev/null');
+  });
+
+  test('offers Discord and Telegram only — step 4 has no iMessage token branch', () => {
+    const start = text.indexOf('If no channels configured');
+    const end = text.indexOf('If entries exist but all are disabled');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const firstBranch = text.slice(start, end);
+    expect(firstBranch).toContain('**Discord**');
+    expect(firstBranch).toContain('**Telegram**');
+    expect(firstBranch).toContain('**Cancel**');
+    // iMessage may be named in the rationale, but never as a selectable option.
+    expect(firstBranch).not.toContain('**iMessage**');
+  });
+});
+
+// ============================================================
 // Stop payload snapshot (TestStopPayloadSnapshot)
 //
 // stop-pipeline.ts writes state/cc-stop-snapshot.json from the Stop payload.

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -1218,8 +1218,10 @@ describe('channel-setup empty-channels branch', () => {
   const text = read(path.join(SKILLS, 'channel-setup', 'SKILL.md'));
 
   test('does not send the operator to hermit-settings to add a channel', () => {
-    expect(text).not.toContain('to add one first');
-    expect(text).not.toContain('hermit-settings channels');
+    // Match the dead-end redirect specifically — a bare 'hermit-settings channels'
+    // or 'to add one first' would also fire on unrelated future prose.
+    expect(text).not.toContain('No channels in config.json');
+    expect(text).not.toMatch(/hermit-settings channels`? to add one first/);
   });
 
   test('creates the entry through hatch-config.ts --reinit, discarding stdout', () => {

--- a/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
@@ -279,6 +279,60 @@ describe('hatch-config.ts', () => {
     expect(out.channels.discord.dm_channel_id).toBe('D1');
   });
 
+  // /channel-setup writes a channels-only payload through --reinit to add a channel
+  // to a hermit hatched with `channels: {}`. Creation (as opposed to merging onto an
+  // existing entry) is the path that skill depends on.
+  test('re-init: a channels-only payload creates an absent channel with full defaults', async () => {
+    const dir = freshDir();
+    const seed = {
+      ...JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8')),
+      agent_name: 'Keeper',
+      foo_custom: true,
+      channels: {},
+    };
+    seedConfig(dir, seed);
+
+    const r = await runHatchConfig(dir, { channels: { telegram: { enabled: true } } }, true);
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(fs.readFileSync(configPathFor(dir), 'utf8'));
+
+    expect(out.channels.telegram).toEqual({
+      enabled: true,
+      dm_channel_id: null,
+      state_dir: '.claude.local/channels/telegram',
+    });
+    // nothing else moved
+    expect(out.agent_name).toBe('Keeper');
+    expect(out.foo_custom).toBe(true);
+    expect(Object.keys(out.channels)).toEqual(['telegram']);
+  });
+
+  // Re-enabling a disabled channel must not clear state learned at pairing time.
+  test('re-init: enabling a disabled channel preserves its learned state', async () => {
+    const dir = freshDir();
+    const seed = {
+      ...JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8')),
+      channels: {
+        telegram: {
+          enabled: false,
+          dm_channel_id: 'T42',
+          state_dir: '.claude.local/channels/telegram',
+          allowed_users: ['777'],
+        },
+      },
+    };
+    seedConfig(dir, seed);
+
+    const r = await runHatchConfig(dir, { channels: { telegram: { enabled: true } } }, true);
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(fs.readFileSync(configPathFor(dir), 'utf8'));
+
+    expect(out.channels.telegram.enabled).toBe(true);
+    expect(out.channels.telegram.dm_channel_id).toBe('T42');
+    expect(out.channels.telegram.allowed_users).toEqual(['777']);
+    expect(out.channels.telegram.state_dir).toBe('.claude.local/channels/telegram');
+  });
+
   test('duplicate plugin in scheduled_checks_plugins does not produce duplicate check ids', async () => {
     const dir = freshDir();
     const r = await runHatchConfig(dir, {


### PR DESCRIPTION
## Summary

`/claude-code-hermit:channel-setup` hard-stopped when `config.json` had `channels: {}`, telling the operator to run `/claude-code-hermit:hermit-settings channels` instead. That skill carries `disable-model-invocation`, so nothing could chain into it — the operator was left to type the command after already being asked whether to proceed.

The empty state is reachable by design, not by accident: `state-templates/config.json.template` ships `"channels": {}` and `hatch` Phase 5 records exactly that when the operator picks **None**. Anyone who declines a channel at hatch and later changes their mind landed on this dead end.

## Changes

- **`skills/channel-setup/SKILL.md`** — on empty `channels`, offer Discord or Telegram (or Cancel) and create the entry via `hatch-config.ts --reinit`, then continue into the existing install/token/pairing steps. An entry with `enabled: false` is now treated as disabled rather than configured, with an offer to re-enable it. Description and intro updated to match.
- **`tests/hatch-config-contract.test.ts`** — two cases covering what the skill now depends on: creating a channel absent from `channels` under `--reinit`, and re-enabling a disabled channel without clearing `dm_channel_id` / `state_dir` / `allowed_users`. Existing coverage only exercised merging onto an entry that already existed.
- **`tests/contracts.test.ts`** — marker assertions that the dead-end prose is gone, the writer is named, stdout is discarded, and iMessage is never offered as a selectable option.
- **`docs/how-to-use.md`, `docs/always-on.md`** — both described the old hatch-first ordering and became inaccurate with this change.

### Notes for review

- **Why `hatch-config.ts --reinit` rather than a new writer.** Its partial-payload contract is documented in the script docstring and in `hatch/SKILL.md`, and `hatch-config-contract.test.ts` already pinned a channels-only reinit before this PR. It validates the whole config and writes atomically; the alternative for channel entries today is a model hand-editing `config.json`. Its stdout is redirected to `/dev/null` because it prints the full config on success, which would otherwise land in operator context.
- **iMessage is deliberately not offered.** Step 4 defines token vars for Discord and Telegram only, and `<TOKEN_VAR>` is used unresolved downstream. The existing guard fires on non-Darwin, so macOS is exactly the case that would fall through into undefined prose.
- **Scope is the local/tmux path.** The Docker check at step 1 returns before this branch, so Docker behavior is unchanged. Docker still has no post-install channel path, because `docker-setup` gates on existing scaffolding (abort, or back up and regenerate) before reaching its channel step. Left for separate work rather than widened into this PR.

## Test plan

- `bun test` from `plugins/claude-code-hermit` — **3942 pass, 0 fail** across 138 files.
- `bunx tsc --noEmit` — exit 0.
- The four new cases were confirmed to run rather than be filtered out (`hatch-config-contract` 15 → 17 tests; the three channel-setup markers pass).
- **Not yet run:** a live `/probe` confirming the model actually follows the new branch in a real session. The contract tests are static text scans and prove the prose is present, not that it is obeyed.