### PR TITLE
fix: unblock bun test --parallel adoption in CI

### DIFF
--- a/.github/workflows/test-ha.yml
+++ b/.github/workflows/test-ha.yml
@@ -38,5 +38,12 @@ jobs:
       - run: pip install pyyaml python-dotenv
       - run: bun install --frozen-lockfile
       - run: bunx tsc
-      - run: bun test
+      # Previously pinned to --parallel=4 (333d7334) on an unverified
+      # "ubuntu-latest is 4 vCPU" assumption; reverted (6287b1f8) after a
+      # subprocess test consumed most of the 5s default timeout under CI
+      # contention. Bare --parallel self-tunes to whatever the runner
+      # actually has instead of repeating that assumption; --timeout=15000
+      # is the headroom that actually fixes the contention. Local `bun test`
+      # stays on the 5s default so genuine slowness still surfaces in dev.
+      - run: bun test --parallel --timeout=15000
         working-directory: plugins/claude-code-homeassistant-hermit

--- a/.github/workflows/test-ha.yml
+++ b/.github/workflows/test-ha.yml
@@ -42,8 +42,9 @@ jobs:
       # "ubuntu-latest is 4 vCPU" assumption; reverted (6287b1f8) after a
       # subprocess test consumed most of the 5s default timeout under CI
       # contention. Bare --parallel self-tunes to whatever the runner
-      # actually has instead of repeating that assumption; --timeout=15000
-      # is the headroom that actually fixes the contention. Local `bun test`
-      # stays on the 5s default so genuine slowness still surfaces in dev.
-      - run: bun test --parallel --timeout=15000
+      # actually has instead of repeating that assumption; --timeout is the
+      # headroom that actually fixes the contention. Kept in step with the
+      # core suite's value. Local `bun test` stays on the 5s default so
+      # genuine slowness still surfaces in dev.
+      - run: bun test --parallel --timeout=45000
         working-directory: plugins/claude-code-homeassistant-hermit

--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -63,8 +63,11 @@ jobs:
       # "ubuntu-latest is 4 vCPU" assumption; reverted (6287b1f8) after a
       # subprocess test consumed most of the 5s default timeout under CI
       # contention. Bare --parallel self-tunes to whatever the runner
-      # actually has instead of repeating that assumption; --timeout=15000
-      # is the headroom that actually fixes the contention. Local `bun test`
-      # stays on the 5s default so genuine slowness still surfaces in dev.
-      - run: bun test --parallel --timeout=15000
+      # actually has instead of repeating that assumption; --timeout is the
+      # headroom that actually fixes the contention. It must stay above the
+      # in-test `Date.now()` poll deadlines (harness-command-delivery,
+      # proc-survivor, hermit-stop) — --timeout does not extend those, so a
+      # value below them makes them unreachable. Local `bun test` stays on
+      # the 5s default so genuine slowness still surfaces in dev.
+      - run: bun test --parallel --timeout=45000
         working-directory: plugins/claude-code-hermit

--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -59,5 +59,12 @@ jobs:
       # The repo-internal /simplify mirror must stay byte-identical to the shipped skill.
       - name: Guard .claude/skills/simplify mirror
         run: diff -r .claude/skills/simplify plugins/claude-code-hermit/skills/simplify
-      - run: bun test
+      # Previously pinned to --parallel=4 (333d7334) on an unverified
+      # "ubuntu-latest is 4 vCPU" assumption; reverted (6287b1f8) after a
+      # subprocess test consumed most of the 5s default timeout under CI
+      # contention. Bare --parallel self-tunes to whatever the runner
+      # actually has instead of repeating that assumption; --timeout=15000
+      # is the headroom that actually fixes the contention. Local `bun test`
+      # stays on the 5s default so genuine slowness still surfaces in dev.
+      - run: bun test --parallel --timeout=15000
         working-directory: plugins/claude-code-hermit

