### PR TITLE
fix: converge legacy Dockerfiles onto the pinned bun installer

### DIFF
--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -1,0 +1,78 @@
+name: Test Docker Build
+
+# The images operators actually rebuild are the current template and whatever
+# docker-bun-pin.ts converges a legacy Dockerfile into. Neither was ever built
+# in CI, so a template edit shipped unverified and the fleet found out on
+# `hermit-docker update`. Path-filtered: this is a multi-minute network build,
+# not something an ordinary core PR should wait on.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/claude-code-hermit/state-templates/docker/**'
+      - 'plugins/claude-code-hermit/scripts/docker-bun-pin.ts'
+      - 'plugins/claude-code-hermit/scripts/render-docker-templates.ts'
+      - 'plugins/claude-code-hermit/tests/fixtures/Dockerfile.hermit.legacy'
+      - '.github/workflows/test-docker-build.yml'
+  pull_request:
+    paths:
+      - 'plugins/claude-code-hermit/state-templates/docker/**'
+      - 'plugins/claude-code-hermit/scripts/docker-bun-pin.ts'
+      - 'plugins/claude-code-hermit/scripts/render-docker-templates.ts'
+      - 'plugins/claude-code-hermit/tests/fixtures/Dockerfile.hermit.legacy'
+      - '.github/workflows/test-docker-build.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shape: [current, converged-legacy]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.4.0'
+
+      # The current template, rendered exactly as /docker-setup renders it with
+      # no operator packages.
+      - name: Render the current template
+        if: matrix.shape == 'current'
+        run: |
+          mkdir -p build
+          echo '{
+            "packages": [],
+            "auth": "oauth-token",
+            "channels": { "envLines": [], "volumeLines": [] },
+            "agentHookProfile": "strict",
+            "networkMode": "bridge",
+            "gitIdentityMount": true
+          }' | bun plugins/claude-code-hermit/scripts/render-docker-templates.ts "$PWD/build"
+
+      # A pre-1.2.0 deployed Dockerfile put through the real migration script.
+      - name: Converge the legacy fixture
+        if: matrix.shape == 'converged-legacy'
+        run: |
+          mkdir -p build/.claude-code-hermit/state
+          cp plugins/claude-code-hermit/tests/fixtures/Dockerfile.hermit.legacy build/Dockerfile.hermit
+          cp plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template \
+             build/docker-entrypoint.hermit.sh
+          cd build
+          verdict=$(AGENT_DIR="$PWD/.claude-code-hermit" \
+            bun ../plugins/claude-code-hermit/scripts/docker-bun-pin.ts \
+              "$PWD/.claude-code-hermit" 1.4.0 ci-build)
+          echo "verdict: $verdict"
+          test "$verdict" = "OK|converged"
+
+      - name: Build the image
+        run: docker build -t hermit-ci:${{ matrix.shape }} -f build/Dockerfile.hermit build
+
+      # The pin is the point: a floating install would still build fine.
+      - name: Verify the pinned runtime inside the image
+        run: |
+          got=$(docker run --rm --entrypoint bash hermit-ci:${{ matrix.shape }} -lc 'bun --version')
+          echo "bun in image: $got"
+          test "$got" = "1.4.0"
+          docker run --rm --entrypoint bash hermit-ci:${{ matrix.shape }} -lc 'claude --version'

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- The 1.2.45 Bun pin deferred as a manual step on most Docker hermits. Scaffolds generated before 1.2.0 install bun through `npm install -g bun` and carry no `ARG BUN_VERSION` line, so the patch found nothing to change. A new `docker-bun-pin.ts` migration classifies the deployed `Dockerfile.hermit` and converges the npm shape onto the pinned native installer, leaving only a rebuild for you.
+
+### Upgrade Instructions
+
+**Docker runtime pinned to Bun 1.4.0 (completes the 1.2.45 step).** Non-Docker hermits: nothing to do — bun comes from the host and `required_bun_version` is unchanged at `>=1.3.0`.
+
+**Step 1 — Pin.** From the project root, run:
+
+```
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/docker-bun-pin.ts .claude-code-hermit 1.4.0 <to>
+```
+
+(`<to>` is the plan's `to` version string, available from the pre-pass result.) The script classifies `Dockerfile.hermit`, applies the right patch, and re-records the template baseline so the drift detector clears. It is idempotent — a hermit already patched by hand is reported, not re-patched.
+
+**Step 2 — Report, by verdict line.**
+
+- `OK|converged` or `OK|repinned <old>-><new>` → set the report's `Docker rebuild` field to `base-patched`. Step 10 emits a rebuild-only notice and suppresses the generic "re-run /docker-setup" drift bullet for `Dockerfile.hermit`.
+- `OK|already-pinned` or `SKIP|absent` → nothing to report.
+- `DEFER|unrecognized bun install shape` → the file no longer matches any shipped shape (bun installed some other way). Record a deferred-migration block with the instruction "manually set bun to 1.4.0 in `Dockerfile.hermit`, then rebuild", and **continue the remaining evolve steps** (do not abort).
+
+No `config.json` changes required.
+
 ## [1.2.45] - 2026-08-23
 
 ### Added
@@ -18,7 +43,7 @@
 
 **Step 1 — Existence / idempotency.** Check for `Dockerfile.hermit` at the project root. If it does not exist, skip to Step 4 (Docker not set up). If it already contains `ARG BUN_VERSION=1.4.0`, skip to Step 3 (already patched; still re-record the baseline so the drift detector clears).
 
-**Step 2 — Surgical patch.** Replace the single line matching `^ARG BUN_VERSION=` in `Dockerfile.hermit` with `ARG BUN_VERSION=1.4.0`. Match on the key, not on the old value — deploys exist on several past pins. If no such line is present (operator restructured how bun is installed), this is a genuine either/or with no safe non-destructive default: record a deferred-migration block with the instruction "manually set bun to 1.4.0 in `Dockerfile.hermit`, then rebuild", skip this patch, and **continue the remaining evolve steps** (do not abort).
+**Step 2 — Surgical patch.** Replace the single line matching `^ARG BUN_VERSION=` in `Dockerfile.hermit` with `ARG BUN_VERSION=1.4.0`. Match on the key, not on the old value — deploys exist on several past pins. If no such line is present, skip this patch **without** recording a deferred-migration block and continue: scaffolds generated before 1.2.0 install bun a different way, and the `docker-bun-pin.ts` step in a later entry classifies and converges them (deferring only a genuinely unrecognized shape).
 
 **Step 3 — Re-record the template baseline** so `classifyDockerTemplates` clears the drift and won't nag on future evolves. Run:
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -15,7 +15,7 @@
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/docker-bun-pin.ts .claude-code-hermit 1.4.0 <to>
 ```
 
-(`<to>` is the plan's `to` version string, available from the pre-pass result.) The script classifies `Dockerfile.hermit`, applies the right patch, and re-records the template baseline so the drift detector clears. It is idempotent — a hermit already patched by hand is reported, not re-patched.
+(`<to>` is the plan's `to` version string, available from the pre-pass result.) The script classifies `Dockerfile.hermit`, applies the right patch, and re-records the template baseline so the drift detector clears. It is idempotent — a hermit already patched by hand is reported, not re-patched. A converged pre-1.2.0 scaffold keeps its old baseline on purpose: only its bun block is current, so the Dockerfile drift nudge on future evolves is a true signal, not a leftover.
 
 **Step 2 — Report, by verdict line.**
 

--- a/plugins/claude-code-hermit/scripts/apply-settings.ts
+++ b/plugins/claude-code-hermit/scripts/apply-settings.ts
@@ -80,6 +80,7 @@ const HERMIT_ALLOW = [
   // session that has no AskUserQuestion to recover with.
   'Bash(bun */scripts/settings-edit.ts*)',
   'Bash(bun */scripts/manifest-seed.ts*)',
+  'Bash(bun */scripts/docker-bun-pin.ts*)',
   'Bash(bun */scripts/apply-settings.ts*)',
   'Bash(bun */scripts/channel-log.ts*)',
   'Bash(bun */scripts/channel-send.ts*)',

--- a/plugins/claude-code-hermit/scripts/docker-bun-pin.ts
+++ b/plugins/claude-code-hermit/scripts/docker-bun-pin.ts
@@ -2,7 +2,6 @@
 // pre-1.2.0 npm install shape onto the canonical ARG + native-installer block.
 //
 // Usage: bun docker-bun-pin.ts <hermit-state-dir> <bun-version> <plugin-version>
-//   (run from the project root — Dockerfile.hermit is resolved against CWD)
 //
 // Verdicts (stdout, one line, exit 0):
 //   SKIP|absent                  no Dockerfile.hermit
@@ -46,8 +45,9 @@ const [stateDirArg, bunVersion, pluginVersion] = process.argv.slice(2);
 if (!stateDirArg || !bunVersion || !pluginVersion) {
   die('usage: bun docker-bun-pin.ts <hermit-state-dir> <bun-version> <plugin-version>');
 }
-// Same pin as manifest-seed.ts: the state dir is not caller-chosen, and this
-// script is reached through a wildcarded grant that covers every argument.
+// Same pin as manifest-seed.ts: the state dir is not caller-chosen, and the
+// allow-list grant for this script (`Bash(bun */scripts/docker-bun-pin.ts*)`)
+// covers every argument.
 const stateDir = pinStateDirOrExit(stateDirArg, 'docker-bun-pin');
 
 // The ENV/RUN half of the canonical install, lifted from the shipped template:
@@ -92,7 +92,9 @@ function readManifest(): { path: string; data: any } | null {
 // Re-records the pristine baseline so evolve-plan's drift classifier stops
 // flagging Dockerfile.hermit.template. Only for a verdict that leaves the
 // deployment matching the shipped template: recording it after a DEFER would
-// clear the drift signal on a hermit whose bun was never pinned.
+// clear the drift signal on a hermit whose bun was never pinned, and after a
+// converge it would vouch for a pre-1.2.0 scaffold that is several template
+// generations behind in everything except the bun block we just spliced in.
 function writeBaseline(manifest: { path: string; data: any } | null): void {
   if (!manifest) return;
   manifest.data.files[MANIFEST_KEY] = {
@@ -104,14 +106,23 @@ function writeBaseline(manifest: { path: string; data: any } | null): void {
   fs.renameSync(tmp, manifest.path);
 }
 
-function commit(dockerfile: string, contents: string, verdict: string): never {
+function commit(contents: string, verdict: string): never {
   fs.writeFileSync(dockerfile, contents, 'utf8');
   writeBaseline(manifest);
   console.log(verdict);
   process.exit(0);
 }
 
-const dockerfile = path.resolve('Dockerfile.hermit');
+function defer(): never {
+  console.log('DEFER|unrecognized bun install shape');
+  process.exit(0);
+}
+
+// Anchored on the state dir's parent, the project root `pinStateDirOrExit` just
+// validated — never on CWD. A shell that drifted (which persists across calls)
+// would otherwise resolve nothing, report SKIP|absent, and leave the hermit
+// silently unpinned: the exact no-op this migration exists to end.
+const dockerfile = path.join(path.dirname(stateDir), 'Dockerfile.hermit');
 if (!fs.existsSync(dockerfile)) {
   console.log('SKIP|absent');
   process.exit(0);
@@ -124,8 +135,12 @@ const lines = original.split('\n');
 // deployed file exactly as it was.
 const manifest = readManifest();
 
+// An ARG line only means "pinned" alongside the installer it feeds. Following
+// the 1.2.45 note by hand on a pre-1.2.0 scaffold produces the ARG with npm
+// still installing a floating bun below it: a dead ARG, not a pin.
 const argIdx = lines.findIndex((l) => /^ARG BUN_VERSION=/.test(l));
-if (argIdx !== -1) {
+const nativeInstall = lines.some((l) => l.includes('https://bun.sh/install'));
+if (argIdx !== -1 && nativeInstall) {
   const current = lines[argIdx].slice('ARG BUN_VERSION='.length).trim();
   if (current === bunVersion) {
     writeBaseline(manifest);
@@ -133,17 +148,25 @@ if (argIdx !== -1) {
     process.exit(0);
   }
   lines[argIdx] = `ARG BUN_VERSION=${bunVersion}`;
-  commit(dockerfile, lines.join('\n'), `OK|repinned ${current}->${bunVersion}`);
+  commit(lines.join('\n'), `OK|repinned ${current}->${bunVersion}`);
 }
 
 // Legacy shape: bun rides along in the npm globals line. Also matches a
 // hand-applied `bun@1.4.0` pin, which converges rather than being re-nagged.
-const npmIdx = lines.findIndex((l) => /^RUN npm install -g bun(@\S+)? /.test(l));
+// A dead ARG is dropped first so the converged file carries exactly one.
+const body = argIdx === -1 ? lines : lines.filter((_, i) => i !== argIdx);
+const npmIdx = body.findIndex((l) => /^RUN npm install -g bun(@\S+)? /.test(l));
 if (npmIdx !== -1) {
-  lines[npmIdx] = lines[npmIdx].replace(/^(RUN npm install -g )bun(@\S+)? /, '$1');
-  lines.splice(npmIdx + 1, 0, '', `ARG BUN_VERSION=${bunVersion}`, canonicalInstallBlock());
-  commit(dockerfile, lines.join('\n'), 'OK|converged');
+  // Splicing into a continued RUN would land the block mid-command and break
+  // the build. Defer instead of writing a Dockerfile that cannot be built.
+  if (/\\\s*$/.test(body[npmIdx])) defer();
+  body[npmIdx] = body[npmIdx].replace(/^(RUN npm install -g )bun(@\S+)? /, '$1');
+  body.splice(npmIdx + 1, 0, '', `ARG BUN_VERSION=${bunVersion}`, canonicalInstallBlock());
+  // No writeBaseline: see the comment there — a converged scaffold is current
+  // in its bun block alone, and the drift nudge on the rest is a true signal.
+  fs.writeFileSync(dockerfile, body.join('\n'), 'utf8');
+  console.log('OK|converged');
+  process.exit(0);
 }
 
-console.log('DEFER|unrecognized bun install shape');
-process.exit(0);
+defer();

--- a/plugins/claude-code-hermit/scripts/docker-bun-pin.ts
+++ b/plugins/claude-code-hermit/scripts/docker-bun-pin.ts
@@ -1,0 +1,149 @@
+// Pins bun to a target version in a deployed Dockerfile.hermit, converging the
+// pre-1.2.0 npm install shape onto the canonical ARG + native-installer block.
+//
+// Usage: bun docker-bun-pin.ts <hermit-state-dir> <bun-version> <plugin-version>
+//   (run from the project root — Dockerfile.hermit is resolved against CWD)
+//
+// Verdicts (stdout, one line, exit 0):
+//   SKIP|absent                  no Dockerfile.hermit
+//   OK|already-pinned            ARG BUN_VERSION already at target
+//   OK|repinned <old>-><new>     ARG BUN_VERSION line moved to target
+//   OK|converged                 legacy `npm install -g bun` replaced by the block
+//   DEFER|unrecognized bun install shape   file untouched, caller defers
+//
+// Deploys exist on every template shape since v1.0.0, so the classification is
+// the contract — a migration step that assumed one shape is what stranded most
+// of the fleet on the 1.2.45 upgrade. Exit is non-zero only for caller error.
+//
+// The inserted block is READ from the shipped template, never inlined here:
+// the template is the single source of truth for what a pinned bun install
+// looks like, and a copy here would silently rot the next time it changes.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { sha256 } from './lib/hash';
+import { pinStateDirOrExit } from './lib/cc-compat';
+
+const MANIFEST_KEY = 'docker/Dockerfile.hermit.template';
+const TEMPLATE = path.resolve(
+  import.meta.dir,
+  '..',
+  'state-templates',
+  'docker',
+  'Dockerfile.hermit.template',
+);
+
+function die(msg: string): never {
+  console.error(`docker-bun-pin: ${msg}`);
+  process.exit(1);
+}
+
+function isPlainObject(v: any): boolean {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+const [stateDirArg, bunVersion, pluginVersion] = process.argv.slice(2);
+if (!stateDirArg || !bunVersion || !pluginVersion) {
+  die('usage: bun docker-bun-pin.ts <hermit-state-dir> <bun-version> <plugin-version>');
+}
+// Same pin as manifest-seed.ts: the state dir is not caller-chosen, and this
+// script is reached through a wildcarded grant that covers every argument.
+const stateDir = pinStateDirOrExit(stateDirArg, 'docker-bun-pin');
+
+// The ENV/RUN half of the canonical install, lifted from the shipped template:
+// everything from the `# Bun is the hermit runtime` comment through the
+// installer RUN line. The ARG is emitted separately so the insert is
+// self-contained wherever it lands.
+function canonicalInstallBlock(): string {
+  let tmpl: string;
+  try {
+    tmpl = fs.readFileSync(TEMPLATE, 'utf8');
+  } catch (err: any) {
+    die(`cannot read the shipped Dockerfile template: ${err.message}`);
+  }
+  const lines = tmpl.split('\n');
+  const start = lines.findIndex((l) => l.startsWith('# Bun is the hermit runtime'));
+  const end = lines.findIndex((l) => l.startsWith('RUN curl -fsSL https://bun.sh/install'));
+  if (start === -1 || end === -1 || end < start) {
+    die('shipped Dockerfile template no longer carries the bun install block — refusing to guess');
+  }
+  return lines.slice(start, end + 1).join('\n');
+}
+
+// Read and validate up front, so a corrupt manifest fails the run before the
+// Dockerfile is touched. Absent manifest = docker-setup never ran; there is no
+// baseline to keep, and one must not be invented.
+function readManifest(): { path: string; data: any } | null {
+  const manifestPath = path.join(stateDir, 'state', 'template-manifest.json');
+  if (!fs.existsSync(manifestPath)) return null;
+
+  let existing: any;
+  try {
+    existing = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (e: any) {
+    die(`existing template-manifest.json is not valid JSON: ${e.message} — refusing to overwrite`);
+  }
+  if (!isPlainObject(existing) || !isPlainObject(existing.files)) {
+    die('existing template-manifest.json: missing or invalid `files` object — refusing to overwrite');
+  }
+  return { path: manifestPath, data: existing };
+}
+
+// Re-records the pristine baseline so evolve-plan's drift classifier stops
+// flagging Dockerfile.hermit.template. Only for a verdict that leaves the
+// deployment matching the shipped template: recording it after a DEFER would
+// clear the drift signal on a hermit whose bun was never pinned.
+function writeBaseline(manifest: { path: string; data: any } | null): void {
+  if (!manifest) return;
+  manifest.data.files[MANIFEST_KEY] = {
+    sha256: sha256(fs.readFileSync(TEMPLATE)),
+    plugin_version: pluginVersion,
+  };
+  const tmp = manifest.path + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(manifest.data, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmp, manifest.path);
+}
+
+function commit(dockerfile: string, contents: string, verdict: string): never {
+  fs.writeFileSync(dockerfile, contents, 'utf8');
+  writeBaseline(manifest);
+  console.log(verdict);
+  process.exit(0);
+}
+
+const dockerfile = path.resolve('Dockerfile.hermit');
+if (!fs.existsSync(dockerfile)) {
+  console.log('SKIP|absent');
+  process.exit(0);
+}
+
+const original = fs.readFileSync(dockerfile, 'utf8');
+const lines = original.split('\n');
+
+// Validated before touching the Dockerfile: a caller-error exit must leave the
+// deployed file exactly as it was.
+const manifest = readManifest();
+
+const argIdx = lines.findIndex((l) => /^ARG BUN_VERSION=/.test(l));
+if (argIdx !== -1) {
+  const current = lines[argIdx].slice('ARG BUN_VERSION='.length).trim();
+  if (current === bunVersion) {
+    writeBaseline(manifest);
+    console.log('OK|already-pinned');
+    process.exit(0);
+  }
+  lines[argIdx] = `ARG BUN_VERSION=${bunVersion}`;
+  commit(dockerfile, lines.join('\n'), `OK|repinned ${current}->${bunVersion}`);
+}
+
+// Legacy shape: bun rides along in the npm globals line. Also matches a
+// hand-applied `bun@1.4.0` pin, which converges rather than being re-nagged.
+const npmIdx = lines.findIndex((l) => /^RUN npm install -g bun(@\S+)? /.test(l));
+if (npmIdx !== -1) {
+  lines[npmIdx] = lines[npmIdx].replace(/^(RUN npm install -g )bun(@\S+)? /, '$1');
+  lines.splice(npmIdx + 1, 0, '', `ARG BUN_VERSION=${bunVersion}`, canonicalInstallBlock());
+  commit(dockerfile, lines.join('\n'), 'OK|converged');
+}
+
+console.log('DEFER|unrecognized bun install shape');
+process.exit(0);

--- a/plugins/claude-code-hermit/tests/docker-bun-pin.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-bun-pin.test.ts
@@ -1,0 +1,212 @@
+// Classification matrix for docker-bun-pin.ts — every Dockerfile.hermit shape
+// the fleet actually carries, from the v1.0.0 npm-globals line through the
+// current ARG pin. The 1.2.45 migration assumed one shape and deferred on most
+// deployed hermits; these cases are what stops that recurring.
+//
+// Usage: bun test tests/docker-bun-pin.test.ts   (from the plugin root)
+
+import { describe, test, expect, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { runScript, PLUGIN_ROOT } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
+
+const { freshDir, cleanup } = freshDirFactory('hermit-dbp-');
+afterAll(cleanup);
+
+const LEGACY = fs.readFileSync(path.join(PLUGIN_ROOT, 'tests/fixtures/Dockerfile.hermit.legacy'), 'utf8');
+const TEMPLATE = fs.readFileSync(
+  path.join(PLUGIN_ROOT, 'state-templates/docker/Dockerfile.hermit.template'),
+  'utf8',
+);
+
+// Lays out a project root with a Dockerfile.hermit and a hermit state dir.
+function project(contents: string | null, manifest?: object): string {
+  const dir = freshDir();
+  fs.mkdirSync(path.join(dir, '.claude-code-hermit', 'state'), { recursive: true });
+  if (contents !== null) fs.writeFileSync(path.join(dir, 'Dockerfile.hermit'), contents);
+  if (manifest) {
+    fs.writeFileSync(
+      path.join(dir, '.claude-code-hermit', 'state', 'template-manifest.json'),
+      JSON.stringify(manifest, null, 2) + '\n',
+    );
+  }
+  return dir;
+}
+
+async function pin(dir: string, bunVersion = '1.4.0', pluginVersion = '1.2.46') {
+  const stateDir = path.join(dir, '.claude-code-hermit');
+  const r = await runScript('docker-bun-pin.ts', {
+    args: [stateDir, bunVersion, pluginVersion],
+    cwd: dir,
+    env: { AGENT_DIR: stateDir },
+  });
+  return { ...r, verdict: r.stdout.trim() };
+}
+
+const dockerfile = (dir: string) => fs.readFileSync(path.join(dir, 'Dockerfile.hermit'), 'utf8');
+const manifest = (dir: string) =>
+  JSON.parse(fs.readFileSync(path.join(dir, '.claude-code-hermit/state/template-manifest.json'), 'utf8'));
+
+describe('docker-bun-pin.ts', () => {
+  test('converges the deployed pre-1.2.0 npm-globals shape', async () => {
+    const dir = project(LEGACY);
+    const r = await pin(dir);
+    expect(r.exitCode).toBe(0);
+    expect(r.verdict).toBe('OK|converged');
+
+    const out = dockerfile(dir);
+    // bun leaves the npm line; Claude Code stays on it.
+    expect(out).not.toMatch(/npm install -g bun/);
+    expect(out).toContain('RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}');
+    expect(out).toContain('ARG BUN_VERSION=1.4.0');
+    expect(out).toContain('RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"');
+    expect(out).toContain('ENV BUN_INSTALL=/home/claude/.bun');
+    expect(out).toContain('ENV PATH=/home/claude/.bun/bin:$PATH');
+  });
+
+  test.each([
+    // The v1.0.0 template had no CLAUDE_CODE_VERSION arg — same bun problem.
+    [
+      'the earliest unversioned npm-globals line',
+      LEGACY.replace(/^RUN npm install -g bun .*$/m, 'RUN npm install -g bun @anthropic-ai/claude-code'),
+      'RUN npm install -g @anthropic-ai/claude-code',
+    ],
+    // An operator who followed the 1.2.45 manual note by hand gets converged
+    // onto the canonical shape, not re-nagged for the fleet's lifetime.
+    [
+      'a hand-applied npm version pin',
+      LEGACY.replace('npm install -g bun ', 'npm install -g bun@1.3.11 '),
+      'ARG BUN_VERSION=1.4.0',
+    ],
+  ])('converges %s', async (_label, contents, expectedLine) => {
+    const dir = project(contents);
+    const r = await pin(dir);
+    expect(r.verdict).toBe('OK|converged');
+    expect(dockerfile(dir)).not.toMatch(/npm install -g bun/);
+    expect(dockerfile(dir)).toContain(expectedLine);
+  });
+
+  test('the inserted block appears exactly once', async () => {
+    const dir = project(LEGACY);
+    await pin(dir);
+    const out = dockerfile(dir);
+    expect(out.split('ENV BUN_INSTALL=').length - 1).toBe(1);
+    expect(out.split('ARG BUN_VERSION=').length - 1).toBe(1);
+  });
+
+  test('repins an older ARG pin, matching on the key not the value', async () => {
+    const dir = project(TEMPLATE.replace('ARG BUN_VERSION=1.4.0', 'ARG BUN_VERSION=1.3.11'));
+    const r = await pin(dir);
+    expect(r.verdict).toBe('OK|repinned 1.3.11->1.4.0');
+    expect(dockerfile(dir)).toContain('ARG BUN_VERSION=1.4.0');
+  });
+
+  test('leaves an already-pinned file untouched', async () => {
+    const dir = project(TEMPLATE);
+    const r = await pin(dir);
+    expect(r.verdict).toBe('OK|already-pinned');
+    expect(dockerfile(dir)).toBe(TEMPLATE);
+  });
+
+  test('is idempotent — a second run reports already-pinned and changes nothing', async () => {
+    const dir = project(LEGACY);
+    await pin(dir);
+    const once = dockerfile(dir);
+    const r = await pin(dir);
+    expect(r.verdict).toBe('OK|already-pinned');
+    expect(dockerfile(dir)).toBe(once);
+  });
+
+  test('skips when Docker was never set up', async () => {
+    const dir = project(null);
+    const r = await pin(dir);
+    expect(r.exitCode).toBe(0);
+    expect(r.verdict).toBe('SKIP|absent');
+  });
+
+  // The genuine "operator restructured how bun is installed" case the 1.2.45
+  // fallback was written for — defer, never guess at a rewrite.
+  test('defers on an unrecognized install shape, leaving the file byte-identical', async () => {
+    const custom = LEGACY.replace(
+      /^RUN npm install -g bun .*$/m,
+      'COPY --from=oven/bun:1.3.11 /usr/local/bin/bun /usr/local/bin/bun',
+    );
+    const dir = project(custom);
+    const r = await pin(dir);
+    expect(r.exitCode).toBe(0);
+    expect(r.verdict).toBe('DEFER|unrecognized bun install shape');
+    expect(dockerfile(dir)).toBe(custom);
+  });
+
+  test('re-records the template baseline, preserving foreign keys', async () => {
+    const dir = project(LEGACY, {
+      version: 1,
+      files: {
+        'templates/SHELL.md.template': { sha256: 'a'.repeat(64), plugin_version: '1.2.40' },
+        'docker/Dockerfile.hermit.template': { sha256: 'b'.repeat(64), plugin_version: '1.2.40' },
+      },
+    });
+    await pin(dir);
+    const m = manifest(dir);
+    expect(m.files['templates/SHELL.md.template'].plugin_version).toBe('1.2.40');
+    const entry = m.files['docker/Dockerfile.hermit.template'];
+    expect(entry.plugin_version).toBe('1.2.46');
+    expect(entry.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(entry.sha256).not.toBe('b'.repeat(64));
+  });
+
+  // Recording the baseline says "this deployment matches the shipped template".
+  // After a defer it does not, so the drift detector has to keep nagging.
+  test('leaves the baseline alone when it defers', async () => {
+    const stale = { sha256: 'b'.repeat(64), plugin_version: '1.2.40' };
+    const dir = project(LEGACY.replace(/^RUN npm install -g bun .*$/m, 'COPY --from=oven/bun:1.3.11 /usr/local/bin/bun /usr/local/bin/bun'), {
+      version: 1,
+      files: { 'docker/Dockerfile.hermit.template': stale },
+    });
+    const r = await pin(dir);
+    expect(r.verdict).toBe('DEFER|unrecognized bun install shape');
+    expect(manifest(dir).files['docker/Dockerfile.hermit.template']).toEqual(stale);
+  });
+
+  test('does not create a manifest when docker-setup never wrote one', async () => {
+    const dir = project(LEGACY);
+    await pin(dir);
+    expect(fs.existsSync(path.join(dir, '.claude-code-hermit/state/template-manifest.json'))).toBe(false);
+  });
+
+  // A corrupt manifest is fatal in evolve-plan; failing before the patch keeps
+  // the deployed Dockerfile exactly as it was.
+  test('fails loud on a corrupt manifest without touching the Dockerfile', async () => {
+    const dir = project(LEGACY);
+    fs.writeFileSync(path.join(dir, '.claude-code-hermit/state/template-manifest.json'), '{ not json');
+    const r = await pin(dir);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('not valid JSON');
+    expect(dockerfile(dir)).toBe(LEGACY);
+  });
+
+  test('rejects a foreign state dir', async () => {
+    const dir = project(LEGACY);
+    const other = freshDir();
+    fs.mkdirSync(path.join(other, '.claude-code-hermit', 'state'), { recursive: true });
+    const r = await runScript('docker-bun-pin.ts', {
+      args: [path.join(other, '.claude-code-hermit'), '1.4.0', '1.2.46'],
+      cwd: dir,
+      env: { AGENT_DIR: path.join(dir, '.claude-code-hermit') },
+    });
+    expect(r.exitCode).toBe(1);
+    expect(dockerfile(dir)).toBe(LEGACY);
+  });
+
+  test('requires all three arguments', async () => {
+    const dir = project(LEGACY);
+    const r = await runScript('docker-bun-pin.ts', {
+      args: [path.join(dir, '.claude-code-hermit'), '1.4.0'],
+      cwd: dir,
+      env: { AGENT_DIR: path.join(dir, '.claude-code-hermit') },
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('usage:');
+  });
+});

--- a/plugins/claude-code-hermit/tests/docker-bun-pin.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-bun-pin.test.ts
@@ -139,8 +139,49 @@ describe('docker-bun-pin.ts', () => {
     expect(dockerfile(dir)).toBe(custom);
   });
 
+  // What following the 1.2.45 note by hand on a pre-1.2.0 scaffold produces:
+  // the ARG is there, but npm still installs a floating bun below it. Reading
+  // the ARG alone would call that pinned and leave the image unpinned forever.
+  test('converges a dead ARG that no native installer reads', async () => {
+    const dir = project(LEGACY.replace(/^ARG CLAUDE_CODE_VERSION=.*$/m, (l) => `ARG BUN_VERSION=1.4.0\n${l}`));
+    const r = await pin(dir);
+    expect(r.verdict).toBe('OK|converged');
+
+    const out = dockerfile(dir);
+    expect(out).not.toMatch(/npm install -g bun/);
+    expect(out).toContain('RUN curl -fsSL https://bun.sh/install');
+    expect(out.split('ARG BUN_VERSION=').length - 1).toBe(1);
+  });
+
+  // Splicing after a continued RUN lands the block mid-command — the image
+  // stops building. Defer beats emitting a Dockerfile that cannot be built.
+  test('defers when the npm line continues onto the next', async () => {
+    const custom = LEGACY.replace(
+      /^(RUN npm install -g bun .*)$/m,
+      '$1 && \\\n    npm cache clean --force',
+    );
+    const dir = project(custom);
+    const r = await pin(dir);
+    expect(r.verdict).toBe('DEFER|unrecognized bun install shape');
+    expect(dockerfile(dir)).toBe(custom);
+  });
+
+  // Shell CWD persists across calls, so a drifted evolve session must not turn
+  // a deployed Dockerfile into a clean "Docker not set up" verdict.
+  test('finds the Dockerfile through the state dir, not CWD', async () => {
+    const dir = project(LEGACY);
+    const stateDir = path.join(dir, '.claude-code-hermit');
+    const r = await runScript('docker-bun-pin.ts', {
+      args: [stateDir, '1.4.0', '1.2.46'],
+      cwd: freshDir(),
+      env: { AGENT_DIR: stateDir },
+    });
+    expect(r.stdout.trim()).toBe('OK|converged');
+    expect(dockerfile(dir)).toContain('ARG BUN_VERSION=1.4.0');
+  });
+
   test('re-records the template baseline, preserving foreign keys', async () => {
-    const dir = project(LEGACY, {
+    const dir = project(TEMPLATE.replace('ARG BUN_VERSION=1.4.0', 'ARG BUN_VERSION=1.3.11'), {
       version: 1,
       files: {
         'templates/SHELL.md.template': { sha256: 'a'.repeat(64), plugin_version: '1.2.40' },
@@ -154,6 +195,17 @@ describe('docker-bun-pin.ts', () => {
     expect(entry.plugin_version).toBe('1.2.46');
     expect(entry.sha256).toMatch(/^[0-9a-f]{64}$/);
     expect(entry.sha256).not.toBe('b'.repeat(64));
+  });
+
+  // A converged pre-1.2.0 scaffold matches the shipped template in its bun
+  // block and nothing else — still on the old base image, without the layers
+  // added since. Vouching for it would silence a true drift signal for good.
+  test('leaves the baseline alone when it converges', async () => {
+    const stale = { sha256: 'b'.repeat(64), plugin_version: '1.2.40' };
+    const dir = project(LEGACY, { version: 1, files: { 'docker/Dockerfile.hermit.template': stale } });
+    const r = await pin(dir);
+    expect(r.verdict).toBe('OK|converged');
+    expect(manifest(dir).files['docker/Dockerfile.hermit.template']).toEqual(stale);
   });
 
   // Recording the baseline says "this deployment matches the shipped template".

--- a/plugins/claude-code-hermit/tests/fixtures/Dockerfile.hermit.legacy
+++ b/plugins/claude-code-hermit/tests/fixtures/Dockerfile.hermit.legacy
@@ -1,0 +1,40 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      tmux python3 python3-venv python3-pip git curl unzip jq ca-certificates \
+      bubblewrap socat && \
+    curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    mkdir -p -m 755 /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+
+
+# Match host UID for volume permissions. Ubuntu 24.04 ships a default
+# 'ubuntu' user at UID 1000 — remove it first.
+ARG HOST_UID=1000
+ARG CLAUDE_CODE_VERSION=latest
+RUN userdel -r ubuntu 2>/dev/null; \
+    useradd -m -s /bin/bash -u ${HOST_UID} claude
+
+USER claude
+
+# Pre-create the config dir so the named volume inherits claude ownership on first mount
+RUN mkdir -p /home/claude/.claude
+
+# Install npm globals as claude user so Claude Code can self-update without sudo
+ENV NPM_CONFIG_PREFIX=/home/claude/.npm-global
+ENV PATH=/home/claude/.npm-global/bin:$PATH
+RUN npm install -g bun @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+COPY --chmod=755 --chown=claude:claude docker-entrypoint.hermit.sh /home/claude/docker-entrypoint.sh
+
+ENTRYPOINT ["/home/claude/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
The 1.2.45 Bun 1.4.0 pin is deferring as a manual step on almost every Docker hermit. Its migration patches the line matching `^ARG BUN_VERSION=`, but that line only exists in scaffolds generated from 1.2.0 onward (`14bd414a`, which moved bun from npm to the pinned native installer) — and 1.2.0's own Upgrade Instructions explicitly told operators *not* to regenerate `Dockerfile.hermit`. So the fallback written for a rare edge ("operator restructured how bun is installed") fires on the majority of deployments, and bun stays on a floating `npm install -g bun`.

This replaces the shape-assuming prose step with a script that classifies the deployed file, and adds the Docker build coverage CI never had.

## Changes
- **`plugins/claude-code-hermit/scripts/docker-bun-pin.ts`** (new) — `bun docker-bun-pin.ts <state-dir> <bun-version> <plugin-version>` classifies `Dockerfile.hermit` and prints one verdict: `SKIP|absent`, `OK|already-pinned`, `OK|repinned <old>-><new>`, `OK|converged`, or `DEFER|unrecognized bun install shape`. The legacy `RUN npm install -g bun …` line loses its bun token and gains the canonical `ARG BUN_VERSION` + `ENV BUN_INSTALL`/`PATH` + native-installer block, read from the shipped template at runtime rather than duplicated in the script. A hand-applied `bun@x.y.z` pin converges too, so operators who followed the 1.2.45 manual note aren't re-nagged. Reuses `pinStateDirOrExit` (`lib/cc-compat.ts`) and `sha256` (`lib/hash.ts`). Future bun bumps are one invocation with a new version argument instead of new migration prose.
- **`plugins/claude-code-hermit/CHANGELOG.md`** — `[Unreleased]` carries the fix bullet and the replacement Upgrade Instructions (run the script, map verdict → report field; `DEFER` still records a deferred-migration block and continues). The released `[1.2.45]` Step 2 fallback is amended to skip *without* recording a deferred block, so a hermit evolving from below 1.2.45 doesn't collect a note that the very next entry resolves.
- **`.github/workflows/test-docker-build.yml`** (new) — path-filtered on the docker templates, the two scripts, and the fixture. Two matrix jobs build the rendered current template and the script-converged legacy fixture, then assert `bun --version` inside each image equals the pin. No workflow built a Dockerfile before this, so template edits shipped unverified.
- **`plugins/claude-code-hermit/tests/`** — `docker-bun-pin.test.ts` (15 tests) covers every deployed shape, idempotency, manifest baseline handling, and the caller-error paths; `fixtures/Dockerfile.hermit.legacy` is the pre-1.2.0 template as deployed, shared with the CI job.

Baseline handling worth flagging for review: the template baseline is written only on `OK` verdicts. Recording it after a `DEFER` would clear the drift signal on a hermit whose bun was never pinned, so validation (which must fail before the Dockerfile is touched) is split from the write.

## Test plan
- `bun test` from `plugins/claude-code-hermit` — 4285/4285 pass.
- `bunx tsc --noEmit` — exit 0.
- **Real Docker builds, run locally** (the point of the new workflow):
  - converged legacy fixture → builds; `bun --version` → `1.4.0`; `claude --version` → `2.1.241`.
  - current template rendered via `render-docker-templates.ts` → builds; same two checks pass.
- Migration smoke: legacy fixture in a scratch project root → `OK|converged`; second run → `OK|already-pinned` with no further diff.
- CI: this PR touches the pin script, the fixture and the workflow, so `test-docker-build.yml` should fire and go green on both shapes — that run is the gate for the fleet-wide rebuild.