### PR TITLE
fix: the telemetry export tests must not shell out to the host's tmux

### DIFF
--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -2905,8 +2905,11 @@ describe('composeRestartMessage / composeWedgeMessage / composePauseMessage', ()
 // telemetry export (step 0d: independent of watchdog.enabled, like 0a-0c)
 // -------------------------------------------------------
 
-/** Minimal config: watchdog disabled (so the process exits right after step 0d, with
- *  no tmux dependency) plus an enabled telemetry_export block pointed at a mock webhook. */
+/** Minimal config: watchdog disabled (so the process exits right after step 0d) plus an
+ *  enabled telemetry_export block pointed at a mock webhook. Steps 0a-0c still shell out
+ *  to tmux before the gate, so these tests stub it like every other one. An unstubbed
+ *  tmux resolves to the host's, and a snap-packaged tmux costs ~3s per call, which alone
+ *  pushes the test past bun's 5s default timeout. */
 function writeTelemetryConfig(h: Hermit, url: string): void {
   fs.writeFileSync(path.join(h.dir, '.claude-code-hermit', 'config.json'), JSON.stringify({
     watchdog: { enabled: false },
@@ -2921,6 +2924,8 @@ function writeTelemetryConfig(h: Hermit, url: string): void {
 
 describe('telemetry export (step 0d)', () => {
   test('fires with watchdog.enabled: false — one POST, state stamped, event logged', withHermit(async (h) => {
+    writeFakeTmux(h, 0);
+    writeFakePgrep(h, 1);
     let calls = 0;
     const server = Bun.serve({ port: 0, fetch: () => { calls++; return new Response('ok', { status: 200 }); } });
     try {
@@ -2938,6 +2943,8 @@ describe('telemetry export (step 0d)', () => {
   }));
 
   test('interval not yet due → no POST', withHermit(async (h) => {
+    writeFakeTmux(h, 0);
+    writeFakePgrep(h, 1);
     let calls = 0;
     const server = Bun.serve({ port: 0, fetch: () => { calls++; return new Response('ok', { status: 200 }); } });
     try {
@@ -2958,6 +2965,8 @@ describe('telemetry export (step 0d)', () => {
   }));
 
   test('no telemetry_export block → nothing leaves the box', withHermit(async (h) => {
+    writeFakeTmux(h, 0);
+    writeFakePgrep(h, 1);
     let calls = 0;
     const server = Bun.serve({ port: 0, fetch: () => { calls++; return new Response('ok', { status: 200 }); } });
     try {


### PR DESCRIPTION
## What

The three `telemetry export (step 0d)` tests in `plugins/claude-code-hermit/tests/watchdog.test.ts` now stub tmux and pgrep, the way every other test in that file already does.

## Why

They were the only tests in the file that never called `writeFakeTmux`/`writeFakePgrep`, so `PATH` fell through to the host's tmux. Steps 0b (`maybeContextClear`) and 0c (`maybeContextCompact`) run *before* the `watchdog.enabled` gate and both reach `world.tmux.alive(...)` (`hermit-watchdog.ts:880-881`), so every run paid for two real tmux invocations.

That is free on CI, which has a fast `/usr/bin/tmux` and runs `--timeout=45000`. It is not free where tmux is snap-packaged (`/snap/bin/tmux` -> `/usr/bin/snap`): one `has-session` costs 2.5s to 3.3s, so two calls straddle bun's 5000ms default and the block failed nondeterministically, in roughly 78% of local runs.

The helper's comment claimed "no tmux dependency", which is what hid this. It now records the real constraint.

## Evidence

- Timing the script directly against the fixture: **6.1s to 6.8s** with `cwd` at the fixture vs **0.02s** from the repo dir.
- `strace -f -tt -e trace=execve,connect` attributed the cost to `snap-confine`, `snap-seccomp`, `systemctl is-system-running` and the snapd socket, and showed the two tmux calls back to back.
- Isolated behaviour was all-three-fail or all-three-pass, never partial, which ruled out contention. With `--timeout 30000` all three passed in 5.9s to 7.0s, confirming slow rather than hung.

## Verification

- Telemetry block at the **default** 5s timeout: **141-335ms**, 10/10 clean (was ~6800ms, failing ~50-78%).
- Full `watchdog.test.ts`: 6/6 runs at 225 pass / 0 fail (previously 222-224 pass with 1-3 failures).
- Full core suite: **4372 pass, 0 fail**.

## Notes

No CHANGELOG entry: test-only, nothing an operator experiences as a shipped change.