### PR TITLE
fix(claude-code-hermit): harden cost corruption handling

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Four sigil-anchored entries replace them: `Bash(*$ANTHROPIC_API_KEY*)` and `Bash(*$CLAUDE_CODE_OAUTH_TOKEN*)`, each in bare and `${…}` spelling. An expansion of a live credential (`echo $ANTHROPIC_API_KEY` while debugging auth) blocks; every bare mention of the name — a grep, a commit message, writing the placeholder into `.env` — stays allowed. The hook enforces them from the shipped template, so nothing needs adding to your settings file.
 
 ### Fixed
+- Cost corruption alerts now keep point-in-time spend out of persistent dashboard warnings, and interrupted cost-log tails no longer consume the next valid appended record.
 - Session archive copies the Progress Log into the report `## Completed` before resetting SHELL.md, so an auto-close no longer drops the day's work record.
 
 ### Upgrade Instructions

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -246,10 +246,13 @@ function checkCost(p: DoctorPaths = PATHS) {
     try {
       const idx = readCostIndex(costIndexPath(hermitDir));
       if (idx && idx.skipped_corrupt_lines > 0) {
+        const corruptCount = idx.skipped_corrupt_lines;
+        const corruptDetail = `${corruptCount} corrupt cost-log ${corruptCount === 1 ? 'line' : 'lines'} skipped; recorded spend may be understated`;
         return {
           id: 'cost',
           status: 'warn',
-          detail: `${detail} — ${idx.skipped_corrupt_lines} corrupt cost-log line(s) skipped; budget figures may be stale`,
+          detail: `${detail}; ${corruptDetail}`,
+          alert_detail: corruptDetail,
         };
       }
     } catch {
@@ -2131,10 +2134,11 @@ function escalate(checks: Json[], nowIso: string, dir: string = PATHS.hermitDir)
     const applied = mutateOwnedAlerts(ledgerPath, (alerts) => {
       for (const [key, c] of failing) {
         const prev = alerts[key];
+        const message = c.alert_detail ?? c.detail;
         alerts[key] = prev
-          ? { ...prev, status: c.status, message: c.detail, last_seen: nowIso,
+          ? { ...prev, status: c.status, message, last_seen: nowIso,
               count: (typeof prev.count === 'number' ? prev.count : 0) + 1 }
-          : { first_seen: nowIso, last_seen: nowIso, status: c.status, message: c.detail,
+          : { first_seen: nowIso, last_seen: nowIso, status: c.status, message,
               suppressed: false, notified: false, count: 1 };
         // Anything not yet confirmed delivered is still owed to the operator.
         if (alerts[key].notified !== true) pending.push({ id: c.id, status: c.status, detail: c.detail });

--- a/plugins/claude-code-hermit/scripts/lib/cost-log.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cost-log.ts
@@ -447,7 +447,22 @@ function buildSubagentCostRow(o: SubagentCostObservation): Json {
  */
 function appendCostRows(costLogFile: string, rows: Json[]): void {
   if (!rows.length) return;
-  fs.appendFileSync(costLogFile, rows.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf-8');
+
+  const serializedRows = rows.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  const fd = fs.openSync(costLogFile, 'a+');
+  try {
+    let needsSeparator = false;
+    const size = fs.fstatSync(fd).size;
+    if (size > 0) {
+      const lastByte = Buffer.allocUnsafe(1);
+      needsSeparator = fs.readSync(fd, lastByte, 0, 1, size - 1) === 1
+        && lastByte[0] !== 0x0a;
+    }
+
+    fs.appendFileSync(fd, (needsSeparator ? '\n' : '') + serializedRows, 'utf-8');
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 // Per-routine cost inside a time window, for the routine-health digest.

--- a/plugins/claude-code-hermit/tests/cost-log.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-log.test.ts
@@ -333,6 +333,55 @@ describe('cost row builders', () => {
     expect(JSON.parse(lines[0]).subagent).toBeUndefined();
     expect(JSON.parse(lines[1]).subagent).toBe(true);
   }));
+
+  test('appendCostRows preserves new rows after an unterminated partial tail', withTmpdir((dir) => {
+    const logPath = path.join(dir, 'cost-log.jsonl');
+    const idxPath = path.join(dir, 'cost-index.json');
+    const partial = '{"timestamp":"interrupted"';
+    const main = buildMainCostRow(mainBase);
+    const sub = buildSubagentCostRow(subBase);
+    fs.writeFileSync(logPath, partial);
+
+    appendCostRows(logPath, [main, sub]);
+
+    const lines = fs.readFileSync(logPath, 'utf-8').trimEnd().split('\n');
+    expect(lines[0]).toBe(partial);
+    expect(JSON.parse(lines[1]).subagent).toBeUndefined();
+    expect(JSON.parse(lines[2]).subagent).toBe(true);
+
+    const idx = updateCostIndex(logPath, idxPath, 'UTC');
+    expect(idx.skipped_corrupt_lines).toBe(1);
+    expect(idx.total_cost_usd).toBeCloseTo(main.estimated_cost_usd + sub.estimated_cost_usd, 8);
+    expect(idx.total_tokens).toBe(main.total_tokens + sub.total_tokens);
+  }));
+
+  test('appendCostRows adds no extra separator to healthy, empty, or missing files', withTmpdir((dir) => {
+    const row = buildMainCostRow(mainBase);
+    const serialized = `${JSON.stringify(row)}\n`;
+    const missingPath = path.join(dir, 'missing.jsonl');
+    const emptyPath = path.join(dir, 'empty.jsonl');
+    const healthyPath = path.join(dir, 'healthy.jsonl');
+    fs.writeFileSync(emptyPath, '');
+    fs.writeFileSync(healthyPath, `${serialized}`);
+
+    appendCostRows(missingPath, [row]);
+    appendCostRows(emptyPath, [row]);
+    appendCostRows(healthyPath, [row]);
+
+    expect(fs.readFileSync(missingPath, 'utf-8')).toBe(serialized);
+    expect(fs.readFileSync(emptyPath, 'utf-8')).toBe(serialized);
+    expect(fs.readFileSync(healthyPath, 'utf-8')).toBe(serialized + serialized);
+  }));
+
+  test('appendCostRows leaves an unterminated tail untouched when no rows are provided', withTmpdir((dir) => {
+    const logPath = path.join(dir, 'cost-log.jsonl');
+    const partial = '{"timestamp":"interrupted"';
+    fs.writeFileSync(logPath, partial);
+
+    appendCostRows(logPath, []);
+
+    expect(fs.readFileSync(logPath, 'utf-8')).toBe(partial);
+  }));
 });
 
 describe('scanRoutineCostWindow', () => {

--- a/plugins/claude-code-hermit/tests/doctor-escalation.test.ts
+++ b/plugins/claude-code-hermit/tests/doctor-escalation.test.ts
@@ -43,7 +43,12 @@ const { escalate: escalateIn, markNotified: markNotifiedIn } =
 const escalate = (checks: any[], nowIso: string) => escalateIn(checks, nowIso, hermit);
 const markNotified = (ids: string[]) => markNotifiedIn(ids, hermit);
 
-const check = (id: string, status: string, detail = `${id} detail`) => ({ id, status, detail });
+const check = (id: string, status: string, detail = `${id} detail`, alertDetail?: string) => ({
+  id,
+  status,
+  detail,
+  ...(alertDetail ? { alert_detail: alertDetail } : {}),
+});
 const readLedger = () => JSON.parse(fs.readFileSync(ledger, 'utf-8')).alerts;
 
 describe('escalate — episode lifecycle', () => {
@@ -93,6 +98,25 @@ describe('escalate — episode lifecycle', () => {
     expect(entry.status).toBe('fail');          // status refreshed
     expect(entry.message).toBe('ports published'); // detail refreshed
     expect(entry.first_seen).toBe('2026-08-01T10:00:00Z');
+  });
+
+  test.serial('alert detail is persisted while the full detail is offered for notification', async () => {
+    const fullDetail = 'today $12.3400; 2 corrupt cost-log lines skipped; recorded spend may be understated';
+    const alertDetail = '2 corrupt cost-log lines skipped; recorded spend may be understated';
+    const first = escalate([check('cost', 'warn', fullDetail, alertDetail)], '2026-08-01T10:00:00Z');
+
+    expect(readLedger()['doctor:cost'].message).toBe(alertDetail);
+    expect(first.new).toEqual([{ id: 'cost', status: 'warn', detail: fullDetail }]);
+
+    markNotified(['cost']);
+    const second = escalate([
+      check('cost', 'warn', 'today $20.0000; 3 corrupt cost-log lines skipped; recorded spend may be understated',
+        '3 corrupt cost-log lines skipped; recorded spend may be understated'),
+    ], '2026-08-02T10:00:00Z');
+
+    expect(second.new).toEqual([]);
+    expect(readLedger()['doctor:cost'].message)
+      .toBe('3 corrupt cost-log lines skipped; recorded spend may be understated');
   });
 
   test.serial('resolution deletes the key and reports it; recurrence is new again', async () => {

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -1756,6 +1756,24 @@ describe('doctor-check', () => {
     expect(c.detail).toContain('today');
   }));
 
+  test('doctor-check (corrupt cost lines keep the snapshot out of the persistent alert)', withDir(async (dir) => {
+    seedDoctor(dir,
+      '{"agent_name":"test","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true},"routines":[]}');
+    const today = new Date().toISOString().slice(0, 10);
+    write(path.join(dir, '.claude', 'cost-log.jsonl'),
+      `{"timestamp":"${today}T10:00:00.000Z","total_tokens":350,"cache_read_tokens":200,"estimated_cost_usd":0.0012}\n`);
+    write(hermit(dir, 'state', 'cost-index.json'),
+      JSON.stringify({ version: 3, skipped_corrupt_lines: 2 }));
+
+    const c = checkById(await doctorReport(dir), 'cost');
+    expect(c.status).toBe('warn');
+    expect(c.detail).toContain('today $0.0012');
+    expect(c.detail).toContain('2 corrupt cost-log lines skipped; recorded spend may be understated');
+    expect(c.alert_detail).toBe('2 corrupt cost-log lines skipped; recorded spend may be understated');
+    expect(c.alert_detail).not.toContain('today $');
+    expect(c.alert_detail).not.toContain('tokens');
+  }));
+
   test('doctor-check (cost visibility — warn when no cost-log)', withDir(async (dir) => {
     seedDoctor(dir,
       '{"agent_name":"test","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true},"routines":[]}');


### PR DESCRIPTION
## Summary

Persistent doctor alerts now describe cost-log corruption without embedding a point-in-time spend snapshot beside the dashboard's current total. Cost-log appends also recover an unterminated tail boundary so the next complete records remain parseable and counted.

## Changes

- Separate the full doctor cost snapshot from the value-free alert ledger message.
- Inspect and append through one file descriptor, adding a line feed only after an unterminated tail.
- Add regression coverage for alert persistence, immediate notification detail, append framing, empty writes, and index totals.

## Test plan

- `cd plugins/claude-code-hermit && bun test` (4542 pass, 0 fail)
- `cd plugins/claude-code-hermit && bunx tsc --noEmit` (exit 0)
- `graphify update .` from the repository root and core plugin directory (exit 0)