### PR TITLE
fix(claude-code-hermit): carry current blockers and findings across context resets

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Observations written with a null `runtime.session_id` stamp the last archived `S-NNN` instead of the shared `"unknown"` sentinel, so `graduation_min_sessions` counts distinct sessions. Ledger graduation skips `"unknown"` rows and promotes a pattern only when it has a row newer than `counters.last_graduation_at` (stamped at the end of step 3b, not by `last_run_at`).
 - `reflection-judge` skips per-report confirmation when `Artifact:` cites `state/observations.jsonl`, and verifies the ledger with a bounded Grep instead of reading the file whole. A Component Health flag whose subject is `reflection-judge` stays on the Progress Log and is not a candidate.
 - Session archive now uses one recorded factual baseline for every archive mode: Task, Findings, Blockers, and current-session compiled Artifacts survive unattended close; close payloads can add missing Blockers and compiled links or mark recorded blockers resolved without deleting their text; and a duration with no provably owned runtime window is reported as unknown instead of zero.
+- Post-compaction context now carries a bounded current blockers line when SHELL.md has one recorded, and a full startup or post-clear context now carries bounded recent Findings, so a compacted or cleared session no longer resumes blind to what was blocking it or what it had just discovered.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -91,6 +91,13 @@ function emitArtifacts(artifacts: Json[], budget: number, headerFn: (a: Json) =>
   }
 }
 
+// Drops the bare "-" a comment-only bullet ("- <!-- resolved ... -->") leaves
+// behind once stripPlaceholders removes the comment. A dash-only line is never
+// a real entry, and injecting it reads as an unnamed blocker or finding.
+function dropBulletResidue(text: string): string {
+  return text.split('\n').filter(l => !/^\s*-+\s*$/.test(l)).join('\n').trim();
+}
+
 // Return last N non-empty lines from a string.
 function lastLines(text: string, n: number): string {
   const lines = text.split('\n').filter(l => l.trim());
@@ -142,13 +149,17 @@ function buildCompactionPointers(agentDir: string): string {
       ? progress.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('<!--')).pop()
       : null;
     if (lastEntry) parts.push(`last progress: ${guarded('sessions/SHELL.md', lastEntry.slice(0, 200))}`);
-    // stripPlaceholders trims the whole section, so a comment-only bullet line
-    // ("- <!-- resolved ... -->") collapses to a bare "-" by the time it's
-    // split — reject that explicitly rather than emitting "blockers: -".
-    const blockerLines = stripPlaceholders(extractSection(shellContent, 'Blockers') ?? '')
-      .split('\n').map(l => l.trim().replace(/^-\s+/, '').trim()).filter(l => l && !/^-+$/.test(l));
+    // dropBulletResidue first: stripPlaceholders trims the whole section, so a
+    // comment-only bullet ("- <!-- resolved ... -->") would otherwise reach here
+    // as a bare "-" and surface as "blockers: -".
+    const blockerLines = dropBulletResidue(stripPlaceholders(extractSection(shellContent, 'Blockers') ?? ''))
+      .split('\n').map(l => l.trim().replace(/^-\s+/, '').trim()).filter(Boolean);
     if (blockerLines.length) {
-      parts.push(`blockers: ${guarded('sessions/SHELL.md', blockerLines.slice(-2).join(' | ').slice(0, 240))}`);
+      // Cap each entry, not the joined string: one verbose blocker would
+      // otherwise eat the whole budget and truncate away the newest one, which
+      // is the entry `slice(-2)` exists to preserve.
+      const blockers = blockerLines.slice(-2).map(l => l.slice(0, 118)).join(' | ');
+      parts.push(`blockers: ${guarded('sessions/SHELL.md', blockers.slice(0, 240))}`);
     }
   } catch {}
 
@@ -265,7 +276,9 @@ function emitCompactCapsule(): void {
     }
     // Truncated: cut back to the last complete line rather than emit a
     // garbled partial one; drop entirely when even the first line doesn't fit.
-    const sliced = pointers.slice(0, maxBody);
+    // maxBody + 1 so a line whose terminator sits exactly at maxBody still
+    // counts as fitting — slicing at maxBody would hide it and drop the line.
+    const sliced = pointers.slice(0, maxBody + 1);
     const cut = sliced.lastIndexOf('\n');
     if (cut <= 0) return;
     process.stdout.write(header + sliced.slice(0, cut) + '\n');
@@ -341,7 +354,7 @@ function emitFullContext(source: string | null) {
       parts.push(`## Progress Log (last 10)\n${recent}`);
     }
 
-    const blockers = stripPlaceholders(extractSection(shellContent, 'Blockers') ?? '');
+    const blockers = dropBulletResidue(stripPlaceholders(extractSection(shellContent, 'Blockers') ?? ''));
     if (blockers) {
       parts.push(`## Blockers\n${blockers}`);
     }
