### PR TITLE
chore: upgrade to Bun 1.4

### DIFF
--- a/.github/workflows/test-cross-plugin.yml
+++ b/.github/workflows/test-cross-plugin.yml
@@ -66,6 +66,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - run: bun install --frozen-lockfile
       - run: bun test tests/cross-plugin/ tests/lib/

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -41,6 +41,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Run test suite
         run: bash tests/run-all.sh

--- a/.github/workflows/test-docs-lint.yml
+++ b/.github/workflows/test-docs-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - run: bun install --frozen-lockfile
       - run: bun test tests/env-example-refs.test.ts
         working-directory: plugins/claude-code-hermit

--- a/.github/workflows/test-feed.yml
+++ b/.github/workflows/test-feed.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -39,6 +39,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Run test suite
         run: bun test

--- a/.github/workflows/test-fitness.yml
+++ b/.github/workflows/test-fitness.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -39,6 +39,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Run test suite
         run: bash tests/run-all.sh

--- a/.github/workflows/test-forge.yml
+++ b/.github/workflows/test-forge.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -46,6 +46,6 @@ jobs:
         run: composer install --no-dev --no-interaction --no-progress --working-dir=php
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Run test suite (PHP unit + hook + skill-structure)
         run: bash tests/run-all.sh

--- a/.github/workflows/test-ha.yml
+++ b/.github/workflows/test-ha.yml
@@ -38,8 +38,5 @@ jobs:
       - run: pip install pyyaml python-dotenv
       - run: bun install --frozen-lockfile
       - run: bunx tsc
-      # Pinned to 4 workers, not bare --parallel (which defaults to CPU count):
-      # workers x --max-concurrency (20) oversubscribes the box, and the
-      # subprocess-spawning tests then time out at 5s. 4 is green and ~40% faster.
-      - run: bun test --parallel=4
+      - run: bun test
         working-directory: plugins/claude-code-homeassistant-hermit

--- a/.github/workflows/test-ha.yml
+++ b/.github/workflows/test-ha.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       # Python here is a TEST FIXTURE only (nothing shipped runs it): the
       # golden-corpus test replays the retired Python hooks against the TS
       # ports, and yaml-parity.test.ts compares against PyYAML.

--- a/.github/workflows/test-ha.yml
+++ b/.github/workflows/test-ha.yml
@@ -38,5 +38,8 @@ jobs:
       - run: pip install pyyaml python-dotenv
       - run: bun install --frozen-lockfile
       - run: bunx tsc
-      - run: bun test
+      # Pinned to 4 workers, not bare --parallel (which defaults to CPU count):
+      # workers x --max-concurrency (20) oversubscribes the box, and the
+      # subprocess-spawning tests then time out at 5s. 4 is green and ~40% faster.
+      - run: bun test --parallel=4
         working-directory: plugins/claude-code-homeassistant-hermit

--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -59,8 +59,5 @@ jobs:
       # The repo-internal /simplify mirror must stay byte-identical to the shipped skill.
       - name: Guard .claude/skills/simplify mirror
         run: diff -r .claude/skills/simplify plugins/claude-code-hermit/skills/simplify
-      # Pinned to 4 workers, not bare --parallel (which defaults to CPU count):
-      # workers x --max-concurrency (20) oversubscribes the box, and the
-      # subprocess-spawning tests then time out at 5s. 4 is green and ~40% faster.
-      - run: bun test --parallel=4
+      - run: bun test
         working-directory: plugins/claude-code-hermit

--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -59,5 +59,8 @@ jobs:
       # The repo-internal /simplify mirror must stay byte-identical to the shipped skill.
       - name: Guard .claude/skills/simplify mirror
         run: diff -r .claude/skills/simplify plugins/claude-code-hermit/skills/simplify
-      - run: bun test
+      # Pinned to 4 workers, not bare --parallel (which defaults to CPU count):
+      # workers x --max-concurrency (20) oversubscribes the box, and the
+      # subprocess-spawning tests then time out at 5s. 4 is green and ~40% faster.
+      - run: bun test --parallel=4
         working-directory: plugins/claude-code-hermit

--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - run: bun install --frozen-lockfile
       # No-op until the first .ts lands; tsc exits 18003 on zero inputs, so gate on file presence.
       - run: |
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       # The repo-internal /simplify mirror must stay byte-identical to the shipped skill.
       - name: Guard .claude/skills/simplify mirror
         run: diff -r .claude/skills/simplify plugins/claude-code-hermit/skills/simplify

--- a/.github/workflows/test-scribe.yml
+++ b/.github/workflows/test-scribe.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - run: bun install --frozen-lockfile
       - run: bunx tsc
 
@@ -37,6 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Run test suite
         run: bash tests/run-all.sh

