### PR TITLE
fix(claude-code-hermit): preserve factual archive state

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Fixed
 - Session archive copies the Progress Log into the report `## Completed` before resetting SHELL.md, so an auto-close no longer drops the day's work record.
-- Session archive now uses one recorded factual baseline for every archive mode: Task, Findings, Blockers, current-session compiled Artifacts, and the matching runtime duration survive unattended close and remain available to briefs and recall.
+- Session archive now uses one recorded factual baseline for every archive mode: Task, Findings, Blockers, and current-session compiled Artifacts survive unattended close; close payloads can add missing Blockers and compiled links or mark recorded blockers resolved without deleting their text; and a duration with no provably owned runtime window is reported as unknown instead of zero.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Session archive copies the Progress Log into the report `## Completed` before resetting SHELL.md, so an auto-close no longer drops the day's work record.
+- Session archive now uses one recorded factual baseline for every archive mode: Task, Findings, Blockers, current-session compiled Artifacts, and the matching runtime duration survive unattended close and remain available to briefs and recall.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/scripts/session-archive.ts
+++ b/plugins/claude-code-hermit/scripts/session-archive.ts
@@ -557,7 +557,10 @@ function recordedArtifacts(
   stateDir: string,
   sessionId: string,
 ): { content: string; contributed: boolean } {
-  const shellLinks = shell.match(/\[\[compiled\/[^\]\r\n]+\]\]/g) || [];
+  const taskScopedShell = ['Task', 'Progress Log', 'Blockers', 'Findings', 'Changed']
+    .map(heading => extractSection(shell, heading))
+    .join('\n');
+  const shellLinks = taskScopedShell.match(/\[\[compiled\/[^\]\r\n]+\]\]/g) || [];
   const stampedLinks = globDir(path.join(stateDir, 'compiled'), /^[^.].*\.md$/)
     .filter(file => readFrontmatter(file)?.session === sessionId)
     .map(file => `[[compiled/${path.basename(file, '.md')}]]`);

--- a/plugins/claude-code-hermit/scripts/session-archive.ts
+++ b/plugins/claude-code-hermit/scripts/session-archive.ts
@@ -80,7 +80,10 @@ function zonedISOStamp(timezone: string, ref: Date): string {
 }
 
 function formatDuration(ms: number): string {
-  const totalMin = Math.max(0, Math.round(ms / 60000));
+  if (ms < 0) return 'unknown';
+  if (ms === 0) return '0m';
+  if (ms < 60000) return '<1m';
+  const totalMin = Math.round(ms / 60000);
   const h = Math.floor(totalMin / 60);
   const m = totalMin % 60;
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
@@ -481,12 +484,95 @@ function firstRecordedTask(shell: string): string {
   return '';
 }
 
-function recordedArtifacts(shell: string, stateDir: string, sessionId: string): string {
-  const links = shell.match(/\[\[compiled\/[^\]\r\n]+\]\]/g) || [];
-  const stamped = globDir(path.join(stateDir, 'compiled'), /^[^.].*\.md$/)
+type MergedPayloadField = 'Blockers' | 'Artifacts';
+
+function blockerText(line: string): string {
+  return line.trim().replace(/^-\s+/, '').trim();
+}
+
+function mergeRecordedBlockers(
+  recorded: string,
+  payload: string,
+  recoveryBlockers: string | undefined,
+  statusNote: string | null,
+): { content: string; contributed: boolean } {
+  const recordedLines = recorded.split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+  const recordedText = recordedLines.map(blockerText);
+  const seen = new Set(recordedText.map(line => line.toLowerCase()));
+  const resolved = new Set<number>();
+  const additions: string[] = [];
+  let contributed = false;
+
+  for (const rawLine of payload.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || /^none$/i.test(line)) continue;
+
+    if (line.startsWith('~')) {
+      const resolution = blockerText(line.slice(1));
+      if (!resolution || /^none$/i.test(resolution)) continue;
+      const prefix = resolution.toLowerCase();
+      const match = recordedText.findIndex(candidate => candidate.toLowerCase().startsWith(prefix));
+      if (match !== -1) {
+        if (!resolved.has(match)) {
+          resolved.add(match);
+          contributed = true;
+        }
+        continue;
+      }
+
+      const key = resolution.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      additions.push(resolution);
+      contributed = true;
+      continue;
+    }
+
+    const key = blockerText(line).toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    additions.push(line);
+    contributed = true;
+  }
+
+  const shellLines = recordedLines.map((line, index) => (
+    resolved.has(index) ? `- [resolved] ${recordedText[index]}` : line
+  ));
+  return {
+    content: [
+      ...shellLines,
+      ...additions,
+      recoveryBlockers,
+      statusNote,
+    ].filter(Boolean).join('\n'),
+    contributed,
+  };
+}
+
+function recordedArtifacts(
+  shell: string,
+  payload: string,
+  stateDir: string,
+  sessionId: string,
+): { content: string; contributed: boolean } {
+  const shellLinks = shell.match(/\[\[compiled\/[^\]\r\n]+\]\]/g) || [];
+  const stampedLinks = globDir(path.join(stateDir, 'compiled'), /^[^.].*\.md$/)
     .filter(file => readFrontmatter(file)?.session === sessionId)
     .map(file => `[[compiled/${path.basename(file, '.md')}]]`);
