### PR TITLE
docs: add an upgrade-time audit that surfaces ungated routines as a precheck candidate

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -11,14 +11,14 @@
 
 **Doctor and daily-auto-close stop waking the session on a quiet day.** In `.claude-code-hermit/config.json`, for each of the `routines[]` entries with `"id": "doctor"` and `"id": "daily-auto-close"`: if its `skill` still starts with the shipped value (`claude-code-hermit:hermit-doctor` / `claude-code-hermit:session-close`) and it has **no** `precheck` key, add `"precheck": "doctor"` or `"precheck": "auto-close"` respectively. On the `doctor` entry also add `"precheck_timeout_s": 120` unless it already sets one — the gate runs the full check sweep, and the 30s default is not enough for an install whose docker or credential probes are slow. If the routine has been renamed, points at a different skill, or already has a `precheck`, leave it untouched and note that in the evolve report — an operator's own gate is never replaced. Removing the key later restores the old always-wake behavior.
 
-**Suggest wake gates for routines that still wake the session on every fire.** Run this after the previous step, so the routines it just gated are not re-flagged.
+**Suggest wake gates for routines that still wake the session on every fire.** Run this after the previous step.
 
-1. Run `bun "${CLAUDE_PLUGIN_ROOT}/scripts/routines.ts" health .claude-code-hermit --days 14` and read the `routines[]` array from the JSON it prints.
-2. Read the configured routines with `settings-edit.ts .claude-code-hermit/config.json get routines`.
-3. Build the candidate list. An entry qualifies when all four hold: `enabled` is not `false`; it has no `precheck` key; its `id` is none of `heartbeat-restart`, `reflect`, `scheduled-checks`, `weekly-review`, `daily-auto-close`, `doctor`, `morning`, `evening`; and its `fires` in the health report is 7 or more.
+1. Run `bun "${CLAUDE_PLUGIN_ROOT}/scripts/routines.ts" health .claude-code-hermit --days 14` and read the JSON it prints. If its `source` is not `ok`, the routine ledger could not be read — record nothing, stop, and note in the evolve report that this audit could not run. Otherwise read its `routines[]` array.
+2. Read the configured routines with `bun "${CLAUDE_PLUGIN_ROOT}/scripts/settings-edit.ts" .claude-code-hermit/config.json get routines`.
+3. Build the candidate list. An entry qualifies when all four hold: `enabled` is `true`; it has no `precheck` key; its `id` is none of `heartbeat-restart`, `reflect`, `scheduled-checks`, `weekly-review`, `daily-auto-close`, `doctor`, `morning`, `evening`; and its `fires` in the health report is 7 or more.
 4. If the list is empty, record nothing and stop: do not run steps 5-7.
-5. Change nothing in `config.json`.
-6. Record one observation per candidate: run `.claude-code-hermit/bin/hermit-run observations observe .claude-code-hermit routine-gate-candidate` with `routine-gate-candidate:<id>` on stdin.
+5. Change nothing in `config.json` in this pass — this step only surfaces candidates. A gate is added later, and only for the branch the operator picks, with `settings-edit.ts .claude-code-hermit/config.json set routines.<n>.precheck <value>`.
+6. Record one observation per candidate: run `.claude-code-hermit/bin/hermit-run observations observe .claude-code-hermit quick-deferral` with `routine-gate-candidate:<id>` on stdin.
 7. Record a deferred-migration block: `source: claude-code-hermit@<version>`, this "Suggest wake gates" entry's text (above, verbatim) as `instruction:`, `options:` naming each candidate id with its fire count and the two branches ("add a `precheck` gate" / "leave as-is"), and `skipped: skipped pending operator`.
 
 **Note:** a gate is a `SKIP`/`WAKE` script declared as the routine's `precheck` — see `docs/routine-authoring.md`. Setting one from chat takes the confirmation-code tier. Removing the key restores always-wake.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,11 +5,23 @@
 ### Changed
 - The `doctor` and `daily-auto-close` routines ship with a builtin `precheck` gate, so a day with nothing to report or close no longer wakes the session. `"precheck": "doctor"` runs the 27 checks and their ledger writes once, in the gate itself, and SKIPs when nothing currently failing is still owed to the operator. `"precheck": "auto-close"` runs the same decision the `--scheduled` archive path already made, and SKIPs on `queued` or `noop` — WAKE only fires an actual close.
 - A hermit that never opened a session (`idle`, no active session id) no longer archives an empty nightly report. The `auto-close` gate stamps the daily context-reset marker itself on that branch, so the `/clear` the archive path used to trigger keeps firing on schedule either way.