@@ -354,7 +367,7 @@ function emitFullContext(source: string | null) {
       }
     }
 
-    const findingsRaw = stripPlaceholders(extractSection(shellContent, 'Findings') ?? '');
+    const findingsRaw = dropBulletResidue(stripPlaceholders(extractSection(shellContent, 'Findings') ?? ''));
     if (findingsRaw) {
       parts.push(`## Findings (last 5)\n${lastLines(findingsRaw, 5).slice(0, 600)}`);
     }

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -142,6 +142,14 @@ function buildCompactionPointers(agentDir: string): string {
       ? progress.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('<!--')).pop()
       : null;
     if (lastEntry) parts.push(`last progress: ${guarded('sessions/SHELL.md', lastEntry.slice(0, 200))}`);
+    // stripPlaceholders trims the whole section, so a comment-only bullet line
+    // ("- <!-- resolved ... -->") collapses to a bare "-" by the time it's
+    // split — reject that explicitly rather than emitting "blockers: -".
+    const blockerLines = stripPlaceholders(extractSection(shellContent, 'Blockers') ?? '')
+      .split('\n').map(l => l.trim().replace(/^-\s+/, '').trim()).filter(l => l && !/^-+$/.test(l));
+    if (blockerLines.length) {
+      parts.push(`blockers: ${guarded('sessions/SHELL.md', blockerLines.slice(-2).join(' | ').slice(0, 240))}`);
+    }
   } catch {}
 
   try {
@@ -250,8 +258,17 @@ function emitCompactCapsule(): void {
     const pointers = buildCompactionPointers(AGENT_DIR);
     if (!pointers) return;
     const header = '---Compaction Pointers---\n';
-    const body = pointers.slice(0, COMPACT_CAP - header.length - 1);
-    process.stdout.write(header + body + '\n');
+    const maxBody = COMPACT_CAP - header.length - 1;
+    if (pointers.length <= maxBody) {
+      process.stdout.write(header + pointers + '\n');
+      return;
+    }
+    // Truncated: cut back to the last complete line rather than emit a
+    // garbled partial one; drop entirely when even the first line doesn't fit.
+    const sliced = pointers.slice(0, maxBody);
+    const cut = sliced.lastIndexOf('\n');
+    if (cut <= 0) return;
+    process.stdout.write(header + sliced.slice(0, cut) + '\n');
   } catch {
     // fail-open — a broken capsule must never block startup
   }
@@ -335,6 +352,11 @@ function emitFullContext(source: string | null) {
       if (monLines.length > 0) {
         parts.push(`## Monitoring (last 5)\n${monLines.slice(-5).join('\n')}`);
       }
+    }
+
+    const findingsRaw = stripPlaceholders(extractSection(shellContent, 'Findings') ?? '');
+    if (findingsRaw) {
+      parts.push(`## Findings (last 5)\n${lastLines(findingsRaw, 5).slice(0, 600)}`);
     }
 
     const sessionOutput = parts.join('\n\n');

--- a/plugins/claude-code-hermit/tests/fixtures/shell-session.md
+++ b/plugins/claude-code-hermit/tests/fixtures/shell-session.md
@@ -15,7 +15,7 @@ Test task for hook validation
 - [10:00] Started test session
 
 ## Blockers
-None
+<!-- What's preventing progress? Include enough context for the next session. -->
 
 ## Findings
 <!-- none -->

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -902,6 +902,18 @@ describe('startup-context', () => {
     expect(r.stdout).not.toContain('## Findings');
   }));
 
