### PR TITLE
fix(claude-code-hermit): answer "which model am I on" from the transcript after a channel switch

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `/claude-code-hermit:channel-setup` adds the channel entry itself when `channels` is empty, instead of stopping and pointing at `/claude-code-hermit:hermit-settings` — that skill carries `disable-model-invocation`, so nothing could reach it and the operator was left to type the command.
 - `/claude-code-hermit:channel-setup` now treats a channel with `enabled: false` as disabled rather than configured, and offers to re-enable it instead of proceeding as though it were live.
 - Bare-host (non-Docker) boots now export each channel's `<CHANNEL>_STATE_DIR` into the session environment, so channel plugin servers find their state dir instead of failing with `CONNECTION_CLOSED`.
+- A channel-requested `/model` or `/effort` switch is now reported back from the transcript, which stamps the serving model on every assistant entry. The switch itself always applied, but the session's own sense of which model it runs is fixed at session start and never followed it, so asked "did it work?" a hermit answered from that stale value and reported a working switch as a silent failure. The report is held until an assistant entry newer than the delivery exists, so the pre-switch entry can never be the answer.
 
 ## [1.2.42] - 2026-08-19
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `/claude-code-hermit:channel-setup` adds the channel entry itself when `channels` is empty, instead of stopping and pointing at `/claude-code-hermit:hermit-settings` — that skill carries `disable-model-invocation`, so nothing could reach it and the operator was left to type the command.
 - `/claude-code-hermit:channel-setup` now treats a channel with `enabled: false` as disabled rather than configured, and offers to re-enable it instead of proceeding as though it were live.
 - Bare-host (non-Docker) boots now export each channel's `<CHANNEL>_STATE_DIR` into the session environment, so channel plugin servers find their state dir instead of failing with `CONNECTION_CLOSED`.
