### PR TITLE
fix(claude-code-hermit): silence startup warning on observations grant

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
     "allow": [
       "Bash(gh issue:*)",
       "Bash(node */skills/hermit-scribe/file-issue.js*)",
-      "Bash(bun */scripts/routines.ts tz-shift *)",
+      "Bash(bun */scripts/routines.ts tz-shift*)",
       "Bash(node */scripts/resolve-outbound-channel.js *)"
     ],
     "deny": []

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Four sigil-anchored entries replace them: `Bash(*$ANTHROPIC_API_KEY*)` and `Bash(*$CLAUDE_CODE_OAUTH_TOKEN*)`, each in bare and `${…}` spelling. An expansion of a live credential (`echo $ANTHROPIC_API_KEY` while debugging auth) blocks; every bare mention of the name — a grep, a commit message, writing the placeholder into `.env` — stays allowed. The hook enforces them from the shipped template, so nothing needs adding to your settings file.
 
 ### Fixed
+- The observations-writer allow rule no longer trips Claude Code 2.1.246's "wildcard before the rest of the command" startup warning; `permissions-sync` retires the old entry on upgrade.
 - Reflect's cost-spike detector now measures whole-day totals from the cost index instead of the last 20 cost-log entries, so it can actually fire on an install busy enough to have a cost problem — the fixed-line tail spanned at most one or two dates and could never assemble a baseline. A spike day flags exactly one reflect run, not one per tick.
 - Cost corruption alerts now keep point-in-time spend out of persistent dashboard warnings, and interrupted cost-log tails no longer consume the next valid appended record.
 - Session archive copies the Progress Log into the report `## Completed` before resetting SHELL.md, so an auto-close no longer drops the day's work record.