+  test('startup-context (bare-bullet Blockers/Findings after placeholder strip → both sections absent)', withDir(async (dir) => {
+    // Comment-only bullets collapse to a bare "-" once stripPlaceholders runs —
+    // must not surface as "## Blockers\n-" / "## Findings (last 5)\n-".
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      '## Blockers\n- <!-- resolved: fixed already -->\n\n## Findings\n- <!-- nothing yet -->\n');
+    const r = await runScript('startup-context.ts', { cwd: dir, env: ENV });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('## Blockers');
+    expect(r.stdout).not.toContain('## Findings');
+  }));
+
   test('startup-context (Findings with more than 5 lines → only the last 5)', withDir(async (dir) => {
     const findings = Array.from({ length: 8 }, (_, i) => `- finding ${i}`).join('\n');
     write(hermit(dir, 'sessions', 'SHELL.md'),
@@ -1195,6 +1207,22 @@ Rota body.
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toMatch(/^blockers: middle blocker \| newest blocker$/m);
     expect(r.stdout).not.toContain('oldest blocker');
+  }));
+
+  test('startup-context (source=compact, two verbose Blockers → newest survives the cap, not just the oldest)', withDir(async (dir) => {
+    // The char cap applies per entry: capping the joined string would spend the
+    // whole budget on the older blocker and truncate the newest one away.
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      `## Blockers\n- OLD ${'o'.repeat(200)}\n- NEW ${'n'.repeat(200)}\n\n## Findings\n`);
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    const line = r.stdout.split('\n').find(l => l.startsWith('blockers: '))!;
+    expect(line).toContain('OLD ');
+    expect(line).toContain('NEW ');
+    expect(line.length).toBeLessThanOrEqual('blockers: '.length + 240);
   }));
 
   test('startup-context (source=compact, bare-bullet Blockers after placeholder strip → no blockers: line)', withDir(async (dir) => {

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -871,6 +871,60 @@ describe('startup-context', () => {
     expect(r.stdout).toContain('No active session');
   }));
 
+  test('startup-context (populated Findings → present after Monitoring)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      '## Blockers\n\n## Monitoring\n- [10:05] watch tick\n\n## Findings\nsomething unexpected was discovered\n');
+    const r = await runScript('startup-context.ts', { cwd: dir, env: ENV });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('## Findings (last 5)');
+    expect(r.stdout).toContain('something unexpected was discovered');
+    const monIdx = r.stdout.indexOf('## Monitoring');
+    const findIdx = r.stdout.indexOf('## Findings');
+    expect(monIdx).toBeGreaterThan(-1);
+    expect(findIdx).toBeGreaterThan(monIdx);
+  }));
+
+  test('startup-context (placeholder-only Findings → absent)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      '## Blockers\n\n## Findings\n<!-- Anything unexpected found during work. -->\n');
+    const r = await runScript('startup-context.ts', { cwd: dir, env: ENV });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('## Findings');
+  }));
+
+  test('startup-context (no ## Findings heading at all → absent, exit 0)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n## Blockers\n');
+    const r = await runScript('startup-context.ts', { cwd: dir, env: ENV });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('## Findings');
+  }));
+
+  test('startup-context (Findings with more than 5 lines → only the last 5)', withDir(async (dir) => {
+    const findings = Array.from({ length: 8 }, (_, i) => `- finding ${i}`).join('\n');
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      `# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n## Blockers\n\n## Findings\n${findings}\n`);
+    const r = await runScript('startup-context.ts', { cwd: dir, env: ENV });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('finding 7');
+    expect(r.stdout).toContain('finding 3');
+    expect(r.stdout).not.toContain('finding 0');
+    expect(r.stdout).not.toContain('finding 2');
+  }));
+
+  test('startup-context (oversized Progress Log alone → Findings dropped, the first of the five sections lost)', withDir(async (dir) => {
+    const progress = Array.from({ length: 10 }, (_, i) => `[10:${String(i).padStart(2, '0')}] ${'P'.repeat(340)}`).join('\n');
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      `# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n${progress}\n\n` +
+      '## Blockers\nwaiting on review\n\n## Monitoring\n- [10:05] watch tick\n\n## Findings\nsomething unexpected was discovered\n');
+    const r = await runScript('startup-context.ts', { cwd: dir, env: ENV });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('## Findings');
+    expect(r.stdout).not.toContain('something unexpected was discovered');
+  }));
+
   test('startup-context (section priority)', withDir(async (dir) => {
     write(hermit(dir, 'OPERATOR.md'), '# Operator\n' + ('x'.repeat(80) + '\n').repeat(22));
     const extra = Array.from({ length: 200 },
@@ -1100,6 +1154,72 @@ Rota body.
     expect(r.stdout).not.toContain('session_state:');
     expect(r.stdout).not.toContain('pending micro-proposals:');
     expect(r.stdout).not.toContain('outbound channel:');
+    // Fixture's ## Blockers is placeholder-only — no blockers: line.
+    expect(r.stdout).not.toMatch(/^blockers: /m);
+  }));
+
+  test('startup-context (source=compact, populated Blockers → bounded blockers: pointer after last progress)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      '## Blockers\nwaiting on review\n\n## Findings\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/^blockers: waiting on review$/m);
+    // Ordered after last progress, before the trailing "Full state" instruction.
+    const lastProgressIdx = r.stdout.indexOf('last progress:');
+    const blockersIdx = r.stdout.indexOf('blockers:');
+    expect(lastProgressIdx).toBeGreaterThan(-1);
+    expect(blockersIdx).toBeGreaterThan(lastProgressIdx);
+  }));
+
+  test('startup-context (source=compact, placeholder-only Blockers → no blockers: line)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      '## Blockers\n<!-- What\'s preventing progress? -->\n\n## Findings\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toMatch(/^blockers: /m);
+  }));
+
+  test('startup-context (source=compact, multi-line Blockers → last 2 entries only, joined)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      '## Blockers\n- oldest blocker\n- middle blocker\n- newest blocker\n\n## Findings\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/^blockers: middle blocker \| newest blocker$/m);
+    expect(r.stdout).not.toContain('oldest blocker');
+  }));
+
+  test('startup-context (source=compact, bare-bullet Blockers after placeholder strip → no blockers: line)', withDir(async (dir) => {
+    // A resolved-blocker comment on its own bullet collapses to a bare "-" once
+    // stripPlaceholders removes the comment — must not surface as "blockers: -".
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      '## Blockers\n- <!-- resolved: fixed already -->\n\n## Findings\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toMatch(/^blockers: /m);
+  }));
+
+  test('startup-context (source=compact, populated Findings → never emitted in the compact capsule)', withDir(async (dir) => {
+    write(hermit(dir, 'sessions', 'SHELL.md'),
+      '# Active Session\n\n## Task\nShip the thing\n\n## Progress Log\n[10:00] Started\n\n' +
+      '## Blockers\n\n## Findings\nsomething unexpected was discovered\n');
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('## Findings');
+    expect(r.stdout).not.toContain('something unexpected was discovered');
   }));
 
   test('startup-context (source=startup → pointer section never emitted, even with state present)', withDir(async (dir) => {
@@ -1270,6 +1390,26 @@ Rota body.
     // The trailing line is cut mid-sentence, proving the capsule hit the cap here.
     expect(r.stdout).not.toContain('to reconstruct context.');
     expect(r.stdout).toContain('operator language: pt (reply in this language)');
+    // Line-boundary truncation: every emitted pointer line is intact, not a
+    // partial fragment of the field that follows it.
+    for (const line of r.stdout.trimEnd().split('\n').slice(1)) {
+      expect(line).toMatch(/^(operator language|session_state|task|last progress|blockers|pending micro-proposals|outbound channel|latest report|operator context|proposals dir): /);
+    }
+  }));
+
+  test('startup-context (source=compact, single oversized field → capsule collapses to nothing, not a garbled line)', withDir(async (dir) => {
+    // No operator language configured, so the unbounded session_state line is
+    // first and alone exceeds the slice budget — there is no earlier newline
+    // to cut back to.
+    write(hermit(dir, 'state', 'runtime.json'), JSON.stringify({
+      session_state: 'waiting', waiting_reason: 'x'.repeat(2000),
+    }));
+    const r = await runScript('startup-context.ts', {
+      cwd: dir, env: ENV, stdin: JSON.stringify({ source: 'compact', session_id: 'x' }),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('---Compaction Pointers---');
+    expect(r.stdout).not.toContain('session_state:');
   }));
 
   test('startup-context (source=compact, language-only state → capsule still emits)', withDir(async (dir) => {


### PR DESCRIPTION
## Summary
PR #815 made recorded SHELL.md facts authoritative at archive time, but the rehydration side stayed a gap: after a compaction or a full context clear, the model was re-seeded from `startup-context.ts` without seeing current `## Blockers` or `## Findings`. A hermit that compacted mid-arc had no way to know it was still blocked and would re-attempt the blocked work, so the now-authoritative archive would then record a stale fact.

Scoped to issue #818's revision comment (not the original body): Blockers is required in the post-compaction capsule, Findings is explicitly dropped from that capsule, and Findings is added to the full startup/clear capsule only, lowest priority.

## Changes
- `buildCompactionPointers()` in `scripts/startup-context.ts` now emits a bounded `blockers: <last 2 entries, ≤240 chars>` pointer line when SHELL.md has real (non-placeholder) blockers, positioned after `last progress:`.
- `emitFullContext()` now emits a bounded `## Findings (last 5 lines, ≤600 chars)` section as the final part of Active Session, after Monitoring, so it's the first content dropped if the section budget is exceeded.
- `emitCompactCapsule()`'s truncation now cuts back to the last complete line instead of a mid-word slice, and returns nothing rather than a garbled fragment when even the first field alone exceeds the budget.
- `tests/fixtures/shell-session.md`'s `## Blockers` placeholder corrected from the literal word `None` to the same HTML-comment placeholder the fixture's own header claims to mirror (`state-templates/SHELL.md.template`) — the two had drifted, and the drift was masking a real gap in the new tests.

Closes #818

## Test plan
- `cd plugins/claude-code-hermit && bun test` — 4584 pass, 0 fail (this repo's full suite).
- `bunx tsc --noEmit` from repo root — exit 0.
- New coverage in `tests/hooks.contract.test.ts`: populated/placeholder-only/multi-line/bare-bullet Blockers on the compact path; Findings never appears on the compact path; populated/placeholder-only/missing/>5-line/budget-eviction Findings on the full path; line-boundary truncation and single-oversized-field collapse-to-nothing on the compact-capsule cap.