### PR TITLE
fix(claude-code-hermit): copy Progress Log into archived ## Completed

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -11,6 +11,9 @@
 - The `Bash(*API_KEY*)`, `Bash(*SECRET*)`, and `Bash(*TOKEN*)` deny patterns are gone from `deny-patterns.json` — trivially bypassable and blocking ordinary work (a grep, a commit message). The anchored `env`/`printenv`/`cat .env*`/`cat ~/.ssh/*`/`cat ~/.aws/*` entries stay; see `docs/security.md` for the full rationale.
 - Four sigil-anchored entries replace them: `Bash(*$ANTHROPIC_API_KEY*)` and `Bash(*$CLAUDE_CODE_OAUTH_TOKEN*)`, each in bare and `${…}` spelling. An expansion of a live credential (`echo $ANTHROPIC_API_KEY` while debugging auth) blocks; every bare mention of the name — a grep, a commit message, writing the placeholder into `.env` — stays allowed. The hook enforces them from the shipped template, so nothing needs adding to your settings file.
 
+### Fixed
+- Session archive copies the Progress Log into the report `## Completed` before resetting SHELL.md, so an auto-close no longer drops the day's work record.
+
 ### Upgrade Instructions
 
 **Migrate `settings_from_chat` to per-channel `settings_policy`.** `settings_policy` is terminal-only, so **this block runs only on a terminal-typed turn** — on a channel-arrived or unattended turn the gate denies step 2. Relay it to the operator as a step for them to run themselves instead, and skip steps 2 and 3; the retired key keeps applying as `deny` until they do, so nothing is reopened by waiting. Read the current value with `bun "${CLAUDE_PLUGIN_ROOT}/scripts/settings-edit.ts" .claude-code-hermit/config.json get settings_from_chat`, and the channels with `… get channels`.

