### PR TITLE
fix(claude-code-hermit): deliver channel state dirs to plugin MCP servers on bare-host boots

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - `/claude-code-hermit:channel-setup` adds the channel entry itself when `channels` is empty, instead of stopping and pointing at `/claude-code-hermit:hermit-settings` — that skill carries `disable-model-invocation`, so nothing could reach it and the operator was left to type the command.
 - `/claude-code-hermit:channel-setup` now treats a channel with `enabled: false` as disabled rather than configured, and offers to re-enable it instead of proceeding as though it were live.
+- Bare-host (non-Docker) boots now export each channel's `<CHANNEL>_STATE_DIR` into the session environment, so channel plugin servers find their state dir instead of failing with `CONNECTION_CLOSED`.
 
 ## [1.2.42] - 2026-08-19
 

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -24,6 +24,7 @@ import { defaultConfigDir, readTokenValue, TOKEN_ENV_VAR } from './lib/setup-tok
 import { sharedLivenessAgeSecs, LIVENESS_FRESH_SECS } from './lib/liveness';
 import { isContainer } from './lib/container';
 import { pyTruthy, isDict, iterChannelConfigs, getEnabledChannels } from './lib/channel-config';
+import { ENV_VAR_RE } from './validate-config';
 import { cmpSemver } from './lib/semver';
 
 type Json = any;
