### PR TITLE
feat: mechanical resident/guest roles, plus a hermit-managed spawn gate

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- A session opened in a hermit folder while the managed hermit is running now gets a short guest banner instead of the full hermit framing — it is told not to answer channels, write session state, or start schedulers. Role assignment is mechanical (the existing `HERMIT_MANAGED` marker plus a tmux liveness check), not a judgment call.
+- `hermit-run rc-server <start|stop|status|gc>` and the `/claude-code-hermit:rc-gate` skill open a hermit-managed Remote Control spawn gate, so you can start new sessions in a project from your phone. Spawns land in isolated worktrees, and `gc` sweeps the locked worktrees left behind when a spawned session is archived from the app. Requires a claude.ai `/login` on the machine.
+
 ### Fixed
 - Notices asking for a decision or reply now always carry a plain-language client leg; the `maintainer` key supplements it with technical detail instead of replacing it. Heartbeat findings, inbox items, and pending-proposal digests were landing maintainer-only — or nowhere on non-technical installs with no maintainer chat configured.
 - Denying a direct `config.json` edit from a channel turn now points to the `settings-edit` recovery path instead of "terminal only", so channel-side settings changes (adding a routine, for example) can self-recover through the tiered script path.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `hermit-run rc-server <start|stop|status|gc>` and the `/claude-code-hermit:rc-gate` skill open a hermit-managed Remote Control spawn gate, so you can start new sessions in a project from your phone. Spawns land in isolated worktrees, and `gc` sweeps the locked worktrees left behind when a spawned session is archived from the app. Requires a claude.ai `/login` on the machine.
 
 ### Fixed
+- Two lifecycle-lock acquirers that both judged the same lock stale could each end up holding it — the takeover moved aside whatever sat at the lock path, including the winner's brand-new lock. Takeovers are now serialized by an exclusive marker naming the exact file being replaced, and that file is re-verified by identity before removal, so `hermit-start`, `hermit-stop`, and the watchdog can no longer run a lifecycle operation concurrently.
 - Notices asking for a decision or reply now always carry a plain-language client leg; the `maintainer` key supplements it with technical detail instead of replacing it. Heartbeat findings, inbox items, and pending-proposal digests were landing maintainer-only — or nowhere on non-technical installs with no maintainer chat configured.
 - Denying a direct `config.json` edit from a channel turn now points to the `settings-edit` recovery path instead of "terminal only", so channel-side settings changes (adding a routine, for example) can self-recover through the tiered script path.
 

--- a/plugins/claude-code-hermit/CLAUDE.md
+++ b/plugins/claude-code-hermit/CLAUDE.md
@@ -16,7 +16,7 @@ After install, run `/claude-code-hermit:hatch` in the target project to create t
 ## Plugin Structure
 
 - `agents/` — subagent definitions (proposal-triage, reflection-judge, evolve-runner, skill-eval-runner; hermit plugins add more subagents)