--- a/plugins/claude-code-hermit/scripts/session-archive.ts
+++ b/plugins/claude-code-hermit/scripts/session-archive.ts
@@ -528,7 +528,8 @@ function buildReport(opts: {
   sections.push(`# Session Report: ${sessionId}`);
   sections.push(`## Overview\n${task || '<!-- One-line task description -->'}`);
   if (payload.plan) sections.push(`## Plan\n${payload.plan}`);
-  sections.push('## Completed\n<!-- What was accomplished (narrative). Durable outputs must also be listed under ## Artifacts. -->');
+  const completed = stripPlaceholders(extractSection(shell, 'Progress Log'));
+  sections.push(`## Completed\n${completed || '<!-- What was accomplished (narrative). Durable outputs must also be listed under ## Artifacts. -->'}`);
   sections.push(`## Changed\n${changed || '<!-- Files modified/created/deleted -->'}`);
   sections.push(`## Artifacts\n${artifacts || '<!-- Links to durable outputs written to compiled/ (cite as [[compiled/<type>-<slug>-<date>]]) -->'}`);
   sections.push(`## Blockers\n${blockers || '<!-- What couldn\'t be resolved -->'}`);

--- a/plugins/claude-code-hermit/tests/session-archive.test.ts
+++ b/plugins/claude-code-hermit/tests/session-archive.test.ts
@@ -368,6 +368,54 @@ describe('idle vs. close reset semantics', () => {
 });
 
 // =============================================================================
+describe('Progress Log preservation in ## Completed', () => {
+  const COMPLETED_PLACEHOLDER =
+    '<!-- What was accomplished (narrative). Durable outputs must also be listed under ## Artifacts. -->';
+  const AUTO_PAYLOAD =
+    'Status: completed\nBlockers: none\nLessons: none\nChanged: none\nArtifacts: none\nClosed Via: auto\nNext Start Point: Fresh start.\n';
+
+  function seedProgressLog(dir: string, body: string) {
+    let shell = readShell(dir);
+    shell = shell.replace(/(## Progress Log\n)([\s\S]*?)(?=\n## )/, `$1${body}\n\n`);
+    writeShell(dir, shell);
+  }
+
+  function completedSection(report: string): string {
+    return report.split('## Completed\n')[1]?.split('\n## ')[0] ?? '';
+  }
+
+  test('auto archive copies a populated Progress Log into ## Completed, then resets SHELL', withTmp(async (dir) => {
+    await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    seedProgressLog(dir,
+      '<!-- Primary record of work -->\n<!-- Format: [HH:MM] Did X — result/outcome -->\n[09:00] shipped the thing');
+    await archive(dir, 'auto', AUTO_PAYLOAD, '2026-07-09T13:00:00Z');
+    const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
+    expect(completedSection(report)).toContain('[09:00] shipped the thing');
+    expect(completedSection(report)).not.toContain(COMPLETED_PLACEHOLDER);
+    expect(readShell(dir)).not.toContain('shipped the thing');
+  }));
+
+  test('auto archive of a placeholder-only Progress Log keeps the Completed template comment', withTmp(async (dir) => {
+    await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    await archive(dir, 'auto', AUTO_PAYLOAD, '2026-07-09T13:00:00Z');
+    const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
+    expect(completedSection(report).trim()).toBe(COMPLETED_PLACEHOLDER);
+  }));
+
+  test('idle archive copies a populated Progress Log into ## Completed, then resets the section', withTmp(async (dir) => {
+    await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    seedProgressLog(dir,
+      '<!-- Primary record of work -->\n<!-- Format: [HH:MM] Did X — result/outcome -->\n[09:00] shipped the thing');
+    await archive(dir, 'idle', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
+    expect(completedSection(report)).toContain('[09:00] shipped the thing');
+    const after = readShell(dir);
+    expect(after).not.toContain('shipped the thing');
+    expect(after).toContain('<!-- Primary record of work -->');
+  }));
+});
+
+// =============================================================================
 describe('compaction roll-up', () => {
   test('rolls up Monitoring entries past the threshold into a bucketed [Earlier] line', withTmp(async (dir) => {
     await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');

--- a/plugins/claude-code-hermit/tests/session-archive.test.ts
+++ b/plugins/claude-code-hermit/tests/session-archive.test.ts
@@ -413,6 +413,19 @@ describe('Progress Log preservation in ## Completed', () => {
     expect(after).not.toContain('shipped the thing');
     expect(after).toContain('<!-- Primary record of work -->');
   }));
+
+  test('close archive copies a populated Progress Log into ## Completed, then resets SHELL', withTmp(async (dir) => {
+    await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
+    seedProgressLog(dir,
+      '<!-- Primary record of work -->\n<!-- Format: [HH:MM] Did X — result/outcome -->\n[09:00] shipped the thing');
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
+    expect(completedSection(report)).toContain('[09:00] shipped the thing');
+    expect(completedSection(report)).not.toContain(COMPLETED_PLACEHOLDER);
+    const after = readShell(dir);
+    expect(after).not.toContain('shipped the thing');
+    expect(after).toContain('<!-- Primary record of work -->');
+  }));
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Session archive wrote an empty `## Completed` and then reset SHELL.md, so a midnight auto-close threw away the day's Progress Log. The report now copies that log before the reset.

Closes #812.

## Changes
- `buildReport()` fills `## Completed` from the SHELL.md Progress Log when it has real content; a placeholder-only log keeps the template comment.
- The fill is unmode-gated (auto, idle, and operator). Operator close on this install was empty too, and idle reset had the same wipe.
- Tests cover populated copy-through, empty keep-comment, and post-archive SHELL reset.

## Test plan
- `cd plugins/claude-code-hermit && bun test tests/session-archive.test.ts` — 60 pass, 0 fail
- `cd plugins/claude-code-hermit && bun test` — 4536 pass, 0 fail
- `cd plugins/claude-code-hermit && bunx tsc --noEmit` — exit 0