--- a/plugins/claude-code-hermit/scripts/apply-settings.ts
+++ b/plugins/claude-code-hermit/scripts/apply-settings.ts
@@ -57,10 +57,15 @@ const HERMIT_ALLOW = [
   'Bash(bun */scripts/reflect-precheck.ts*)',
   'Bash(bun */scripts/archive-shell.ts*)',
   'Bash(bun */scripts/evaluate-session.ts*)',
-  // Verb-scoped: `observe` is the only thing this script does, and pinning it keeps
-  // the grant from widening if it ever grows a second verb. Replaces the old
+  // Verb-scoped: `observe` is the only thing this script does. No space before the
+  // trailing `*` — CC 2.1.246 warns at startup on a fully-literal argument following
+  // a wildcard-containing one (e.g. `observe *`), so this mirrors the other
+  // verb-pinned `bun */scripts/…` entries below (`tz-shift*`, `precheck*`, etc).
+  // `observations.ts:32` still hard-rejects any verb but `observe`, so `observe*`
+  // matching a hypothetical `observeXYZ` reaches a script that refuses it — the
+  // grant is not actually widened by dropping the space. Replaces the old
   // append-metrics.ts entry, which granted "write any JSON to any path".
-  'Bash(bun */scripts/observations.ts observe *)',
+  'Bash(bun */scripts/observations.ts observe*)',
   'Bash(bun */scripts/proposal.ts*)',
   'Bash(bun */scripts/generate-summary.ts*)',
   'Bash(bun */scripts/update-reflection-state.ts*)',
@@ -172,6 +177,9 @@ const HERMIT_OBSOLETE = [
   'Bash(bun */scripts/routine-precheck.ts*)',
   'Bash(bun */scripts/cron-registry.ts*)',
   'Bash(bun */scripts/cron-tz-shift.ts*)',
+  // Superseded by the no-space form above — CC 2.1.246 warns at startup on this shape
+  // (fully-literal `observe` argument following the `*/scripts/…` wildcard).
+  'Bash(bun */scripts/observations.ts observe *)',
 ];
 
 // Hardened extras — a subset of always_on patterns safe to persist to settings.

--- a/plugins/claude-code-hermit/scripts/apply-settings.ts
+++ b/plugins/claude-code-hermit/scripts/apply-settings.ts
@@ -148,8 +148,9 @@ const HERMIT_ALLOW = [
 // Entries this plugin itself shipped in an earlier version and has since retired.
 // permissions-sync removes these from an operator's settings; nothing else is ever
 // removed, so an operator's own rules cannot be caught by a shape or prefix match.
-// Append here in the same change that deletes a permissioned script — this registry
-// is what makes a deletion reach already-hatched hermits.
+// Append here in the same change that deletes a permissioned script, or that respells
+// an entry still in HERMIT_ALLOW — this registry is what makes a deletion or a respelling
+// reach already-hatched hermits.
 const HERMIT_OBSOLETE = [
   'Bash(python3:*)',
   'Bash(node:*)',

--- a/plugins/claude-code-hermit/scripts/observations.ts
+++ b/plugins/claude-code-hermit/scripts/observations.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
   }
 
   // The state dir is not caller-chosen. Reachable through a pre-approved
-  // `Bash(bun */scripts/observations.ts observe *)` grant that covers every
+  // `Bash(bun */scripts/observations.ts observe*)` grant that covers every
   // argument after the verb, so an unvalidated root let one such call append
   // model-authored rows to another project's observations ledger — the same
   // mis-invocation class, and refused the same way. See cc-compat.ts.

--- a/plugins/claude-code-hermit/tests/apply-settings-permissions.test.ts
+++ b/plugins/claude-code-hermit/tests/apply-settings-permissions.test.ts
@@ -159,7 +159,11 @@ describe('sealed registries', () => {
 
   // Regression guard for the lint shape itself: no HERMIT_ALLOW entry should have a
   // fully-literal argument following a wildcard-containing argument, else Claude Code
-  // warns at every hermit session start.
+  // warns at every hermit session start. Option-shaped arguments are exempt — Claude
+  // Code's own check skips them, so flagging one here would fail CI on a rule it
+  // accepts. Otherwise deliberately stricter than the real check (which also spares a
+  // rule whose first token is wildcarded, or that ends in `:*`): a narrower shape rule
+  // is cheaper to keep than a faithful port of someone else's linter.
   test('no allow rule has a literal argument trailing a wildcard-containing argument', () => {
     const offenders = HERMIT_ALLOW.filter((rule) => {
       const inner = rule.match(/^[A-Za-z]+\((.*)\)$/)?.[1];
@@ -167,7 +171,9 @@ describe('sealed registries', () => {
       const args = inner.split(' ');
       const firstWildcardIdx = args.findIndex((a) => a.includes('*'));
       if (firstWildcardIdx === -1) return false;
-      return args.slice(firstWildcardIdx + 1).some((a) => a.length > 0 && !a.includes('*'));
+      return args
+        .slice(firstWildcardIdx + 1)
+        .some((a) => a.length > 0 && !a.includes('*') && !a.startsWith('-'));
     });
     expect(offenders).toEqual([]);
   });

--- a/plugins/claude-code-hermit/tests/apply-settings-permissions.test.ts
+++ b/plugins/claude-code-hermit/tests/apply-settings-permissions.test.ts
@@ -146,8 +146,30 @@ describe('sealed registries', () => {
   // JSON to an arbitrary path, so it has to be actively retired from existing
   // installs, not merely dropped from the canonical list.
   test('the observations writer is granted and its arbitrary-path predecessor retired', () => {
-    expect(HERMIT_ALLOW).toContain('Bash(bun */scripts/observations.ts observe *)');
+    expect(HERMIT_ALLOW).toContain('Bash(bun */scripts/observations.ts observe*)');
     expect(HERMIT_OBSOLETE).toContain('Bash(bun */scripts/append-metrics.ts*)');
+  });
+
+  // CC 2.1.246 warns at startup on a fully-literal argument following a
+  // wildcard-containing one (e.g. `Bash(bun */scripts/x.ts observe *)`). The
+  // space-before-verb form was retired in favor of the no-space form above.
+  test('the observations writer\'s space-before-verb predecessor is retired', () => {
+    expect(HERMIT_OBSOLETE).toContain('Bash(bun */scripts/observations.ts observe *)');
+  });
+
+  // Regression guard for the lint shape itself: no HERMIT_ALLOW entry should have a
+  // fully-literal argument following a wildcard-containing argument, else Claude Code
+  // warns at every hermit session start.
+  test('no allow rule has a literal argument trailing a wildcard-containing argument', () => {
+    const offenders = HERMIT_ALLOW.filter((rule) => {
+      const inner = rule.match(/^[A-Za-z]+\((.*)\)$/)?.[1];
+      if (!inner) return false;
+      const args = inner.split(' ');
+      const firstWildcardIdx = args.findIndex((a) => a.includes('*'));
+      if (firstWildcardIdx === -1) return false;
+      return args.slice(firstWildcardIdx + 1).some((a) => a.length > 0 && !a.includes('*'));
+    });
+    expect(offenders).toEqual([]);
   });
 
   test('the routine Monitor subprocess is granted without widening to arbitrary shell scripts', () => {

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -1555,7 +1555,7 @@ describe('observations.ts observe', () => {
   }));
 
   // observations.ts is reachable through a pre-approved
-  // `Bash(bun */scripts/observations.ts observe *)` grant that covers every
+  // `Bash(bun */scripts/observations.ts observe*)` grant that covers every
   // argument after the verb (docs/security.md § Script Argument Trust).
   test('state-dir pin: refuses a ledger belonging to another project', withDir(async (mine) => {
     await withDir(async (victim) => {


### PR DESCRIPTION
## Summary
Claude Code 2.1.246 warns at startup on an allow rule with a fully-literal argument trailing a wildcard-containing one. The observations-writer grant (`Bash(bun */scripts/observations.ts observe *)`) has that exact shape, so it fired on every hermit session start.

## Changes
- Retire the space-before-verb grant in favor of the no-space form already used by every other verb-pinned `bun */scripts/…` entry (`observe*` instead of `observe *`); `observations.ts` still hard-rejects any verb but `observe`, so the grant isn't actually widened.
- Add the retired string to `HERMIT_OBSOLETE` so `permissions-sync` removes it from already-hatched hermits on the normal upgrade path.
- Add a regression test asserting no `HERMIT_ALLOW` entry has a fully-literal argument trailing a wildcard-containing argument, so this warning shape can't be reintroduced silently.
- Sync the two comment-only references to the retired literal.
- CHANGELOG entry under `[Unreleased] ### Fixed`.

This does not touch the broader flag-injection surface shared by all `bun */scripts/*` grants (e.g. `bun --preload evil.ts <legit script>` still matches) — that's tracked separately in #823.

## Test plan
- `bun test` — 4588 pass, 0 fail (full core plugin suite)
- `bunx tsc --noEmit` — clean, exit 0