### PR TITLE
fix(claude-code-hermit): edit routines one entry at a time, so a plain add or remove needs no code

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - The `doctor` and `daily-auto-close` routines ship with a builtin `precheck` gate, so a day with nothing to report or close no longer wakes the session. `"precheck": "doctor"` runs the 27 checks and their ledger writes once, in the gate itself, and SKIPs when nothing currently failing is still owed to the operator. `"precheck": "auto-close"` runs the same decision the `--scheduled` archive path already made, and SKIPs on `queued` or `noop` — WAKE only fires an actual close.
 - A hermit that never opened a session (`idle`, no active session id) no longer archives an empty nightly report. The `auto-close` gate stamps the daily context-reset marker itself on that branch, so the `/clear` the archive path used to trigger keeps firing on schedule either way.
+- Adding or removing a routine from a channel writes one entry by index instead of rewriting the whole `routines` array, so it no longer asks for a confirmation code. Only an entry that carries a `precheck` still does.
 
 ### Upgrade Instructions
 
@@ -13,6 +14,7 @@
 
 ### Fixed
 - The `hermit-run rc-server` verbs (`start`, `stop`, `status`, `gc`) are in the sealed allow-list, so opening or checking the spawn gate no longer hits a permission prompt that an unattended session cannot answer.
+- `settings-edit … unset routines.<n>` removed the entry but left a `null` in its place, which failed validation on every later settings write. Array indices now splice, and `set` at an index past the end of an array is refused instead of creating a hole.
 
 ## [1.2.47] - 2026-08-24
 

--- a/plugins/claude-code-hermit/scripts/settings-edit.ts
+++ b/plugins/claude-code-hermit/scripts/settings-edit.ts
@@ -86,9 +86,23 @@ export function getPath(obj: Json, dotted?: string): Json {
   return cur;
 }
 