+- The spawn gate's `start` and `stop` sit on the everyday authority tier instead of asking for an echoed confirmation code from the settings chat. A spawned session is bound to the claude.ai account signed in on the machine, so the gate changes where the operator can spawn from, not who can.
 
 ### Upgrade Instructions
 
 **Doctor and daily-auto-close stop waking the session on a quiet day.** In `.claude-code-hermit/config.json`, for each of the `routines[]` entries with `"id": "doctor"` and `"id": "daily-auto-close"`: if its `skill` still starts with the shipped value (`claude-code-hermit:hermit-doctor` / `claude-code-hermit:session-close`) and it has **no** `precheck` key, add `"precheck": "doctor"` or `"precheck": "auto-close"` respectively. On the `doctor` entry also add `"precheck_timeout_s": 120` unless it already sets one — the gate runs the full check sweep, and the 30s default is not enough for an install whose docker or credential probes are slow. If the routine has been renamed, points at a different skill, or already has a `precheck`, leave it untouched and note that in the evolve report — an operator's own gate is never replaced. Removing the key later restores the old always-wake behavior.
-- The spawn gate's `start` and `stop` sit on the everyday authority tier instead of asking for an echoed confirmation code from the settings chat. A spawned session is bound to the claude.ai account signed in on the machine, so the gate changes where the operator can spawn from, not who can.
+
+**Suggest wake gates for routines that still wake the session on every fire.** Run this after the previous step, so the routines it just gated are not re-flagged.
+
+1. Run `bun "${CLAUDE_PLUGIN_ROOT}/scripts/routines.ts" health .claude-code-hermit --days 14` and read the `routines[]` array from the JSON it prints.
+2. Read the configured routines with `settings-edit.ts .claude-code-hermit/config.json get routines`.
+3. Build the candidate list. An entry qualifies when all four hold: `enabled` is not `false`; it has no `precheck` key; its `id` is none of `heartbeat-restart`, `reflect`, `scheduled-checks`, `weekly-review`, `daily-auto-close`, `doctor`, `morning`, `evening`; and its `fires` in the health report is 7 or more.
+4. If the list is empty, record nothing and stop: do not run steps 5-7.
+5. Change nothing in `config.json`.
+6. Record one observation per candidate: run `.claude-code-hermit/bin/hermit-run observations observe .claude-code-hermit routine-gate-candidate` with `routine-gate-candidate:<id>` on stdin.
+7. Record a deferred-migration block: `source: claude-code-hermit@<version>`, this "Suggest wake gates" entry's text (above, verbatim) as `instruction:`, `options:` naming each candidate id with its fire count and the two branches ("add a `precheck` gate" / "leave as-is"), and `skipped: skipped pending operator`.
+
+**Note:** a gate is a `SKIP`/`WAKE` script declared as the routine's `precheck` — see `docs/routine-authoring.md`. Setting one from chat takes the confirmation-code tier. Removing the key restores always-wake.
 
 ### Fixed
 - The `hermit-run rc-server` verbs (`start`, `stop`, `status`, `gc`) are in the sealed allow-list, so opening or checking the spawn gate no longer hits a permission prompt that an unattended session cannot answer.


### PR DESCRIPTION
## Summary
The v1.2.47 `precheck` wake gate lets a routine SKIP its fire at zero token cost, and `[Unreleased]` already gates the two remaining core-shipped routines (`doctor`, `daily-auto-close`). Operator-authored routines have no such nudge: the `routine-precheck` doctor check only audits routines that already have a gate, so it reports fully healthy even when an operator's own daily-firing routine has none.

This adds a third Upgrade Instructions step under `[Unreleased]` that reads the existing bounded `routines.ts health` digest, cross-references the operator's configured routines, and — when it finds enabled, ungated, non-core routines that have fired 7+ times in 14 days — records a deferred-migration block naming them as `precheck` candidates. It never writes `config.json`; the operator (interactively or via the channel relay) decides whether to add a gate.

Also fixes a merge artifact: a `### Changed` bullet (the spawn-gate authority-tier change) had landed below the `### Upgrade Instructions` heading.

## Changes
- `plugins/claude-code-hermit/CHANGELOG.md`: moved the misplaced bullet back under `### Changed`; added the "Suggest wake gates for routines that still wake the session on every fire" Upgrade Instructions step.

## Test plan
- `bun test` — 4419 tests, 1 pre-existing local-only flake (`tests/proc.test.ts` tmux timeout, passes in isolation; known snap-tmux timing issue, green on CI) — otherwise all pass.
- `bunx tsc --noEmit` — clean.
- Verified `[Unreleased]` is not sliced/executed by `evolve-plan.ts` (`tests/evolve-plan.test.ts`, 50/50 pass) — this step activates only once `/release` promotes the section.
- Negative control: ran `routines.ts health .claude-code-hermit --days 14` against this project's own hermit and confirmed its one operator-authored routine (`pipeline-digest`, already gated) and the still-ungated `doctor`/`daily-auto-close` are correctly excluded by the candidate filter.
- Positive case: confirmed via the real `routines.ts log-event`/`health` row schema (`routine_id`, `event`, `delivery`; `fires` counts `fired` terminals) that 7+ synthetic `fired` rows for a non-shipped routine id surface it in the health digest with `fires >= 7`.