### PR TITLE
fix(hermit): report context reload after evolve

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `/claude-code-hermit:hermit-evolve` now tells the operator to reload project context after it refreshes a core or downstream CLAUDE-APPEND block, recommending `/compact` while naming `/clear` or a Claude session restart as alternatives; `/reload-plugins` alone is no longer implied to be sufficient.
+
 ## [1.2.43] - 2026-08-21
 
 ### Added

--- a/plugins/claude-code-hermit/agents/evolve-runner.md
+++ b/plugins/claude-code-hermit/agents/evolve-runner.md
@@ -77,6 +77,7 @@ Bin wrappers: <restored/replaced(.bak) | none>
 Docker entrypoint: <refreshed | conflict-replaced(<backup path>) | n/a>
 Docker rebuild: <needed + order | base-patched | no>
 CLAUDE-APPEND: <updated | unchanged>
+Context reload: <required (comma-separated plugin names) | no>
 Sibling hermits: <one or more of the following per sibling, space-separated, or "none">
   <name vOLD->vNEW>           (confirmed by finalizer — only from siblings_confirmed)
   <name current>              (no version gap)

--- a/plugins/claude-code-hermit/agents/evolve-runner.md
+++ b/plugins/claude-code-hermit/agents/evolve-runner.md
@@ -57,7 +57,9 @@ never block:
 - **Version bump (step 9):** run `evolve-finalize.ts` and parse its stdout JSON. Use `core.confirmed` as
   `vNEW` in the report — NOT `plan.to`. If the script exits non-zero, `core.matched` is false, or `errors`
   is non-empty, return `Upgrade: blocked: config version bump failed — <joined error messages>` and omit