-/** A dotted segment read as an array index: whole, non-negative, canonically spelled. */
+/**
+ * A dotted segment read as an array index: whole, non-negative, canonically spelled.
+ * Leading zeros are rejected rather than normalized — `routines.01` is a typo, and
+ * silently splicing index 1 for it is worse than refusing.
+ */
 function arrayIndex(key: string): number | null {
-  return /^\d+$/.test(key) ? Number(key) : null;
+  return /^(0|[1-9]\d*)$/.test(key) ? Number(key) : null;
+}
+
+/** The range error both the leaf and the traversal raise, so they read the same. */
+function indexRangeError(dotted: string, key: string, len: number, appendable: boolean): Error {
+  const max = appendable ? len : len - 1;
+  if (max < 0) return new Error(`${dotted}: "${key}" indexes an empty array`);
+  return new Error(
+    `${dotted}: index out of range — valid indices are 0..${max}` +
+      (appendable ? `, where ${len} appends a new entry` : ''),
+  );
 }
 
 /**
@@ -96,21 +110,25 @@ function arrayIndex(key: string): number | null {
  *
  * An index past the end of an array is refused rather than written: JS would grow the
  * array with holes, and a `null` entry fails validation from then on. `=== length` is
- * the append every add goes through, so it is allowed.
+ * the append every add goes through, so it is allowed at the LEAF only — an interior
+ * segment (`routines.<n>.enabled`) is editing an entry that has to already exist, so
+ * there `length` is out of range like anything past it.
  */
 export function setPath(obj: Json, dotted: string, value: Json): Json {
   const keys = dotted.split('.');
   const leaf = keys.pop()!;
   let cur = obj;
   for (const key of keys) {
+    if (Array.isArray(cur)) {
+      const i = arrayIndex(key);
+      if (i === null || i >= cur.length) throw indexRangeError(dotted, key, cur.length, false);
+    }
     if (typeof cur[key] !== 'object' || cur[key] === null) cur[key] = {};
     cur = cur[key];
   }
   if (Array.isArray(cur)) {
     const i = arrayIndex(leaf);
-    if (i === null || i > cur.length) {
-      throw new Error(`${dotted}: index out of range — valid indices are 0..${cur.length}, where ${cur.length} appends a new entry`);
-    }
+    if (i === null || i > cur.length) throw indexRangeError(dotted, leaf, cur.length, true);
   }
   cur[leaf] = value;
   return obj;

--- a/plugins/claude-code-hermit/scripts/settings-edit.ts
+++ b/plugins/claude-code-hermit/scripts/settings-edit.ts
@@ -86,6 +86,18 @@ export function getPath(obj: Json, dotted?: string): Json {
   return cur;
 }
 
+/** A dotted segment read as an array index: whole, non-negative, canonically spelled. */
+function arrayIndex(key: string): number | null {
+  return /^\d+$/.test(key) ? Number(key) : null;
+}
+
+/**
+ * Write one value at a dotted path.
+ *
+ * An index past the end of an array is refused rather than written: JS would grow the
+ * array with holes, and a `null` entry fails validation from then on. `=== length` is
+ * the append every add goes through, so it is allowed.
+ */
 export function setPath(obj: Json, dotted: string, value: Json): Json {
   const keys = dotted.split('.');
   const leaf = keys.pop()!;
@@ -94,11 +106,24 @@ export function setPath(obj: Json, dotted: string, value: Json): Json {
     if (typeof cur[key] !== 'object' || cur[key] === null) cur[key] = {};
     cur = cur[key];
   }
+  if (Array.isArray(cur)) {
+    const i = arrayIndex(leaf);
+    if (i === null || i > cur.length) {
+      throw new Error(`${dotted}: index out of range — valid indices are 0..${cur.length}, where ${cur.length} appends a new entry`);
+    }
+  }
   cur[leaf] = value;
   return obj;
 }
 
-/** Delete a leaf. Parent objects stay — an empty `channels` is still a valid config. */
+/**
+ * Delete a leaf. Parent objects stay — an empty `channels` is still a valid config.
+ *
+ * An array index splices instead: `delete arr[1]` leaves a hole that serializes as
+ * `null`, and every later write then fails validation on an entry with no `id`. The
+ * whole point of `unset routines.<n>` is removing one routine without rewriting the
+ * array, so it has to leave the array dense.
+ */
 export function unsetPath(obj: Json, dotted: string): boolean {
   const keys = dotted.split('.');
   const leaf = keys.pop()!;
@@ -106,6 +131,12 @@ export function unsetPath(obj: Json, dotted: string): boolean {
   for (const key of keys) {
     if (typeof cur[key] !== 'object' || cur[key] === null) return false;
     cur = cur[key];
+  }
+  if (Array.isArray(cur)) {
+    const i = arrayIndex(leaf);
+    if (i === null || i >= cur.length) return false;
+    cur.splice(i, 1);
+    return true;
   }
   if (!(leaf in cur)) return false;
   delete cur[leaf];
@@ -377,7 +408,12 @@ if (import.meta.main) {
       const dotted = rest[0];
       if (!dotted) { console.error('set requires a dotted.path argument'); process.exit(1); }
       if (rest.length < 2) { console.error('set requires a value argument'); process.exit(1); }
-      setPath(config, dotted, parseValue(rest[1]));
+      try {
+        setPath(config, dotted, parseValue(rest[1]));
+      } catch (err) {
+        console.error((err as Error).message);
+        process.exit(1);
+      }
       persist();
       break;
     }

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -250,6 +250,10 @@ Note: "Channel changes take effect on next `hermit-start` run. `channels.primary
   whole `routines` array: the settings gate reads the value of a container write, and a value it cannot parse
   (`$(cat …)`, a heredoc, a shell variable) escalates to the confirmation code even when nothing is gated.
   Entry JSON goes inline, single-quoted, in the command itself.
+- **Indices are only valid until the next add or remove.** An add appends and a remove closes the gap, so the
+  numbers from the listing above are stale the moment either lands. Re-run `get routines` and re-show the
+  table after every add and every remove, and derive the next index from that fresh listing — a stale index
+  is an in-range write that silently replaces or edits the wrong routine, with nothing to refuse it.
 - Ask: "Add / edit / remove / enable / disable? (or 'done')"
 - **Add wizard:** ask for:
   - ID (unique name, e.g., "weekly-deps")
@@ -262,11 +266,12 @@ Note: "Channel changes take effect on next `hermit-start` run. `channels.primary
     - Custom → operator types raw cron
   - Skill to run (full slash-command name, e.g. `claude-code-hermit:brief` for plugin skills, `ha-refresh-context` for local project skills)
   - Enabled (yes/no, default yes)
-  - Append it with `set routines.<count> '<entry as JSON>'`, where `<count>` is the number of routines just
-    listed (the first free index). A duplicate id is only a warning, so check the id against the listed ones
-    before writing; an invalid cron is refused by the script — relay its error rather than retrying.
+  - Append it with `set routines.<count> '<entry as JSON>'`, where `<count>` is the number of routines in the
+    latest listing (the first free index). A duplicate id is only a warning, so check the id against the
+    listed ones before writing; an invalid cron is refused by the script — relay its error rather than
+    retrying. Then re-list before the next write.
 - **Edit:** select by number, then `set routines.<index>.<field> <value>` (one call per changed field; siblings are preserved).
-- **Remove:** select by number, then `unset routines.<index>` — one call, and the remaining entries close the gap (their numbers shift, so re-list before a second removal).
+- **Remove:** select by number, then `unset routines.<index>` — one call, and the remaining entries close the gap (so re-list before the next write).
 - **Enable/disable:** select by number, `set routines.<index>.enabled true|false`.
 - Loop until operator says "done".
 - **After all edits are written**, invoke `/claude-code-hermit:hermit-routines load` via the Skill tool to apply the new schedule live (no restart). Surface the result inline:

--- a/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-settings/SKILL.md
@@ -246,6 +246,10 @@ Note: "Channel changes take effect on next `hermit-start` run. `channels.primary
   Gate = the routine's `precheck`, run by the routine monitor before it wakes the session;
   `—` means the routine always wakes it. Adding or changing one needs the confirmation code.
   ```
+- Every write below names **one entry** — `routines.<index>`, 0-based, so table number − 1. Never write the
+  whole `routines` array: the settings gate reads the value of a container write, and a value it cannot parse
+  (`$(cat …)`, a heredoc, a shell variable) escalates to the confirmation code even when nothing is gated.
+  Entry JSON goes inline, single-quoted, in the command itself.
 - Ask: "Add / edit / remove / enable / disable? (or 'done')"
 - **Add wizard:** ask for:
   - ID (unique name, e.g., "weekly-deps")
@@ -258,9 +262,11 @@ Note: "Channel changes take effect on next `hermit-start` run. `channels.primary
     - Custom → operator types raw cron
   - Skill to run (full slash-command name, e.g. `claude-code-hermit:brief` for plugin skills, `ha-refresh-context` for local project skills)
   - Enabled (yes/no, default yes)
-  - Read the current array (`get routines`), append the new entry, and write it back with `set routines '<whole array as JSON>'`. An invalid cron or a duplicate id is refused by the script — relay its error rather than retrying.
+  - Append it with `set routines.<count> '<entry as JSON>'`, where `<count>` is the number of routines just
+    listed (the first free index). A duplicate id is only a warning, so check the id against the listed ones
+    before writing; an invalid cron is refused by the script — relay its error rather than retrying.
 - **Edit:** select by number, then `set routines.<index>.<field> <value>` (one call per changed field; siblings are preserved).
-- **Remove:** select by number, then read the array, drop that element, and `set routines '<remaining array>'` (array indices shift, so a whole-array write is safer than `unset routines.<index>`).
+- **Remove:** select by number, then `unset routines.<index>` — one call, and the remaining entries close the gap (their numbers shift, so re-list before a second removal).
 - **Enable/disable:** select by number, `set routines.<index>.enabled true|false`.
 - Loop until operator says "done".
 - **After all edits are written**, invoke `/claude-code-hermit:hermit-routines load` via the Skill tool to apply the new schedule live (no restart). Surface the result inline:

--- a/plugins/claude-code-hermit/tests/channel-settings-gate.test.ts
+++ b/plugins/claude-code-hermit/tests/channel-settings-gate.test.ts
@@ -530,6 +530,52 @@ describe('channel-settings-gate — maintainer tier', () => {
     expect(r.exitCode).toBe(0);
   });
 
+  // The add/remove path hermit-settings uses: one entry at a time, so the value
+  // stays legible and only an armed gate escalates. Pins the tiers the skill's
+  // instructions depend on — a change here breaks routine editing from a channel.
+  describe('routines edited one entry at a time', () => {
+    const routines = [
+      { id: 'morning', schedule: '0 9 * * *', skill: 'claude-code-hermit:brief', enabled: true },
+      { id: 'reflect', schedule: '0 9 * * *', skill: 'claude-code-hermit:reflect', precheck: 'reflect' },
+    ];
+    const withRoutines = () => ({ ...configWithMaintainer(), routines });
+    const edit = (op: string, ...args: string[]) =>
+      ['bun /p/scripts/settings-edit.ts .claude-code-hermit/config.json', op, ...args].join(' ');
+    const entry = (extra: any = {}) =>
+      `'${JSON.stringify({ id: 'added', schedule: '0 9 * * *', skill: 'claude-code-hermit:brief', ...extra })}'`;
+
+    test('removing one by index needs no code', async () => {
+      const { dir, transcript } = fixture(maintainerPrompt('remove the morning routine'), withRoutines());
+      const r = await runGate(
+        payload({ dir, transcript, tool: 'Bash', input: { command: edit('unset', 'routines.0') } }),
+        dir
+      );
+      expect(r.exitCode).toBe(0);
+    });
+
+    test('appending a gateless entry needs no code', async () => {
+      const { dir, transcript } = fixture(maintainerPrompt('add a routine'), withRoutines());
+      const r = await runGate(
+        payload({ dir, transcript, tool: 'Bash', input: { command: edit('set', 'routines.2', entry()) } }),
+        dir
+      );
+      expect(r.exitCode).toBe(0);
+    });
+
+    test('appending an entry that arms a precheck still needs the code', async () => {
+      const { dir, transcript } = fixture(maintainerPrompt('add a gated routine'), withRoutines());
+      const r = await runGate(
+        payload({
+          dir, transcript, tool: 'Bash',
+          input: { command: edit('set', 'routines.2', entry({ precheck: 'tools/gate.sh' })) },
+        }),
+        dir
+      );
+      expect(r.exitCode).toBe(2);
+      expect(r.stderr).toContain('Second factor required');
+    });
+  });
+
   test('the same write from the home chat is refused', async () => {
     const { dir, transcript } = fixture(
       maintainerPrompt('turn escalation on', { chatId: HOME_CHAT }),

--- a/plugins/claude-code-hermit/tests/settings-edit.test.ts
+++ b/plugins/claude-code-hermit/tests/settings-edit.test.ts
@@ -91,6 +91,22 @@ describe('getPath / setPath / togglePath', () => {
     expect(() => setPath(obj, 'routines.7', { id: 'gap' })).toThrow(/0\.\.2/);
     expect(obj.routines).toHaveLength(2);
   });
+
+  // An interior index edits an entry that has to already exist, so `length` is out of
+  // range there too — otherwise the traversal creates it and the array grows holes.
+  test('setPath refuses an out-of-range index in the middle of a path', () => {
+    const obj: any = { routines: [{ id: 'a' }, { id: 'b' }] };
+    expect(() => setPath(obj, 'routines.2.enabled', false)).toThrow(/0\.\.1/);
+    expect(() => setPath(obj, 'routines.9.enabled', false)).toThrow(/0\.\.1/);
+    expect(obj.routines).toEqual([{ id: 'a' }, { id: 'b' }]);
+  });
+
+  test('setPath rejects a non-canonical array index', () => {
+    const obj: any = { routines: [{ id: 'a' }, { id: 'b' }] };
+    expect(() => setPath(obj, 'routines.01', { id: 'x' })).toThrow();
+    expect(unsetPath(obj, 'routines.01')).toBe(false);
+    expect(obj.routines).toEqual([{ id: 'a' }, { id: 'b' }]);
+  });
 });
 
 // --- CLI integration tests (subprocess) ---

--- a/plugins/claude-code-hermit/tests/settings-edit.test.ts
+++ b/plugins/claude-code-hermit/tests/settings-edit.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, afterAll } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { runScript, PLUGIN_ROOT } from './helpers/run';
-import { getPath, setPath, togglePath, renderShow, applyKnown } from '../scripts/settings-edit';
+import { getPath, setPath, unsetPath, togglePath, renderShow, applyKnown } from '../scripts/settings-edit';
 import { SETTINGS, tableSettings } from '../scripts/lib/settings/registry';
 import { freshDirFactory } from './helpers/workdir';
 
@@ -58,6 +58,38 @@ describe('getPath / setPath / togglePath', () => {
 
   test('togglePath throws on non-boolean current value', () => {
     expect(() => togglePath({ remote: 'yes' }, 'remote')).toThrow();
+  });
+
+  // Removing one routine by index is the whole point of `unset routines.<n>`: a
+  // `delete` would leave a hole that serializes as `null`, and validation then
+  // fails on an entry with no id for every later write.
+  test('unsetPath splices an array index, leaving the array dense', () => {
+    const obj: any = { routines: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] };
+    expect(unsetPath(obj, 'routines.1')).toBe(true);
+    expect(obj.routines).toEqual([{ id: 'a' }, { id: 'c' }]);
+  });
+
+  test('unsetPath leaves an out-of-range index alone', () => {
+    const obj: any = { routines: [{ id: 'a' }] };
+    expect(unsetPath(obj, 'routines.5')).toBe(false);
+    expect(unsetPath(obj, 'routines.x')).toBe(false);
+    expect(obj.routines).toEqual([{ id: 'a' }]);
+  });
+
+  test('unsetPath still deletes an object leaf', () => {
+    const obj: any = { channels: { discord: { enabled: true }, telegram: {} } };
+    expect(unsetPath(obj, 'channels.discord')).toBe(true);
+    expect(obj.channels).toEqual({ telegram: {} });
+  });
+
+  test('setPath appends at length but refuses a sparse index', () => {
+    const obj: any = { routines: [{ id: 'a' }] };
+    setPath(obj, 'routines.1', { id: 'b' });
+    expect(obj.routines).toEqual([{ id: 'a' }, { id: 'b' }]);
+    setPath(obj, 'routines.0.enabled', false);
+    expect(obj.routines[0]).toEqual({ id: 'a', enabled: false });
+    expect(() => setPath(obj, 'routines.7', { id: 'gap' })).toThrow(/0\.\.2/);
+    expect(obj.routines).toHaveLength(2);
   });
 });
 
@@ -417,6 +449,50 @@ describe('settings-edit unset', () => {
     const r = await runScript('settings-edit.ts', { args: [file, 'unset', 'nope.not.here'] });
     expect(r.exitCode).toBe(0);
     expect(auditRows(dir)).toHaveLength(0);
+  });
+});
+
+// The add/remove path hermit-settings uses from a channel: one entry at a time,
+// so the gate sees a legible value and no confirmation code is asked for.
+describe('settings-edit routines by index', () => {
+  const routine = (id: string, extra: any = {}) => ({
+    id, schedule: '0 9 * * *', skill: 'claude-code-hermit:brief', enabled: true, ...extra,
+  });
+
+  test('unset removes one routine and leaves the rest writable', async () => {
+    const dir = freshDir();
+    const file = seedConfig(dir, validConfig({
+      routines: [routine('morning'), routine('gated', { precheck: 'reflect' }), routine('evening')],
+    }));
+    const r = await runScript('settings-edit.ts', { args: [file, 'unset', 'routines.1'] });
+    expect(r.exitCode).toBe(0);
+    expect(readConfig(file).routines.map((x: any) => x.id)).toEqual(['morning', 'evening']);
+
+    // The hole a `delete` used to leave made this next write fail validation.
+    const after = await runScript('settings-edit.ts', { args: [file, 'set', 'routines.1.enabled', 'false'] });
+    expect(after.exitCode).toBe(0);
+    expect(readConfig(file).routines[1]).toMatchObject({ id: 'evening', enabled: false });
+  });
+
+  test('set at the array length appends one routine', async () => {
+    const dir = freshDir();
+    const file = seedConfig(dir, validConfig({ routines: [routine('morning')] }));
+    const r = await runScript('settings-edit.ts', {
+      args: [file, 'set', 'routines.1', JSON.stringify(routine('evening'))],
+    });
+    expect(r.exitCode).toBe(0);
+    expect(readConfig(file).routines.map((x: any) => x.id)).toEqual(['morning', 'evening']);
+  });
+
+  test('set past the end is refused, naming the valid range', async () => {
+    const dir = freshDir();
+    const file = seedConfig(dir, validConfig({ routines: [routine('morning')] }));
+    const r = await runScript('settings-edit.ts', {
+      args: [file, 'set', 'routines.7', JSON.stringify(routine('gap'))],
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('0..1');
+    expect(readConfig(file).routines).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Removing a routine from the maintainer chat asked for a confirmation code even though nothing gated was involved. The issue diagnosed this as `precheckSetChanged()` over-triggering on the whole-array diff, but that turned out not to reproduce: the escalation came from the *value*. `hermit-settings` instructed the model to rewrite the entire `routines` array, the model reached for `set routines "$(cat /tmp/arr.json)"`, and the gate — which cannot expand a shell substitution — correctly treats an unparseable value as opaque and escalates.

The fix is to stop rewriting the array at all. The gate already judges the single-entry spellings correctly, but `unset routines.<n>` was unusable: it deleted the index and left a `null` behind, which then failed validation on every later settings write. That defect is why the skill steered to whole-array writes in the first place.

`channel-settings-gate.ts` is unchanged — its verdicts were already right, and three new tests pin them.

## Changes

- `settings-edit.ts`: `unsetPath` splices an array index instead of deleting it, so the array stays dense; an out-of-range index stays a no-op. Object leaves are unaffected.
- `settings-edit.ts`: `setPath` refuses an index past the end of an array (`=== length` still appends), instead of growing it with holes. The `set` CLI case reports the error and exits 1, matching the existing `toggle` case.
- `hermit-settings` skill: add is now `set routines.<count> '<entry>'`, remove is `unset routines.<index>`, with the 0-based index mapping stated once and an explicit "never `$(cat …)`, a heredoc, or a variable" rule. Also corrects a false claim: a duplicate routine id is a warning, not a refusal (`validate-config.ts:192`).
- Tests: unit coverage for the splice/append/refuse paths, CLI coverage including the regression where a write after a removal used to fail, and three gate tests pinning that removing or appending a gateless entry needs no code while an entry carrying a `precheck` still does.

## Test plan

- `bun test` in `plugins/claude-code-hermit/` → 4429 pass, 0 fail
- `bunx tsc --noEmit` → exit 0
- Manual, against a scratch copy of a real config: `unset routines.5` leaves a dense array and a following `set routines.1.enabled false` succeeds (it crashed before); `set routines.<len>` appends; `set routines.99` exits 1 naming the valid range.

Note: the auto-mode classifier remains an independent second gate on these writes and is unstable on them (#800). This PR changes what the hermit's own hook asks for; it does not affect that.

Closes #798