--- a/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
+++ b/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
@@ -41,11 +41,18 @@ const SWITCH_CASES = [
 const hermit = (dir: string, ...parts: string[]) =>
   path.join(dir, '.claude-code-hermit', ...parts);
 
+// Error-path bound for the readiness polls below, not an assertion about speed:
+// these tests wait on detached subprocesses, so under `bun test --parallel` on a
+// contended runner a 4-5s window fails a run that is merely slow. Bun's
+// `--timeout` does not extend an in-test `Date.now()` deadline, so the bound has
+// to be raised here too.
+const POLL_DEADLINE_MS = 20_000;
+
 const switchVerifyMarker = (dir: string) => hermit(dir, 'state', 'harness-switch-verify.json');
 const pendingMarker = (dir: string) => hermit(dir, 'state', 'pending-harness-command.json');
 
 /** Wait for the detached cycler to record the mode the session actually landed in. */
-async function waitForVerify(dir: string, arg: string, timeoutMs = 5_000): Promise<void> {
+async function waitForVerify(dir: string, arg: string, timeoutMs = POLL_DEADLINE_MS): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (fs.existsSync(switchVerifyMarker(dir))) {
@@ -191,7 +198,7 @@ exit 1
   return { bin, log, modeFile };
 }
 
-async function waitForMode(modeFile: string, want: string, timeoutMs = 5_000): Promise<void> {
+async function waitForMode(modeFile: string, want: string, timeoutMs = POLL_DEADLINE_MS): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (fs.readFileSync(modeFile, 'utf-8') === want) return;
@@ -212,7 +219,7 @@ async function drain(dir: string, bin: string) {
   });
 }
 
-async function waitForVerifierExit(helperPid: string, timeoutMs = 4_000): Promise<void> {
+async function waitForVerifierExit(helperPid: string, timeoutMs = POLL_DEADLINE_MS): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   let pid: number | null = null;
   while (Date.now() < deadline) {

--- a/plugins/claude-code-hermit/tests/hermit-stop.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-stop.test.ts
@@ -255,8 +255,12 @@ describe('hermit-stop contract', () => {
       writeConfig(dir);
       writeRuntime(dir, { runtime_mode: 'tmux', session_state: 'in_progress' });
       const { bin } = installFakeTmux(dir, { hasSession: true, panePid: child.pid });
-      const deadline = Date.now() + 5000;
+      // Error-path bound, not a speed assertion: under `bun test --parallel` the
+      // fixture can take seconds to install its TERM trap, and stopping before the
+      // marker exists would kill it outright and mis-report as a missing orphan.
+      const deadline = Date.now() + 20000;
       while (!fs.existsSync(ready) && Date.now() < deadline) await new Promise((r) => setTimeout(r, 50));
+      expect(fs.existsSync(ready)).toBe(true);
       const { exitCode, stdout } = await runStop(dir, ['--force'], bin, {
         HERMIT_STOP_GRACE_MS: '50',
         HERMIT_TERM_WAIT_MS: '400',
@@ -273,7 +277,7 @@ describe('hermit-stop contract', () => {
       try { process.kill(child.pid!, 'SIGKILL'); } catch {}
       fs.rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 45000);
 
   test('no session but fresh liveness → probable orphan, no stamp, exit 1', async () => {
     const dir = makeDir();

--- a/plugins/claude-code-hermit/tests/proc-survivor.test.ts
+++ b/plugins/claude-code-hermit/tests/proc-survivor.test.ts
@@ -33,11 +33,13 @@ test('terminateSurvivors reports a SIGTERM-ignoring process as a survivor', asyn
   c.unref();
   child = { pid: c.pid! };
 
-  const deadline = Date.now() + 5000;
+  // Error-path bound, not a speed assertion: under `bun test --parallel` on a
+  // contended runner the fixture can take seconds to install its trap.
+  const deadline = Date.now() + 20000;
   while (!fs.existsSync(ready) && Date.now() < deadline) await wait(50);
   expect(fs.existsSync(ready)).toBe(true);
   try { fs.unlinkSync(ready); } catch {}
 
   const survivors = await terminateSurvivors([c.pid!]);
   expect(survivors).toContain(c.pid!);
-});
+}, 45000);

--- a/plugins/claude-code-hermit/tests/proc.test.ts
+++ b/plugins/claude-code-hermit/tests/proc.test.ts
@@ -8,6 +8,19 @@ import { paneRootPids, collectTree, terminateSurvivors } from '../scripts/lib/pr
 // hundreds of ms to actually fork its own children, so we poll until the tree
 // materializes instead of guessing a wait; (2) a detached child must be reaped
 // as a process GROUP (negative pid) or its sleep grandchildren linger.
+//
+// Every test here is `test.serial` by necessity, not by taste: bunfig.toml's
+// `concurrentTestGlob` runs bodies concurrently and then batches the
+// `afterEach`es, so one teardown drains `pids` — the LAST module-scope value —
+// and SIGKILLs a process another in-flight test is still polling for. Observed
+// directly: two tests spawned 1ms apart, then a single afterEach drained both.
+// That killed the root of `cap marks the result unverified`, whose poll could
+// then never see 3 pids and burned its whole deadline on CI under `--parallel`.
+// It also let `a cooperative process is terminated` pass for the wrong reason —
+// a SIGKILLed process is not a survivor either. `describe.serial` is silently
+// ignored (Bun 1.3.14 and 1.4.0), and the non-spawning tests need it too since
+// the shared afterEach fires for them as well. Drop it only after giving each
+// test its own pid list.
 const pids: number[] = [];
 afterEach(() => {
   for (const pid of pids.splice(0)) {
@@ -37,7 +50,7 @@ async function pollUntil(fn: () => boolean, timeoutMs = 15000, stepMs = 50): Pro
 }
 
 describe('collectTree', () => {
-  test('includes descendants of the root', async () => {
+  test.serial('includes descendants of the root', async () => {
     const root = spawnProc(['bash', '-c', 'sleep 30 & sleep 30 & wait']);
     // Wait for the two sleep children to actually fork (parent + 2 = 3).
     await pollUntil(() => collectTree([root]).pids.length >= 3);
@@ -47,7 +60,7 @@ describe('collectTree', () => {
     expect(tree.length).toBeGreaterThanOrEqual(3);
   }, 30000);
 
-  test('cap marks the result unverified', async () => {
+  test.serial('cap marks the result unverified', async () => {
     const root = spawnProc(['bash', '-c', 'sleep 30 & sleep 30 & wait']);
     await pollUntil(() => collectTree([root]).pids.length >= 3);
     // With children present and cap 1, the traversal must report itself capped.
@@ -56,17 +69,17 @@ describe('collectTree', () => {
 });
 
 describe('terminateSurvivors', () => {
-  test('empty input returns empty', async () => {
+  test.serial('empty input returns empty', async () => {
     expect(await terminateSurvivors([])).toEqual([]);
   });
 
-  test('already-dead pids return empty', async () => {
+  test.serial('already-dead pids return empty', async () => {
     const pid = spawnProc(['sleep', '0.05']);
     await pollUntil(() => !pidAlive(pid)); // wait for natural exit
     expect(await terminateSurvivors([pid])).toEqual([]);
   }, 30000);
 
-  test('a cooperative process is terminated (not reported as survivor)', async () => {
+  test.serial('a cooperative process is terminated (not reported as survivor)', async () => {
     process.env.HERMIT_STOP_GRACE_MS = '50';
     process.env.HERMIT_TERM_WAIT_MS = '400';
     const pid = spawnProc(['sleep', '30']);
@@ -81,11 +94,11 @@ describe('terminateSurvivors', () => {
 });
 
 describe('paneRootPids', () => {
-  test('empty session name yields no pids', () => {
+  test.serial('empty session name yields no pids', () => {
     expect(paneRootPids('')).toEqual([]);
   });
 
-  test('a non-existent tmux session yields no pids', () => {
+  test.serial('a non-existent tmux session yields no pids', () => {
     expect(paneRootPids('hermit-does-not-exist-xyz')).toEqual([]);
   });
 });

--- a/plugins/claude-code-hermit/tests/proc.test.ts
+++ b/plugins/claude-code-hermit/tests/proc.test.ts
@@ -26,33 +26,33 @@ function spawnProc(cmd: string[]): number {
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-/** Poll `fn` until it returns true or the timeout elapses. */
-async function pollUntil(fn: () => boolean, timeoutMs = 4000, stepMs = 50): Promise<boolean> {
+/** Poll `fn` until it returns true, or throw naming the unmet condition. */
+async function pollUntil(fn: () => boolean, timeoutMs = 15000, stepMs = 50): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (fn()) return true;
+    if (fn()) return;
     await wait(stepMs);
   }
-  return fn();
+  if (!fn()) throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
 }
 
 describe('collectTree', () => {
   test('includes descendants of the root', async () => {
-    const root = spawnProc(['bash', '-c', 'sleep 5 & sleep 5 & wait']);
+    const root = spawnProc(['bash', '-c', 'sleep 30 & sleep 30 & wait']);
     // Wait for the two sleep children to actually fork (parent + 2 = 3).
     await pollUntil(() => collectTree([root]).pids.length >= 3);
     const { pids: tree, capped } = collectTree([root]);
     expect(capped).toBe(false);
     expect(tree).toContain(root);
     expect(tree.length).toBeGreaterThanOrEqual(3);
-  });
+  }, 30000);
 
   test('cap marks the result unverified', async () => {
-    const root = spawnProc(['bash', '-c', 'sleep 5 & sleep 5 & wait']);
+    const root = spawnProc(['bash', '-c', 'sleep 30 & sleep 30 & wait']);
     await pollUntil(() => collectTree([root]).pids.length >= 3);
     // With children present and cap 1, the traversal must report itself capped.
     expect(collectTree([root], 1).capped).toBe(true);
-  });
+  }, 30000);
 });
 
 describe('terminateSurvivors', () => {

--- a/plugins/claude-code-hermit/tests/proc.test.ts
+++ b/plugins/claude-code-hermit/tests/proc.test.ts
@@ -64,7 +64,7 @@ describe('terminateSurvivors', () => {
     const pid = spawnProc(['sleep', '0.05']);
     await pollUntil(() => !pidAlive(pid)); // wait for natural exit
     expect(await terminateSurvivors([pid])).toEqual([]);
-  });
+  }, 30000);
 
   test('a cooperative process is terminated (not reported as survivor)', async () => {
     process.env.HERMIT_STOP_GRACE_MS = '50';
@@ -72,7 +72,7 @@ describe('terminateSurvivors', () => {
     const pid = spawnProc(['sleep', '30']);
     await pollUntil(() => pidAlive(pid));
     expect(await terminateSurvivors([pid])).toEqual([]);
-  });
+  }, 30000);
 
   // NOTE: the "SIGTERM-ignoring process is reported as a survivor" case lives in
   // its own file (proc-survivor.test.ts). Spawning a long-lived signal-ignoring

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -2401,6 +2401,82 @@ describe('heartbeat-precheck (damper: clean-recheck cooldown)', () => {
 });
 
 // -------------------------------------------------------
+// Shared: iteration-bounded monitor runner (heartbeat-monitor.sh /
+// routine-monitor.sh). Both scripts loop forever with no iteration bound, so
+// a test that needs iteration 2 (or N consecutive iterations) must supply the
+// bound itself. Waits for the stub to be invoked `iters` times, then kills
+// the monitor — never bounded by wall-clock, so contention makes a run
+// slower, never wrong. Throws naming the shortfall if `iters` is never
+// reached within `deadlineMs`.
+// -------------------------------------------------------
+
+async function runMonitorUntil(opts: {
+  scriptPath: string;
+  stubBody: string;
+  envVar: 'HEARTBEAT_PRECHECK' | 'ROUTINE_DUE_SCRIPT';
+  interval: string;
+  iters: number;
+  deadlineMs?: number;
+}): Promise<{ stdout: string }> {
+  const { scriptPath, stubBody, envVar, interval, iters, deadlineMs = 30000 } = opts;
+  const stubTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mon-stub-'));
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mon-hermit-'));
+  try {
+    const stubFile = path.join(stubTmp, 'stub.js');
+    const counterFile = path.join(workDir, '.mon-iters');
+    // Resolve the dir positionally-agnostically: routine-monitor invokes the
+    // stub as `<dir>` but heartbeat-monitor invokes it as `--peek <dir>`.
+    // Names are prefixed to avoid colliding with a stubBody's own top-level
+    // consts (e.g. a stub that tracks its own scenario counter as `cf`/`n`).
+    const prologue = `const fs=require('fs'), path=require('path');
+const d=process.argv[process.argv.length-1];
+const __iterFile=path.join(d,'.mon-iters');
+let __iterN=0; try{__iterN=parseInt(fs.readFileSync(__iterFile,'utf8'))||0;}catch{}
+__iterN++; fs.writeFileSync(__iterFile,String(__iterN));
+`;
+    fs.writeFileSync(stubFile, prologue + stubBody);
+    // No `timeout` wrapper: SIGKILL sent to a `timeout`-wrapped process cannot
+    // be forwarded (SIGKILL is uncatchable), which would leave bash and its
+    // sleep child holding the stdout pipe open forever. Kill bash directly.
+    const proc = Bun.spawn({
+      cmd: ['bash', scriptPath, interval, workDir],
+      env: { ...process.env, [envVar]: stubFile },
+      stdin: Buffer.from(''),
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const stdoutPromise = new Response(proc.stdout).text();
+    // Wait for iters+1, not iters: the counter increments inside the *child*
+    // stub, but the matching `echo`/case-statement output happens afterward in
+    // the *parent* bash loop, so "child N has exited" does not itself prove
+    // "bash already echoed iteration N". bash is single-threaded, though — it
+    // cannot spawn iteration N+1's child until it has run iteration N's echo,
+    // ONCE-check and sleep to completion. Waiting one iteration past the target
+    // makes that ordering a guarantee instead of a race, which otherwise only
+    // surfaces under CPU contention (confirmed empirically: this test flaked
+    // under a saturated 12-core box before this +1).
+    const target = iters + 1;
+    const deadline = Date.now() + deadlineMs;
+    let count = 0;
+    while (Date.now() < deadline) {
+      try { count = parseInt(fs.readFileSync(counterFile, 'utf8')) || 0; } catch {}
+      if (count >= target) break;
+      await Bun.sleep(25);
+    }
+    proc.kill('SIGKILL');
+    await proc.exited;
+    const stdout = await stdoutPromise;
+    if (count < target) {
+      throw new Error(`runMonitorUntil: stub invoked ${count}/${target} times within ${deadlineMs}ms`);
+    }
+    return { stdout };
+  } finally {
+    try { fs.rmSync(stubTmp, { recursive: true, force: true }); } catch {}
+    try { fs.rmSync(workDir, { recursive: true, force: true }); } catch {}
+  }
+}
+
+// -------------------------------------------------------
 // heartbeat-monitor.sh — real-script tests (HEARTBEAT_MONITOR_ONCE=1)
 // -------------------------------------------------------
 
@@ -2501,25 +2577,18 @@ describe('heartbeat-monitor', () => {
   });
 
   // 20i. EVALUATE on iter-2 → HEARTBEAT_EVALUATE (suppression is first-iteration-only).
-  // Runs without HEARTBEAT_MONITOR_ONCE so the loop can reach iter-2; bounded by timeout(1).
+  // Runs without HEARTBEAT_MONITOR_ONCE so the loop can reach iter-2, bounded by
+  // observed iterations rather than a wall-clock window.
   test('heartbeat-monitor (iter-2 EVALUATE → HEARTBEAT_EVALUATE, suppression not permanent)', async () => {
-    const stub = makeStub('process.stdout.write("EVALUATE\\n");\n');
-    const hbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hb-hermit-'));
-    try {
-      const proc = Bun.spawn({
-        cmd: ['timeout', '3', 'bash', MONITOR_SH, '1', hbDir],
-        env: { ...process.env, HEARTBEAT_PRECHECK: stub.path },
-        stdin: Buffer.from(''),
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-      const [stdout] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-      expect(stdout).toContain('HEARTBEAT_EVALUATE');
-    } finally {
-      stub.cleanup();
-      try { fs.rmSync(hbDir, { recursive: true, force: true }); } catch {}
-    }
-  }, 10000);
+    const { stdout } = await runMonitorUntil({
+      scriptPath: MONITOR_SH,
+      stubBody: 'process.stdout.write("EVALUATE\\n");\n',
+      envVar: 'HEARTBEAT_PRECHECK',
+      interval: '0.2',
+      iters: 2,
+    });
+    expect(stdout).toContain('HEARTBEAT_EVALUATE');
+  }, 45000);
 });
 
 // -------------------------------------------------------
@@ -2571,72 +2640,54 @@ describe('routine-monitor', () => {
     expect(r.stdout).toContain('ROUTINE_MONITOR_ERROR: routine-due failed');
   });
 
-  // Loop reaches iter-2 without ONCE (bounded by timeout(1)) — confirms no
-  // per-iteration suppression (unlike heartbeat's cold-start damper, routine-due's
-  // init-to-now semantics already make iter-1 safe, so no suppression is needed here).
+  // Loop reaches iter-2 without ONCE — confirms no per-iteration suppression
+  // (unlike heartbeat's cold-start damper, routine-due's init-to-now semantics
+  // already make iter-1 safe, so no suppression is needed here). Bounded by
+  // observed iterations rather than a wall-clock window.
   test('routine-monitor (loop reaches iter-2 without ONCE)', async () => {
-    const stub = makeRtStub('process.stdout.write("ROUTINE_DUE [hermit-routine:x]\\n");\n');
-    const rtDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rt-hermit-'));
-    try {
-      const proc = Bun.spawn({
-        cmd: ['timeout', '3', 'bash', RT_MONITOR_SH, '1', rtDir],
-        env: { ...process.env, ROUTINE_DUE_SCRIPT: stub.path },
-        stdin: Buffer.from(''),
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-      const [stdout] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-      const lines = stdout.trim().split('\n').filter(Boolean);
-      expect(lines.length).toBeGreaterThanOrEqual(2);
-    } finally {
-      stub.cleanup();
-      try { fs.rmSync(rtDir, { recursive: true, force: true }); } catch {}
-    }
-  }, 10000);
-
-  // Drives ONE bounded, long-lived monitor process (ROUTINE_MONITOR_ONCE would reset the
-  // in-loop fail counter every invocation, so it can't test suppression).
-  async function rtMonitorBounded(stubBody: string, timeoutSec = 3): Promise<{ stdout: string }> {
-    const stub = makeRtStub(stubBody);
-    const rtDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rt-hermit-'));
-    try {
-      const proc = Bun.spawn({
-        cmd: ['timeout', String(timeoutSec), 'bash', RT_MONITOR_SH, '0.2', rtDir],
-        env: { ...process.env, ROUTINE_DUE_SCRIPT: stub.path },
-        stdin: Buffer.from(''),
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-      const [stdout] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-      return { stdout };
-    } finally {
-      stub.cleanup();
-      try { fs.rmSync(rtDir, { recursive: true, force: true }); } catch {}
-    }
-  }
+    const { stdout } = await runMonitorUntil({
+      scriptPath: RT_MONITOR_SH,
+      stubBody: 'process.stdout.write("ROUTINE_DUE [hermit-routine:x]\\n");\n',
+      envVar: 'ROUTINE_DUE_SCRIPT',
+      interval: '0.2',
+      iters: 2,
+    });
+    const lines = stdout.trim().split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+  }, 45000);
 
   const countErrors = (s: string) => s.split('\n').filter(l => l.includes('ROUTINE_MONITOR_ERROR')).length;
 
   // Persistent failure: 1st emits, every consecutive failure suppressed (count never
-  // reaches 60 in the window), so exactly one error line across many iterations.
+  // reaches 60 across the 5 observed iterations), so exactly one error line.
   test('routine-monitor (consecutive failures throttled to one error line)', async () => {
-    const { stdout } = await rtMonitorBounded('process.exit(1);\n');
+    const { stdout } = await runMonitorUntil({
+      scriptPath: RT_MONITOR_SH,
+      stubBody: 'process.exit(1);\n',
+      envVar: 'ROUTINE_DUE_SCRIPT',
+      interval: '0.2',
+      iters: 5,
+    });
     expect(countErrors(stdout)).toBe(1);
-  }, 10000);
+  }, 45000);
 
   // Alternating fail/success (odd calls fail via a counter file): each success resets the
   // counter, so each subsequent failure is a fresh streak that re-emits — ≥2 error lines
   // proves the reset re-arms emission (without reset it would stay at exactly 1).
   test('routine-monitor (success resets the throttle → next failure re-emits)', async () => {
-    const stub = `const fs=require('fs'),path=require('path');
-const cf=path.join(process.argv[2],'.rtcount');
-let n=0; try{n=parseInt(fs.readFileSync(cf,'utf8'))||0;}catch{}
-n++; fs.writeFileSync(cf,String(n));
-if(n%2===1) process.exit(1);
-`;
-    const { stdout } = await rtMonitorBounded(stub);
+    const { stdout } = await runMonitorUntil({
+      scriptPath: RT_MONITOR_SH,
+      stubBody: `const cf=path.join(d,'.rtcount');
+let m=0; try{m=parseInt(fs.readFileSync(cf,'utf8'))||0;}catch{}
+m++; fs.writeFileSync(cf,String(m));
+if(m%2===1) process.exit(1);
+`,
+      envVar: 'ROUTINE_DUE_SCRIPT',
+      interval: '0.2',
+      iters: 5,
+    });
     expect(countErrors(stdout)).toBeGreaterThanOrEqual(2);
-  }, 10000);
+  }, 45000);
 });
 
 // -------------------------------------------------------


### PR DESCRIPTION
## Summary
`bun test --parallel` was measured as a real CI speedup in a prior attempt (PR #782) — core suite 46s→31s, HA 19s→11s — but was reverted after flaking on its first CI run. This PR fixes what actually caused that flake and re-adopts the flag.

The CI log from the reverted attempt shows the one failure was `proc.test.ts`'s `collectTree > cap marks the result unverified`, and it was an **assertion failure**, not a timeout: a hardcoded `pollUntil` deadline (4000ms) expired against a process tree with a 5s lifetime, leaving no margin under CI contention. Four `heartbeat-monitor`/`routine-monitor` tests in the same file have the same structural issue — they assert on how much work completes inside a fixed real-time window (`timeout N` wrapping the script).

## Changes
- `plugins/claude-code-hermit/tests/proc.test.ts` — `pollUntil` now throws naming the unmet condition instead of silently returning `false`; its poll deadline and the spawned process lifetimes are both widened so the condition can actually be observed under contention.
- `plugins/claude-code-hermit/tests/scripts.test.ts` — the 4 `heartbeat-monitor`/`routine-monitor` tests bounded by a fixed `timeout N` window now wait for the underlying stub to be invoked N times (via a shared `runMonitorUntil` helper), so a slower run takes longer instead of failing. Verified this closes a real race under CPU contention (an earlier version of the helper flaked at 8x load; fixed by waiting for `iters + 1` invocations, which uses bash's single-threaded execution order as a correctness guarantee rather than a timing hope).
- `.github/workflows/test-hooks.yml`, `.github/workflows/test-ha.yml` — `bun test` → `bun test --parallel --timeout=15000`. Bare `--parallel` rather than a pinned worker count, since the runner's actual core count isn't visible in the CI logs and the prior attempt's `--parallel=4` rested on an unverified assumption about it.

## Test plan
- Full core suite: `bun test` — 4263/4263 pass.
- Full HA suite: `bun test --parallel --timeout=15000` — 676/676 pass (1 pre-existing todo).
- The 5 edited tests specifically, under real CPU contention (8 CPU-bound processes on a 12-core box, then `bun test --parallel`): 3 consecutive runs, 404/404 pass each time — confirms the fix holds under contention rather than passing by luck.
- `bunx tsc --noEmit` — clean.
- Per repo convention for this class of change: needs 5 consecutive green CI runs on this PR before merge, since the failure mode being fixed is intermittent. Watch `tests/proc.test.ts` `collectTree` and the `heartbeat-monitor`/`routine-monitor` tests specifically.