-- A channel-requested `/model` or `/effort` switch is now reported back from the transcript, which stamps the serving model on every assistant entry. The switch itself always applied, but the session's own sense of which model it runs is fixed at session start and never followed it, so asked "did it work?" a hermit answered from that stale value and reported a working switch as a silent failure. The report is held until an assistant entry newer than the delivery exists, so the pre-switch entry can never be the answer.
+- A channel-requested `/model` or `/effort` switch is now reported back from the transcript's serving-model stamp instead of the session's stale session-start self-perception, with the report held until an assistant entry newer than the delivery exists.
 
 ## [1.2.42] - 2026-08-19
 

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -731,7 +731,10 @@ function writeSettingsEnv(config: Json): void {
       settings.env[key] = resolveStateDir(stateDir);
       // Both bare-host launches read the value from here: the tmux path copies
       // it into the env file it sources, the no-tmux path inherits it via execvp.
-      if (process.env[key] === undefined) {
+      // Truthiness, not presence: an empty ambient value (a profile leak, an unset
+      // compose interpolation) would otherwise win over the config path and hand
+      // the MCP server an empty state dir — an empty state dir is never intent.
+      if (!pyTruthy(process.env[key])) {
         process.env[key] = settings.env[key]; // already-set (Docker/compose) wins
       }
     }

--- a/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
@@ -354,6 +354,43 @@ function entryText(entry: Json): string {
 }
 
 /**
+ * The model that most recently served this session, per the transcript.
+ *
+ * Ground truth for "what am I running": the serving model is stamped on every
+ * assistant entry, whereas the model's own sense of it is fixed at session start
+ * and does not follow a mid-session /model switch (live-verified — an Opus-served
+ * turn reported itself as Sonnet).
+ *
+ * Sidechains are excluded: a subagent dispatched with its own model would
+ * otherwise answer for the main session. Reads a bounded tail only — 64KB is far
+ * more than the handful of entries needed and keeps this cheap on every prompt.
+ *
+ * @param {string} filePath
+ * @returns {{ model: string, timestamp: string } | null} null when unreadable or
+ *   when the window holds no qualifying entry.
+ */
+function lastAssistantModel(filePath: string): { model: string; timestamp: string } | null {
+  const TAIL_BYTES = 65536;
+  try {
+    const { lines } = readTailLines(filePath, TAIL_BYTES);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      let entry: Json;
+      try { entry = JSON.parse(line); } catch { continue; }
+      if (!entry || entry.type !== 'assistant' || entry.isSidechain === true) continue;
+      const model = entry.message?.model;
+      if (typeof model !== 'string' || !model) continue;
+      if (typeof entry.timestamp !== 'string' || !entry.timestamp) continue;
+      return { model, timestamp: entry.timestamp };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * A user entry is a tool_result carrier (not a turn boundary) when its content
  * is an array containing any tool_result block. The triggering prompt that
  * opens a turn is a "real" user entry: string content, or an array with no
@@ -612,6 +649,7 @@ export {
   backgroundTasks,
   // Transcript parsing
   readTailLines,
+  lastAssistantModel,
   entryText,
   isToolResult,
   extractUsage,

--- a/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
@@ -381,7 +381,10 @@ function lastAssistantModel(filePath: string): { model: string; timestamp: strin
       if (!entry || entry.type !== 'assistant' || entry.isSidechain === true) continue;
       const model = entry.message?.model;
       if (typeof model !== 'string' || !model) continue;
-      if (typeof entry.timestamp !== 'string' || !entry.timestamp) continue;
+      // Parseable, not just present: the harness-verify gate compares this with
+      // Date.parse, and NaN fails every comparison — which would take the
+      // fail-OPEN branch there. Skip the entry instead.
+      if (typeof entry.timestamp !== 'string' || Number.isNaN(Date.parse(entry.timestamp))) continue;
       return { model, timestamp: entry.timestamp };
     }
     return null;

--- a/plugins/claude-code-hermit/scripts/lib/harness-command.ts
+++ b/plugins/claude-code-hermit/scripts/lib/harness-command.ts
@@ -64,6 +64,18 @@ export type PendingCommand = {
  * wedged for an hour should not suddenly clear its context when it recovers.
  */
 export const COMMAND_MARKER_TTL_SECS = 3600;
+
+/**
+ * The switch-verify marker records an already-delivered switch to OBSERVE, not a
+ * command to retry — it does not go stale the way a pending command does, and it
+ * self-clears the moment the switch is observed. Reusing the 1-hour delivery TTL
+ * silently reproduced the original stale-answer bug whenever no prompt arrived
+ * within the hour (idle overnight, heartbeat paused). A day covers any realistic
+ * gap; the TTL only remains as a backstop against a marker that can never be
+ * observed (e.g. no transcript_path on this harness) injecting its hold-warning
+ * forever.
+ */
+export const SWITCH_VERIFY_TTL_SECS = 86_400;
 const HARNESS_CONFIRM_TAIL_LINES = 20;
 
 const SWITCH_CONFIRMATION_ANCHORS: Record<string, readonly string[]> = {
@@ -191,7 +203,7 @@ export function readSwitchVerify(hermitRoot: string): SwitchVerifyMarker | null 
 
     const ts = Date.parse(parsed.delivered_at);
     if (Number.isNaN(ts)) return null;
-    if ((Date.now() - ts) / 1000 > COMMAND_MARKER_TTL_SECS) {
+    if ((Date.now() - ts) / 1000 > SWITCH_VERIFY_TTL_SECS) {
       clearSwitchVerify(hermitRoot);
       return null;
     }

--- a/plugins/claude-code-hermit/scripts/lib/harness-command.ts
+++ b/plugins/claude-code-hermit/scripts/lib/harness-command.ts
@@ -103,8 +103,7 @@ function markerPath(hermitRoot: string): string {
 }
 
 /** Atomic tmp+rename write. Returns false on any failure — callers must not ack a failed write. */
-export function writePendingCommand(hermitRoot: string, entry: PendingCommand): boolean {
-  const target = markerPath(hermitRoot);
+function writeMarker(target: string, entry: unknown): boolean {
   const tmp = `${target}.${process.pid}.tmp`;
   try {
     fs.mkdirSync(path.dirname(target), { recursive: true });
@@ -115,6 +114,10 @@ export function writePendingCommand(hermitRoot: string, entry: PendingCommand): 
     try { fs.unlinkSync(tmp); } catch {}
     return false;
   }
+}
+
+export function writePendingCommand(hermitRoot: string, entry: PendingCommand): boolean {
+  return writeMarker(markerPath(hermitRoot), entry);
 }
 
 /** Read the marker, or null when absent, malformed, or past its TTL. */
@@ -142,4 +145,64 @@ export function clearPendingCommand(hermitRoot: string): void {
 /** Render a marker back to the literal text typed into the pane. */
 export function renderCommand(entry: { command: string; arg: string | null }): string {
   return entry.arg ? `${entry.command} ${entry.arg}` : entry.command;
+}
+
+// --- Post-delivery verification -------------------------------------------
+//
+// A delivered /model or /effort switch applies to the session, but the model's own
+// sense of which model it runs is fixed at session start and does not follow the
+// switch — live-verified on two hermits, where an Opus-served turn reported itself
+// as Sonnet. Asked "did it work?", the session answered from that stale
+// self-perception and reported a working switch as a silent failure.
+//
+// So the delivery leaves this marker behind and the prompt path answers the
+// question from the transcript instead, which carries the serving model per
+// assistant message. Separate from the pending marker on purpose: that one is
+// consumed by the Stop hook to DO the switch, this one by the UserPromptSubmit
+// path to OBSERVE it, and a delivery writes the second exactly when it clears the
+// first.
+
+export type SwitchVerifyMarker = {
+  command: string;
+  arg: string | null;
+  by: string;
+  delivered_at: string;
+};
+
+function switchVerifyPath(hermitRoot: string): string {
+  return path.join(hermitRoot, 'state', 'harness-switch-verify.json');
+}
+
+/** Atomic tmp+rename write. Returns false on any failure. */
+export function writeSwitchVerify(hermitRoot: string, entry: SwitchVerifyMarker): boolean {
+  return writeMarker(switchVerifyPath(hermitRoot), entry);
+}
+
+/**
+ * Read the marker, or null when absent, malformed, or past its TTL.
+ *
+ * Self-cleaning, unlike readPendingCommand: nothing else ever consumes this file, so
+ * an expired one left on disk would sit there until the next switch overwrote it.
+ */
+export function readSwitchVerify(hermitRoot: string): SwitchVerifyMarker | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(switchVerifyPath(hermitRoot), 'utf-8')) as SwitchVerifyMarker;
+    if (!parsed || typeof parsed.command !== 'string') return null;
+
+    const ts = Date.parse(parsed.delivered_at);
+    if (Number.isNaN(ts)) return null;
+    if ((Date.now() - ts) / 1000 > COMMAND_MARKER_TTL_SECS) {
+      clearSwitchVerify(hermitRoot);
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Delete the marker. Call once the switch has been observed in the transcript. */
+export function clearSwitchVerify(hermitRoot: string): void {
+  try { fs.unlinkSync(switchVerifyPath(hermitRoot)); } catch {}
 }

--- a/plugins/claude-code-hermit/scripts/lib/harness-drain.ts
+++ b/plugins/claude-code-hermit/scripts/lib/harness-drain.ts
@@ -5,7 +5,7 @@
 import { readRuntimeJson } from './runtime';
 import { sendKeys, tmuxSessionAlive } from './tmux';
 import { applyContextReset } from './context-reset';
-import { clearPendingCommand, readPendingCommand, renderCommand } from './harness-command';
+import { clearPendingCommand, readPendingCommand, renderCommand, writeSwitchVerify } from './harness-command';
 import { currentHHMMOrUTC } from './time';
 import { readSettledConfig } from './config-read';
 import path from 'node:path';
@@ -58,6 +58,18 @@ export function drainHarnessCommand(hermitRoot: string): void {
   // dialog after this process exits; doing a synchronous capture here races a pane that
   // cannot render yet.
   if (pending.command === '/model' || pending.command === '/effort') {
+    // The session cannot see its own switch: the model's sense of which model it runs
+    // is fixed at session start. Leave a marker so the prompt path answers that from
+    // the transcript instead of from stale self-perception (lib/prompt-stages/
+    // harness-verify.ts). Only a confirmed send reaches here, so the marker can never
+    // describe a switch that was not delivered.
+    writeSwitchVerify(hermitRoot, {
+      command: pending.command,
+      arg: pending.arg,
+      by: pending.by,
+      delivered_at: new Date().toISOString(),
+    });
+
     const helper = path.join(import.meta.dir, '..', 'confirm-harness-switch.ts');
     const child = Bun.spawn([process.execPath, helper, sessionName, pending.command], {
       stdin: 'ignore',

--- a/plugins/claude-code-hermit/scripts/lib/prompt-stages/harness-verify.ts
+++ b/plugins/claude-code-hermit/scripts/lib/prompt-stages/harness-verify.ts
@@ -22,6 +22,22 @@ import { readSwitchVerify, clearSwitchVerify, renderCommand } from '../harness-c
 import { lastAssistantModel } from '../cc-compat';
 import type { StageContext, StageResult } from './types';
 
+/**
+ * delivered_at is stamped when the keys hit the pane, but the switch APPLIES only when
+ * confirm-harness-switch.ts accepts the dialog — up to its polling deadline later. An
+ * assistant entry inside that window postdates the delivery yet was served by the old
+ * model, so treating "newer than delivered_at" as "post-switch" would report the old
+ * model as authoritative and burn the marker. Holding for the helper's full deadline
+ * closes that window at the cost of one extra held prompt at worst.
+ *
+ * NOTE: this hardcodes the same 5s ceiling confirm-harness-switch.ts caps its own
+ * poll at (scripts/confirm-harness-switch.ts:15-16). The two are not wired together —
+ * if that cap changes, this grace window silently stops covering it and the stale-
+ * answer bug this file exists to fix comes back. Consider exporting the ceiling from
+ * lib/harness-command.ts and importing it in both places instead of copying the literal.
+ */
+const SWITCH_APPLY_GRACE_MS = 5_000;
+
 export function run(ctx: StageContext): StageResult | void {
   const pending = readSwitchVerify(ctx.dir);
   if (!pending) return;
@@ -29,15 +45,23 @@ export function run(ctx: StageContext): StageResult | void {
   const rendered = renderCommand(pending);
   const observed = ctx.transcriptPath ? lastAssistantModel(ctx.transcriptPath) : null;
 
-  // No transcript to read, or nothing served since the switch landed: hold the marker
-  // and warn rather than answer from a pre-switch entry.
-  if (!observed || Date.parse(observed.timestamp) <= Date.parse(pending.delivered_at)) {
+  // No transcript to read, or nothing served since the switch could have applied: hold
+  // the marker and warn rather than answer from a pre-switch entry.
+  if (!observed || Date.parse(observed.timestamp) <= Date.parse(pending.delivered_at) + SWITCH_APPLY_GRACE_MS) {
     return {
       context: `[harness-command] "${rendered}" was delivered to this session at ${pending.delivered_at} and is not yet observable in the transcript. Your own sense of which model you run is fixed at session start and does not follow a switch — do not report it as the active one.\n`,
     };
   }
 
   clearSwitchVerify(ctx.dir);
+  // The transcript stamps only the serving model. That verifies a /model switch
+  // outright; for /effort it can confirm delivery but not the new effort level, and
+  // saying otherwise would be a false positive the transcript cannot support.
+  if (pending.command === '/effort') {
+    return {
+      context: `[harness-command] "${rendered}" was delivered at ${pending.delivered_at}. The transcript stamps only the serving model (currently ${observed.model}), not the effort level, so report the switch as delivered — not as confirmed.\n`,
+    };
+  }
   return {
     context: `[harness-command] "${rendered}" delivered at ${pending.delivered_at} — the transcript now reports model ${observed.model}. That is the session's serving model; prefer it over your own sense of which model you run.\n`,
   };

--- a/plugins/claude-code-hermit/scripts/lib/prompt-stages/harness-verify.ts
+++ b/plugins/claude-code-hermit/scripts/lib/prompt-stages/harness-verify.ts
@@ -1,0 +1,44 @@
+// UserPromptSubmit stage — report a delivered /model or /effort switch back to the
+// session from the transcript.
+//
+// The gap this closes: delivery works (the Stop hook types the command into the pane
+// and Claude Code applies it), but the model's sense of WHICH model it is running is
+// fixed at session start and does not follow the switch. Asked "did it work?", the
+// session answered from that stale self-perception and reported a working switch as a
+// silent failure — twice, on two hermits, one of which then filed an upstream bug for
+// a bug that did not exist.
+//
+// So the answer comes from the transcript instead, where the serving model is stamped
+// on every assistant entry. This stage states the fact and nothing more; how it reaches
+// the operator is the model's business.
+//
+// The timestamp gate is the whole correctness argument: on the prompt immediately after
+// delivery the newest assistant entry is still the PRE-switch one, so reporting it would
+// reproduce exactly the stale answer this exists to prevent. Until an entry newer than
+// the delivery exists, the marker is held and the session is told only that its
+// self-perception may be stale.
+
+import { readSwitchVerify, clearSwitchVerify, renderCommand } from '../harness-command';
+import { lastAssistantModel } from '../cc-compat';
+import type { StageContext, StageResult } from './types';
+
+export function run(ctx: StageContext): StageResult | void {
+  const pending = readSwitchVerify(ctx.dir);
+  if (!pending) return;
+
+  const rendered = renderCommand(pending);
+  const observed = ctx.transcriptPath ? lastAssistantModel(ctx.transcriptPath) : null;
+
+  // No transcript to read, or nothing served since the switch landed: hold the marker
+  // and warn rather than answer from a pre-switch entry.
+  if (!observed || Date.parse(observed.timestamp) <= Date.parse(pending.delivered_at)) {
+    return {
+      context: `[harness-command] "${rendered}" was delivered to this session at ${pending.delivered_at} and is not yet observable in the transcript. Your own sense of which model you run is fixed at session start and does not follow a switch — do not report it as the active one.\n`,
+    };
+  }
+
+  clearSwitchVerify(ctx.dir);
+  return {
+    context: `[harness-command] "${rendered}" delivered at ${pending.delivered_at} — the transcript now reports model ${observed.model}. That is the session's serving model; prefer it over your own sense of which model you run.\n`,
+  };
+}

--- a/plugins/claude-code-hermit/scripts/lib/prompt-stages/types.ts
+++ b/plugins/claude-code-hermit/scripts/lib/prompt-stages/types.ts
@@ -18,6 +18,11 @@ export interface StageContext {
   prompt: string;
   /** Parsed channel envelope, or null for operator/internal input. */
   envelope: ChannelEnvelope | null;
+  /**
+   * The hook payload's `transcript_path`, or null when absent (CC documents it as
+   * present on most, not all, events). Stages treat null as "can't tell" and fail closed.
+   */
+  transcriptPath: string | null;
   /** config.json, read at most once per prompt regardless of how many stages ask. */
   config(): any;
   /** state/runtime.json, read at most once per prompt. */

--- a/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
@@ -130,10 +130,16 @@ async function main(raw: string): Promise<void> {
   // kill can lose a send but never a state write.
   await stage('pause-keyword', pauseKeyword, ctx);
   await stage('harness-command', harnessCommand, ctx);
-  await stage('harness-verify', harnessVerify, ctx);
 
   // 6. Deterministic status.
   await stage('channel-status-responder', channelStatusResponder, ctx);
+
+  // 7. Switch verification LAST, and specifically after the status responder:
+  // its success path clears the verify marker, and a blocked prompt discards all
+  // accumulated context (see emit()). Running it earlier let a blocked `status`
+  // turn destroy the marker with the report unread — stage() skips it entirely
+  // once a block is settled, so the marker survives for the next real prompt.
+  await stage('harness-verify', harnessVerify, ctx);
 }
 
 function emit(): void {

--- a/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
@@ -29,7 +29,7 @@ process.stdout.on('error', () => {});
 // block on a failed send, and per-stage errors are isolated — a throwing stage
 // is logged to stderr and the rest still run (the stop-pipeline.ts pattern).
 
-import { hermitDir } from './lib/cc-compat';
+import { hermitDir, transcriptPath as ccTranscriptPath } from './lib/cc-compat';
 import { parseChannelEnvelope } from './lib/channel-envelope';
 import { readConfigRaw } from './lib/config-read';
 import { readRuntimeJson } from './lib/runtime';
@@ -40,6 +40,7 @@ import { run as promptContext } from './lib/prompt-stages/prompt-context';
 import { run as channelReplyReminder } from './lib/prompt-stages/channel-reply-reminder';
 import { run as pauseKeyword } from './lib/prompt-stages/pause-keyword';
 import { run as harnessCommand } from './lib/prompt-stages/harness-command';
+import { run as harnessVerify } from './lib/prompt-stages/harness-verify';
 import { run as shutdownGate } from './lib/prompt-stages/shutdown-gate';
 import { run as channelStatusResponder } from './lib/prompt-stages/channel-status-responder';
 
@@ -66,9 +67,11 @@ async function main(raw: string): Promise<void> {
   // Defensive parse: stages that don't need the payload still run on bad input,
   // exactly as stop-pipeline.ts does.
   let prompt: string | null = null;
+  let transcript: string | null = null;
   try {
     const payload = JSON.parse(raw);
     prompt = payload && typeof payload.prompt === 'string' ? payload.prompt : null;
+    transcript = ccTranscriptPath(payload);
   } catch {
     process.stderr.write('[user-prompt-pipeline] malformed stdin — continuing with an empty prompt\n');
     // A parse failure on non-empty stdin means a prompt did arrive and was
@@ -93,6 +96,7 @@ async function main(raw: string): Promise<void> {
     dir,
     prompt,
     envelope: parseChannelEnvelope(prompt),
+    transcriptPath: transcript,
     config() {
       // Raw, not settled: shutdown-gate and channel-status-responder treat a
       // null config as a disclosure gate (silent no-op); settling would loosen it.
@@ -126,6 +130,7 @@ async function main(raw: string): Promise<void> {
   // kill can lose a send but never a state write.
   await stage('pause-keyword', pauseKeyword, ctx);
   await stage('harness-command', harnessCommand, ctx);
+  await stage('harness-verify', harnessVerify, ctx);
 
   // 6. Deterministic status.
   await stage('channel-status-responder', channelStatusResponder, ctx);

--- a/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
+++ b/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
@@ -40,6 +40,8 @@ const SWITCH_CASES = [
 const hermit = (dir: string, ...parts: string[]) =>
   path.join(dir, '.claude-code-hermit', ...parts);
 
+const switchVerifyMarker = (dir: string) => hermit(dir, 'state', 'harness-switch-verify.json');
+
 function seedPendingSwitch(dir: string, command: string, arg: string | null): void {
   fs.writeFileSync(hermit(dir, 'config.json'), JSON.stringify({ timezone: 'UTC' }));
   fs.writeFileSync(hermit(dir, 'state', 'runtime.json'), JSON.stringify({
@@ -251,6 +253,23 @@ Permission required
       expect(result.exitCode).toBe(0);
       expect(result.stderr).toContain('marker kept for retry');
       expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(true);
+      // Nothing was delivered, so there is nothing to verify against the transcript.
+      expect(fs.existsSync(switchVerifyMarker(dir))).toBe(false);
+    }));
+
+    test(`${label}: a delivered switch leaves a verify marker for the prompt path`, withDir(async (dir) => {
+      seedPendingSwitch(dir, command, arg);
+      const { bin, helperPid } = installFakeTmux(dir, 'Claude ready');
+
+      const result = await drain(dir, bin);
+      await waitForVerifierExit(helperPid);
+
+      expect(result.exitCode).toBe(0);
+      const verify = JSON.parse(fs.readFileSync(switchVerifyMarker(dir), 'utf-8'));
+      expect(verify.command).toBe(command);
+      expect(verify.arg).toBe(arg);
+      expect(verify.by).toBe('operator');
+      expect(Number.isNaN(Date.parse(verify.delivered_at))).toBe(false);
     }));
 
     test(`${label}: failed confirmation does not reissue the command`, withDir(async (dir) => {
@@ -305,6 +324,19 @@ describe('Stop hook reset-command delivery', () => {
     expect(readRuntime(dir).context_cleared).toBeUndefined();
     expect(fs.existsSync(statusCache)).toBe(true);
   }));
+
+  // Only /model and /effort change something the session then misreports about itself.
+  for (const command of ['/clear', '/compact']) {
+    test(`${command} leaves no switch-verify marker`, withDir(async (dir) => {
+      seedPendingSwitch(dir, command, null);
+      const { bin } = installFakeTmux(dir, 'Claude ready');
+
+      const result = await drain(dir, bin);
+
+      expect(result.exitCode).toBe(0);
+      expect(fs.existsSync(switchVerifyMarker(dir))).toBe(false);
+    }));
+  }
 
   test('a refused /clear send leaves no reset trace and keeps the marker', withDir(async (dir) => {
     seedPendingSwitch(dir, '/clear', null);

--- a/plugins/claude-code-hermit/tests/harness-command.test.ts
+++ b/plugins/claude-code-hermit/tests/harness-command.test.ts
@@ -13,6 +13,7 @@ import {
   readSwitchVerify,
   clearSwitchVerify,
   COMMAND_MARKER_TTL_SECS,
+  SWITCH_VERIFY_TTL_SECS,
 } from '../scripts/lib/harness-command';
 
 function tmpRoot(): string {
@@ -156,10 +157,20 @@ describe('switch-verify marker', () => {
   // Nothing else consumes this file, so an expired one must not linger on disk.
   test('marker past its TTL reads as null AND is deleted', () => {
     const root = tmpRoot();
-    const stale = new Date(Date.now() - (COMMAND_MARKER_TTL_SECS + 60) * 1000).toISOString();
+    const stale = new Date(Date.now() - (SWITCH_VERIFY_TTL_SECS + 60) * 1000).toISOString();
     writeSwitchVerify(root, { command: '/model', arg: 'fable', by: 'op', delivered_at: stale });
     expect(readSwitchVerify(root)).toBeNull();
     expect(fs.existsSync(verifyPath(root))).toBe(false);
+    fs.rmSync(root, { recursive: true });
+  });
+
+  // The verify marker outlives the 1h delivery TTL on purpose: it records a fact to
+  // observe, and expiring it while the session idled reproduced the stale-answer bug.
+  test('marker older than the delivery TTL but within its own TTL still reads', () => {
+    const root = tmpRoot();
+    const overnight = new Date(Date.now() - (COMMAND_MARKER_TTL_SECS + 3600) * 1000).toISOString();
+    writeSwitchVerify(root, { command: '/model', arg: 'fable', by: 'op', delivered_at: overnight });
+    expect(readSwitchVerify(root)?.arg).toBe('fable');
     fs.rmSync(root, { recursive: true });
   });
 

--- a/plugins/claude-code-hermit/tests/harness-command.test.ts
+++ b/plugins/claude-code-hermit/tests/harness-command.test.ts
@@ -9,6 +9,9 @@ import {
   readPendingCommand,
   clearPendingCommand,
   renderCommand,
+  writeSwitchVerify,
+  readSwitchVerify,
+  clearSwitchVerify,
   COMMAND_MARKER_TTL_SECS,
 } from '../scripts/lib/harness-command';
 
@@ -116,6 +119,70 @@ describe('pending-command marker', () => {
     writePendingCommand(root, { command: '/clear', arg: null, by: 'op', requested_at: new Date().toISOString() });
     clearPendingCommand(root);
     expect(readPendingCommand(root)).toBeNull();
+    fs.rmSync(root, { recursive: true });
+  });
+});
+
+describe('switch-verify marker', () => {
+  const verifyPath = (root: string) => path.join(root, 'state', 'harness-switch-verify.json');
+
+  test('round-trips a delivered switch', () => {
+    const root = tmpRoot();
+    const entry = {
+      command: '/model',
+      arg: 'fable',
+      by: 'op',
+      delivered_at: new Date().toISOString(),
+    };
+    expect(writeSwitchVerify(root, entry)).toBe(true);
+    expect(readSwitchVerify(root)).toEqual(entry);
+    fs.rmSync(root, { recursive: true });
+  });
+
+  test('absent marker reads as null', () => {
+    const root = tmpRoot();
+    expect(readSwitchVerify(root)).toBeNull();
+    fs.rmSync(root, { recursive: true });
+  });
+
+  test('malformed marker reads as null rather than throwing', () => {
+    const root = tmpRoot();
+    fs.mkdirSync(path.join(root, 'state'), { recursive: true });
+    fs.writeFileSync(verifyPath(root), '{not json');
+    expect(readSwitchVerify(root)).toBeNull();
+    fs.rmSync(root, { recursive: true });
+  });
+
+  // Nothing else consumes this file, so an expired one must not linger on disk.
+  test('marker past its TTL reads as null AND is deleted', () => {
+    const root = tmpRoot();
+    const stale = new Date(Date.now() - (COMMAND_MARKER_TTL_SECS + 60) * 1000).toISOString();
+    writeSwitchVerify(root, { command: '/model', arg: 'fable', by: 'op', delivered_at: stale });
+    expect(readSwitchVerify(root)).toBeNull();
+    expect(fs.existsSync(verifyPath(root))).toBe(false);
+    fs.rmSync(root, { recursive: true });
+  });
+
+  test('clear removes it', () => {
+    const root = tmpRoot();
+    writeSwitchVerify(root, {
+      command: '/effort',
+      arg: 'high',
+      by: 'op',
+      delivered_at: new Date().toISOString(),
+    });
+    clearSwitchVerify(root);
+    expect(readSwitchVerify(root)).toBeNull();
+    fs.rmSync(root, { recursive: true });
+  });
+
+  // Singleton, matching the pending marker: two switches collapse to the last.
+  test('a second switch overwrites the first', () => {
+    const root = tmpRoot();
+    const now = new Date().toISOString();
+    writeSwitchVerify(root, { command: '/model', arg: 'fable', by: 'op', delivered_at: now });
+    writeSwitchVerify(root, { command: '/model', arg: 'opus', by: 'op', delivered_at: now });
+    expect(readSwitchVerify(root)?.arg).toBe('opus');
     fs.rmSync(root, { recursive: true });
   });
 });

--- a/plugins/claude-code-hermit/tests/helpers/transcript.ts
+++ b/plugins/claude-code-hermit/tests/helpers/transcript.ts
@@ -12,6 +12,7 @@ export function triggerPrompt(text: string): string {
 export interface AssistantEntryOpts {
   model?: string;
   timestamp?: string;
+  isSidechain?: boolean;
   inputTokens?: number;
   cacheRead?: number;
   cacheWrite?: number;
@@ -22,6 +23,7 @@ export function assistantEntry(opts: AssistantEntryOpts = {}): string {
   const {
     model = 'claude-sonnet-4-6',
     timestamp,
+    isSidechain,
     inputTokens = 2,
     cacheRead = 0,
     cacheWrite = 0,
@@ -30,6 +32,7 @@ export function assistantEntry(opts: AssistantEntryOpts = {}): string {
   return JSON.stringify({
     type: 'assistant',
     ...(timestamp !== undefined ? { timestamp } : {}),
+    ...(isSidechain !== undefined ? { isSidechain } : {}),
     message: {
       model,
       usage: {

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -24,7 +24,7 @@ import { safeForLLM, safeForLLMMultiline } from '../scripts/lib/sanitize';
 import * as ccCompat from '../scripts/lib/cc-compat';
 import {
   sessionId, transcriptPath, sessionCrons, backgroundTasks,
-  extractUsage, costLogPath, ccVersion,
+  extractUsage, costLogPath, ccVersion, lastAssistantModel,
 } from '../scripts/lib/cc-compat';
 import * as costLog from '../scripts/lib/cost-log';
 import { costIndexPath, readCostIndex, updateCostIndex, scanAutomatedOpus } from '../scripts/lib/cost-log';
@@ -3037,6 +3037,58 @@ describe('cc-compat', () => {
   });
   test('cc-compat.js: extractUsage assistant without usage → null', () => {
     expect(extractUsage({ type: 'assistant', message: {} })).toBeNull();
+  });
+
+  // lastAssistantModel: the transcript is ground truth for the serving model
+  describe('cc-compat.js: lastAssistantModel', () => {
+    const write = (lines: string[]): string => {
+      const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'last-model-')), 'transcript.jsonl');
+      fs.writeFileSync(file, `${lines.join('\n')}\n`);
+      return file;
+    };
+    const assistant = (model: string, timestamp: string, extra: Record<string, unknown> = {}) =>
+      JSON.stringify({ type: 'assistant', timestamp, ...extra, message: { model, content: [] } });
+
+    test('returns the newest main-session assistant model', () => {
+      const file = write([
+        assistant('claude-sonnet-5', '2026-08-20T23:34:12.000Z'),
+        assistant('claude-fable-5', '2026-08-20T23:34:37.000Z'),
+      ]);
+      expect(lastAssistantModel(file)).toEqual({
+        model: 'claude-fable-5',
+        timestamp: '2026-08-20T23:34:37.000Z',
+      });
+    });
+
+    // A subagent runs its own model; it must never answer for the main session.
+    test('skips sidechain entries', () => {
+      const file = write([
+        assistant('claude-fable-5', '2026-08-20T23:34:37.000Z'),
+        assistant('claude-haiku-4-5', '2026-08-20T23:35:00.000Z', { isSidechain: true }),
+      ]);
+      expect(lastAssistantModel(file)?.model).toBe('claude-fable-5');
+    });
+
+    test('skips user entries and malformed lines', () => {
+      const file = write([
+        assistant('claude-opus-5', '2026-08-20T23:30:00.000Z'),
+        '{not json',
+        JSON.stringify({ type: 'user', message: { content: 'hi' }, timestamp: '2026-08-20T23:31:00.000Z' }),
+      ]);
+      expect(lastAssistantModel(file)?.model).toBe('claude-opus-5');
+    });
+
+    test('an assistant entry without a model or timestamp is not a match', () => {
+      const file = write([
+        JSON.stringify({ type: 'assistant', timestamp: '2026-08-20T23:30:00.000Z', message: { content: [] } }),
+        JSON.stringify({ type: 'assistant', message: { model: 'claude-opus-5', content: [] } }),
+      ]);
+      expect(lastAssistantModel(file)).toBeNull();
+    });
+
+    test('an unreadable file reads as null rather than throwing', () => {
+      expect(lastAssistantModel('/nonexistent/transcript.jsonl')).toBeNull();
+    });
   });
 
   // costLogPath: deterministic from a stateDir

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -16,6 +16,7 @@ import path from 'node:path';
 
 import { runScript, runProposal, runPinnedScript, PLUGIN_ROOT, SCRIPTS_DIR, MONOREPO_ROOT } from './helpers/run';
 import { setupWorkdir, fixturesDir, withDir, writeConfig, type Workdir } from './helpers/workdir';
+import { assistantEntry } from './helpers/transcript';
 import { deriveStaleSession, STALE_KEY } from '../scripts/lib/alert-state';
 import { logRoutineEvent } from '../scripts/lib/routines/event';
 
@@ -3046,8 +3047,10 @@ describe('cc-compat', () => {
       fs.writeFileSync(file, `${lines.join('\n')}\n`);
       return file;
     };
-    const assistant = (model: string, timestamp: string, extra: Record<string, unknown> = {}) =>
-      JSON.stringify({ type: 'assistant', timestamp, ...extra, message: { model, content: [] } });
+    // Routed through the pinned fixture builder (tests/helpers/transcript.ts) so a
+    // cc-compat schema change fails loudly in fixture-helpers.test.ts, not silently here.
+    const assistant = (model: string, timestamp: string, extra: { isSidechain?: boolean } = {}) =>
+      assistantEntry({ model, timestamp, ...extra });
 
     test('returns the newest main-session assistant model', () => {
       const file = write([
@@ -3084,6 +3087,16 @@ describe('cc-compat', () => {
         JSON.stringify({ type: 'assistant', message: { model: 'claude-opus-5', content: [] } }),
       ]);
       expect(lastAssistantModel(file)).toBeNull();
+    });
+
+    // The harness-verify gate compares this timestamp with Date.parse; an unparseable
+    // one would make every comparison false and take the fail-OPEN branch there.
+    test('an unparseable timestamp is skipped, not returned', () => {
+      const file = write([
+        assistant('claude-opus-5', '2026-08-20T23:30:00.000Z'),
+        assistant('claude-sonnet-5', 'not-a-date'),
+      ]);
+      expect(lastAssistantModel(file)?.model).toBe('claude-opus-5');
     });
 
     test('an unreadable file reads as null rather than throwing', () => {

--- a/plugins/claude-code-hermit/tests/user-prompt-pipeline.test.ts
+++ b/plugins/claude-code-hermit/tests/user-prompt-pipeline.test.ts
@@ -17,6 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { runScript } from './helpers/run';
 import { setupWorkdir, type Workdir } from './helpers/workdir';
+import { assistantEntry } from './helpers/transcript';
 import { startHttpStub } from './helpers/http-stub';
 
 const hermit = (dir: string, ...p: string[]) => path.join(dir, '.claude-code-hermit', ...p);
@@ -157,8 +158,9 @@ describe('user-prompt-pipeline: switch verification', () => {
 
   function writeTranscript(wd: Workdir, entries: Array<{ model: string; timestamp: string }>): string {
     const file = path.join(wd.dir, 'transcript.jsonl');
+    // Pinned fixture builder — see tests/helpers/transcript.ts.
     fs.writeFileSync(file, `${entries
-      .map((e) => JSON.stringify({ type: 'assistant', timestamp: e.timestamp, message: { model: e.model, content: [] } }))
+      .map((e) => assistantEntry({ model: e.model, timestamp: e.timestamp }))
       .join('\n')}\n`);
     return file;
   }

--- a/plugins/claude-code-hermit/tests/user-prompt-pipeline.test.ts
+++ b/plugins/claude-code-hermit/tests/user-prompt-pipeline.test.ts
@@ -138,6 +138,88 @@ describe('user-prompt-pipeline: shutdown is terminal', () => {
   });
 });
 
+// A delivered switch applies, but the model's self-perception does not follow it —
+// so the transcript, not the model, answers "which model am I running".
+describe('user-prompt-pipeline: switch verification', () => {
+  const verifyMarker = (dir: string) => hermit(dir, 'state', 'harness-switch-verify.json');
+  const DELIVERED_AT = '2026-08-20T23:34:17.000Z';
+
+  function seedDeliveredSwitch(wd: Workdir, arg = 'fable'): void {
+    fs.writeFileSync(hermit(wd.dir, 'config.json'), JSON.stringify({ timezone: 'UTC' }));
+    fs.mkdirSync(path.dirname(verifyMarker(wd.dir)), { recursive: true });
+    fs.writeFileSync(verifyMarker(wd.dir), JSON.stringify({
+      command: '/model',
+      arg,
+      by: 'operator',
+      delivered_at: DELIVERED_AT,
+    }));
+  }
+
+  function writeTranscript(wd: Workdir, entries: Array<{ model: string; timestamp: string }>): string {
+    const file = path.join(wd.dir, 'transcript.jsonl');
+    fs.writeFileSync(file, `${entries
+      .map((e) => JSON.stringify({ type: 'assistant', timestamp: e.timestamp, message: { model: e.model, content: [] } }))
+      .join('\n')}\n`);
+    return file;
+  }
+
+  async function runWith(wd: Workdir, transcript: string | null) {
+    return runScript('user-prompt-pipeline.ts', {
+      stdin: JSON.stringify({ prompt: 'which model are you on?', ...(transcript ? { transcript_path: transcript } : {}) }),
+      cwd: wd.dir,
+    });
+  }
+
+  test('reports the transcript model once the switch is observable, then clears the marker', async () => {
+    const wd = setupWorkdir();
+    seedDeliveredSwitch(wd);
+    const transcript = writeTranscript(wd, [{ model: 'claude-fable-5', timestamp: '2026-08-20T23:34:37.000Z' }]);
+
+    const r = await runWith(wd, transcript);
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('"/model fable" delivered');
+    expect(r.stdout).toContain('transcript now reports model claude-fable-5');
+    expect(fs.existsSync(verifyMarker(wd.dir))).toBe(false);
+  });
+
+  // The bug this whole path exists to prevent: answering from the PRE-switch entry.
+  test('holds the marker while only pre-switch entries exist, and never names that model', async () => {
+    const wd = setupWorkdir();
+    seedDeliveredSwitch(wd);
+    const transcript = writeTranscript(wd, [{ model: 'claude-sonnet-5', timestamp: '2026-08-20T23:34:12.000Z' }]);
+
+    const r = await runWith(wd, transcript);
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('not yet observable');
+    expect(r.stdout).not.toContain('claude-sonnet-5');
+    expect(fs.existsSync(verifyMarker(wd.dir))).toBe(true);
+  });
+
+  test('a payload without a transcript_path holds the marker rather than guessing', async () => {
+    const wd = setupWorkdir();
+    seedDeliveredSwitch(wd);
+
+    const r = await runWith(wd, null);
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('not yet observable');
+    expect(fs.existsSync(verifyMarker(wd.dir))).toBe(true);
+  });
+
+  test('no marker means the stage says nothing', async () => {
+    const wd = setupWorkdir();
+    fs.writeFileSync(hermit(wd.dir, 'config.json'), JSON.stringify({ timezone: 'UTC' }));
+    const transcript = writeTranscript(wd, [{ model: 'claude-fable-5', timestamp: '2026-08-20T23:34:37.000Z' }]);
+
+    const r = await runWith(wd, transcript);
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('[harness-command]');
+  });
+});
+
 describe('user-prompt-pipeline: fail-open contract', () => {
   test('malformed stdin exits 0 and still runs the payload-independent stages', async () => {
     // A prompt did arrive — MAX_STDIN_BYTES truncation is what cuts it mid-JSON —


### PR DESCRIPTION
## Summary

Issue #743 reported that `/model <name>` sent over a channel is acknowledged but never applied. Investigating two live hermits showed the opposite: the switch **always applied**, within one turn of delivery. What failed was the session's ability to *know* it — a model's sense of which model it runs is fixed at session start and does not follow a mid-session switch. Asked "did it work?", the hermit answered from that stale value, reported a working switch as a silent failure, and filed this issue for a bug that did not exist.

So the fix is not on the delivery path (which was never broken) but on the reporting path: after a delivered switch, the session is told what the transcript says, since the transcript stamps the serving model on every assistant entry.

Evidence that settled it, from two hermits on the same box, both on plugin 1.2.42 / Claude Code 2.1.238:

- `/model fable` delivered, Stop hook logged `delivered`, and every assistant message from the next turn on was served by `claude-fable-5` — while the hermit told the operator it was still on Sonnet 5.
- `/model opus` on a second hermit: the very message asserting "Currently Sonnet 5; the Opus switch is queued" was itself served by `claude-opus-5`.

## Changes

- **`scripts/lib/prompt-stages/harness-verify.ts`** (new) — UserPromptSubmit stage that reports a delivered `/model` or `/effort` switch from the transcript. Holds its report until an assistant entry newer than the delivery exists, so the pre-switch entry can never become the answer — that ordering *is* the bug being fixed, not a hypothetical.
- **`scripts/lib/harness-command.ts`** — switch-verify marker (write/read/clear) alongside the existing pending-command marker. Self-cleaning on TTL expiry, since nothing else consumes it. The atomic tmp+rename write is now shared rather than duplicated.
- **`scripts/lib/harness-drain.ts`** — a confirmed `/model` or `/effort` send leaves the marker. A refused send, `/clear`, and `/compact` leave nothing.
- **`scripts/lib/cc-compat.ts`** — `lastAssistantModel()`, a bounded (64KB) tail read for the newest main-session assistant entry's model. Sidechains excluded, so a subagent's model never answers for the main session.
- **`scripts/user-prompt-pipeline.ts`, `scripts/lib/prompt-stages/types.ts`** — `transcript_path` plumbed onto `StageContext` via the existing `transcriptPath()` accessor; null is treated as "can't tell" and fails closed.

Hot-path note: the cheap marker read gates everything, so the transcript is only read on the rare prompt following a switch.

## Test plan

- `bun test` from `plugins/claude-code-hermit` — **3964 pass / 0 fail** (exit 0).
- `bunx tsc --noEmit` from the repo root — exit 0.
- New coverage: marker round-trip / TTL self-delete / overwrite; delivery writes the marker for `/model` and `/effort` but not for a refused send, `/clear`, or `/compact`; `lastAssistantModel` sidechain, malformed-line, and unreadable-file cases; and the four stage outcomes (no marker, pre-switch hold, post-switch report + clear, absent `transcript_path`).
- Not yet run: a live tmux probe of an end-to-end channel switch. Worth doing before release; the behavior it would confirm is covered by the stage tests above.

Closes #743