@@ -658,8 +659,9 @@ function buildClaudeCommand(config: Json, tools: Json): string[] {
  * Write config env vars to .claude/settings.local.json.
  *
  * Claude Code reads the `env` key from settings.json and exports those
- * values to all subprocesses (hooks, MCP servers, Bash tool calls).
- * This is the canonical way to set env vars per the official docs.
+ * values to hooks and Bash tool calls. It does NOT reach plugin MCP servers
+ * (anthropics/claude-code#11927, open), so anything a channel plugin needs is
+ * also hydrated into process.env here — see the channel loop below.
  *
  * Auth vars (ANTHROPIC_API_KEY, CLAUDE_CONFIG_DIR) are NOT written here —
  * they must be in the shell env before claude launches. OAuth credentials
@@ -717,9 +719,19 @@ function writeSettingsEnv(config: Json): void {
     const stateDir = chCfg.state_dir;
     if (pyTruthy(stateDir)) {
       // Relative paths resolved against project root (cwd at boot).
-      // In Docker, compose sets *_STATE_DIR via ${PWD} (host-side);
-      // this expansion covers the non-Docker (tmux) boot path.
-      settings.env[`${chName.toUpperCase()}_STATE_DIR`] = resolveStateDir(stateDir);
+      const key = `${chName.toUpperCase()}_STATE_DIR`;
+      settings.env[key] = resolveStateDir(stateDir);
+      // Both bare-host launches read the value from here: the tmux path copies
+      // it into the env file it sources, the no-tmux path inherits it via execvp.
+      //
+      // Skip a name that isn't a valid shell identifier — that env file is
+      // sourced as `export <key>=...`, where the key cannot be quoted, so an
+      // invalid one aborts the boot and a hostile one could inject a command.
+      if (!ENV_VAR_RE.test(key)) {
+        console.log(`[hermit] Warning: channel "${chName}" has no valid env-var name — ${key} not exported.`);
+      } else if (process.env[key] === undefined) {
+        process.env[key] = settings.env[key]; // already-set (Docker/compose) wins
+      }
     }
   }
 

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -718,18 +718,20 @@ function writeSettingsEnv(config: Json): void {
   for (const [chName, chCfg] of iterChannelConfigs(config)) {
     const stateDir = chCfg.state_dir;
     if (pyTruthy(stateDir)) {
-      // Relative paths resolved against project root (cwd at boot).
       const key = `${chName.toUpperCase()}_STATE_DIR`;
+      // Skip a name that isn't a valid shell identifier — the tmux env file is
+      // sourced as `export <key>=...`, where the key cannot be quoted, so an
+      // invalid one aborts the boot and a hostile one could inject a command.
+      // The forwardVars loop in main() drops the same names for that reason.
+      if (!ENV_VAR_RE.test(key)) {
+        console.log(`[hermit] Warning: channel "${chName}" has no valid env-var name — ${key} not exported.`);
+        continue;
+      }
+      // Relative paths resolved against project root (cwd at boot).
       settings.env[key] = resolveStateDir(stateDir);
       // Both bare-host launches read the value from here: the tmux path copies
       // it into the env file it sources, the no-tmux path inherits it via execvp.
-      //
-      // Skip a name that isn't a valid shell identifier — that env file is
-      // sourced as `export <key>=...`, where the key cannot be quoted, so an
-      // invalid one aborts the boot and a hostile one could inject a command.
-      if (!ENV_VAR_RE.test(key)) {
-        console.log(`[hermit] Warning: channel "${chName}" has no valid env-var name — ${key} not exported.`);
-      } else if (process.env[key] === undefined) {
+      if (process.env[key] === undefined) {
         process.env[key] = settings.env[key]; // already-set (Docker/compose) wins
       }
     }
@@ -1066,9 +1068,14 @@ async function main(): Promise<void> {
   // inherit shell env but don't read settings.local.json.
   const forwardVars = ['CLAUDE_CONFIG_DIR', 'ANTHROPIC_API_KEY', TOKEN_ENV_VAR, 'AGENT_HOOK_PROFILE'];
   // *_STATE_DIR vars must reach MCP servers via OS env — see writeSettingsEnv.
+  // The same identifier guard applies here: these become unquotable
+  // `export <key>=...` lines below, so an ambient var under an invalid name
+  // (compose `environment:`, an `env NAME=... hermit-start` wrapper) must not
+  // slip through and break the sourcing — or inject a command.
   for (const [chName, chCfg] of iterChannelConfigs(config)) {
-    if (pyTruthy(chCfg.state_dir)) {
-      forwardVars.push(`${chName.toUpperCase()}_STATE_DIR`);
+    const key = `${chName.toUpperCase()}_STATE_DIR`;
+    if (pyTruthy(chCfg.state_dir) && ENV_VAR_RE.test(key)) {
+      forwardVars.push(key);
     }
   }
   const envFile = path.join('/tmp', `.hermit-env-${sessionName}`);

--- a/plugins/claude-code-hermit/scripts/validate-config.ts
+++ b/plugins/claude-code-hermit/scripts/validate-config.ts
@@ -648,7 +648,7 @@ function main() {
 }
 
 // Allow tests to import individual functions
-export { parseCronField, validateCronSchedule, validate, isLoopbackUrl, ROUTINE_ID_RE };
+export { parseCronField, validateCronSchedule, validate, isLoopbackUrl, ROUTINE_ID_RE, ENV_VAR_RE };
 
 if (import.meta.main) {
   main();

--- a/plugins/claude-code-hermit/tests/hermit-start.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-start.test.ts
@@ -797,6 +797,8 @@ describe('writeSettingsEnv', () => {
     captureLog(() => writeSettingsEnv(config));
     expect(stateDirEnv('MS-TEAMS')).toBeUndefined();
     expect(stateDirEnv('X; TOUCH /TMP/HERMIT-PWNED')).toBeUndefined();
+    // Nor persisted to settings.local.json, which Claude Code also exports.
+    expect(readSettings().env['MS-TEAMS_STATE_DIR']).toBeUndefined();
   });
 
   test('existing *_STATE_DIR in env wins over config (Docker sets it via compose)', () => {

--- a/plugins/claude-code-hermit/tests/hermit-start.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-start.test.ts
@@ -66,12 +66,21 @@ let origCwd = '';
 let origProfile: string | undefined;
 let origContainer: string | undefined;
 let origPath: string | undefined;
+// writeSettingsEnv hydrates <CHANNEL>_STATE_DIR into process.env, so any test
+// that configures a channel state_dir leaks it into the next one without this.
+// Swept generically: the hydration is per-channel, not a fixed set of names.
+let origStateDirs: Record<string, string | undefined> = {};
 
 beforeEach(() => {
   origCwd = process.cwd();
   origProfile = process.env.AGENT_HOOK_PROFILE;
   origContainer = process.env.container;
   origPath = process.env.PATH;
+  origStateDirs = Object.fromEntries(
+    Object.keys(process.env)
+      .filter((k) => k.endsWith('_STATE_DIR'))
+      .map((k) => [k, process.env[k]]),
+  );
   tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-start-test-'));
   process.chdir(tmpdir);
   fs.mkdirSync('.claude-code-hermit/state', { recursive: true });
@@ -88,12 +97,18 @@ afterEach(() => {
   restore('AGENT_HOOK_PROFILE', origProfile);
   restore('container', origContainer);
   restore('PATH', origPath);
+  const stateDirKeys = new Set([
+    ...Object.keys(process.env).filter((k) => k.endsWith('_STATE_DIR')),
+    ...Object.keys(origStateDirs),
+  ]);
+  for (const k of stateDirKeys) restore(k, origStateDirs[k]);
 });
 
 // ---------- small helpers ----------
 
 // Accessor defeats TS control-flow narrowing after `delete process.env...`.
 const profileEnv = (): string | undefined => process.env.AGENT_HOOK_PROFILE;
+const stateDirEnv = (channel: string): string | undefined => process.env[`${channel}_STATE_DIR`];
 
 const writeConfig = (config: any) =>
   fs.writeFileSync('.claude-code-hermit/config.json', JSON.stringify(config));
@@ -744,6 +759,54 @@ describe('writeSettingsEnv', () => {
     captureLog(() => writeSettingsEnv(config));
     const expected = path.join(process.cwd(), '.claude.local/channels/discord');
     expect(readSettings().env.DISCORD_STATE_DIR).toBe(expected);
+  });
+
+  // Claude Code does not pass settings env to plugin MCP servers
+  // (anthropics/claude-code#11927), so the bare-host boot paths depend on this
+  // hydration to get the value into the tmux env file / execvp'd process.
+  test('every channel state_dir is hydrated into process env for MCP servers', () => {
+    writeConfig({
+      channels: {
+        discord: { enabled: true, state_dir: '.claude.local/channels/discord' },
+        telegram: { enabled: true, state_dir: '.claude.local/channels/telegram' },
+      },
+    });
+    const config = loadConfig();
+    delete process.env.DISCORD_STATE_DIR;
+    delete process.env.TELEGRAM_STATE_DIR;
+    captureLog(() => writeSettingsEnv(config));
+    expect(stateDirEnv('DISCORD')).toBe(
+      path.join(process.cwd(), '.claude.local/channels/discord'),
+    );
+    expect(stateDirEnv('TELEGRAM')).toBe(
+      path.join(process.cwd(), '.claude.local/channels/telegram'),
+    );
+  });
+
+  // The tmux boot writes `export <key>=...` into a file it sources, and the key
+  // is not quotable there: an invalid identifier fails the sourcing and kills
+  // the boot, a hostile one injects a command.
+  test('channel name that is not a valid env identifier is not hydrated', () => {
+    writeConfig({
+      channels: {
+        'ms-teams': { enabled: true, state_dir: '/tmp/teams' },
+        'x; touch /tmp/hermit-pwned': { enabled: true, state_dir: '/tmp/evil' },
+      },
+    });
+    const config = loadConfig();
+    captureLog(() => writeSettingsEnv(config));
+    expect(stateDirEnv('MS-TEAMS')).toBeUndefined();
+    expect(stateDirEnv('X; TOUCH /TMP/HERMIT-PWNED')).toBeUndefined();
+  });
+
+  test('existing *_STATE_DIR in env wins over config (Docker sets it via compose)', () => {
+    writeConfig({
+      channels: { discord: { enabled: true, state_dir: '/tmp/from-config' } },
+    });
+    const config = loadConfig();
+    process.env.DISCORD_STATE_DIR = '/container/state/discord';
+    captureLog(() => writeSettingsEnv(config));
+    expect(stateDirEnv('DISCORD')).toBe('/container/state/discord');
   });
 
   test('invalid AGENT_HOOK_PROFILE defaults to standard in process env', () => {


### PR DESCRIPTION
## Summary

On a bare-host (tmux or no-tmux) hermit, channel plugins never received their `<CHANNEL>_STATE_DIR`. The plugin fell back to `~/.claude/channels/<plugin>/`, found no credentials, and exited — the operator saw only `CONNECTION_CLOSED`. Docker hermits were unaffected, which is why this went unnoticed.

The root cause is upstream: Claude Code does not pass `settings.json` / `settings.local.json` `env` entries to plugin MCP servers ([anthropics/claude-code#11927](https://github.com/anthropics/claude-code/issues/11927), still open and reproducing on 2.1.235). `hermit-start` wrote the value into `settings.local.json` and then forwarded it into the tmux env file by reading it back out of `process.env` — where nothing had ever set it. Under Docker, compose sets the variable in the container environment, so that read found a real value and forwarding worked.

The fix hydrates `process.env` from the config instead, following the existing `hydrateSetupTokenEnv` precedent in the same file. That covers both bare-host launches at once: the tmux path copies it into the env file it sources, and the no-tmux path inherits it through `execvp`. An already-set value still wins, so Docker keeps its current behaviour. The `settings.local.json` write is kept as forward-compat for whenever the upstream bug is fixed.

## Changes

- `scripts/hermit-start.ts` — hydrate each channel's `<CHANNEL>_STATE_DIR` into `process.env` inside the existing `writeSettingsEnv` channel loop; corrected two comments that documented the settings-`env` mechanism as reaching MCP servers.
- Guard on the derived name being a valid shell identifier. The tmux env file is sourced as `export <key>=...` with an unquotable key, so a channel named `ms-teams` would emit an invalid assignment, fail the sourcing, and short-circuit the `&& claude` chain — the hermit would never boot. A hostile name could inject a command the same way. Invalid names are skipped with a warning, which is exactly today's behaviour, so nothing regresses.
- `scripts/validate-config.ts` — export the existing `ENV_VAR_RE` (same pattern, already used to validate `bearer_env`) rather than duplicating the regex; joins `ROUTINE_ID_RE` as a shared constant.
- `tests/hermit-start.test.ts` — three new cases: multi-channel hydration (discord + telegram, proving it is not channel-specific), invalid/hostile channel names are not hydrated, and a pre-set env value wins over config. Env save/restore in the shared harness now sweeps `*_STATE_DIR` generically so tests can't leak into each other.

## Test plan

- `bun test` from `plugins/claude-code-hermit/` — 3945 pass, 0 fail.
- `bunx tsc --noEmit` from the repo root — exit 0.
- The new hydration test was confirmed to fail (`Received: undefined`) with the source change reverted, so it genuinely exercises the fix.
- The boot-breaking `export MS-TEAMS_STATE_DIR=...` behaviour was reproduced in a shell before adding the guard: bash rejects it and the `&&` chain aborts.
- Manual check for a bare-host hermit with a configured channel: boot via `.claude-code-hermit/bin/hermit-start`, then `echo $DISCORD_STATE_DIR` shows the resolved path and `/mcp` shows the plugin connected.

## Notes for review

Two things deliberately left out of scope:

- `/discord:access` writes its allowlist to the default path while the server reads the one under `DISCORD_STATE_DIR` ([anthropics/claude-code#83057](https://github.com/anthropics/claude-code/issues/83057)) — worth knowing during manual verification, since an allowlist edit may appear to no-op.
- A channel plugin that reads some other env var name (not `<CHANNEL>_STATE_DIR`) still can't be served, since `config.env` also lands only in `settings.local.json` and hits the same upstream bug. Pre-existing; worth its own issue if a channel ever needs it.

Closes #741