-  return Array.from(new Set([...links, ...stamped])).map(link => `- ${link}`).join('\n');
+  const recorded = new Set([...shellLinks, ...stampedLinks]);
+  const payloadOnly: string[] = [];
+  for (const link of payload.match(/\[\[compiled\/[^\]\r\n]+\]\]/g) || []) {
+    if (recorded.has(link)) continue;
+    recorded.add(link);
+    payloadOnly.push(link);
+  }
+  const links = Array.from(new Set([...shellLinks, ...payloadOnly, ...stampedLinks]));
+  return {
+    content: links.map(link => `- ${link}`).join('\n'),
+    contributed: payloadOnly.length > 0,
+  };
 }
 
 function resolveDuration(
@@ -496,25 +582,25 @@ function resolveDuration(
   closedAt: string | undefined,
   now: Date,
 ): string {
-  if (runtimeSessionId !== sessionId || !openedAt) return '0m';
+  if (runtimeSessionId !== sessionId || !openedAt) return 'unknown';
   const start = Date.parse(openedAt);
-  if (!Number.isFinite(start)) return '0m';
+  if (!Number.isFinite(start)) return 'unknown';
   const parsedEnd = closedAt ? Date.parse(closedAt) : NaN;
-  const end = Number.isFinite(parsedEnd) && parsedEnd > start ? parsedEnd : now.getTime();
+  const end = Number.isFinite(parsedEnd) ? parsedEnd : now.getTime();
   return formatDuration(end - start);
 }
 
 function buildReport(opts: {
   sessionId: string; mode: 'idle' | 'close' | 'auto'; now: Date;
   payload: Record<string, string> & { plan?: string }; shell: string; stateDir: string; config: Json;
-  runtimeSessionId?: string; openedAt?: string; closedAt?: string; recoveryBlockers?: string;
-}): { content: string; statusNote: string | null; cost: { cost_usd: number; tokens: number } } {
-  const { sessionId, mode, now, payload, shell, stateDir, config, runtimeSessionId, openedAt, closedAt, recoveryBlockers } = opts;
+  runtimeSessionId?: string; openedAt?: string; durationClosedAt?: string; costClosedAt?: string; recoveryBlockers?: string;
+}): { content: string; statusNote: string | null; cost: { cost_usd: number; tokens: number }; mergedPayloadFields: MergedPayloadField[] } {
+  const { sessionId, mode, now, payload, shell, stateDir, config, runtimeSessionId, openedAt, durationClosedAt, costClosedAt, recoveryBlockers } = opts;
   const sessionsDir = path.join(stateDir, 'sessions');
   const timezone = resolveTimezone(config);
   const { status, note: statusNote } = normalizeStatus(payload['Status'] || '');
-  const duration = resolveDuration(sessionId, runtimeSessionId, openedAt, closedAt, now);
-  const cost = resolveCost(payload, { logPath: costLogPath(stateDir), openedAt, closedAt: closedAt ?? localISOStamp(now) });
+  const duration = resolveDuration(sessionId, runtimeSessionId, openedAt, durationClosedAt, now);
+  const cost = resolveCost(payload, { logPath: costLogPath(stateDir), openedAt, closedAt: costClosedAt ?? localISOStamp(now) });
   const { cost_usd, tokens } = cost;
   const tags = extractTags(shell);
   const proposalsCreated = extractProposalIds(shell);
@@ -523,15 +609,21 @@ function buildReport(opts: {
   const operatorTurns = resolveOperatorTurns(sessionsDir);
   const closedVia = payload['Closed Via'] || (mode === 'auto' ? 'auto' : 'operator');
 
-  const blockers = [
+  const blockersMerge = mergeRecordedBlockers(
     stripPlaceholders(extractSection(shell, 'Blockers')),
+    payload['Blockers'] || '',
     recoveryBlockers,
     statusNote,
-  ].filter(Boolean).join('\n');
+  );
+  const blockers = blockersMerge.content;
   const changed = mergeSessionDiff(payload['Changed'] || '', stateDir);
-  const artifacts = recordedArtifacts(shell, stateDir, sessionId);
+  const artifactsMerge = recordedArtifacts(shell, payload['Artifacts'] || '', stateDir, sessionId);
+  const artifacts = artifactsMerge.content;
   const findings = stripPlaceholders(extractSection(shell, 'Findings'));
   const lessons = payload['Lessons'] || '';
+  const mergedPayloadFields: MergedPayloadField[] = [];
+  if (blockersMerge.contributed) mergedPayloadFields.push('Blockers');
+  if (artifactsMerge.contributed) mergedPayloadFields.push('Artifacts');
   // Idle-mode payloads may still carry a stale 'Next Start Point:' line (it isn't
   // part of the idle contract, same as the omitted body section below) — force it
   // empty so frontmatter and body agree.
@@ -574,7 +666,7 @@ function buildReport(opts: {
     sections.push(`## Next Start Point\n${nextStart || '<!-- Exactly what the next session should do first -->'}`);
   }
 
-  return { content: fm + '\n\n' + sections.join('\n\n') + '\n', statusNote, cost };
+  return { content: fm + '\n\n' + sections.join('\n\n') + '\n', statusNote, cost, mergedPayloadFields };
 }
 
 // ---------------------------------------------------------------------------
@@ -703,7 +795,11 @@ function applyPostArchiveMarkers(stateDir: string, mode: 'idle' | 'close' | 'aut
 // Verb: archive
 // ---------------------------------------------------------------------------
 
-function verbArchive(flags: Record<string, string | true>, stdin: string, opts: { skipMarkerWrites?: boolean; recoveryBlockers?: string } = {}): Json {
+function verbArchive(
+  flags: Record<string, string | true>,
+  stdin: string,
+  opts: { skipMarkerWrites?: boolean; recoveryBlockers?: string; includeMergedPayloadFields?: boolean } = {},
+): Json {
   const mode = flags['mode'];
   if (mode !== 'idle' && mode !== 'close' && mode !== 'auto') {
     return { ok: false, reason: `archive requires --mode=idle|close|auto, got: ${mode ?? '(none)'}` };
@@ -735,14 +831,14 @@ function verbArchive(flags: Record<string, string | true>, stdin: string, opts: 
   const config = readConfig(stateDir);
   const runtimeSessionId = typeof runtimeBefore.session_id === 'string' ? runtimeBefore.session_id : undefined;
   const openedAt = typeof runtimeBefore.opened_at === 'string' ? runtimeBefore.opened_at : undefined;
-  // A closed_at at or before opened_at is a stale bound left by an earlier arc. Passing
-  // it through would measure an inverted window, which sums to a silent zero — drop it
-  // so the window ends at `now` instead (buildReport's `closedAt ?? localISOStamp(now)`).
+  // Cost aggregation keeps its prior positive-window requirement. Preserve a raw zero or
+  // inverted bound for honest duration reporting, but let cost resolution end at `now`.
   const rawClosedAt = typeof runtimeBefore.closed_at === 'string' ? runtimeBefore.closed_at : undefined;
-  const closedAt = rawClosedAt && Date.parse(rawClosedAt) > Date.parse(openedAt ?? '') ? rawClosedAt : undefined;
-  const { content: reportContent, cost: reportCost } = buildReport({
+  const costClosedAt = rawClosedAt && Date.parse(rawClosedAt) > Date.parse(openedAt ?? '') ? rawClosedAt : undefined;
+  const { content: reportContent, cost: reportCost, mergedPayloadFields } = buildReport({
     sessionId, mode, now, payload, shell, stateDir, config,
-    runtimeSessionId, openedAt, closedAt, recoveryBlockers: opts.recoveryBlockers,
+    runtimeSessionId, openedAt, durationClosedAt: rawClosedAt, costClosedAt,
+    recoveryBlockers: opts.recoveryBlockers,
   });
 
   const reportPath = path.join(sessionsDir, `${sessionId}-REPORT.md`);
@@ -774,7 +870,9 @@ function verbArchive(flags: Record<string, string | true>, stdin: string, opts: 
   if (!clearTransition.ok) return { ok: false, reason: clearTransition.reason };
 
   const markers = applyPostArchiveMarkers(stateDir, mode, now, !!opts.skipMarkerWrites);
-  return { ok: true, archived: true, session_id: sessionId, report_path: reportPath, mode, markers };
+  const result: Json = { ok: true, archived: true, session_id: sessionId, report_path: reportPath, mode, markers };
+  if (opts.includeMergedPayloadFields !== false) result.merged_payload_fields = mergedPayloadFields;
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -868,7 +966,7 @@ function verbRecover(flags: Record<string, string | true>): Json {
     const result = verbArchive(
       { mode, 'state-dir': stateDir },
       syntheticPayload,
-      { skipMarkerWrites: true, recoveryBlockers: blockers },
+      { skipMarkerWrites: true, recoveryBlockers: blockers, includeMergedPayloadFields: false },
     );
     if (!result.ok) {
       // Re-archive couldn't complete (e.g. SHELL.md itself is gone, so buildReport

--- a/plugins/claude-code-hermit/scripts/session-archive.ts
+++ b/plugins/claude-code-hermit/scripts/session-archive.ts
@@ -258,13 +258,6 @@ function extractTags(shell: string): string[] {
   return raw.split(',').map(s => s.trim()).filter(Boolean);
 }
 
-function extractStartedAt(shell: string): Date | null {
-  const m = /\*\*Started:\*\*\s*(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/.exec(shell);
-  if (!m) return null;
-  const d = new Date(m[1].replace(' ', 'T'));
-  return isNaN(d.getTime()) ? null : d;
-}
-
 // Scans the whole of SHELL.md for proposal IDs. session-mgr.md's own spec is
 // ambiguous about which section holds "Proposals Created" (SHELL.md.template
 // has no such heading — proposals get created via a separate skill during the
@@ -473,30 +466,71 @@ function contentLines(s: string): string[] {
     .map(l => l.length > maxLen ? l.slice(0, maxLen - 1) + '…' : l);
 }
 
+function firstRecordedTask(shell: string): string {
+  const task = firstContentLine(extractSection(shell, 'Task'), 120);
+  if (task) return task;
+
+  const progress = stripPlaceholders(extractSection(shell, 'Progress Log'));
+  for (const line of progress.split('\n')) {
+    const candidate = line.trim().replace(/^-\s+/, '');
+    if (!candidate) continue;
+    if (/^\[archived\]\s+previous entries\b/i.test(candidate)) continue;
+    if (/^\[\d{2}:\d{2}\]\s+context (?:compacted|cleared)\b/i.test(candidate)) continue;
+    return candidate.slice(0, 120);
+  }
+  return '';
+}
+
+function recordedArtifacts(shell: string, stateDir: string, sessionId: string): string {
+  const links = shell.match(/\[\[compiled\/[^\]\r\n]+\]\]/g) || [];
+  const stamped = globDir(path.join(stateDir, 'compiled'), /^[^.].*\.md$/)
+    .filter(file => readFrontmatter(file)?.session === sessionId)
+    .map(file => `[[compiled/${path.basename(file, '.md')}]]`);
+  return Array.from(new Set([...links, ...stamped])).map(link => `- ${link}`).join('\n');
+}
+
+function resolveDuration(
+  sessionId: string,
+  runtimeSessionId: string | undefined,
+  openedAt: string | undefined,
+  closedAt: string | undefined,
+  now: Date,
+): string {
+  if (runtimeSessionId !== sessionId || !openedAt) return '0m';
+  const start = Date.parse(openedAt);
+  if (!Number.isFinite(start)) return '0m';
+  const parsedEnd = closedAt ? Date.parse(closedAt) : NaN;
+  const end = Number.isFinite(parsedEnd) && parsedEnd > start ? parsedEnd : now.getTime();
+  return formatDuration(end - start);
+}
+
 function buildReport(opts: {
   sessionId: string; mode: 'idle' | 'close' | 'auto'; now: Date;
   payload: Record<string, string> & { plan?: string }; shell: string; stateDir: string; config: Json;
-  openedAt?: string; closedAt?: string;
+  runtimeSessionId?: string; openedAt?: string; closedAt?: string; recoveryBlockers?: string;
 }): { content: string; statusNote: string | null; cost: { cost_usd: number; tokens: number } } {
-  const { sessionId, mode, now, payload, shell, stateDir, config, openedAt, closedAt } = opts;
+  const { sessionId, mode, now, payload, shell, stateDir, config, runtimeSessionId, openedAt, closedAt, recoveryBlockers } = opts;
   const sessionsDir = path.join(stateDir, 'sessions');
   const timezone = resolveTimezone(config);
   const { status, note: statusNote } = normalizeStatus(payload['Status'] || '');
-  const startedAt = extractStartedAt(shell);
-  const duration = startedAt ? formatDuration(now.getTime() - startedAt.getTime()) : '0m';
+  const duration = resolveDuration(sessionId, runtimeSessionId, openedAt, closedAt, now);
   const cost = resolveCost(payload, { logPath: costLogPath(stateDir), openedAt, closedAt: closedAt ?? localISOStamp(now) });
   const { cost_usd, tokens } = cost;
   const tags = extractTags(shell);
   const proposalsCreated = extractProposalIds(shell);
-  const task = firstContentLine(extractSection(shell, 'Task'), 120);
+  const task = firstRecordedTask(shell);
   const escalation = resolveEscalation(config);
   const operatorTurns = resolveOperatorTurns(sessionsDir);
   const closedVia = payload['Closed Via'] || (mode === 'auto' ? 'auto' : 'operator');
 
-  let blockers = payload['Blockers'] || '';
-  if (statusNote) blockers = blockers ? blockers + '\n' + statusNote : statusNote;
+  const blockers = [
+    stripPlaceholders(extractSection(shell, 'Blockers')),
+    recoveryBlockers,
+    statusNote,
+  ].filter(Boolean).join('\n');
   const changed = mergeSessionDiff(payload['Changed'] || '', stateDir);
-  const artifacts = payload['Artifacts'] || '';
+  const artifacts = recordedArtifacts(shell, stateDir, sessionId);
+  const findings = stripPlaceholders(extractSection(shell, 'Findings'));
   const lessons = payload['Lessons'] || '';
   // Idle-mode payloads may still carry a stale 'Next Start Point:' line (it isn't
   // part of the idle contract, same as the omitted body section below) — force it
@@ -530,6 +564,7 @@ function buildReport(opts: {
   if (payload.plan) sections.push(`## Plan\n${payload.plan}`);
   const completed = stripPlaceholders(extractSection(shell, 'Progress Log'));
   sections.push(`## Completed\n${completed || '<!-- What was accomplished (narrative). Durable outputs must also be listed under ## Artifacts. -->'}`);
+  sections.push(`## Findings\n${findings || '<!-- Anything unexpected found during work. Proposal-worthy items get their own file. -->'}`);
   sections.push(`## Changed\n${changed || '<!-- Files modified/created/deleted -->'}`);
   sections.push(`## Artifacts\n${artifacts || '<!-- Links to durable outputs written to compiled/ (cite as [[compiled/<type>-<slug>-<date>]]) -->'}`);
   sections.push(`## Blockers\n${blockers || '<!-- What couldn\'t be resolved -->'}`);
@@ -668,7 +703,7 @@ function applyPostArchiveMarkers(stateDir: string, mode: 'idle' | 'close' | 'aut
 // Verb: archive
 // ---------------------------------------------------------------------------
 
-function verbArchive(flags: Record<string, string | true>, stdin: string, opts: { skipMarkerWrites?: boolean } = {}): Json {
+function verbArchive(flags: Record<string, string | true>, stdin: string, opts: { skipMarkerWrites?: boolean; recoveryBlockers?: string } = {}): Json {
   const mode = flags['mode'];
   if (mode !== 'idle' && mode !== 'close' && mode !== 'auto') {
     return { ok: false, reason: `archive requires --mode=idle|close|auto, got: ${mode ?? '(none)'}` };
@@ -698,13 +733,17 @@ function verbArchive(flags: Record<string, string | true>, stdin: string, opts: 
   if (!setTransition.ok) return { ok: false, reason: setTransition.reason };
 
   const config = readConfig(stateDir);
+  const runtimeSessionId = typeof runtimeBefore.session_id === 'string' ? runtimeBefore.session_id : undefined;
   const openedAt = typeof runtimeBefore.opened_at === 'string' ? runtimeBefore.opened_at : undefined;
   // A closed_at at or before opened_at is a stale bound left by an earlier arc. Passing
   // it through would measure an inverted window, which sums to a silent zero — drop it
   // so the window ends at `now` instead (buildReport's `closedAt ?? localISOStamp(now)`).
   const rawClosedAt = typeof runtimeBefore.closed_at === 'string' ? runtimeBefore.closed_at : undefined;
   const closedAt = rawClosedAt && Date.parse(rawClosedAt) > Date.parse(openedAt ?? '') ? rawClosedAt : undefined;
-  const { content: reportContent, cost: reportCost } = buildReport({ sessionId, mode, now, payload, shell, stateDir, config, openedAt, closedAt });
+  const { content: reportContent, cost: reportCost } = buildReport({
+    sessionId, mode, now, payload, shell, stateDir, config,
+    runtimeSessionId, openedAt, closedAt, recoveryBlockers: opts.recoveryBlockers,
+  });
 
   const reportPath = path.join(sessionsDir, `${sessionId}-REPORT.md`);
   try {
@@ -825,8 +864,12 @@ function verbRecover(flags: Record<string, string | true>): Json {
       'Recovered from interrupted archiving transition — pre-crash close payload was not persisted; status inferred as partial.',
       ...(legacyNote ? [legacyNote] : []),
     ].join('\n');
-    const syntheticPayload = `Status: partial\nBlockers: ${blockers}\nClosed Via: recovered\n`;
-    const result = verbArchive({ mode, 'state-dir': stateDir }, syntheticPayload, { skipMarkerWrites: true });
+    const syntheticPayload = `Status: partial\nClosed Via: recovered\n`;
+    const result = verbArchive(
+      { mode, 'state-dir': stateDir },
+      syntheticPayload,
+      { skipMarkerWrites: true, recoveryBlockers: blockers },
+    );
     if (!result.ok) {
       // Re-archive couldn't complete (e.g. SHELL.md itself is gone, so buildReport
       // has nothing to work from). Clear the transition markers so the next start

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -31,11 +31,15 @@ When invoked with `--auto` by heartbeat, skip steps 1â€“5 and jump directly to s
 
 ```
 Status: completed
+Blockers: <optional additions, ~ <prefix> to mark a recorded blocker resolved, or none>
 Lessons: none
 Changed: <from session-diff.json if available, else none>
+Artifacts: <optional [[compiled/...]] additions, or none>
 Closed Via: auto
 Next Start Point: Fresh start.
 ```
+
+SHELL.md remains the factual floor. `Blockers:` can add facts but cannot erase its `## Blockers`; a `~ <prefix>` line marks the first trimmed, case-insensitive SHELL blocker prefix as `- [resolved] <recorded text>` in the report. An unmatched `~` line is kept as an ordinary blocker with the tilde removed. `Artifacts:` accepts only `[[compiled/...]]` links not already recorded in SHELL.md or found by the session-stamped scan.
 
 If step 7 returns `ok === false`, no markers were written and `pending-close.json` is left in place automatically, so a later tick retries the drain. Both drainers share a backoff marker (`state/pending-close-drain.json`) and defer while an operator turn is open, so the retry is the first eligible heartbeat tick or routine poll after that window. The backoff is 30 minutes for the 60-second routine poll; the heartbeat drainer halves it once `heartbeat.every` reaches 30 minutes, so a slow heartbeat retries on its next tick rather than the one after it.
 
@@ -59,8 +63,9 @@ This path is intentionally silent: no operator notification on queue or drain â€
 ---
 
 1. Finalize the factual record on disk, then compile judgment and handoff data **in context**. `session-archive.ts` owns the report write and reads the same factual baseline in every archive mode:
-   - Ensure SHELL.md `## Task`, `## Findings`, and `## Blockers` reflect the final recorded state. A correction is authoritative only after it is written there; payload prose cannot replace or erase these sections.
+   - Ensure SHELL.md `## Task`, `## Findings`, and `## Blockers` reflect the final recorded state. These sections remain the factual floor. Payload Blockers can add missing facts or annotate a recorded blocker as resolved, but cannot erase recorded text.
    - `Status:` one of `completed` | `partial` | `blocked`
+   - `Blockers:` optional additions, one line each. Use `~ <prefix>` to mark the first trimmed, case-insensitive prefix match in SHELL.md `## Blockers` resolved. The report keeps the full recorded text as `- [resolved] <recorded text>`; an unmatched `~` line becomes an ordinary addition with the tilde removed.
    - `Lessons:` only genuinely useful ones. Before compiling, run the close debrief â€” answer three self-directed questions:
      1. *"What did I build ad-hoc this session (throwaway scripts, repeated manual procedures, long waits a tool would remove) that should persist?"*
      2. *"What did I have to re-derive or re-discover that a compiled note or memory entry should have told me?"*
@@ -77,7 +82,7 @@ This path is intentionally silent: no operator notification on queue or drain â€
    - `Artifacts:` if this session produced a durable output, route it by shape:
      - **Evolving subject** the hermit will touch again (a monitored domain, a recurring decision area, accumulated know-how): **update or create** `compiled/topic-<slug>.md`. Merge new findings into the existing sections rather than appending a dated copy; bump `updated`, refresh the one-line `summary`, keep the page under 150 lines (compact older material when merging), and cross-link related pages with `[[wikilinks]]`.
      - **One-off output** (point-in-time research note, decision doc, audit summary): write `compiled/<type>-<slug>-<date>.md` as before.
-     Either way include `session: S-NNN` in the frontmatter. The archive discovers that exact session stamp, plus any `[[compiled/...]]` links already recorded in SHELL.md, and deduplicates them. Don't leave domain output wedged in SHELL.md Findings or a proposal body.
+     Either way include `session: S-NNN` in the frontmatter. The archive discovers that exact session stamp, plus any `[[compiled/...]]` links already recorded in SHELL.md, and deduplicates them. The optional payload field accepts only `[[compiled/...]]` additions. Don't leave domain output wedged in SHELL.md Findings or a proposal body.
 2. Ensure the Progress Log reflects each step's final state (done, partial, blocked)
 3. Confirm the "Next Start Point" is clear enough for a fresh session to resume without questions
 4. If any high-leverage improvements were discovered during work, create proposals via the `claude-code-hermit:proposal-create` skill
@@ -89,13 +94,15 @@ This path is intentionally silent: no operator notification on queue or drain â€
    ```
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts archive --mode=close --state-dir=.claude-code-hermit <<'HERMIT_PAYLOAD'
    Status: <completed|partial|blocked>
+   Blockers: <optional additions, ~ <prefix> resolutions, or none>
    Lessons: <one line each, or none>
    Changed: <file list, or none>
+   Artifacts: <optional [[compiled/...]] additions, or none>
    Closed Via: <operator|auto>
    Next Start Point: <one line>
    HERMIT_PAYLOAD
    ```
-   Parse the single line of JSON printed to stdout. **`ok === false`** means the archive did NOT happen â€” no markers were written; surface the returned `reason` to the operator and retry once before giving up.
+   Parse the single line of JSON printed to stdout. On success, `merged_payload_fields` lists which optional `Blockers` or `Artifacts` fields added report content; `[]` means SHELL.md and the stamped artifact scan already contained everything. **`ok === false`** means the archive did NOT happen: no markers were written. Surface the returned `reason` to the operator and retry once before giving up.
 8. **Pending-close cleanup** *(now automatic)*. `session-archive.ts` deletes `state/pending-close.json` itself on close/auto archive success (reported in its `markers` output field) â€” any pending midnight-drain flag is invalidated by a successful close, regardless of trigger. Nothing to do here.
 9. **Context-reset marker** *(now automatic, `--auto` only)*. On auto archive success the script writes `state/clear-requested.json` itself. The watchdog reads it on the next tick and sends `/clear` when the session is still alive + idle + unattended, resetting stale conversation context before the next scheduled wake incurs a cold cache-write. `/clear` preserves CronCreate routines and Monitor tasks; no re-arm is needed.
 

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -31,15 +31,11 @@ When invoked with `--auto` by heartbeat, skip steps 1â€“5 and jump directly to s
 
 ```
 Status: completed
-Blockers: none
 Lessons: none
 Changed: <from session-diff.json if available, else none>
-Artifacts: none
 Closed Via: auto
 Next Start Point: Fresh start.
 ```
-
-Write `Auto-closed by heartbeat.` as the first line of `## Overview` in the session report.
 
 If step 7 returns `ok === false`, no markers were written and `pending-close.json` is left in place automatically, so a later tick retries the drain. Both drainers share a backoff marker (`state/pending-close-drain.json`) and defer while an operator turn is open, so the retry is the first eligible heartbeat tick or routine poll after that window. The backoff is 30 minutes for the 60-second routine poll; the heartbeat drainer halves it once `heartbeat.every` reaches 30 minutes, so a slow heartbeat retries on its next tick rather than the one after it.
 
@@ -62,9 +58,9 @@ This path is intentionally silent: no operator notification on queue or drain â€
 
 ---
 
-1. Compile final session data **in context** â€” do NOT write to SHELL.md yet. `session-archive.ts` owns the final write. Gather:
+1. Finalize the factual record on disk, then compile judgment and handoff data **in context**. `session-archive.ts` owns the report write and reads the same factual baseline in every archive mode:
+   - Ensure SHELL.md `## Task`, `## Findings`, and `## Blockers` reflect the final recorded state. A correction is authoritative only after it is written there; payload prose cannot replace or erase these sections.
    - `Status:` one of `completed` | `partial` | `blocked`
-   - `Blockers:` one line each, enough context for a cold start
    - `Lessons:` only genuinely useful ones. Before compiling, run the close debrief â€” answer three self-directed questions:
      1. *"What did I build ad-hoc this session (throwaway scripts, repeated manual procedures, long waits a tool would remove) that should persist?"*
      2. *"What did I have to re-derive or re-discover that a compiled note or memory entry should have told me?"*
@@ -81,7 +77,7 @@ This path is intentionally silent: no operator notification on queue or drain â€
    - `Artifacts:` if this session produced a durable output, route it by shape:
      - **Evolving subject** the hermit will touch again (a monitored domain, a recurring decision area, accumulated know-how): **update or create** `compiled/topic-<slug>.md`. Merge new findings into the existing sections rather than appending a dated copy; bump `updated`, refresh the one-line `summary`, keep the page under 150 lines (compact older material when merging), and cross-link related pages with `[[wikilinks]]`.
      - **One-off output** (point-in-time research note, decision doc, audit summary): write `compiled/<type>-<slug>-<date>.md` as before.
-     Either way include `session: S-NNN` in the frontmatter and list the wikilink here. Don't leave domain output wedged in SHELL.md Findings or a proposal body.
+     Either way include `session: S-NNN` in the frontmatter. The archive discovers that exact session stamp, plus any `[[compiled/...]]` links already recorded in SHELL.md, and deduplicates them. Don't leave domain output wedged in SHELL.md Findings or a proposal body.
 2. Ensure the Progress Log reflects each step's final state (done, partial, blocked)
 3. Confirm the "Next Start Point" is clear enough for a fresh session to resume without questions
 4. If any high-leverage improvements were discovered during work, create proposals via the `claude-code-hermit:proposal-create` skill
@@ -93,10 +89,8 @@ This path is intentionally silent: no operator notification on queue or drain â€
    ```
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts archive --mode=close --state-dir=.claude-code-hermit <<'HERMIT_PAYLOAD'
    Status: <completed|partial|blocked>
-   Blockers: <one line each, or none>
    Lessons: <one line each, or none>
    Changed: <file list, or none>
-   Artifacts: <wikilinks to compiled/ outputs produced this session, or none>
    Closed Via: <operator|auto>
    Next Start Point: <one line>
    HERMIT_PAYLOAD
@@ -116,7 +110,7 @@ Verify these before proceeding with close (applies to both modes):
 - [ ] All changed files are listed in the Changed section
 - [ ] Blockers are described with enough context for a cold start
 - [ ] Cost data is recorded (if available from the cost-tracker hook)
-- [ ] If `## Completed` claims a deliverable that a skill persists to `compiled/` (e.g. a deep-dive, briefing, or decision doc), confirm it appears in `## Artifacts`. If it doesn't, verify whether the output actually reached `compiled/`: if it did, add it to `## Artifacts`; if it didn't, the deliverable was dropped, so record it in `## Blockers` rather than leaving `## Completed` asserting success.
+- [ ] If `## Completed` claims a deliverable that a skill persists to `compiled/` (e.g. a deep-dive, briefing, or decision doc), confirm the file exists with `session: S-NNN` frontmatter or is linked from SHELL.md. If it does not exist, the deliverable was dropped, so record that in `## Blockers` rather than leaving `## Completed` asserting success.
 - [ ] If status is `blocked`: have you run `/debug` to check for tool/hook failures? Include diagnosis in blockers if relevant
 
 **Full shutdown only:**

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -45,15 +45,15 @@ When the work is done, or the operator decides to move on (even if partial or bl
 
 **Completion notification is the final step of this flow, not a substitute for it.** Skipping the idle transition (step 5 below) leaves the session `in_progress`, which triggers stale-session heartbeat alerts and delays report archival until the time-based backstops kick in.
 
-1. Compile final session data **in context** — do NOT write to SHELL.md at this point. `session-archive.ts` owns the final write. Gather:
+1. Finalize the factual record on disk, then compile judgment data **in context**. `session-archive.ts` owns the report write and reads the same factual baseline in every archive mode:
+   - Ensure SHELL.md `## Blockers` reflects the final recorded state. A correction is authoritative only after it is written there; payload prose cannot replace or erase this section.
    - `Status:` one of `completed` | `partial` | `blocked`
-   - `Blockers:` one line each, enough context for a cold start
    - `Lessons:` only genuinely useful ones
    - `Changed:` list of files modified
 2. Verify quality in-context before archiving:
    - Task status is one of `completed` | `partial` | `blocked`
    - Changed files are identified
-   - Blockers have enough context for a cold start
+   - SHELL.md `## Blockers` has enough context for a cold start
 3. Create proposals for any high-leverage improvements discovered during work
 4. **Reflect (with debounce).** Read `state/reflection-state.json` for `last_reflection`. Only invoke the `claude-code-hermit:reflect` skill if `last_reflection` is null or older than 4 hours. For quick tasks (single-step, under 5 minutes), skip entirely — progress log is sufficient.
 4b. **Session-triggered scheduled checks.** For each `scheduled_checks` entry (from config already loaded) with `trigger: "session"` and `enabled: true`, invoke the skill. If a skill is unavailable or errors, skip it and continue — never block session finalization on a scheduled check failure. For each check that completed successfully, run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/update-reflection-state.ts .claude-code-hermit/state/reflection-state.json --scheduled-check-run <id>` (writes only that check's `last_run`; fail-open). Do not run it for failed checks.
@@ -62,7 +62,6 @@ When the work is done, or the operator decides to move on (even if partial or bl
    ```
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts archive --mode=idle --state-dir=.claude-code-hermit <<'HERMIT_PAYLOAD'
    Status: <completed|partial|blocked>
-   Blockers: <one line each, or none>
    Lessons: <one line each, or none>
    Changed: <file list, or none>
    HERMIT_PAYLOAD

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -46,10 +46,12 @@ When the work is done, or the operator decides to move on (even if partial or bl
 **Completion notification is the final step of this flow, not a substitute for it.** Skipping the idle transition (step 5 below) leaves the session `in_progress`, which triggers stale-session heartbeat alerts and delays report archival until the time-based backstops kick in.
 
 1. Finalize the factual record on disk, then compile judgment data **in context**. `session-archive.ts` owns the report write and reads the same factual baseline in every archive mode:
-   - Ensure SHELL.md `## Blockers` reflects the final recorded state. A correction is authoritative only after it is written there; payload prose cannot replace or erase this section.
+   - Ensure SHELL.md `## Blockers` reflects the final recorded state. It remains the factual floor. Payload Blockers can add missing facts or annotate a recorded blocker as resolved, but cannot erase recorded text.
    - `Status:` one of `completed` | `partial` | `blocked`
+   - `Blockers:` optional additions, one line each. Use `~ <prefix>` to mark the first trimmed, case-insensitive prefix match in SHELL.md `## Blockers` resolved. The report keeps the full recorded text as `- [resolved] <recorded text>`; an unmatched `~` line becomes an ordinary addition with the tilde removed.
    - `Lessons:` only genuinely useful ones
    - `Changed:` list of files modified
+   - `Artifacts:` optional `[[compiled/...]]` links not already recorded in SHELL.md or found by the session-stamped scan
 2. Verify quality in-context before archiving:
    - Task status is one of `completed` | `partial` | `blocked`
    - Changed files are identified
@@ -62,11 +64,13 @@ When the work is done, or the operator decides to move on (even if partial or bl
    ```
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/session-archive.ts archive --mode=idle --state-dir=.claude-code-hermit <<'HERMIT_PAYLOAD'
    Status: <completed|partial|blocked>
+   Blockers: <optional additions, ~ <prefix> resolutions, or none>
    Lessons: <one line each, or none>
    Changed: <file list, or none>
+   Artifacts: <optional [[compiled/...]] additions, or none>
    HERMIT_PAYLOAD
    ```
-   Parse the single line of JSON the script prints to stdout. **Gate every following step on the returned `ok` field.** `ok === true` → the transition succeeded, continue to step 6. `ok === false` → the archive did NOT happen — do not proceed as if it did. Append the returned `reason` to SHELL.md `## Findings` and retry once; if it fails again, notify the operator and leave the session `in_progress` rather than silently losing the report.
+   Parse the single line of JSON the script prints to stdout. On success, `merged_payload_fields` lists which optional `Blockers` or `Artifacts` fields added report content; `[]` means SHELL.md and the stamped artifact scan already contained everything. **Gate every following step on the returned `ok` field.** `ok === true` → the transition succeeded, continue to step 6. `ok === false` → the archive did NOT happen, so do not proceed as if it did. Append the returned `reason` to SHELL.md `## Findings` and retry once; if it fails again, notify the operator and leave the session `in_progress` rather than silently losing the report.
 6. If `heartbeat.enabled` is true in config and heartbeat is not already running: start it (`/claude-code-hermit:heartbeat start`)
 6b. **Compaction boundary marker** *(now automatic)*. The step-5 idle archive itself wrote `state/compact-requested.json` (see `markers.compact_requested` in its output) — the archived arc is fully on disk, so the watchdog's routine-hygiene compactor (`maybeContextCompact`) may waive its interval cooldown on the next tick. The marker is self-reaping: `maybeContextCompact` consumes it when the compaction fires and deletes it stale-on-read past `COMPACT_MARKER_TTL_SECS`, and `session-start` step 3 unconditionally deletes any survivor on boot as a backstop. Nothing to do here.
 7. After the idle transition (step 5) succeeds (`ok === true`), check `.claude-code-hermit/sessions/NEXT-TASK.md` and read `escalation` from config:

--- a/plugins/claude-code-hermit/state-templates/SESSION-REPORT.md.template
+++ b/plugins/claude-code-hermit/state-templates/SESSION-REPORT.md.template
@@ -20,6 +20,9 @@ closed_via: operator  # operator | auto
 ## Completed
 <!-- What was accomplished (narrative). Durable outputs must also be listed under ## Artifacts. -->
 
+## Findings
+<!-- Anything unexpected found during work. Proposal-worthy items get their own file. -->
+
 ## Changed
 <!-- Files modified/created/deleted -->
 

--- a/plugins/claude-code-hermit/tests/session-archive.test.ts
+++ b/plugins/claude-code-hermit/tests/session-archive.test.ts
@@ -178,12 +178,13 @@ describe('outcome contract', () => {
     expect(result.reason).toContain('archive, open, recover');
   }));
 
-  test('a clean archive returns ok:true with session_id and report_path', withTmp(async (dir) => {
+  test('a clean archive returns ok:true with session_id, report_path, and no payload contributions', withTmp(async (dir) => {
     await open(dir, 'Task: ship it\n', '2026-07-09T12:00:00Z');
     const result = await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
     expect(result.ok).toBe(true);
     expect(result.session_id).toBe('S-001');
     expect(fs.existsSync(result.report_path)).toBe(true);
+    expect(result.merged_payload_fields).toEqual([]);
   }));
 });
 
@@ -435,12 +436,12 @@ describe('Progress Log preservation in ## Completed', () => {
 
 // =============================================================================
 describe('recorded factual baseline', () => {
-  const CONFLICTING_PAYLOAD =
+  const ADDITIVE_PAYLOAD =
     'Status: completed\nTask: payload task\nBlockers: payload blocker\nLessons: none\nChanged: none\n' +
     'Artifacts: [[compiled/payload-only]]\nClosed Via: auto\nNext Start Point: Fresh start.\n';
 
   for (const mode of ['idle', 'close', 'auto'] as const) {
-    test(`${mode} archive uses the same on-disk facts and ignores factual payload overrides`, withTmp(async (dir) => {
+    test(`${mode} archive preserves recorded facts and merges additive payload facts`, withTmp(async (dir) => {
       await open(dir, 'Task: recorded task\n', '2026-07-09T12:00:00Z');
       seedShellSection(dir, 'Progress Log', '[12:10] completed recorded work');
       seedShellSection(dir, 'Findings', '- found recorded evidence\n- [[compiled/shell-declared]]');
@@ -452,25 +453,91 @@ describe('recorded factual baseline', () => {
       fs.writeFileSync(hermit(dir, 'compiled', 'stale.md'), '---\nsession: S-000\n---\n');
       fs.writeFileSync(hermit(dir, 'compiled', 'mtime-only.md'), '---\ntype: note\n---\n');
 
-      await archive(dir, mode, CONFLICTING_PAYLOAD, '2026-07-09T13:00:00Z');
+      const result = await archive(dir, mode, ADDITIVE_PAYLOAD, '2026-07-09T13:00:00Z');
       const reportPath = path.join(sessionsDir(dir), 'S-001-REPORT.md');
       const report = fs.readFileSync(reportPath, 'utf-8');
       const fm = readFrontmatter(reportPath);
 
       expect(fm.task).toBe('recorded task');
-      expect(fm.blockers).toEqual(['waiting on recorded dependency']);
-      expect(fm.artifacts).toEqual(['[[compiled/shell-declared]]', '[[compiled/stamped-only]]']);
+      expect(fm.blockers).toEqual(['waiting on recorded dependency', 'payload blocker']);
+      expect(fm.artifacts).toEqual(['[[compiled/shell-declared]]', '[[compiled/payload-only]]', '[[compiled/stamped-only]]']);
+      expect(result.merged_payload_fields).toEqual(['Blockers', 'Artifacts']);
       expect(report).toContain('## Findings\n- found recorded evidence\n- [[compiled/shell-declared]]');
-      expect(report).toContain('## Blockers\n- waiting on recorded dependency');
+      expect(report).toContain('## Blockers\n- waiting on recorded dependency\npayload blocker');
       const artifactsBody = report.split('## Artifacts\n')[1]?.split('\n## ')[0] ?? '';
       expect(artifactsBody.match(/\[\[compiled\/shell-declared\]\]/g)).toHaveLength(1);
       expect(report).not.toContain('payload task');
-      expect(report).not.toContain('payload blocker');
-      expect(report).not.toContain('payload-only');
       expect(report).not.toContain('[[compiled/stale]]');
       expect(report).not.toContain('[[compiled/mtime-only]]');
     }));
   }
+
+  test('payload blockers append after SHELL, deduplicate case-insensitively, and ignore none', withTmp(async (dir) => {
+    await open(dir, 'Task: blockers\n', '2026-07-09T12:00:00Z');
+    seedShellSection(dir, 'Blockers', '- Waiting on CI\n- Needs approval');
+    const payload =
+      'Status: completed\nBlockers: waiting on ci\nPAYLOAD only\nnone\npayload ONLY\n' +
+      'Lessons: none\nChanged: none\n';
+    const result = await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
+    const reportPath = path.join(sessionsDir(dir), 'S-001-REPORT.md');
+    const report = fs.readFileSync(reportPath, 'utf-8');
+
+    expect(readFrontmatter(reportPath).blockers).toEqual(['Waiting on CI', 'Needs approval', 'PAYLOAD only']);
+    expect(report).toContain('## Blockers\n- Waiting on CI\n- Needs approval\nPAYLOAD only');
+    expect(result.merged_payload_fields).toEqual(['Blockers']);
+  }));
+
+  test('resolved annotations mark the first case-insensitive SHELL prefix and keep unmatched text', withTmp(async (dir) => {
+    await open(dir, 'Task: blockers\n', '2026-07-09T12:00:00Z');
+    seedShellSection(dir, 'Blockers', '- Waiting on CI for Linux\n- Waiting on CI for macOS\n- Needs approval');
+    const payload =
+      'Status: completed\nBlockers: ~ waiting ON ci\n~ waiting ON ci\n~ missing vendor reply\n' +
+      'Lessons: none\nChanged: none\n';
+    const result = await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
+    const reportPath = path.join(sessionsDir(dir), 'S-001-REPORT.md');
+    const report = fs.readFileSync(reportPath, 'utf-8');
+
+    expect(readFrontmatter(reportPath).blockers).toEqual([
+      '[resolved] Waiting on CI for Linux',
+      'Waiting on CI for macOS',
+      'Needs approval',
+      'missing vendor reply',
+    ]);
+    expect(report).toContain(
+      '## Blockers\n- [resolved] Waiting on CI for Linux\n- Waiting on CI for macOS\n- Needs approval\nmissing vendor reply',
+    );
+    expect(result.merged_payload_fields).toEqual(['Blockers']);
+  }));
+
+  test('payload artifact order is SHELL, payload-only, then stamped, with exact contribution reporting', withTmp(async (dir) => {
+    await open(dir, 'Task: artifacts\n', '2026-07-09T12:00:00Z');
+    seedShellSection(dir, 'Findings', '- [[compiled/shell-declared]]');
+    fs.mkdirSync(hermit(dir, 'compiled'));
+    fs.writeFileSync(hermit(dir, 'compiled', 'shell-declared.md'), '---\nsession: S-001\n---\n');
+    fs.writeFileSync(hermit(dir, 'compiled', 'stamped-only.md'), '---\nsession: S-001\n---\n');
+    const payload =
+      'Status: completed\nBlockers: none\nArtifacts: [[compiled/stamped-only]]\n' +
+      '[[compiled/payload-only]]\n[[compiled/payload-only]]\nChanged: none\n';
+    const result = await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
+    const reportPath = path.join(sessionsDir(dir), 'S-001-REPORT.md');
+
+    expect(readFrontmatter(reportPath).artifacts).toEqual([
+      '[[compiled/shell-declared]]',
+      '[[compiled/payload-only]]',
+      '[[compiled/stamped-only]]',
+    ]);
+    expect(result.merged_payload_fields).toEqual(['Artifacts']);
+  }));
+
+  test('a payload artifact already found by the stamped scan is not a contribution', withTmp(async (dir) => {
+    await open(dir, 'Task: artifacts\n', '2026-07-09T12:00:00Z');
+    fs.mkdirSync(hermit(dir, 'compiled'));
+    fs.writeFileSync(hermit(dir, 'compiled', 'stamped-only.md'), '---\nsession: S-001\n---\n');
+    const payload = 'Status: completed\nBlockers: none\nArtifacts: [[compiled/stamped-only]]\nChanged: none\n';
+    const result = await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
+
+    expect(result.merged_payload_fields).toEqual([]);
+  }));
 
   test('empty Task falls back to the first work entry, not reset or snapshot breadcrumbs', withTmp(async (dir) => {
     await open(dir, 'Task: none\n', '2026-07-09T12:00:00Z');
@@ -480,7 +547,7 @@ describe('recorded factual baseline', () => {
       '- [12:00] context compacted (auto) — arc may have unfinished work\n' +
       '- [12:01] context cleared (watchdog) — arc may have unfinished work\n' +
       '[12:02] investigated the failing deployment');
-    await archive(dir, 'auto', CONFLICTING_PAYLOAD, '2026-07-09T13:00:00Z');
+    await archive(dir, 'auto', ADDITIVE_PAYLOAD, '2026-07-09T13:00:00Z');
     const reportPath = path.join(sessionsDir(dir), 'S-001-REPORT.md');
     const report = fs.readFileSync(reportPath, 'utf-8');
     expect(readFrontmatter(reportPath).task).toBe('[12:02] investigated the failing deployment');
@@ -503,20 +570,53 @@ describe('duration ownership', () => {
     expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('45m');
   }));
 
-  test('an unowned runtime arc records 0m even when SHELL Started is parseable', withTmp(async (dir) => {
+  test('an unowned runtime arc records unknown even when SHELL Started is parseable', withTmp(async (dir) => {
     await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
     const { session_id, ...unownedRuntime } = readRuntime(dir);
     writeRuntime(dir, unownedRuntime);
     writeShell(dir, readShell(dir).replace('YYYY-MM-DD HH:MM', '2026-07-09 12:00'));
     await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
-    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('0m');
+    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('unknown');
   }));
 
-  test('an invalid matching opened_at records 0m', withTmp(async (dir) => {
+  test('a missing matching opened_at records unknown', withTmp(async (dir) => {
+    await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
+    const { opened_at, ...runtimeWithoutOpenedAt } = readRuntime(dir);
+    writeRuntime(dir, runtimeWithoutOpenedAt);
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('unknown');
+  }));
+
+  test('an invalid matching opened_at records unknown', withTmp(async (dir) => {
     await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
     writeRuntime(dir, { ...readRuntime(dir), opened_at: 'not-a-date' });
     await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('unknown');
+  }));
+
+  test('a negative owned window records unknown without changing cost fallback behavior', withTmp(async (dir) => {
+    await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
+    writeRuntime(dir, { ...readRuntime(dir), closed_at: '2026-07-09T11:59:00Z' });
+    seedCostLog(dir, [{ timestamp: '2026-07-09T12:30:00Z', estimated_cost_usd: 0.07, total_tokens: 700 }]);
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    const fm = readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md'));
+    expect(fm.duration).toBe('unknown');
+    expect(fm.cost_usd).toBe('0.07');
+    expect(fm.tokens).toBe('700');
+  }));
+
+  test('an exact zero-length owned window records 0m', withTmp(async (dir) => {
+    await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
+    writeRuntime(dir, { ...readRuntime(dir), closed_at: '2026-07-09T12:00:00Z' });
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
     expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('0m');
+  }));
+
+  test('a positive owned window under one minute records <1m', withTmp(async (dir) => {
+    await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
+    writeRuntime(dir, { ...readRuntime(dir), closed_at: '2026-07-09T12:00:30Z' });
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('<1m');
   }));
 });
 
@@ -618,6 +718,7 @@ describe('recovery matrix', () => {
     const result = await recover(dir, '2026-07-09T13:00:00Z');
     expect(result.ok).toBe(true);
     expect(result.recovery_path).toBe('re-archive');
+    expect(result.merged_payload_fields).toBeUndefined();
     const report = fs.readFileSync(path.join(sessionsDir(dir), 'S-001-REPORT.md'), 'utf-8');
     expect(report).toContain('status: partial');
     expect(report).toContain('closed_via: recovered');

--- a/plugins/claude-code-hermit/tests/session-archive.test.ts
+++ b/plugins/claude-code-hermit/tests/session-archive.test.ts
@@ -27,6 +27,7 @@ import path from 'node:path';
 
 import { runScript, runPinnedScript } from './helpers/run';
 import { readFrontmatter } from '../scripts/lib/frontmatter';
+import { replaceSectionInPlace } from '../scripts/lib/md-write';
 
 const hermit = (dir: string, ...p: string[]) => path.join(dir, '.claude-code-hermit', ...p);
 const sessionsDir = (dir: string) => hermit(dir, 'sessions');
@@ -90,6 +91,10 @@ function writeShell(dir: string, content: string) {
 }
 function readShell(dir: string): string {
   return fs.readFileSync(shellPath(dir), 'utf-8');
+}
+function seedShellSection(dir: string, heading: string, body: string) {
+  const shell = readShell(dir);
+  writeShell(dir, replaceSectionInPlace(shell, heading, `\n${body}\n\n`));
 }
 
 const BASIC_CLOSE_PAYLOAD =
@@ -429,6 +434,93 @@ describe('Progress Log preservation in ## Completed', () => {
 });
 
 // =============================================================================
+describe('recorded factual baseline', () => {
+  const CONFLICTING_PAYLOAD =
+    'Status: completed\nTask: payload task\nBlockers: payload blocker\nLessons: none\nChanged: none\n' +
+    'Artifacts: [[compiled/payload-only]]\nClosed Via: auto\nNext Start Point: Fresh start.\n';
+
+  for (const mode of ['idle', 'close', 'auto'] as const) {
+    test(`${mode} archive uses the same on-disk facts and ignores factual payload overrides`, withTmp(async (dir) => {
+      await open(dir, 'Task: recorded task\n', '2026-07-09T12:00:00Z');
+      seedShellSection(dir, 'Progress Log', '[12:10] completed recorded work');
+      seedShellSection(dir, 'Findings', '- found recorded evidence\n- [[compiled/shell-declared]]');
+      seedShellSection(dir, 'Blockers', '- waiting on recorded dependency');
+
+      fs.mkdirSync(hermit(dir, 'compiled'));
+      fs.writeFileSync(hermit(dir, 'compiled', 'shell-declared.md'), '---\nsession: S-001\n---\n');
+      fs.writeFileSync(hermit(dir, 'compiled', 'stamped-only.md'), '---\nsession: S-001\n---\n');
+      fs.writeFileSync(hermit(dir, 'compiled', 'stale.md'), '---\nsession: S-000\n---\n');
+      fs.writeFileSync(hermit(dir, 'compiled', 'mtime-only.md'), '---\ntype: note\n---\n');
+
+      await archive(dir, mode, CONFLICTING_PAYLOAD, '2026-07-09T13:00:00Z');
+      const reportPath = path.join(sessionsDir(dir), 'S-001-REPORT.md');
+      const report = fs.readFileSync(reportPath, 'utf-8');
+      const fm = readFrontmatter(reportPath);
+
+      expect(fm.task).toBe('recorded task');
+      expect(fm.blockers).toEqual(['waiting on recorded dependency']);
+      expect(fm.artifacts).toEqual(['[[compiled/shell-declared]]', '[[compiled/stamped-only]]']);
+      expect(report).toContain('## Findings\n- found recorded evidence\n- [[compiled/shell-declared]]');
+      expect(report).toContain('## Blockers\n- waiting on recorded dependency');
+      const artifactsBody = report.split('## Artifacts\n')[1]?.split('\n## ')[0] ?? '';
+      expect(artifactsBody.match(/\[\[compiled\/shell-declared\]\]/g)).toHaveLength(1);
+      expect(report).not.toContain('payload task');
+      expect(report).not.toContain('payload blocker');
+      expect(report).not.toContain('payload-only');
+      expect(report).not.toContain('[[compiled/stale]]');
+      expect(report).not.toContain('[[compiled/mtime-only]]');
+    }));
+  }
+
+  test('empty Task falls back to the first work entry, not reset or snapshot breadcrumbs', withTmp(async (dir) => {
+    await open(dir, 'Task: none\n', '2026-07-09T12:00:00Z');
+    seedShellSection(dir, 'Progress Log',
+      '<!-- snapshot @ 2026-07-09T12:00:00Z -->\n' +
+      '- [archived] previous entries → snapshots/SHELL-2026-07-09.md\n' +
+      '- [12:00] context compacted (auto) — arc may have unfinished work\n' +
+      '- [12:01] context cleared (watchdog) — arc may have unfinished work\n' +
+      '[12:02] investigated the failing deployment');
+    await archive(dir, 'auto', CONFLICTING_PAYLOAD, '2026-07-09T13:00:00Z');
+    const reportPath = path.join(sessionsDir(dir), 'S-001-REPORT.md');
+    const report = fs.readFileSync(reportPath, 'utf-8');
+    expect(readFrontmatter(reportPath).task).toBe('[12:02] investigated the failing deployment');
+    expect(report).toContain('## Overview\n[12:02] investigated the failing deployment');
+  }));
+});
+
+// =============================================================================
+describe('duration ownership', () => {
+  test('matching runtime arc measures from opened_at to archive time', withTmp(async (dir) => {
+    await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('1h 0m');
+  }));
+
+  test('matching runtime arc uses a valid closed_at as its end', withTmp(async (dir) => {
+    await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
+    writeRuntime(dir, { ...readRuntime(dir), closed_at: '2026-07-09T12:45:00Z' });
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('45m');
+  }));
+
+  test('an unowned runtime arc records 0m even when SHELL Started is parseable', withTmp(async (dir) => {
+    await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
+    const { session_id, ...unownedRuntime } = readRuntime(dir);
+    writeRuntime(dir, unownedRuntime);
+    writeShell(dir, readShell(dir).replace('YYYY-MM-DD HH:MM', '2026-07-09 12:00'));
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('0m');
+  }));
+
+  test('an invalid matching opened_at records 0m', withTmp(async (dir) => {
+    await open(dir, 'Task: duration\n', '2026-07-09T12:00:00Z');
+    writeRuntime(dir, { ...readRuntime(dir), opened_at: 'not-a-date' });
+    await archive(dir, 'close', BASIC_CLOSE_PAYLOAD, '2026-07-09T13:00:00Z');
+    expect(readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md')).duration).toBe('0m');
+  }));
+});
+
+// =============================================================================
 describe('compaction roll-up', () => {
   test('rolls up Monitoring entries past the threshold into a bucketed [Earlier] line', withTmp(async (dir) => {
     await open(dir, 'Task: x\n', '2026-07-09T12:00:00Z');
@@ -659,7 +751,7 @@ describe('structural equivalence with the session-mgr.md spec', () => {
     'escalation', 'operator_turns', 'closed_via',
   ];
   const REQUIRED_SECTIONS = [
-    '## Overview', '## Completed', '## Changed', '## Artifacts',
+    '## Overview', '## Completed', '## Findings', '## Changed', '## Artifacts',
     '## Blockers', '## Lessons', '## Proposals Created',
   ];
 
@@ -698,18 +790,20 @@ describe('structural equivalence with the session-mgr.md spec', () => {
 describe('structured report frontmatter', () => {
   test('multi-line prose fields round-trip as arrays via the shared frontmatter parser', withTmp(async (dir) => {
     await open(dir, 'Task: structured fields\n', '2026-07-09T12:00:00Z');
+    seedShellSection(dir, 'Blockers', 'waiting on review, needs sign-off\nstill blocked on infra');
+    fs.mkdirSync(hermit(dir, 'compiled'));
+    fs.writeFileSync(hermit(dir, 'compiled', 'report-1.md'), '---\nsession: S-001\n---\n');
+    fs.writeFileSync(hermit(dir, 'compiled', 'report-2.md'), '---\nsession: S-001\n---\n');
     const payload =
       'Status: completed\n' +
-      'Blockers: waiting on review, needs sign-off\nstill blocked on infra\n' +
       'Lessons: cache invalidation matters\nretry logic needs backoff\n' +
-      'Artifacts: compiled/report-1.md\ncompiled/report-2.md\n' +
       'Changed: none\n' +
       'Next Start Point: pick up the migration script\n';
     await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
     const fm = readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md'));
     expect(fm.blockers).toEqual(['waiting on review, needs sign-off', 'still blocked on infra']);
     expect(fm.lessons).toEqual(['cache invalidation matters', 'retry logic needs backoff']);
-    expect(fm.artifacts).toEqual(['compiled/report-1.md', 'compiled/report-2.md']);
+    expect(fm.artifacts).toEqual(['[[compiled/report-1]]', '[[compiled/report-2]]']);
     expect(fm.next_start).toBe('pick up the migration script');
   }));
 
@@ -726,7 +820,8 @@ describe('structured report frontmatter', () => {
 
   test('YAML-hostile characters and internal commas in a blocker line stay parseable as one item', withTmp(async (dir) => {
     await open(dir, 'Task: hostile chars\n', '2026-07-09T12:00:00Z');
-    const payload = 'Status: completed\nBlockers: #urgent fix, needs {infra} and [approval]\nChanged: none\n';
+    seedShellSection(dir, 'Blockers', '#urgent fix, needs {infra} and [approval]');
+    const payload = 'Status: completed\nChanged: none\n';
     await archive(dir, 'close', payload, '2026-07-09T13:00:00Z');
     const fm = readFrontmatter(path.join(sessionsDir(dir), 'S-001-REPORT.md'));
     expect(fm.blockers).toEqual(['#urgent fix, needs {infra} and [approval]']);

--- a/plugins/claude-code-hermit/tests/session-archive.test.ts
+++ b/plugins/claude-code-hermit/tests/session-archive.test.ts
@@ -37,6 +37,9 @@ const shellPath = (dir: string) => hermit(dir, 'sessions', 'SHELL.md');
 const SHELL_TEMPLATE = fs.readFileSync(
   path.join(import.meta.dir, '..', 'state-templates', 'SHELL.md.template'), 'utf-8'
 );
+const REPORT_TEMPLATE = fs.readFileSync(
+  path.join(import.meta.dir, '..', 'state-templates', 'SESSION-REPORT.md.template'), 'utf-8'
+);
 
 interface Tmp { dir: string; cleanup(): void }
 
@@ -529,6 +532,24 @@ describe('recorded factual baseline', () => {
     expect(result.merged_payload_fields).toEqual(['Artifacts']);
   }));
 
+  test('retained SHELL history does not contribute artifacts to a later task', withTmp(async (dir) => {
+    await open(dir, 'Task: current task\n', '2026-07-09T12:00:00Z');
+    seedShellSection(dir, 'Findings', '- [[compiled/current-finding]]');
+    seedShellSection(dir, 'Monitoring', '- old monitor cited [[compiled/old-monitor]]');
+    seedShellSection(dir, 'Session Summary', '**S-000**: old task cited [[compiled/old-summary]]');
+
+    const result = await archive(
+      dir,
+      'idle',
+      'Status: completed\nBlockers: none\nArtifacts: none\nChanged: none\n',
+      '2026-07-09T13:00:00Z',
+    );
+    const reportPath = path.join(sessionsDir(dir), 'S-001-REPORT.md');
+
+    expect(readFrontmatter(reportPath).artifacts).toEqual(['[[compiled/current-finding]]']);
+    expect(result.merged_payload_fields).toEqual([]);
+  }));
+
   test('a payload artifact already found by the stamped scan is not a contribution', withTmp(async (dir) => {
     await open(dir, 'Task: artifacts\n', '2026-07-09T12:00:00Z');
     fs.mkdirSync(hermit(dir, 'compiled'));
@@ -855,6 +876,12 @@ describe('structural equivalence with the session-mgr.md spec', () => {
     '## Overview', '## Completed', '## Findings', '## Changed', '## Artifacts',
     '## Blockers', '## Lessons', '## Proposals Created',
   ];
+
+  test('shipped report template includes every generated body section', () => {
+    for (const section of [...REQUIRED_SECTIONS, '## Next Start Point']) {
+      expect(REPORT_TEMPLATE).toContain(section);
+    }
+  });
 
   test('close-mode report has every frontmatter key and body section the template defines', withTmp(async (dir) => {
     await open(dir, 'Task: full structural check\n', '2026-07-09T12:00:00Z');

--- a/plugins/claude-code-hermit/tests/session-work-done-drain.test.ts
+++ b/plugins/claude-code-hermit/tests/session-work-done-drain.test.ts
@@ -26,6 +26,13 @@ describe('session work-done NEXT-TASK drain', () => {
     expect(skill).toContain('escalation');
   });
 
+  test('idle finalization records blockers in SHELL rather than the archive payload', () => {
+    expect(skill).toContain('Ensure SHELL.md `## Blockers` reflects the final recorded state');
+    const payload = skill.match(/archive --mode=idle[^\n]*<<'HERMIT_PAYLOAD'\n([\s\S]*?)\n\s*HERMIT_PAYLOAD/)?.[1] ?? '';
+    expect(payload).toContain('Status: <completed|partial|blocked>');
+    expect(payload).not.toContain('Blockers:');
+  });
+
   test('balanced/autonomous auto-starts the queued task as the terminal action', () => {
     expect(skill).toContain('balanced` or `autonomous`');
     expect(skill).toContain('Starting on [NEXT-TASK.md summary] next');

--- a/plugins/claude-code-hermit/tests/session-work-done-drain.test.ts
+++ b/plugins/claude-code-hermit/tests/session-work-done-drain.test.ts
@@ -26,11 +26,15 @@ describe('session work-done NEXT-TASK drain', () => {
     expect(skill).toContain('escalation');
   });
 
-  test('idle finalization records blockers in SHELL rather than the archive payload', () => {
-    expect(skill).toContain('Ensure SHELL.md `## Blockers` reflects the final recorded state');
+  test('idle finalization keeps SHELL as the factual floor and allows additive payload facts', () => {
+    expect(skill).toContain('It remains the factual floor');
+    expect(skill).toContain('cannot erase recorded text');
+    expect(skill).toContain('Use `~ <prefix>`');
     const payload = skill.match(/archive --mode=idle[^\n]*<<'HERMIT_PAYLOAD'\n([\s\S]*?)\n\s*HERMIT_PAYLOAD/)?.[1] ?? '';
     expect(payload).toContain('Status: <completed|partial|blocked>');
-    expect(payload).not.toContain('Blockers:');
+    expect(payload).toContain('Blockers: <optional additions, ~ <prefix> resolutions, or none>');
+    expect(payload).toContain('Artifacts: <optional [[compiled/...]] additions, or none>');
+    expect(skill).toContain('merged_payload_fields');
   });
 
   test('balanced/autonomous auto-starts the queued task as the terminal action', () => {


### PR DESCRIPTION
## Summary

Make every session archive mode preserve the same on-disk factual baseline. This follows #813 by extending Progress Log preservation to Task, Findings, Blockers, current-session compiled artifacts, and runtime-owned duration data used by briefs and recall.

## Changes

- Read factual report fields from SHELL.md and session-stamped compiled artifacts for idle, close, and auto archives.
- Accept judgment and handoff fields from the close payload without allowing it to replace recorded facts.
- Calculate duration only when runtime.json owns the report session, using a valid closed_at or archive time.
- Keep interrupted-archive recovery diagnostics and existing reflect eligibility behavior intact.
- Document the unified close contract and add regression coverage across archive modes and runtime ownership cases.

## Test plan

- `cd plugins/claude-code-hermit && bun test` (4,545 passed, 0 failed)
- `bunx tsc --noEmit` (exit 0)
- `cd plugins/claude-code-hermit && bun test tests/session-archive.test.ts` (69 passed, 0 failed)

Closes #814