-- `skills/` — skill definitions (namespaced as `/claude-code-hermit:*`): session, session-start, session-close, brief, watch, heartbeat, hermit-routines, hermit-settings, proposal-create, proposal-list, proposal-act, reflect, capability-brainstorm, channel-responder, channel-setup, hatch, hermit-evolve, docker-setup, docker-security, simplify, smoke-test, hermit-evolution, cost-reflect, hermit-health, weekly-review, migrate, hermit-doctor, recall, relogin, hermit-dashboard-design
+- `skills/` — skill definitions (namespaced as `/claude-code-hermit:*`): session, session-start, session-close, brief, watch, heartbeat, hermit-routines, hermit-settings, proposal-create, proposal-list, proposal-act, reflect, capability-brainstorm, channel-responder, channel-setup, hatch, hermit-evolve, docker-setup, docker-security, simplify, smoke-test, hermit-evolution, cost-reflect, hermit-health, weekly-review, migrate, hermit-doctor, recall, relogin, hermit-dashboard-design, rc-gate
 - `hooks/hooks.json` — hook registrations
 - `scripts/` — hook implementation scripts + boot scripts (hermit-start.ts, hermit-stop.ts)
 - `state-templates/` — templates copied into target projects by the `hatch` skill

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -55,6 +55,8 @@ claude --permission-mode auto
 
 [Remote control](https://code.claude.com/docs/en/remote-control) connects from any browser or phone. Enable via config (`/hermit-settings remote`) or `--remote-control`. Connect at [claude.ai/code](https://claude.ai/code).
 
+To spawn *new* sessions into a project from your phone, ask the hermit to open the spawn gate (`/claude-code-hermit:rc-gate`), or supervise a standalone server per project with the systemd recipe in [Remote Endpoint](remote-endpoint.md). Both need a claude.ai `/login` on the machine.
+
 ---
 
 ## 2. Always-On Lifecycle

--- a/plugins/claude-code-hermit/docs/remote-endpoint.md
+++ b/plugins/claude-code-hermit/docs/remote-endpoint.md
@@ -1,0 +1,97 @@
+# Always-Reachable Remote Endpoint (Linux/systemd)
+
+Turn a machine into a **phone-spawnable endpoint**: a supervised
+`claude remote-control` server per project, so you can start new sessions from
+the Claude app without anyone at the keyboard.
+
+This is the unattended sibling of the hermit's own spawn gate
+(`/claude-code-hermit:rc-gate`, backed by `hermit-run rc-server`). The gate is
+better when the hermit is running and you want conversational control; this
+recipe is better when nothing is running and you still want the machine
+reachable after a reboot or a network flap.
+
+## Prerequisites
+
+- **A claude.ai `/login` on this machine.** Remote Control rejects setup-token
+  auth outright ("must be logged in… only available with claude.ai
+  subscriptions"). Adding `/login` to a setup-token box flips that install's
+  auth precedence for everything on it — it is an either/or per machine, not an
+  addition.
+- Linux with systemd user units. macOS/launchd is unwritten; the unit below does
+  not translate directly.
+- A machine that stays awake. Laptops sleep; this recipe assumes a box that
+  doesn't.
+
+## The unit
+
+`~/.config/systemd/user/claude-rc@.service` — a template unit, one instance per
+project. Keep it installed with no instances enabled until you enroll a folder.
+
+```ini
+[Unit]
+Description=Claude Remote Control gate for %I
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/%I
+ExecStart=/usr/bin/script -qfc "/usr/local/bin/claude remote-control --spawn worktree --no-create-session-in-dir" /dev/null
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=default.target
+```
+
+Four details are load-bearing, each of which failed before being fixed:
+
+- **`WorkingDirectory=/%I`** — the leading slash is required. `%I` unescapes the
+  path without it and systemd refuses with "path is not absolute".
+- **Absolute `claude` path.** User units get no shell PATH. Substitute the output
+  of `which claude`.
+- **`/usr/bin/script -qfc "…" /dev/null`.** The server wants a pty; under bare
+  systemd it never reaches Ready. The `script` wrapper supplies one.
+- **`Restart=on-failure` + `RestartSec=15`.** The server self-exits after ~10
+  minutes of failed reconnects, so without supervision the endpoint is reachable
+  only until the first network flap. Verified: `kill -9` of MainPID → scheduled
+  restart → active with a new PID, and a quick restart stays inside the ~4h
+  session-resume window.
+
+## Enroll a project
+
+```sh
+systemctl --user enable --now claude-rc@$(systemd-escape -p /path/to/project)
+loginctl enable-linger "$USER"   # only needed for reboot-before-login
+```
+
+One enroll line per project. Instances run side by side: two projects were
+verified active simultaneously, each reaching Ready with its own environment id,
+each appearing as a separate environment in the app picker with its own
+32-session capacity. No account-level cap was observed at n=2; larger n is
+untested.
+
+Check with `systemctl --user status 'claude-rc@*'`. Don't tail the journal for
+status — the server's TUI redraws continuously and floods any follower.
+
+## Flags
+
+- `--spawn worktree` puts every phone-spawned session in its own git worktree,
+  so spawns never collide with each other or with work in the folder.
+- `--no-create-session-in-dir` suppresses the session the server otherwise
+  pre-creates in the project directory (the default exists so a device has
+  somewhere to type immediately). For an endpoint it prevents a second session
+  squatting in the folder. Trade: with that flag the server's sessions archive
+  when it stops.
+
+## Caveats
+
+- **No worktree GC here.** Archiving a spawned session from the Claude app reads
+  as a crash to the server and leaves a *locked* worktree behind. The recipe does
+  not clean those up; run `.claude-code-hermit/bin/hermit-run rc-server gc` in
+  the project, or unlock/remove/prune by hand.
+- **Anyone who can reach your Claude account can spawn sessions into an enrolled
+  folder** while its instance is running. Enroll deliberately, and
+  `systemctl --user disable --now` the instance when you don't need it.
+- **This recipe is disposable by design.** Server mode, capacity limits and
+  resume flags all point at Anthropic shipping a supervised daemon; when that
+  lands, delete the unit and keep using the CLI.

--- a/plugins/claude-code-hermit/scripts/lib/lockfile.ts
+++ b/plugins/claude-code-hermit/scripts/lib/lockfile.ts
@@ -12,6 +12,9 @@
 import fs from 'node:fs';
 
 const DEFAULT_STALE_MS = 15 * 60 * 1000;
+// A takeover is a handful of syscalls; a claim marker older than this was left
+// behind by a stealer that died mid-swap.
+const STALE_CLAIM_MS = 30 * 1000;
 
 function pidAlive(pid: number): boolean {
   try {
@@ -47,6 +50,38 @@ function tryCreate(lockPath: string): boolean {
   }
 }
 
+// The marker naming the exact file a takeover is replacing. Every racer stats
+// the same unchanging file, so they all derive the same name.
+function claimPathFor(lockPath: string, ino: number, mtimeMs: number): string {
+  return `${lockPath}.steal.${ino}.${Math.round(mtimeMs)}`;
+}
+
+// Exclusive-create the marker naming one specific stale lock file: the only
+// compare-and-swap the filesystem offers. Whoever creates it is the single
+// process allowed to replace that file. Returns false if a takeover of the same
+// file is already in flight.
+function claimStale(claimPath: string): boolean {
+  try {
+    fs.writeFileSync(claimPath, String(process.pid), { flag: 'wx' });
+    return true;
+  } catch (e: any) {
+    if (!e || e.code !== 'EEXIST') throw e; // real fs error — surface it
+  }
+  try {
+    if (Date.now() - fs.statSync(claimPath).mtimeMs < STALE_CLAIM_MS) return false;
+    // The stealer died mid-swap. Dropping its marker reopens the race, which
+    // the exclusive create below re-serializes.
+    fs.unlinkSync(claimPath);
+    fs.writeFileSync(claimPath, String(process.pid), { flag: 'wx' });
+    return true;
+  } catch {
+    // Deliberately fail closed here: the marker vanished, or another racer got
+    // to it first. Reporting contention costs the caller a retry; guessing
+    // wrong in the other direction costs two holders.
+    return false;
+  }
+}
+
 /**
  * Try to acquire the lock. Returns true on success, false on live contention.
  * Stale locks (dead PID, empty/unparseable content, or mtime older than
@@ -57,13 +92,27 @@ function acquireLock(lockPath: string, staleMs: number = DEFAULT_STALE_MS): bool
 
   let holderPid: number | null = null;
   let mtimeMs = 0;
+  let ino = 0;
+  // Read the PID and the identity through ONE descriptor: a separate open for
+  // each could straddle a concurrent takeover, judging the old file's dead PID
+  // while identifying the replacement, and then delete a live lock.
+  let fd: number | null = null;
   try {
-    const content = fs.readFileSync(lockPath, 'utf-8').trim();
+    fd = fs.openSync(lockPath, 'r');
+    const st = fs.fstatSync(fd);
+    mtimeMs = st.mtimeMs;
+    ino = st.ino;
+    const content = fs.readFileSync(fd, 'utf-8').trim();
     holderPid = /^\d+$/.test(content) ? parseInt(content, 10) : null;
-    mtimeMs = fs.statSync(lockPath).mtimeMs;
   } catch {
     // Vanished between create-attempt and read — retry once.
     return tryCreate(lockPath);
+  } finally {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch {}
+    }
   }
 
   const fresh = Date.now() - mtimeMs < staleMs;
@@ -72,24 +121,28 @@ function acquireLock(lockPath: string, staleMs: number = DEFAULT_STALE_MS): bool
   }
 
   // Stale: dead holder, no/garbage PID (legacy empty flock file), or expired
-  // mtime. Claim it by atomic rename, NOT unlink-by-path: two racers that both
-  // judged the lock stale would otherwise each unlink the path and each create
-  // a fresh lock (the second deletes the first's live lock) → double-acquire.
-  // renameSync is atomic on a given inode, so exactly one racer moves it aside;
-  // the loser's rename throws ENOENT and falls through to a clean retry.
-  const graveyard = `${lockPath}.stale.${process.pid}`;
+  // mtime. Two racers that both judged THIS file stale must not both replace
+  // it, so serialize on a marker naming the exact file they judged. Neither
+  // rename nor unlink can do this: both act on a path, not an inode, so a slow
+  // racer would move or delete the winner's brand-new lock and acquire on top
+  // of it → double-acquire.
+  const claim = claimPathFor(lockPath, ino, mtimeMs);
+  if (!claimStale(claim)) return false; // a takeover of this file is already in flight
   try {
-    if (fs.statSync(lockPath).mtimeMs !== mtimeMs) return false; // renewed in-window → back off
-    fs.renameSync(lockPath, graveyard);
-  } catch {
-    // Vanished or lost the takeover race — retry create; if someone else won,
-    // tryCreate returns false (genuinely held now).
+    try {
+      const st = fs.statSync(lockPath);
+      // Still the file we judged? If not it was already replaced — leave it be
+      // and let tryCreate report the truth.
+      if (st.ino === ino && st.mtimeMs === mtimeMs) fs.unlinkSync(lockPath);
+    } catch {
+      // Vanished — fall through to the create.
+    }
     return tryCreate(lockPath);
+  } finally {
+    try {
+      fs.unlinkSync(claim);
+    } catch {}
   }
-  try {
-    fs.unlinkSync(graveyard);
-  } catch {}
-  return tryCreate(lockPath);
 }
 
 /** Release the lock if this process holds it. */
@@ -100,4 +153,4 @@ function releaseLock(lockPath: string): void {
   } catch {}
 }
 
-export { acquireLock, releaseLock, pidAlive, DEFAULT_STALE_MS };
+export { acquireLock, releaseLock, pidAlive, claimPathFor, DEFAULT_STALE_MS };

--- a/plugins/claude-code-hermit/scripts/rc-server.ts
+++ b/plugins/claude-code-hermit/scripts/rc-server.ts
@@ -50,11 +50,18 @@ function repoRoot(): string {
   return r.status === 0 && r.stdout.trim() ? r.stdout.trim() : process.cwd();
 }
 
-/** Status read off an already-captured pane, so callers holding one don't re-spawn tmux. */
+/**
+ * Status read off an already-captured pane, so callers holding one don't re-spawn tmux.
+ *
+ * A live tmux session is not by itself proof the server is serving: `start`
+ * leaves the session running when it times out, so 'ready' has to come from the
+ * same signal `start` waits on, not from mere liveness.
+ */
 function statusFromPane(pane: string): string {
   const cap = pane.match(CAPACITY_RE);
   if (cap && Number(cap[1]) > 0) return `connected ${cap[1]}/${cap[2]}`;
-  return 'ready';
+  if (READY_RE.test(pane) || URL_RE.test(pane)) return 'ready';
+  return 'starting';
 }
 
 /** One-line status derived from a single pane capture. */
@@ -148,6 +155,12 @@ function worktreeBranches(root: string): Map<string, string> {
  * session from the Claude app reads as a crash to the server and orphans a
  * *locked* worktree, so unlock comes first and `git worktree remove` needs a
  * --force fallback.
+ *
+ * A dirty worktree is never swept. Once the lock is gone the only thing
+ * `remove` still refuses is uncommitted work, so the --force fallback would be
+ * a delete of exactly that. An orphan holding a spawned session's unsaved work
+ * is the operator's to resolve; gc reports it and moves on. Committed work is
+ * covered separately, by deleting the branch with -d rather than -D.
  */
 function gc(): number {
   const root = repoRoot();
@@ -167,18 +180,33 @@ function gc(): number {
   }
 
   const branches = worktreeBranches(root);
+  let removed = 0;
   for (const name of entries) {
     const dir = path.join(wtDir, name);
     if (inUse(cwds, dir)) continue;
-    sh('git', ['-C', root, 'worktree', 'unlock', dir]); // absent lock → non-zero, ignored
-    if (sh('git', ['-C', root, 'worktree', 'remove', dir]).status !== 0) {
-      sh('git', ['-C', root, 'worktree', 'remove', '--force', dir]);
+    // Untracked files count: a spawned session's new files are usually the work.
+    if (sh('git', ['-C', dir, 'status', '--porcelain']).stdout.trim()) {
+      console.log(`kept ${name} (uncommitted changes)`);
+      continue;
     }
-    sh('git', ['-C', root, 'worktree', 'prune']);
+    sh('git', ['-C', root, 'worktree', 'unlock', dir]); // absent lock → non-zero, ignored
+    if (
+      sh('git', ['-C', root, 'worktree', 'remove', dir]).status !== 0 &&
+      sh('git', ['-C', root, 'worktree', 'remove', '--force', dir]).status !== 0
+    ) {
+      console.error(`[rc-server] could not remove ${name} — left in place.`);
+      continue;
+    }
+    // -d, not -D: the dirty check above only catches *uncommitted* work, so a
+    // session that committed and never pushed still reads as clean here. -d
+    // refuses an unmerged branch, leaving a stray local branch rather than
+    // destroying the commits behind it.
     const branch = branches.get(dir);
-    if (branch) sh('git', ['-C', root, 'branch', '-D', branch]);
+    if (branch) sh('git', ['-C', root, 'branch', '-d', branch]);
     console.log(`removed ${name}`);
+    removed++;
   }
+  if (removed) sh('git', ['-C', root, 'worktree', 'prune']);
   return 0;
 }
 

--- a/plugins/claude-code-hermit/scripts/rc-server.ts
+++ b/plugins/claude-code-hermit/scripts/rc-server.ts
@@ -1,0 +1,207 @@
+// rc-server.ts — the hermit's spawn gate over `claude remote-control`.
+//
+// Server mode lets a phone spawn NEW sessions into this project; it is a
+// separate leg from the hermit's own `--remote-control` flag (which makes the
+// hermit itself reachable). The server runs as a hermit-owned tmux child so
+// open/close/status are ordinary chat verbs, and never auto-starts: opening
+// remote spawn is a deliberate, settings-authority-tier act.
+//
+// Launched with `--spawn worktree --no-create-session-in-dir` so the project
+// folder stays single-session and every phone spawn lands in its own worktree.
+// Trade documented upstream: with that flag the server's sessions archive when
+// it stops.
+//
+// Reached via: .claude-code-hermit/bin/hermit-run rc-server <subcommand>
+// Subcommands: start | stop | status | gc
+//
+// Status is a single one-shot pane capture, never a tail: the server's TUI
+// redraws its status line continuously and floods any log follower.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmuxSessionAlive, capturePane as tmuxCapturePane } from './lib/tmux';
+
+const TMUX_SESSION = 'hermit-rc-gate';
+const READY_TIMEOUT_MS = 60_000;
+const POLL_MS = 1000;
+
+const URL_RE = /https?:\/\/claude\.ai\/code\?environment=\S+/;
+const CAPACITY_RE = /Capacity[:\s]+(\d+)\s*\/\s*(\d+)/i;
+const READY_RE = /\bReady\b/;
+const LOGIN_RE = /must be logged in|claude\.ai subscription|please run \/login/i;
+
+function sh(cmd: string, args: string[]): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync(cmd, args, { encoding: 'utf-8' });
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function sessionAlive(): boolean {
+  return tmuxSessionAlive(TMUX_SESSION);
+}
+
+// The shared helper caps the capture at 5s, so a wedged server can't hang a verb.
+function capturePane(): string {
+  return tmuxCapturePane(TMUX_SESSION) ?? '';
+}
+
+function repoRoot(): string {
+  const r = sh('git', ['rev-parse', '--show-toplevel']);
+  return r.status === 0 && r.stdout.trim() ? r.stdout.trim() : process.cwd();
+}
+
+/** Status read off an already-captured pane, so callers holding one don't re-spawn tmux. */
+function statusFromPane(pane: string): string {
+  const cap = pane.match(CAPACITY_RE);
+  if (cap && Number(cap[1]) > 0) return `connected ${cap[1]}/${cap[2]}`;
+  return 'ready';
+}
+
+/** One-line status derived from a single pane capture. */
+function statusLine(): string {
+  if (!sessionAlive()) return 'down';
+  return statusFromPane(capturePane());
+}
+
+function start(): number {
+  if (sessionAlive()) {
+    const pane = capturePane();
+    const url = pane.match(URL_RE);
+    console.log(statusFromPane(pane) + (url ? ` ${url[0]}` : '') + ' (already open)');
+    return 0;
+  }
+
+  const cmd = 'claude remote-control --spawn worktree --no-create-session-in-dir';
+  const r = sh('tmux', ['new-session', '-d', '-s', TMUX_SESSION, '-c', repoRoot(), cmd]);
+  if (r.status !== 0) {
+    console.error(`[rc-server] tmux new-session failed: ${r.stderr.trim() || 'unknown error'}`);
+    return 1;
+  }
+
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    Bun.sleepSync(POLL_MS);
+    if (!sessionAlive()) {
+      console.error('[rc-server] the server exited during startup — run `status` after retrying, or check `tmux capture-pane`.');
+      return 1;
+    }
+    const pane = capturePane();
+    // Auth is the one failure worth naming: Remote Control rejects setup-token
+    // installs outright, and no workaround exists on this side.
+    if (LOGIN_RE.test(pane)) {
+      sh('tmux', ['kill-session', '-t', TMUX_SESSION]);
+      console.error("[rc-server] Remote Control needs a claude.ai /login on this machine; this install's auth doesn't support it.");
+      return 1;
+    }
+    const url = pane.match(URL_RE);
+    if (url || READY_RE.test(pane)) {
+      console.log(`ready${url ? ` ${url[0]}` : ''}`);
+      return 0;
+    }
+  }
+
+  console.error(`[rc-server] no Ready line after ${READY_TIMEOUT_MS / 1000}s — session left running; inspect with \`tmux attach -t ${TMUX_SESSION}\`.`);
+  return 1;
+}
+
+/**
+ * cwds of every live process, for deciding whether a bridge worktree is still
+ * in use. Returns null when /proc can't be read (non-Linux): with no liveness
+ * signal, gc refuses to delete rather than guessing.
+ */
+function liveCwds(): Set<string> | null {
+  let pids: string[];
+  try {
+    pids = fs.readdirSync('/proc').filter(n => /^\d+$/.test(n));
+  } catch {
+    return null;
+  }
+  const cwds = new Set<string>();
+  for (const pid of pids) {
+    try { cwds.add(fs.readlinkSync(`/proc/${pid}/cwd`)); } catch {}
+  }
+  return cwds;
+}
+
+function inUse(cwds: Set<string>, dir: string): boolean {
+  for (const c of cwds) if (c === dir || c.startsWith(dir + path.sep)) return true;
+  return false;
+}
+
+/**
+ * Branch checked out in each worktree, by worktree path. Read rather than
+ * derived: a worktree's directory name and its branch name are independent, so
+ * guessing one from the other leaves stray branches behind.
+ */
+function worktreeBranches(root: string): Map<string, string> {
+  const byPath = new Map<string, string>();
+  let current = '';
+  for (const line of sh('git', ['-C', root, 'worktree', 'list', '--porcelain']).stdout.split('\n')) {
+    if (line.startsWith('worktree ')) current = line.slice(9);
+    else if (line.startsWith('branch ')) byPath.set(current, line.slice(7).replace(/^refs\/heads\//, ''));
+  }
+  return byPath;
+}
+
+/**
+ * Sweep worktrees left behind by phone-spawned sessions. Archiving a spawned
+ * session from the Claude app reads as a crash to the server and orphans a
+ * *locked* worktree, so unlock comes first and `git worktree remove` needs a
+ * --force fallback.
+ */
+function gc(): number {
+  const root = repoRoot();
+  const wtDir = path.join(root, '.claude', 'worktrees');
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(wtDir).filter(n => n.startsWith('bridge-'));
+  } catch {
+    return 0; // no worktrees dir → nothing to sweep
+  }
+  if (entries.length === 0) return 0;
+
+  const cwds = liveCwds();
+  if (cwds === null) {
+    console.error('[rc-server] cannot determine session liveness on this platform (no /proc) — skipping gc.');
+    return 0;
+  }
+
+  const branches = worktreeBranches(root);
+  for (const name of entries) {
+    const dir = path.join(wtDir, name);
+    if (inUse(cwds, dir)) continue;
+    sh('git', ['-C', root, 'worktree', 'unlock', dir]); // absent lock → non-zero, ignored
+    if (sh('git', ['-C', root, 'worktree', 'remove', dir]).status !== 0) {
+      sh('git', ['-C', root, 'worktree', 'remove', '--force', dir]);
+    }
+    sh('git', ['-C', root, 'worktree', 'prune']);
+    const branch = branches.get(dir);
+    if (branch) sh('git', ['-C', root, 'branch', '-D', branch]);
+    console.log(`removed ${name}`);
+  }
+  return 0;
+}
+
+function stop(): number {
+  if (sessionAlive()) {
+    sh('tmux', ['kill-session', '-t', TMUX_SESSION]);
+    console.log('closed');
+  } else {
+    console.log('down');
+  }
+  return gc();
+}
+
+function main(argv: string[]): number {
+  switch (argv[0]) {
+    case 'start': return start();
+    case 'stop': return stop();
+    case 'status': console.log(statusLine()); return 0;
+    case 'gc': return gc();
+    default:
+      console.error('Usage: hermit-run rc-server <start|stop|status|gc>');
+      return 2;
+  }
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -20,6 +20,8 @@ import { operatorLanguage as resolveOperatorLanguage } from './lib/operator-lang
 import { readSettledConfig } from './lib/config-read';
 import { extractSection, firstContentLine, stripPlaceholders } from './lib/md-write';
 import { readMicroProposals } from './lib/micro-proposals-io';
+import { tmuxSessionAlive } from './lib/tmux';
+import { readRuntimeJson } from './lib/runtime';
 
 type Json = any;
 
@@ -185,7 +187,41 @@ function buildCompactionPointers(agentDir: string): string {
   return parts.join('\n');
 }
 
+// --- Residency: resident vs guest ---------------------------------------
+// A hatched folder can hold more than one session at once. The managed
+// always-on hermit is the one carrying HERMIT_MANAGED=1 (stamped into the tmux
+// env-file by hermit-start; a hand-launched `claude` in the same folder never
+// inherits it). So a session WITHOUT the marker, in a project whose managed
+// tmux session is still alive, is a *guest*: it gets a short banner instead of
+// the full hermit framing, making role assignment mechanical rather than a
+// judgment call. No new state file — the marker plus runtime.json's
+// tmux_session is the whole signal.
+function residentSessionActive(agentDir: string): boolean {
+  if (process.env.HERMIT_MANAGED === '1') return false; // this session IS the resident
+  const runtime = readRuntimeJson(path.resolve(agentDir, 'state'));
+  const tmuxSession = runtime && typeof runtime.tmux_session === 'string' ? runtime.tmux_session : '';
+  // Unreadable state or no recorded session → no resident claim, full framing (fail-open).
+  if (!tmuxSession) return false;
+  return tmuxSessionAlive(tmuxSession);
+}
+
+// The guest injection: identity, the one fact that matters, and the three
+// things only the resident may do. Deliberately short — a guest session is here
+// to do ordinary work, not to be briefed on the hermit.
+function emitGuestBanner(agentDir: string): void {
+  const project = path.basename(path.dirname(path.resolve(agentDir)));
+  console.log('---Guest Session---');
+  console.log(`Project: ${safe(project)} — a managed hermit session is already running here.`);
+  console.log('You are a guest, not the hermit. Do not answer channel messages, do not write');
+  console.log('sessions/SHELL.md or other hermit state, and do not start the heartbeat, routines,');
+  console.log('or watches — the resident session owns all of that. Otherwise work normally.');
+}
+
 function main(source: string | null) {
+  if (residentSessionActive(AGENT_DIR)) {
+    emitGuestBanner(AGENT_DIR);
+    return;
+  }
   if (source === 'compact') {
     emitCompactCapsule();
   } else {

--- a/plugins/claude-code-hermit/skills/rc-gate/SKILL.md
+++ b/plugins/claude-code-hermit/skills/rc-gate/SKILL.md
@@ -19,9 +19,9 @@ All four are `.claude-code-hermit/bin/hermit-run rc-server <verb>`:
 | Verb | What it does | Output |
 |---|---|---|
 | `start` | opens the gate (tmux session `hermit-rc-gate`), waits for the server | `ready <url>` or a one-line refusal |
-| `status` | one pane read | `down`, `ready`, or `connected N/32` |
+| `status` | one pane read | `down`, `starting` (up but not serving yet), `ready`, or `connected N/32` |
 | `stop` | closes the gate, then sweeps | `closed` / `down`, plus any removals |
-| `gc` | sweeps worktrees left by archived spawns | one line per removed worktree |
+| `gc` | sweeps worktrees left by archived spawns | one line per worktree removed, or kept because it holds uncommitted work |
 
 `start` prints the `claude.ai/code?environment=…` URL — that is what the operator
 opens or scans. Hand it over as a link, not as a command.
@@ -58,4 +58,5 @@ carry it. Say so once, don't retry, and don't propose workarounds.
 Run `gc` whenever the operator mentions leftover or stuck worktrees, and after
 any `stop`. Archiving a spawned session from the Claude app reads as a crash to
 the server and leaves a locked worktree behind — that sweep is the hermit's job,
-not the server's.
+not the server's. A `kept` line means that worktree still holds uncommitted work;
+tell the operator it is there and let them decide, never delete it for them.

--- a/plugins/claude-code-hermit/skills/rc-gate/SKILL.md
+++ b/plugins/claude-code-hermit/skills/rc-gate/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: rc-gate
+description: Open, close, or check the Remote Control spawn gate — the hermit-managed `claude remote-control` server that lets a phone spawn new sessions into this project. Activates on messages like "open the spawn gate", "let me start sessions from my phone", "close the gate", "is the gate open", "give me the remote link", "clean up the leftover worktrees".
+---
+# RC Gate
+
+The spawn gate is a `claude remote-control` server the hermit runs as its own
+tmux child. While it is open, the operator can spawn **new** sessions into this
+project from claude.ai/code or the mobile app; each spawn lands in its own git
+worktree, so this folder stays single-session and the hermit keeps its own state.
+
+This is a different leg from `config.remote`, which makes *the hermit itself*
+reachable. Both can be on; neither implies the other.
+
+## Verbs
+
+All four are `.claude-code-hermit/bin/hermit-run rc-server <verb>`:
+
+| Verb | What it does | Output |
+|---|---|---|
+| `start` | opens the gate (tmux session `hermit-rc-gate`), waits for the server | `ready <url>` or a one-line refusal |
+| `status` | one pane read | `down`, `ready`, or `connected N/32` |
+| `stop` | closes the gate, then sweeps | `closed` / `down`, plus any removals |
+| `gc` | sweeps worktrees left by archived spawns | one line per removed worktree |
+
+`start` prints the `claude.ai/code?environment=…` URL — that is what the operator
+opens or scans. Hand it over as a link, not as a command.
+
+## Authority
+
+Opening the gate widens who can reach this machine, so treat it like an
+execution-adjacent setting, not an everyday one:
+
+- **Terminal** — always fine.
+- **Chat** — only the settings chat, and only with an echoed confirmation code
+  (the `nonce` tier in `docs/security.md` § Tiered settings authority). Any other
+  chat: report the current status, say where to ask, and stop.
+- `status` and `gc` are reads/cleanup — the everyday `allowed` tier.
+
+Be honest about what enforces this: `channel-settings-gate.ts` covers
+`settings-edit` writes, not this verb, so the fence here is your judgment. Do not
+route around a refusal by invoking the tmux command directly.
+
+## Behavior
+
+Report state, not mechanics. The operator wants to know whether they can spawn
+from their phone, and the link if so — never the tmux session name, the flags, or
+the pane text.
+
+A time-boxed open ("open it for two hours") is `start` now plus a Progress Log
+note naming the close time; there is no scheduler behind it, so say that you will
+close it when you next see the clock pass that mark, and close it when you do.
+
+When `start` refuses with the not-logged-in verdict, that is final: Remote Control
+requires a claude.ai `/login` on this machine and this install's auth does not
+carry it. Say so once, don't retry, and don't propose workarounds.
+
+Run `gc` whenever the operator mentions leftover or stuck worktrees, and after
+any `stop`. Archiving a spawned session from the Claude app reads as a crash to
+the server and leaves a locked worktree behind — that sweep is the hermit's job,
+not the server's.

--- a/plugins/claude-code-hermit/tests/lockfile.test.ts
+++ b/plugins/claude-code-hermit/tests/lockfile.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { acquireLock, releaseLock } from '../scripts/lib/lockfile';
+import { acquireLock, releaseLock, claimPathFor } from '../scripts/lib/lockfile';
 
 function makeDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hermit-lock-'));
@@ -128,9 +128,9 @@ describe('lockfile', () => {
     const dir = makeDir();
     try {
       const lock = path.join(dir, '.lifecycle.lock');
-      // Pre-seed an hour-old stale lock, then race N acquirers. The rename-based
-      // takeover must let exactly one win — unlink-by-path takeover would let the
-      // loser delete the winner's fresh lock and both end up "holding" it.
+      // Pre-seed an hour-old stale lock, then race N acquirers. Exactly one must
+      // win — a takeover acting on the path rather than on the file it judged
+      // lets a loser displace the winner's fresh lock and both end up "holding" it.
       fs.writeFileSync(lock, '999999'); // bogus pid, hour-old → unambiguously stale
       const old = new Date(Date.now() - 60 * 60 * 1000);
       fs.utimesSync(lock, old, old);
@@ -146,6 +146,47 @@ describe('lockfile', () => {
       }));
       expect(outs.filter((o) => o === 'WON').length).toBe(1);
       expect(outs.length).toBe(8);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Only the marker's holder may replace the file it names, which is what
+  // keeps two racers from both replacing it. Derived through the production
+  // formula so the two can't drift apart.
+  function claimMarker(lock: string): string {
+    const st = fs.statSync(lock);
+    return claimPathFor(lock, st.ino, st.mtimeMs);
+  }
+
+  test('takeover backs off while another process is already replacing the same stale lock', () => {
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      fs.writeFileSync(lock, '999999');
+      const old = new Date(Date.now() - 60 * 60 * 1000);
+      fs.utimesSync(lock, old, old);
+      fs.writeFileSync(claimMarker(lock), '4242'); // an in-flight takeover
+      expect(acquireLock(lock)).toBe(false);
+      expect(fs.readFileSync(lock, 'utf-8')).toBe('999999'); // left for the stealer
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a takeover marker left by a crashed stealer does not wedge the lock forever', () => {
+    const dir = makeDir();
+    try {
+      const lock = path.join(dir, '.lifecycle.lock');
+      fs.writeFileSync(lock, '999999');
+      const old = new Date(Date.now() - 60 * 60 * 1000);
+      fs.utimesSync(lock, old, old);
+      const claim = claimMarker(lock);
+      fs.writeFileSync(claim, '4242');
+      fs.utimesSync(claim, old, old); // stealer died mid-swap an hour ago
+      expect(acquireLock(lock)).toBe(true);
+      expect(fs.readFileSync(lock, 'utf-8')).toBe(String(process.pid));
+      expect(fs.existsSync(claim)).toBe(false); // and the marker is cleaned up
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/plugins/claude-code-hermit/tests/rc-server.test.ts
+++ b/plugins/claude-code-hermit/tests/rc-server.test.ts
@@ -86,6 +86,44 @@ describe('rc-server.ts', () => {
     }
   });
 
+  it('gc sweeps a committed-but-unmerged worktree without destroying its commits', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const wt = path.join(wd.dir, '.claude', 'worktrees', 'bridge-committed321');
+      git(wd.dir, 'worktree', 'add', '-q', '-b', 'cse-session-committed', wt);
+      // A spawned session that finished its work and committed it: the tree is
+      // clean, so the dirty guard waves it through — only -d keeps the commits.
+      fs.writeFileSync(path.join(wt, 'done.txt'), 'finished work\n');
+      git(wt, 'add', 'done.txt');
+      git(wt, 'commit', '-qm', 'work from a spawned session');
+
+      const res = await rcServer(wd.dir, ['gc']);
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toContain('removed bridge-committed321');
+      expect(fs.existsSync(wt)).toBe(false);
+      expect(git(wd.dir, 'branch', '--list', 'cse-session-committed').trim()).not.toBe('');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('gc keeps a bridge worktree holding uncommitted work', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const wt = path.join(wd.dir, '.claude', 'worktrees', 'bridge-dirty789');
+      git(wd.dir, 'worktree', 'add', '-q', '-b', 'cse-session-dirty', wt);
+      fs.writeFileSync(path.join(wt, 'unsaved.txt'), 'work the operator has not committed\n');
+
+      const res = await rcServer(wd.dir, ['gc']);
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toContain('kept bridge-dirty789');
+      expect(fs.existsSync(wt)).toBe(true);
+      expect(git(wd.dir, 'branch', '--list', 'cse-session-dirty').trim()).not.toBe('');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
   it('status reports down when no gate session exists', async () => {
     const wd = setupGitWorkdir();
     try {

--- a/plugins/claude-code-hermit/tests/rc-server.test.ts
+++ b/plugins/claude-code-hermit/tests/rc-server.test.ts
@@ -1,0 +1,120 @@
+// Contract tests for the rc-server spawn-gate verb.
+// Covers gc (the only subcommand with real logic that runs without a live
+// Remote Control server), status against a fake tmux, and argument handling.
+// No live RC server is started here — `start` is exercised manually.
+//
+// Usage: bun test tests/rc-server.test.ts   (from the plugin root)
+
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { runScript } from './helpers/run';
+import { setupGitWorkdir } from './helpers/workdir';
+
+// A fake `tmux` on PATH so status/gc never touch the real server.
+function fakeTmux(dir: string, exitCode: number): string {
+  const binDir = path.join(dir, 'fakebin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const tmux = path.join(binDir, 'tmux');
+  fs.writeFileSync(tmux, `#!/bin/sh\nexit ${exitCode}\n`);
+  fs.chmodSync(tmux, 0o755);
+  return `${binDir}:${process.env.PATH ?? ''}`;
+}
+
+function git(dir: string, ...args: string[]): string {
+  return execFileSync('git', ['-C', dir, ...args], { encoding: 'utf-8' });
+}
+
+async function rcServer(dir: string, args: string[], pathOverride?: string) {
+  return runScript('rc-server.ts', {
+    args,
+    cwd: dir,
+    env: { PATH: pathOverride ?? fakeTmux(dir, 1) },
+  });
+}
+
+describe('rc-server.ts', () => {
+  it('gc removes an orphaned locked bridge worktree and its branch', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const wt = path.join(wd.dir, '.claude', 'worktrees', 'bridge-fake123');
+      // Branch name deliberately unrelated to the directory name: gc must read
+      // the branch from `git worktree list`, not derive it from the path.
+      git(wd.dir, 'worktree', 'add', '-q', '-b', 'cse-session-xyz', wt);
+      git(wd.dir, 'worktree', 'lock', wt);
+
+      const res = await rcServer(wd.dir, ['gc']);
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toContain('removed bridge-fake123');
+      expect(fs.existsSync(wt)).toBe(false);
+      expect(git(wd.dir, 'branch', '--list', 'cse-session-xyz').trim()).toBe('');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('gc on a repo with no bridge worktrees is a silent no-op', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const res = await rcServer(wd.dir, ['gc']);
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout.trim()).toBe('');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('gc leaves a bridge worktree that a live process is sitting in', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const wt = path.join(wd.dir, '.claude', 'worktrees', 'bridge-live456');
+      git(wd.dir, 'worktree', 'add', '-q', '-b', 'worktree-bridge-live456', wt);
+
+      // A live process whose cwd IS the worktree — the liveness signal gc reads.
+      const holder = Bun.spawn({ cmd: ['sleep', '30'], cwd: wt });
+      try {
+        const res = await rcServer(wd.dir, ['gc']);
+        expect(res.exitCode).toBe(0);
+        expect(res.stdout).not.toContain('bridge-live456');
+        expect(fs.existsSync(wt)).toBe(true);
+      } finally {
+        holder.kill();
+      }
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('status reports down when no gate session exists', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const res = await rcServer(wd.dir, ['status']);
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout.trim()).toBe('down');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('unknown subcommand exits 2 with usage', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const res = await rcServer(wd.dir, ['bogus']);
+      expect(res.exitCode).toBe(2);
+      expect(res.stderr).toContain('Usage: hermit-run rc-server');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('missing subcommand exits 2', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const res = await rcServer(wd.dir, []);
+      expect(res.exitCode).toBe(2);
+    } finally {
+      wd.cleanup();
+    }
+  });
+});

--- a/plugins/claude-code-hermit/tests/rc-server.test.ts
+++ b/plugins/claude-code-hermit/tests/rc-server.test.ts
@@ -95,7 +95,10 @@ describe('rc-server.ts', () => {
       // clean, so the dirty guard waves it through — only -d keeps the commits.
       fs.writeFileSync(path.join(wt, 'done.txt'), 'finished work\n');
       git(wt, 'add', 'done.txt');
-      git(wt, 'commit', '-qm', 'work from a spawned session');
+      // Identity passed inline: CI runners have none configured, same reason
+      // setupGitWorkdir spells it out for its own commits.
+      git(wt, '-c', 'user.name=test', '-c', 'user.email=test@test', '-c', 'commit.gpgsign=false',
+        'commit', '-qm', 'work from a spawned session');
 
       const res = await rcServer(wd.dir, ['gc']);
       expect(res.exitCode).toBe(0);

--- a/plugins/claude-code-hermit/tests/startup-context-guest.test.ts
+++ b/plugins/claude-code-hermit/tests/startup-context-guest.test.ts
@@ -1,0 +1,101 @@
+// Residency branch in startup-context.ts's SessionStart injection.
+// Verifies: the managed session (HERMIT_MANAGED=1) always gets the full
+// framing; an unmanaged session in a project whose managed tmux session is
+// alive gets the short guest banner and nothing else; and a dead or absent
+// tmux session falls back to the full framing (fail-open).
+//
+// The tmux probe runs through spawnSync, so the fake tmux must be a real
+// executable on PATH — an in-process PATH edit would not reach it.
+//
+// Usage: bun test tests/startup-context-guest.test.ts   (from the plugin root)
+
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { runScript } from './helpers/run';
+import { setupWorkdir } from './helpers/workdir';
+
+const SESSION = 'hermit-fixture';
+
+// Writes a runtime.json naming the managed tmux session, plus a fake `tmux`
+// on PATH that exits with `exitCode` for `has-session`. Returns the env
+// overlay a run needs to see both.
+function fixture(dir: string, opts: { tmuxSession?: string; tmuxExit?: number }): Record<string, string> {
+  const stateDir = path.join(dir, '.claude-code-hermit', 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, 'runtime.json'),
+    JSON.stringify({ version: 1, session_state: 'idle', tmux_session: opts.tmuxSession ?? null }),
+  );
+
+  const binDir = path.join(dir, 'fakebin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const tmux = path.join(binDir, 'tmux');
+  fs.writeFileSync(tmux, `#!/bin/sh\nexit ${opts.tmuxExit ?? 0}\n`);
+  fs.chmodSync(tmux, 0o755);
+
+  return {
+    AGENT_DIR: path.join(dir, '.claude-code-hermit'),
+    PATH: `${binDir}:${process.env.PATH ?? ''}`,
+  };
+}
+
+async function run(dir: string, env: Record<string, string>) {
+  return runScript('startup-context.ts', { stdin: '{}', env });
+}
+
+describe('startup-context.ts — resident vs guest', () => {
+  it('managed session gets the full framing even while its tmux session is alive', async () => {
+    const wd = setupWorkdir();
+    try {
+      const env = fixture(wd.dir, { tmuxSession: SESSION, tmuxExit: 0 });
+      const res = await run(wd.dir, { ...env, HERMIT_MANAGED: '1' });
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).not.toContain('---Guest Session---');
+      expect(res.stdout).toContain('---Active Session---');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('unmanaged session with a live resident gets the guest banner and nothing else', async () => {
+    const wd = setupWorkdir();
+    try {
+      const env = fixture(wd.dir, { tmuxSession: SESSION, tmuxExit: 0 });
+      const res = await run(wd.dir, { ...env, HERMIT_MANAGED: '' });
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toContain('---Guest Session---');
+      expect(res.stdout).toContain('a managed hermit session is already running here');
+      expect(res.stdout).not.toContain('---Active Session---');
+      expect(res.stdout.trim().split('\n').length).toBeLessThanOrEqual(8);
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('unmanaged session with a dead resident gets the full framing', async () => {
+    const wd = setupWorkdir();
+    try {
+      const env = fixture(wd.dir, { tmuxSession: SESSION, tmuxExit: 1 });
+      const res = await run(wd.dir, { ...env, HERMIT_MANAGED: '' });
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).not.toContain('---Guest Session---');
+      expect(res.stdout).toContain('---Active Session---');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('unmanaged session with no tmux_session recorded gets the full framing', async () => {
+    const wd = setupWorkdir();
+    try {
+      const env = fixture(wd.dir, { tmuxExit: 0 });
+      const res = await run(wd.dir, { ...env, HERMIT_MANAGED: '' });
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).not.toContain('---Guest Session---');
+      expect(res.stdout).toContain('---Active Session---');
+    } finally {
+      wd.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

Two independent pieces of the multi-session residency work, plus the docs recipe behind them.

**Residency: resident vs guest.** A hatched folder can hold more than one session, and until now every one of them got the full hermit framing — active session state, channel rules, session discipline — with nothing saying "you are not the hermit". Whether a plain `claude` opened alongside the managed hermit wrote `SHELL.md` or answered a channel message was left to model judgment.

The signal for this already existed: `hermit-start` stamps `HERMIT_MANAGED=1` into the managed session's env precisely so a hand-launched `claude` in the same folder is distinguishable (`hermit-start.ts:1222-1228`; three shipped hooks already gate on it). `startup-context.ts` now pairs that marker with a `tmux has-session` liveness check on `runtime.json`'s `tmux_session`: unmanaged session + live resident → a short guest banner instead of the full injection. Managed session, dead resident, no recorded session, or unreadable state → today's behavior byte-for-byte. No new state file, no boot-command change, no `hermit-stop` change.

**Spawn gate.** `hermit-run rc-server <start|stop|status|gc>` runs `claude remote-control --spawn worktree --no-create-session-in-dir` as a hermit-owned tmux child, so new sessions can be spawned into a project from the phone while the folder itself stays single-session and every spawn lands in its own worktree. `/claude-code-hermit:rc-gate` is the conversational surface. The gate never auto-starts and adds no config field — opening remote spawn is a deliberate, settings-authority-tier act.

`status` is a single pane capture, never a tail: the server's TUI redraws its status line continuously and floods any follower. `gc` sweeps the worktrees left behind when a spawned session is archived from the Claude app — that reads as a crash to the server and orphans a *locked* worktree, so unlock comes first and `worktree remove` needs a `--force` fallback.

**Docs.** `docs/remote-endpoint.md` carries the systemd template unit for the unattended case, with the four fixes that each failed before being right: `WorkingDirectory=/%I`, an absolute `claude` path, the `script -qfc` pty wrapper, and `Restart=on-failure`.

## Notes

- Remote Control requires a claude.ai `/login` on the machine; setup-token installs are rejected by the CLI itself, and `start` reports that as a clean one-line verdict rather than retrying.
- The authority fence in the skill is model steering, not a deterministic gate — `channel-settings-gate.ts` covers `settings-edit` writes, not this verb. The skill says so plainly.
- Scope deliberately excludes: a standalone plugin, cross-session-messaging/manager layers, channel-server dormancy, auto-start, and `mode`/`url` subcommands (both would scrape a live TUI pane).

## Verification

- `bun test` from `plugins/claude-code-hermit`: 4302 pass, 1 fail.
- `bunx tsc --noEmit`: exit 0.
- New: 4 residency tests (managed / live resident / dead resident / no session recorded), 6 `rc-server` tests (gc removes an orphaned locked worktree, gc leaves one a live process sits in, no-op on a clean repo, status down, two arg-handling cases).

**Pre-existing failure, not from this branch:** `tests/watchdog.test.ts` → `telemetry export (step 0d)` times out (1–3 cases depending on concurrency). Reproduced on the unmodified base commit, sandboxed and unsandboxed. Worth a separate look.