-  the rest of the report. Copy the finalizer's `audit_scope` into the report's `Audit scope:` line —
+  the rest of the report **except the `Context reload:` line** — steps 6/7 may already have rewritten
+  project instructions on disk, and a blocked version bump does not undo those writes.
+  Copy the finalizer's `audit_scope` into the report's `Audit scope:` line —
   `version-only` is not a failure and never blocks.
 
 Everything else (version gates 0/0b, the plan pre-pass, classification, copies, manifest write, config

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -80,7 +80,7 @@ conversation. Stop.
 
 **Print the summary** from the report fields. Omit lines where nothing changed. End with "Run /claude-code-hermit:hermit-settings to adjust any settings." if settings were added.
 
-**Project-context reload notice.** If `Context reload` is `required (<names>)`, append this to the summary in every delivery mode: "Project instructions updated for <names>. Run `/compact` to load them now; `/clear` or restarting the Claude session also works. `/reload-plugins` alone does not reload CLAUDE.md." If the field is `no`, omit the notice. Never issue `/compact`, `/clear`, or a restart on the operator's behalf.
+**Project-context reload notice.** If `Context reload` is `required (<names>)`, append this to the summary in every delivery mode: "Project instructions updated for <names>. Run `/compact` to load them now; `/clear` or restarting the Claude session also works. `/reload-plugins` alone does not reload CLAUDE.md." If the field is `no`, omit the notice. Deliver it on a `blocked:` report too — a blocked version bump does not undo a CLAUDE-APPEND write, and a re-run sees the block as already current, so this is the only time the operator hears about it. Never issue `/compact`, `/clear`, or a restart on the operator's behalf.
 
 **Resolve deferrals by execution and delivery mode.** If "Deferred for operator" is non-empty:
 - **Interactive execution:** for each deferred-migration block, present its `instruction` + `options` to the operator via `AskUserQuestion`, then apply the chosen branch inline (this is the only place changelog/migration text re-enters the main loop, and only for the rare deferred step).

--- a/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/SKILL.md
@@ -47,6 +47,7 @@ Bin wrappers: <restored/replaced(.bak) | none>
 Docker entrypoint: <refreshed | conflict-replaced(<backup path>) | n/a>
 Docker rebuild: <needed + order | base-patched | no>
 CLAUDE-APPEND: <updated | unchanged>
+Context reload: <required (comma-separated plugin names) | no>
 Sibling hermits: <one or more of the following per sibling, space-separated, or "none">
   <name vOLD->vNEW>           (confirmed by finalizer — only from siblings_confirmed)
   <name current>              (no version gap)
@@ -79,6 +80,8 @@ conversation. Stop.
 
 **Print the summary** from the report fields. Omit lines where nothing changed. End with "Run /claude-code-hermit:hermit-settings to adjust any settings." if settings were added.
 
+**Project-context reload notice.** If `Context reload` is `required (<names>)`, append this to the summary in every delivery mode: "Project instructions updated for <names>. Run `/compact` to load them now; `/clear` or restarting the Claude session also works. `/reload-plugins` alone does not reload CLAUDE.md." If the field is `no`, omit the notice. Never issue `/compact`, `/clear`, or a restart on the operator's behalf.
+
 **Resolve deferrals by execution and delivery mode.** If "Deferred for operator" is non-empty:
 - **Interactive execution:** for each deferred-migration block, present its `instruction` + `options` to the operator via `AskUserQuestion`, then apply the chosen branch inline (this is the only place changelog/migration text re-enters the main loop, and only for the rare deferred step).
 - **Unattended execution:** relay each deferred block verbatim ("migration deferred for operator review: <source> — <instruction>") through the selected delivery route: direct reply for direct-channel delivery, maintainer-only notice for automated-maintainer delivery. **Do not apply — never run the migration's settings writes from this session.** If the deferred `instruction` text contains an explicit channel resolution stanza (a fenced `options: [...]` array and an `on_resolve: "..."` skill invocation with an `{answer}` placeholder — the CHANGELOG's artifact-publish-authorization migration is the current example), additionally queue a micro-proposal entry per `reflect` § Queuing procedure using that exact `options` and `on_resolve` (`tier: 1`, `"kind":"ask"` on the `micro-queued` event) and render the numbered options in the relay, so the operator's reply resolves it through `channel-responder` § Micro-approval response — the same bridge any other skill's bounded ask uses. An `on_resolve` reached this way may only alter hermit config/state, never `.claude/settings*.json` — a boot-time wrapper (e.g. `hermit-start`) applies any resulting permission grant out-of-session, never this session.
@@ -100,8 +103,8 @@ fails, append that failure and the manual `hermit-routines load` next action to 
 **Deliver the result.** Compose a condensed one-line message such as `"Hermit upgraded: vOLD → vNEW.
 N settings added, M templates refreshed."` Omit segments where nothing changed. **Append the
 deferred/auto-applied segments**: settings set to defaults (Step 4), permission entries added (Step
-8), template conflicts parked as `.new` (Step 5), and any deferred migrations — so the operator can
-follow up via `/hermit-settings`.
+8), template conflicts parked as `.new` (Step 5), any deferred migrations, and the project-context
+reload notice when required — so the operator can follow up via `/hermit-settings`.
 
 - **Automated-maintainer:** deliver through `channel-send.ts --notice` with
   `{"maintainer":"<complete condensed result>"}` on stdin and no `client` leg. Follow CLAUDE-APPEND.md

--- a/plugins/claude-code-hermit/skills/hermit-evolve/reference.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/reference.md
@@ -207,6 +207,7 @@ For each entry in `plan.siblings`:
     - `sibling.claude_append_needs_render` → report `<name> block refresh deferred to /<name>:hatch (template requires rendering)`; apply no Edit. Core cannot render a template carrying `mode:` markers — that is the owning plugin's own hatch's job.
     - `sibling.claude_append_block_missing` → report `<name> block-missing — run /<name>:hatch to install it`; apply no Edit. **Never append a sibling's block** — core has no way to guarantee an append would render it the way the sibling's own hatch does.
     - `sibling.claude_append_ambiguous` → report `<name> block-ambiguous — the marker appears more than once, manual review needed`; apply no Edit.
