### PR TITLE
fix: collapse the proposals-page deep link to one bare URL per announcement

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `/claude-code-hermit:channel-setup` now treats a channel with `enabled: false` as disabled rather than configured, and offers to re-enable it instead of proceeding as though it were live.
 - Bare-host (non-Docker) boots now export each channel's `<CHANNEL>_STATE_DIR` into the session environment, so channel plugin servers find their state dir instead of failing with `CONNECTION_CLOSED`.
 - A channel-requested `/model` or `/effort` switch is now reported back from the transcript's serving-model stamp instead of the session's stale session-start self-perception, with the report held until an assistant entry newer than the delivery exists.
+- Creating several proposals in one run now appends at most one bare proposals-page link to the announcement message, instead of a separate `#prop-nnn` deep link per proposal that the claude.ai artifact viewer couldn't resolve anyway.
 
 ## [1.2.42] - 2026-08-19
 

--- a/plugins/claude-code-hermit/docs/artifacts.md
+++ b/plugins/claude-code-hermit/docs/artifacts.md
@@ -163,14 +163,7 @@ proposal renders as a collapsed-by-default `<details class="proposal" id="prop-n
 chip, id, title, created-date) that expands to the full body on click, the same pattern
 the dashboard already uses for its proposals card. A heading above the list shows the open
 count (e.g. "3 Open"); deferred/resolved/dismissed proposals stay one-line history entries
-— the same "other" bucket the dashboard already computes.
-
-The `id` is inert as a deep link, though: the claude.ai artifact viewer renders the page
-inside a sandboxed cross-origin iframe whose `src` carries no fragment — confirmed by
-navigating a published proposals page with `#prop-nnn` appended, where the top-level
-document held zero `prop-*` anchors and the iframe never received the fragment. The `id`
-stays in the markup anyway, since it's free and still resolves for a locally opened or
-remixed copy of the page. Rendered by
+— the same "other" bucket the dashboard already computes. Rendered by
 `scripts/lib/proposals-page.ts` (reuses the dashboard's proposal loader, markdown
 converter, and CSS — no CSS changes were needed since `.proposal`/`.proposal-body` already
 existed for the dashboard's own `<details>`). `<title>` is `<agent_name> — Proposals`,
@@ -179,6 +172,13 @@ omits proposal age-in-days (unlike the dashboard) — age is `Date.now()`-derive
 otherwise mint a new artifact version once a day even with zero activity; created-date
 is shown instead, keeping the hash purely activity-driven (the open count is likewise
 activity-driven, not date-driven, so it doesn't reintroduce that churn).
+
+The `id` is inert as a deep link, though: the claude.ai artifact viewer renders the page
+inside a sandboxed cross-origin iframe whose `src` carries no fragment — confirmed by
+navigating a published proposals page with `#prop-nnn` appended, where the top-level
+document held zero `prop-*` anchors and the iframe never received the fragment. The `id`
+stays in the markup anyway, since it's free and still resolves for a locally opened or
+remixed copy of the page.
 
 Refresh triggers: `proposal-create` (step 6), `proposal-act` (every accept/defer/
 dismiss/resolve flow, after its Respond step). Both refresh silently by default,

--- a/plugins/claude-code-hermit/docs/artifacts.md
+++ b/plugins/claude-code-hermit/docs/artifacts.md
@@ -159,11 +159,18 @@ it, or none.
 
 `config.artifacts.proposals`, state key `proposals`. Every open (`proposed`/`accepted`)
 proposal renders as a collapsed-by-default `<details class="proposal" id="prop-nnn">`
-(lowercased `PROP-NNN` prefix as the `id`, for deep-linking) — a one-line summary (status
+(lowercased `PROP-NNN` prefix as the `id`) — a one-line summary (status
 chip, id, title, created-date) that expands to the full body on click, the same pattern
 the dashboard already uses for its proposals card. A heading above the list shows the open
 count (e.g. "3 Open"); deferred/resolved/dismissed proposals stay one-line history entries
-— the same "other" bucket the dashboard already computes. Rendered by
+— the same "other" bucket the dashboard already computes.
+
+The `id` is inert as a deep link, though: the claude.ai artifact viewer renders the page
+inside a sandboxed cross-origin iframe whose `src` carries no fragment — confirmed by
+navigating a published proposals page with `#prop-nnn` appended, where the top-level
+document held zero `prop-*` anchors and the iframe never received the fragment. The `id`
+stays in the markup anyway, since it's free and still resolves for a locally opened or
+remixed copy of the page. Rendered by
 `scripts/lib/proposals-page.ts` (reuses the dashboard's proposal loader, markdown
 converter, and CSS — no CSS changes were needed since `.proposal`/`.proposal-body` already
 existed for the dashboard's own `<details>`). `<title>` is `<agent_name> — Proposals`,
@@ -176,16 +183,12 @@ activity-driven, not date-driven, so it doesn't reintroduce that churn).
 Refresh triggers: `proposal-create` (step 6), `proposal-act` (every accept/defer/
 dismiss/resolve flow, after its Respond step). Both refresh silently by default,
 matching the dashboard's existing no-URL-re-post convention — with one exception:
-`proposal-create`'s own announcement message carries a deep link to the just-created
-proposal, since that's the moment the operator is most likely to want to jump straight
-to it: `📎 <url>#prop-nnn ("PROP-NNN: <title>")`. The anchor lives on the `<details>`
-element itself, so a browser that auto-opens the `:target`ed `<details>` (current Chrome/
-Safari/Firefox) lands the operator directly on the expanded proposal. Where a viewer
-doesn't do that — the claude.ai artifact viewer's fragment behavior is unverified (no
-browser access at the time this was written, though the anchor element's presence in the
-rendered DOM was confirmed) — the link still scrolls to the correct proposal's collapsed
-summary line, which already shows the chip, id, and title; the section name is included in
-text unconditionally so the link is useful either way.
+when the refresh returns a URL, the flow that just created one or more proposals
+appends a single bare `📎 <url>` line to its own announcement, whether it created
+one proposal or several. No fragment, and no proposal id or title in the link text
+(`PROP-NNN` in an operator-facing message violates CLAUDE-APPEND.md § Channel voice).
+When no URL is returned — the page is disabled, publish is unauthorized, or the
+publish failed — the line is omitted entirely and the rest of the message is unaffected.
 
 ## Localization
 

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -240,7 +240,7 @@ Publishing of hermit-generated pages to Claude Code's [Artifacts](https://code.c
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `dashboard` | boolean | `true` | Publish the Hermit Dashboard (status, latest brief, proposal queue, weekly evolution, compiled-docs index), refreshed by `brief`, `weekly-review`, `proposal-create`, and `proposal-act`. |
-| `proposals` | boolean | `true` | Publish the full text of open proposals, each anchored for deep-linking, refreshed by `proposal-create` and `proposal-act`. |
+| `proposals` | boolean | `true` | Publish the full text of open proposals, refreshed by `proposal-create` and `proposal-act`. |
 | `weekly_review` | boolean | `true` | Publish the latest compiled weekly review as a stable-URL page, refreshed by `weekly-review`. |
 | `publish_authorized` | boolean \| `null` | `null` | Whether unattended sessions may publish without a permission prompt. `null` = undecided, `true` = authorized (grant applied at next boot), `false` = declined (attended banking instead). See below. Set via `/hermit-settings artifact-authorization`, never edited directly. |
 | `backend` | string | `"claude"` | Where pages publish. `"claude"` is Claude Code's native Artifacts. Any other value names a connected MCP artifact server. See below. |

--- a/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
+++ b/plugins/claude-code-hermit/scripts/lib/proposals-page.ts
@@ -2,8 +2,10 @@
 // scripts/lib/dashboard.ts's render/hash-gate discipline (see docs/artifacts.md).
 // Open (proposed/accepted) proposals render as collapsed-by-default
 // <details class="proposal" id="prop-nnn"> — a one-line summary that expands to
-// full text on click, each anchored for deep-linking from channel messages;
-// deferred/resolved/dismissed proposals are one-line history entries, same bucket the
+// full text on click. The id is inert in the claude.ai artifact viewer (sandboxed
+// cross-origin iframe, no fragment reaches it) but is kept for a locally opened or
+// remixed copy of the page; deferred/resolved/dismissed proposals are one-line
+// history entries, same bucket the
 // dashboard already computes. Self-contained fragment — no
 // <!DOCTYPE>/<html>/<head>/<body> (Artifact tool wraps it).
 

--- a/plugins/claude-code-hermit/scripts/lib/settings/registry.ts
+++ b/plugins/claude-code-hermit/scripts/lib/settings/registry.ts
@@ -78,7 +78,7 @@ export const SETTINGS: readonly Setting[] = [
   { arg: 'artifact-dashboard', path: 'artifacts.dashboard', kind: 'boolean', group: 'Artifacts',
     label: 'Dashboard page', hint: 'status, proposal queue, weekly evolution' },
   { arg: 'artifact-proposals', path: 'artifacts.proposals', kind: 'boolean', group: 'Artifacts',
-    label: 'Proposals page', hint: 'full text of open proposals, deep-linked' },
+    label: 'Proposals page', hint: 'full text of open proposals' },
   { arg: 'artifact-weekly-review', path: 'artifacts.weekly_review', kind: 'boolean', group: 'Artifacts',
     label: 'Weekly-review page', hint: 'the compiled weekly report at a stable URL' },
   { arg: 'artifact-backend', path: 'artifacts.backend', kind: 'string', group: 'Artifacts',

--- a/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
+++ b/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
@@ -92,6 +92,8 @@ Send one message following the Operator Notification protocol in CLAUDE.md (empt
    PROP-NNN created  ·  (or: suppressed — <code>  ·  or: duplicate of PROP-NNN)
 
 2. **<short title>** — ...
+
+📎 <proposals page URL>   (omit this line entirely if `proposal-create` returned no URL)
 ```
 
 If zero ideas were generated or all were suppressed/duplicated, the message is:

--- a/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
+++ b/plugins/claude-code-hermit/skills/capability-brainstorm/SKILL.md
@@ -93,8 +93,10 @@ Send one message following the Operator Notification protocol in CLAUDE.md (empt
 
 2. **<short title>** — ...
 
-📎 <proposals page URL>   (omit this line entirely if `proposal-create` returned no URL)
+📎 <proposals page URL>
 ```
+
+The `📎` line is a single slot for the whole batch, not one per idea — omit it entirely when the proposals-page refresh returned no URL.
 
 If zero ideas were generated or all were suppressed/duplicated, the message is:
 ```

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -40,7 +40,7 @@ On a channel-tagged turn, every free-form `Ask:` prompt below is delivered via t
 /claude-code-hermit:hermit-settings reflection       — tune graduation threshold (graduation_min_sessions)
 /claude-code-hermit:hermit-settings push-notifications — toggle PushNotification doorbell (fires when no channel is enabled or a configured channel is unreachable)
 /claude-code-hermit:hermit-settings artifact-dashboard — toggle the Hermit Dashboard artifact (single-URL status/proposals/weekly-evolution page)
-/claude-code-hermit:hermit-settings artifact-proposals — toggle the Proposals-page artifact (full-text open-proposal page with deep-linked anchors)
+/claude-code-hermit:hermit-settings artifact-proposals — toggle the Proposals-page artifact (full-text open-proposal page)
 /claude-code-hermit:hermit-settings artifact-weekly-review — toggle the Weekly-review artifact (stable-URL passthrough of the compiled weekly report)
 /claude-code-hermit:hermit-settings artifact-authorization — record the unattended Artifact publish decision (applied by hermit-start at boot, not from this session)
 /claude-code-hermit:hermit-settings artifact-backend — where pages publish: `claude` (default), or the name of a connected MCP artifact server you registered yourself

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -48,7 +48,7 @@ All timestamps in frontmatter and Operator Decision text use ISO 8601 with timez
 
 ## Dashboard Refresh
 
-Every flow below (accept, defer, dismiss, resolve) changes a proposal's status. After its final "Respond" step, refresh the dashboard and the proposals page (`config.artifacts.proposals`) per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md` — both silently, no URL re-post (unlike `proposal-create`'s initial announcement, these status-change confirmations don't carry a deep link).
+Every flow below (accept, defer, dismiss, resolve) changes a proposal's status. After its final "Respond" step, refresh the dashboard and the proposals page (`config.artifacts.proposals`) per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md` — both silently, no URL re-post (unlike `proposal-create`'s initial announcement, these status-change confirmations don't append the proposals-page URL).
 
 ## Accept Flow
 

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -118,7 +118,7 @@ Body guidance:
 - Leave `## Operator Decision` blank — the operator fills that in.
 - Do NOT write bullet-point metadata (`- **Created:**`, etc.) — all metadata lives in the header lines / frontmatter only.
 
-Finally, refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md` (silently — no URL re-post; the proposal queue changed). Also refresh the proposals page (`config.artifacts.proposals`) per the same doc. Unlike the dashboard, when the proposals page returns a URL, surface a deep link for whatever flow announces this proposal to the operator to append to its message: `📎 <url>#prop-nnn ("PROP-NNN: <title>")` (lowercased `PROP-NNN` prefix as the anchor; include the section name in text since fragment auto-scroll in the artifact viewer is unconfirmed).
+Finally, refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md` (silently — no URL re-post; the proposal queue changed). Also refresh the proposals page (`config.artifacts.proposals`) per the same doc. Unlike the dashboard, when the proposals page returns a URL, surface it for whatever flow announces this proposal to the operator: append **at most one** `📎 <url>` line to that flow's message, regardless of how many proposals it created in this run — never one per proposal, and never one at all when no URL was returned.
 
 ## Do NOT Create Proposals For
 

--- a/plugins/claude-code-hermit/tests/proposals-page.test.ts
+++ b/plugins/claude-code-hermit/tests/proposals-page.test.ts
@@ -87,7 +87,7 @@ describe('renderProposalsPage', () => {
     expect(html).toContain('<title>Hermit — Proposals</title>');
   }));
 
-  test('renders each open proposal as a collapsed <details> anchored for deep-linking', withHermitDir((hermitDir) => {
+  test('renders each open proposal as a collapsed <details> carrying a prop-nnn id', withHermitDir((hermitDir) => {
     writeProposal(hermitDir, 'PROP-025-hub-spoke-100000.md',
       { id: 'PROP-025-hub-spoke-100000', title: '"Hub and spoke"', status: 'proposed', created: '2026-07-01T10:00:00Z' },
       'Full text of the proposal.');


### PR DESCRIPTION
## Summary
Creating several proposals in one run (`reflect`, `capability-brainstorm`) was appending one `📎 <url>#prop-nnn` deep link per proposal, all pointing at the same page URL with a fragment that never worked. Verified live against a published proposals page: the claude.ai artifact viewer renders the page inside a sandboxed cross-origin iframe whose `src` carries no fragment, so `#prop-nnn` never reaches the document — the top-level page held zero `prop-*` anchors and the iframe never received the fragment.

## Changes
- `skills/proposal-create/SKILL.md` — drop the `#prop-nnn` fragment and the `PROP-NNN` title text (which also violated the channel-voice rule against internal IDs in operator messages); the announcing flow now appends **at most one** bare `📎 <url>` line regardless of how many proposals it created, and none when no URL is returned.
- `skills/capability-brainstorm/SKILL.md` — the one flow that provably batches (up to 2 proposals per run) gets an explicit single link slot in its batch-message template.
- `skills/proposal-act/SKILL.md`, `docs/artifacts.md`, `docs/config-reference.md`, `scripts/lib/proposals-page.ts`, `scripts/lib/settings/registry.ts` — corrected the now-stale claims that the anchors enable deep-linking from a channel message. The `id="prop-nnn"` attributes themselves are untouched — they're free and still resolve for a locally opened or remixed copy of the page, just not through claude.ai's viewer.
- The `config.artifacts.proposals` gate and the "only when a URL is returned" conditional are preserved exactly as before — the fix changes what the link contains and how many appear, never whether one appears.

## Test plan
- `bun test` (plugin-scoped): 3984 pass, 0 fail. `tests/proposals-page.test.ts` untouched — confirms the renderer and its anchor output weren't touched.
- `bunx tsc --noEmit`: exit 0.
- `grep -rn '#prop-' plugins/claude-code-hermit/`: only two surviving hits, both explanatory prose (the new CHANGELOG bullet and the `docs/artifacts.md` paragraph describing why the fragment fails) — no skill emits one anymore.