--- a/bun.lock
+++ b/bun.lock
@@ -5,18 +5,18 @@
     "": {
       "name": "claude-code-hermit-monorepo",
       "devDependencies": {
-        "@types/bun": "~1.3.11",
+        "@types/bun": "~1.4.0",
         "fast-check": "^4.1.0",
         "typescript": "~5.8.0",
       },
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "bash scripts/test-all.sh"
   },
   "devDependencies": {
-    "@types/bun": "~1.3.11",
+    "@types/bun": "~1.4.0",
     "fast-check": "^4.1.0",
     "typescript": "~5.8.0"
   }

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- Docker images now install Bun 1.4.0 (was 1.3.11), picking up its Rust rewrite's faster startup and lower idle CPU and memory. Existing hermits need a `Dockerfile.hermit` patch and a rebuild — see Upgrade Instructions.
+
+### Upgrade Instructions
+
+**Docker runtime bump to Bun 1.4.0.** Existing hermits with a deployed `Dockerfile.hermit` need a surgical `ARG BUN_VERSION` patch and a rebuild. Non-Docker hermits: nothing to do — their bun comes from the host, and `required_bun_version` is unchanged at `>=1.3.0`, so no host upgrade is forced.
+
+**Step 1 — Existence / idempotency.** Check for `Dockerfile.hermit` at the project root. If it does not exist, skip to Step 4 (Docker not set up). If it already contains `ARG BUN_VERSION=1.4.0`, skip to Step 3 (already patched; still re-record the baseline so the drift detector clears).
+
+**Step 2 — Surgical patch.** Replace the single line matching `^ARG BUN_VERSION=` in `Dockerfile.hermit` with `ARG BUN_VERSION=1.4.0`. Match on the key, not on the old value — deploys exist on several past pins. If no such line is present (operator restructured how bun is installed), this is a genuine either/or with no safe non-destructive default: record a deferred-migration block with the instruction "manually set bun to 1.4.0 in `Dockerfile.hermit`, then rebuild", skip this patch, and **continue the remaining evolve steps** (do not abort).
+
+**Step 3 — Re-record the template baseline** so `classifyDockerTemplates` clears the drift and won't nag on future evolves. Run:
+
+```
+bun -e '
+  const fs=require("node:fs"), c=require("node:crypto");
+  const [tmpl, ver]=process.argv.slice(2);
+  const mp=".claude-code-hermit/state/template-manifest.json";
+  if(!fs.existsSync(mp)) process.exit(0);
+  const m=JSON.parse(fs.readFileSync(mp,"utf8")); m.files ??= {};
+  const h=c.createHash("sha256").update(fs.readFileSync(tmpl)).digest("hex");
+  m.files["docker/Dockerfile.hermit.template"]={sha256:h, plugin_version:ver};
+  fs.writeFileSync(mp, JSON.stringify(m,null,2)+"\n");
+' "${CLAUDE_PLUGIN_ROOT}/state-templates/docker/Dockerfile.hermit.template" "<to>"
+```
+
+(`<to>` is the plan's `to` version string, available from the pre-pass result.)
+
+If `.claude-code-hermit/state/template-manifest.json` does not exist, skip this step — drift was `unknown` and the patch alone is sufficient (docker-setup was never run, so there is no baseline to update).
+
+**Step 4 — Report.** Set the report's `Docker rebuild` field to `base-patched`. Step 10 will emit a rebuild-only notice and suppress the generic "re-run /docker-setup" drift bullet for `Dockerfile.hermit`.
+
+No `config.json` changes required.
+
 ## [1.2.44] - 2026-08-22
 
 ### Added

--- a/plugins/claude-code-hermit/state-templates/docker/Dockerfile.hermit.template
+++ b/plugins/claude-code-hermit/state-templates/docker/Dockerfile.hermit.template
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # 'ubuntu' user at UID 1000 — remove it first.
 ARG HOST_UID=1000
 ARG CLAUDE_CODE_VERSION=latest
-ARG BUN_VERSION=1.3.11
+ARG BUN_VERSION=1.4.0
 RUN userdel -r ubuntu 2>/dev/null; \
     useradd -m -s /bin/bash -u ${HOST_UID} claude
 

--- a/plugins/claude-code-hermit/tests/hook-cwd-drift.test.ts
+++ b/plugins/claude-code-hermit/tests/hook-cwd-drift.test.ts
@@ -56,7 +56,7 @@ function driftEnv(): Record<string, string> {
 
 // The second test overwrites (and restores) the shared hermitDir/config.json
 // fixture in-place — a mutation of tmpRoot, not just a read — which the first
-// test also reads via an absolute path. Empirically confirmed (bun 1.3.14):
+// test also reads via an absolute path. Empirically confirmed (bun 1.3.14 & 1.4.0):
 // describe.serial does not reliably force sequential execution of its own
 // child tests under --concurrent — per-test .serial marking does.
 describe('validate-config with drifted cwd (#384 regression)', () => {

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -151,7 +151,7 @@ describe('cost-tracker', () => {
 // freezes its CWD-relative state paths (.status.json etc.) at import time. So we
 // chdir into ONE shared workdir for the first (and only) import, restore CWD, and
 // both cases rewrite .status.json inside that same frozen workdir.
-// Empirically confirmed (bun 1.3.14): describe.serial does not reliably force
+// Empirically confirmed (bun 1.3.14 & 1.4.0): describe.serial does not reliably force
 // sequential execution under --concurrent — per-test .serial marking does,
 // and also keeps this describe's beforeAll (which does a real process.chdir)
 // out of the concurrent pool.

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -2859,7 +2859,7 @@ describe('reflect-precheck', () => {
 
 describe('routines.ts log-event', () => {
 
-  // Empirically confirmed (bun 1.3.14): describe.serial does not reliably
+  // Empirically confirmed (bun 1.3.14 & 1.4.0): describe.serial does not reliably
   // force sequential execution of its own child tests under --concurrent —
   // only per-test .serial marking does. So each test below is marked individually.
   describe('hermit root resolution', () => {

--- a/plugins/claude-code-hermit/tests/skill-correction-ledger.test.ts
+++ b/plugins/claude-code-hermit/tests/skill-correction-ledger.test.ts
@@ -61,7 +61,7 @@ describe('session-close: skill-correction capture', () => {
 
 // ── 2. observations ledger: observations.ts behavioral test ─────────────────
 
-// Empirically confirmed (bun 1.3.14): describe.serial does not reliably force
+// Empirically confirmed (bun 1.3.14 & 1.4.0): describe.serial does not reliably force
 // sequential execution of its own child tests under --concurrent — only
 // per-test .serial marking does. So each test below is marked individually.
 describe('observations.ts: skill-correction row round-trip', () => {


### PR DESCRIPTION
## Summary

Moves the repo to Bun 1.4.0 — the first release of Bun's Rust rewrite, which cuts startup time and idle CPU/memory. That profile is the one that matters here, since hermits keep long-lived Bun processes alive.

Beyond the pins the issue listed, this also bumps the **shipped Docker template**, which was still on `1.3.11` — behind even CI — and is the actual runtime for Dockerized hermits.

Closes #779

## Changes

**Version pins**
- 15 `bun-version` pins `1.3.14` → `1.4.0` across 9 workflows
- `@types/bun` `~1.3.11` → `~1.4.0`, `bun.lock` regenerated

**Shipped runtime** (the scope gap)
- `Dockerfile.hermit.template`: `ARG BUN_VERSION` `1.3.11` → `1.4.0`
- CHANGELOG `[Unreleased]` with a surgical `base-patched` migration, following the Ubuntu 24.04→26.04 precedent — operators get a one-line `ARG` patch that preserves their Dockerfile customizations plus a rebuild, instead of being told to re-run the whole `/docker-setup` wizard

**Concurrency contract re-probed on 1.4** (the rewrite reworked the test runner)
- `describe.serial` is **still silently ignored**: `be1 be2 be3 be4`
- `test.serial` still interleaves correctly: `be1 ae1 be2 ae2 be3 ae3 be4`
- So the per-test markers can't be collapsed. Four comments now record both versions so the next upgrade needn't re-run the probe.

### Deliberately unchanged

`required_bun_version` stays `>=1.3.0`. It's a floor, not a pin, and no 1.4-only API is adopted — raising it would fail `/hermit-doctor` for operators still on 1.3.x for zero benefit.

## Test plan

Compatibility was established **before** any pin was edited — the untouched tree was run against 1.4.0, so a failure couldn't be confused with a bad edit.

- [x] All 8 plugin suites green on 1.4.0 with a **zero-line diff**, then again after every change
- [x] `bunx tsc` clean both before and after the `@types/bun` bump, isolating type errors from runtime errors
- [x] `bun install --frozen-lockfile` passes — the exact command CI runs; lockfile format is unchanged (`lockfileVersion: 1`)
- [x] `docker-baseline-content.test.ts` 33 pass after the template bump
- [x] Flake check: core suite 3× consecutive, 4263/4263 each time

## `--parallel` was tried and reverted

Commits 2 and 3 are an experiment and its revert, kept in history because the negative result is the useful part.

`bun test --parallel=4` cut the core suite 60s → ~37s and HA 24s → ~14s, green on 4/4 local runs. On CI it flaked immediately: `proc.test.ts` → `collectTree > cap marks the result unverified` failed at **4057ms against a 5000ms timeout** on the first run, and passed on a re-run of the same job.

That test spawns `bash -c 'sleep 5 & sleep 5 & wait'` and polls until the process tree reaches three pids, so it leans on the OS promptly scheduling forked children. Four workers on four slower CI vCPUs eats the margin — 81% of the timeout consumed, nothing left for a noisy neighbour. A 12-core dev box has the headroom; the runner does not.

A ~40% faster suite is not worth an intermittently red check, so the net diff here is the upgrade alone. If it's worth revisiting: raise the timeout on the handful of genuinely slow subprocess tests (they aren't broken — 5s is just tight for what they do), or try `--parallel=2`. Either needs measuring **on CI**, since local numbers are exactly what misled this attempt.