+    - `sibling.claude_append_changed !== true` → report `<name> block current`; apply no Edit and add no reload target. The plan only supplies `claude_append_old_block` for a block that actually differs, so an already-current block has nothing to replace — treating it as the append case would duplicate the block.
     - Otherwise: same replace procedure as Step 6, using `sibling.marker` and `sibling.claude_append_old_block`. After the replacement succeeds, add `<name>` to `context_reload_targets`.
   - Collect the sibling name for the `--sibling=<name>=<to>` flag in Step 9.
 
@@ -220,8 +221,6 @@ For each entry in `plan.siblings`:
 - **No version gap + `claude_append_changed == false` (or absent):** report `<name> current`, skip. (`claude_append_needs_render` may also be set here — it is a static property of the sibling's template, not pending work; core only acts on it inside the version-gap branch above.)
 
 Keep `context_reload_targets` deduplicated in stable order (core first, then `plan.siblings` order). Never add a target for an unchanged block, a no-gap `block-drifted` advisory, `claude_append_needs_render`, `claude_append_block_missing`, or `claude_append_ambiguous`; none of those branches wrote project instructions.
-
-In the final report, emit `Context reload: no` when the list is empty. Otherwise emit `Context reload: required (<names>)`, joining `context_reload_targets` with `, `.
 
 If `plan.siblings_path_unresolved` is non-empty, report each as `<name> path-unresolved` (registered in `_hermit_versions` but not found in the project-effective plugin list).
 
@@ -262,3 +261,7 @@ where `<resolved-settings-file>` is `.claude/settings.local.json` (local) or `.c
   - Parse stdout as JSON. The finalizer's `core.confirmed` is the **authoritative on-disk version** — use it as `vNEW` in the Step 10 report, NOT `plan.to`.
   - `audit_scope` reports whether the Step 1 snapshot was usable: `whole-run` means this upgrade's config changes are attributed in the settings ledger, `version-only` means only the version stamp was recorded. Carry it into the Step 10 report. It is never a failure — a `version-only` upgrade succeeded, it just left less history behind.
   - If `core.matched` is `false` or `errors` is non-empty, the bump did not land: set the `Upgrade:` line in the Step 10 report to `blocked: config version bump failed (<joined errors>)` and stop.
+
+### Report field: Context reload
+
+Always fill this field, whatever path the run took — including a core-only upgrade with no siblings, and a run blocked by the Step 9 finalizer after Steps 6/7 already wrote. In the final report, emit `Context reload: no` when the list is empty. Otherwise emit `Context reload: required (<names>)`, joining `context_reload_targets` with `, `.

--- a/plugins/claude-code-hermit/skills/hermit-evolve/reference.md
+++ b/plugins/claude-code-hermit/skills/hermit-evolve/reference.md
@@ -70,6 +70,8 @@ Parse stdout as JSON (the "plan"). The plan's `errors` array is the **sole error
 
 **Version check:** the plan reports `from`, `to`, `up_to_date`, and `work_pending`. If `work_pending` is `false` (core current AND no sibling gap, drift, path-unresolved, or warnings), report "You're up to date (v<to>). Nothing to upgrade." and stop. If `up_to_date` is `true` but `work_pending` is `true` (sibling-only work), announce: "Core is current (v<to>); processing sibling hermits." and run only Steps 7, 8, 9, and 10 — the core-content steps (2 through 6) have no pending work when core is current. (Sibling migrations and CLAUDE-APPEND sync happen inside Step 7.) Otherwise (core has a gap) announce: "Upgrading from v<from> to v<to>." and run all steps.
 
+Before entering either the full or sibling-only path, initialize `context_reload_targets` as an empty ordered list. Add a plugin name only after its CLAUDE-APPEND write succeeds; Step 10 uses this list to distinguish instructions that changed on disk from drift or refresh work that was only reported.
+
 **Snapshot the config for the audit ledger.** Once the version check above has decided the run proceeds (so a stop-here run writes nothing), record what `config.json` looked like before any migration touches it:
 
 ```
@@ -190,7 +192,7 @@ If the plan's `claude_append_changed` is `false`, skip this step. If `true`, rea
 
 - **`claude_append_old_block` present** (marker found — replace case): the new content is the marker-onward portion of `CLAUDE-APPEND.md` — from the `<!-- claude-code-hermit: Session Discipline -->` marker through its closing `<!-- /claude-code-hermit: Session Discipline -->` marker when the template carries one, else to the end of the block (the leading `---` already sits above the marker in the target). Apply a targeted `Edit` to the target file with `old_string` = `claude_append_old_block` (the exact current block) and `new_string` = that marker-onward content. **Do not read the whole target file** — the exact `old_string` is supplied by the plan, and the `---` must not be duplicated.
 - **`claude_append_old_block` absent** (marker not found — append case): append the **full `CLAUDE-APPEND.md` including its leading `---`** to the target file (same as init — the `---` separates the project's content from the block).
-- Report what changed.
+- After the targeted Edit or append succeeds, add `claude-code-hermit` to `context_reload_targets`, then report what changed.
 
 ### 7. Hermit upgrades
 
@@ -205,7 +207,7 @@ For each entry in `plan.siblings`:
     - `sibling.claude_append_needs_render` → report `<name> block refresh deferred to /<name>:hatch (template requires rendering)`; apply no Edit. Core cannot render a template carrying `mode:` markers — that is the owning plugin's own hatch's job.
     - `sibling.claude_append_block_missing` → report `<name> block-missing — run /<name>:hatch to install it`; apply no Edit. **Never append a sibling's block** — core has no way to guarantee an append would render it the way the sibling's own hatch does.
     - `sibling.claude_append_ambiguous` → report `<name> block-ambiguous — the marker appears more than once, manual review needed`; apply no Edit.
-    - Otherwise: same replace procedure as Step 6, using `sibling.marker` and `sibling.claude_append_old_block`.
+    - Otherwise: same replace procedure as Step 6, using `sibling.marker` and `sibling.claude_append_old_block`. After the replacement succeeds, add `<name>` to `context_reload_targets`.
   - Collect the sibling name for the `--sibling=<name>=<to>` flag in Step 9.
 
 - **No version gap (`up_to_date == true`) + `claude_append_changed == true`:**
@@ -216,6 +218,10 @@ For each entry in `plan.siblings`:
     - Otherwise → `<name> block-drifted` — advisory note for the operator to review manually.
 
 - **No version gap + `claude_append_changed == false` (or absent):** report `<name> current`, skip. (`claude_append_needs_render` may also be set here — it is a static property of the sibling's template, not pending work; core only acts on it inside the version-gap branch above.)
+
+Keep `context_reload_targets` deduplicated in stable order (core first, then `plan.siblings` order). Never add a target for an unchanged block, a no-gap `block-drifted` advisory, `claude_append_needs_render`, `claude_append_block_missing`, or `claude_append_ambiguous`; none of those branches wrote project instructions.
+
+In the final report, emit `Context reload: no` when the list is empty. Otherwise emit `Context reload: required (<names>)`, joining `context_reload_targets` with `, `.
 
 If `plan.siblings_path_unresolved` is non-empty, report each as `<name> path-unresolved` (registered in `_hermit_versions` but not found in the project-effective plugin list).
 

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -1514,6 +1514,7 @@ describe('gate-agent memory contract', () => {
 
 describe('hermit-evolve delegation contract', () => {
   const skill = read(path.join(SKILLS, 'hermit-evolve', 'SKILL.md'));
+  const reference = read(path.join(SKILLS, 'hermit-evolve', 'reference.md'));
 
   test('SKILL.md dispatches evolve-runner fully-qualified', () => {
     expect(skill).toContain('claude-code-hermit:evolve-runner');
@@ -1549,6 +1550,34 @@ describe('hermit-evolve delegation contract', () => {
     const block = (text: string) => extractBlock(text, 'Upgrade: vOLD -> vNEW', '--- end ---');
     const agent = read(path.join(AGENTS, 'evolve-runner.md'));
     expect(block(agent)).toBe(block(skill));
+  });
+
+  test('report carries successful CLAUDE-APPEND writes into the context-reload notice', () => {
+    expect(skill).toContain('Context reload: <required (comma-separated plugin names) | no>');
+    expect(reference).toContain('initialize `context_reload_targets` as an empty ordered list');
+    expect(reference).toContain('After the targeted Edit or append succeeds, add `claude-code-hermit`');
+    expect(reference).toContain('After the replacement succeeds, add `<name>`');
+    expect(reference).toContain('emit `Context reload: no` when the list is empty');
+    expect(reference).toContain('emit `Context reload: required (<names>)`');
+  });
+
+  test('context reload is not requested for CLAUDE-APPEND branches that do not write', () => {
+    expect(reference).toContain('Never add a target for an unchanged block');
+    for (const branch of [
+      'block-drifted',
+      'claude_append_needs_render',
+      'claude_append_block_missing',
+      'claude_append_ambiguous',
+    ]) {
+      expect(reference).toContain(branch);
+    }
+  });
+
+  test('context-reload notice names every supported reload path and rejects plugin reload', () => {
+    expect(skill).toContain('Run `/compact` to load them now');
+    expect(skill).toContain('`/clear` or restarting the Claude session also works');
+    expect(skill).toContain('`/reload-plugins` alone does not reload CLAUDE.md');
+    expect(skill).toContain('Never issue `/compact`, `/clear`, or a restart on the operator\'s behalf');
   });
 
   test('evolve-runner reads reference.md, not SKILL.md, for steps 0-9', () => {

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -1573,6 +1573,17 @@ describe('hermit-evolve delegation contract', () => {
     }
   });
 
+  test('evolve-runner keeps Context reload alive on a blocked report', () => {
+    const agent = read(path.join(AGENTS, 'evolve-runner.md'));
+    expect(agent).toContain('except the `Context reload:` line');
+    expect(skill).toContain('Deliver it on a `blocked:` report too');
+  });
+
+  test('an unchanged sibling CLAUDE-APPEND block is reported without an Edit or reload target', () => {
+    expect(reference).toContain('`sibling.claude_append_changed !== true` → report `<name> block current`');
+    expect(reference).toContain('apply no Edit and add no reload target');
+  });
+
   test('context-reload notice names every supported reload path and rejects plugin reload', () => {
     expect(skill).toContain('Run `/compact` to load them now');
     expect(skill).toContain('`/clear` or restarting the Claude session also works');


### PR DESCRIPTION
## Summary

- track successful core and downstream CLAUDE-APPEND writes in the evolve runner report
- tell operators to use `/compact`, `/clear`, or a Claude session restart to load refreshed project instructions
- make clear that `/reload-plugins` alone does not reload project CLAUDE.md context

## Changes

- add a producer/consumer report field carrying the ordered plugin names whose blocks were actually written
- exclude unchanged, drift-only, missing, ambiguous, and render-deferred branches from the reload notice
- deliver the notice in inline, direct-channel, and automated-maintainer summaries without automatically resetting the session
- preserve `evolve-finalize.ts` as the version-stamp and audit boundary
- add contract coverage and an Unreleased changelog entry

## Test plan

- `bun test tests/contracts.test.ts` — 301 passed
- `bun test` — 4,105 passed
- `bunx tsc --noEmit` — passed
- `graphify update .` — completed; rebuilt 6,724 nodes and 11,907 edges
