### PR TITLE
fix(claude-code-hermit): count allowlisted channel messages as operator activity

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Messages from an allowlisted channel sender now advance the operator-activity clock from the `UserPromptSubmit` hook itself instead of relying on a skill step, so a chat-only conversation no longer reads as silence to the post-close `/clear`, the 12h auto-close, and the context-hygiene backoff. Senders outside `allowed_users` are still ignored.
+
 ### Changed
 - Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator`, or `feature-dev`, and no longer seeds their `scheduled_checks` entries — Claude Code's native `Plan`/`Explore` agents, auto-memory, and `/doctor` CLAUDE.md trims cover the same ground, and every loaded skill description is paid on every API call of an always-on hermit. The `scheduled_checks` mechanism itself is unchanged; register any plugin's skill with `/hermit-settings scheduled-checks`.
 - `proposal-act` authors `## Skill Improvement` and `## Skill Draft` bodies in-main from the source brief instead of delegating to `skill-creator`; the falsification gate's read-only pass always uses the native `Plan` agent instead of `feature-dev:code-explorer`.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [Unreleased]
 
-### Fixed
-- Messages from an allowlisted channel sender now advance the operator-activity clock from the `UserPromptSubmit` hook itself instead of relying on a skill step, so a chat-only conversation no longer reads as silence to the post-close `/clear`, the 12h auto-close, and the context-hygiene backoff. Senders outside `allowed_users` are still ignored.
-
 ### Changed
 - Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator`, or `feature-dev`, and no longer seeds their `scheduled_checks` entries — Claude Code's native `Plan`/`Explore` agents, auto-memory, and `/doctor` CLAUDE.md trims cover the same ground, and every loaded skill description is paid on every API call of an always-on hermit. The `scheduled_checks` mechanism itself is unchanged; register any plugin's skill with `/hermit-settings scheduled-checks`.
 - `proposal-act` authors `## Skill Improvement` and `## Skill Draft` bodies in-main from the source brief instead of delegating to `skill-creator`; the falsification gate's read-only pass always uses the native `Plan` agent instead of `feature-dev:code-explorer`.
 - The first-session baseline audit offer (`.baseline-pending`) is removed along with the plugins it audited.
+
+### Fixed
+- Channel messages from a sender that clears `allowed_users` now advance the operator-activity clock from the `UserPromptSubmit` hook, so a chat-only conversation no longer reads as silence to the post-close `/clear`, the 12h auto-close, and the context-hygiene backoff. Other senders are still ignored.
 
 ### Upgrade Instructions
 - **Decide whether to keep the plugins hatch used to recommend.** Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator` or `feature-dev`; Claude Code covers them natively (see `${CLAUDE_PLUGIN_ROOT}/docs/recommended-plugins.md`). Nothing is removed for you. First, unconditionally delete `.claude-code-hermit/.baseline-pending` if it exists. Then inventory: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/settings-edit.ts" .claude-code-hermit/config.json get scheduled_checks` for entries whose `plugin` is `claude-code-setup` or `claude-md-management`; `… get docker.recommended_plugins` for entries naming any of the four; `claude plugin list` for any of the four installed. If all three are empty, skip silently. Otherwise this is the operator's decision with no default: **defer per SKILL.md Step 10** with `options: ["Keep", "Remove"]` and no `on_resolve`; the choice is applied in attended Step 10 only.

--- a/plugins/claude-code-hermit/scripts/record-operator-action.ts
+++ b/plugins/claude-code-hermit/scripts/record-operator-action.ts
@@ -35,11 +35,21 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { hermitDir } from './lib/cc-compat';
 import { isAllowedSender } from './lib/channel-auth';
-import { parseChannelEnvelope } from './lib/channel-envelope';
+import { parseChannelEnvelope, type ChannelEnvelope } from './lib/channel-envelope';
 import { readConfigRaw } from './lib/config-read';
 import { appendUsageEvent } from './lib/usage-ledger';
 
 type Json = any;
+
+// What the channel allowlist gate needs, supplied by a caller that already has
+// it. The pipeline hands over the envelope it parsed and the raw config it
+// memoizes, so neither is computed twice per prompt; omitted (direct-script
+// path) they are derived here, and only for a `<channel` prompt — the one
+// shape whose verdict depends on them.
+export interface ChannelGateInputs {
+  envelope: ChannelEnvelope | null;
+  config: Json;
+}
 
 const AGENT_DIR = hermitDir();
 const STATE_PATH = path.join(AGENT_DIR, 'state', 'last-operator-action.json');
@@ -83,7 +93,7 @@ const INJECTED_EXACT = new Set([
   '/claude-code-hermit:session-close --shutdown',
 ]);
 
-function isRoutinePrompt(prompt: string, config: Json = null): boolean {
+function isRoutinePrompt(prompt: string, channel?: ChannelGateInputs): boolean {
   if (prompt.startsWith('[hermit-routine:')) return true;
   const t = prompt.trim();
   // A channel turn is operator activity exactly when its sender clears the same
@@ -92,8 +102,12 @@ function isRoutinePrompt(prompt: string, config: Json = null): boolean {
   // An unparseable `<channel` prefix keeps the old blanket skip — it carries no
   // identity to check, so it cannot be attributed to the operator.
   if (t.startsWith('<channel')) {
-    const envelope = parseChannelEnvelope(t);
+    const envelope = channel ? channel.envelope : parseChannelEnvelope(t);
     if (!envelope) return true;
+    // Presence of `channel`, not truthiness of its config: an unreadable config
+    // is a legitimate null the caller already resolved (fail-open → accept-all),
+    // and re-reading it here would just repeat that read.
+    const config = channel ? channel.config : readConfigRaw(AGENT_DIR);
     return !isAllowedSender(config, envelope.source, envelope.userId);
   }
   if (INJECTED_EXACT.has(t)) return true;
@@ -173,10 +187,9 @@ function appendSkillUsage(name: string): void {
 }
 
 // The UserPromptSubmit half, callable in-process by user-prompt-pipeline.ts.
-// `config` feeds the channel allowlist gate only; the pipeline passes its own
-// lazily-read raw config so this module never re-reads it on a hot path.
-export function run(prompt: string, config: Json = null): void {
-  if (!isRoutinePrompt(prompt, config)) {
+// `channel` feeds the channel allowlist gate only — see ChannelGateInputs.
+export function run(prompt: string, channel?: ChannelGateInputs): void {
+  if (!isRoutinePrompt(prompt, channel)) {
     // Skill-usage capture is operator-activity only — hermit's own injected
     // slash commands (INJECTED_EXACT) are routine prompts, so gating on the
     // same filter keeps automated heartbeat/session-close/routines fires out
@@ -200,15 +213,9 @@ function main(raw: string): void {
     return;
   }
 
-  // Direct-script path (SessionStart, tests). The pipeline hands run() its own
-  // config; here the read is ours to make — and only worth making for a channel
-  // prompt, the one shape whose verdict depends on it.
-  let config: Json = null;
-  if (prompt.trim().startsWith('<channel')) {
-    try { config = readConfigRaw(AGENT_DIR); } catch { /* fail-open — accept-all */ }
-  }
-
-  run(prompt, config);
+  // Direct-script path: no caller-supplied envelope or config, so isRoutinePrompt
+  // derives both itself — for a `<channel` prompt only.
+  run(prompt);
 }
 
 // Entry shell only when executed directly — importing this module (the pipeline

--- a/plugins/claude-code-hermit/scripts/record-operator-action.ts
+++ b/plugins/claude-code-hermit/scripts/record-operator-action.ts
@@ -18,8 +18,13 @@ process.stdout.on('error', () => {});
 //
 // Filtered prompts (not operator activity):
 //   [hermit-routine:…   — cron-delivered routine prompts (hermit-routines/SKILL.md:43-54)
-//   <channel…           — unauthorized DMs arrive here before channel-responder's allowlist
-//                          check; recording them would let bot traffic suppress AUTO_CLOSE
+//   <channel…           — only when the sender fails the channel's `allowed_users` gate;
+//                          recording those would let stranger/bot traffic suppress
+//                          AUTO_CLOSE. An allowlisted sender IS operator activity and is
+//                          recorded here (issue #835 — a channel-only conversation left
+//                          the clock frozen, so the midnight post-close /clear fired
+//                          mid-exchange). This hook is the mechanical write site;
+//                          channel-responder/SKILL.md 1d's --force is a fallback.
 //   HEARTBEAT_EVALUATE/HEARTBEAT_ERROR/ROUTINE_DUE/ROUTINE_MONITOR_ERROR — Monitor-delivered
 //                          scheduler wake notifications (heartbeat-monitor.sh, routines.ts due,
 //                          routine-monitor.sh) — see isRoutinePrompt below
@@ -29,7 +34,12 @@ process.stdout.on('error', () => {});
 import fs from 'node:fs';
 import path from 'node:path';
 import { hermitDir } from './lib/cc-compat';
+import { isAllowedSender } from './lib/channel-auth';
+import { parseChannelEnvelope } from './lib/channel-envelope';
+import { readConfigRaw } from './lib/config-read';
 import { appendUsageEvent } from './lib/usage-ledger';
+
+type Json = any;
 
 const AGENT_DIR = hermitDir();
 const STATE_PATH = path.join(AGENT_DIR, 'state', 'last-operator-action.json');
@@ -73,10 +83,19 @@ const INJECTED_EXACT = new Set([
   '/claude-code-hermit:session-close --shutdown',
 ]);
 
-function isRoutinePrompt(prompt: string): boolean {
+function isRoutinePrompt(prompt: string, config: Json = null): boolean {
   if (prompt.startsWith('[hermit-routine:')) return true;
   const t = prompt.trim();
-  if (t.startsWith('<channel')) return true;
+  // A channel turn is operator activity exactly when its sender clears the same
+  // `allowed_users` gate channel-responder applies (lib/channel-auth.ts owns the
+  // semantics: absent list → accept all, [] → lockdown, unverifiable id → closed).
+  // An unparseable `<channel` prefix keeps the old blanket skip — it carries no
+  // identity to check, so it cannot be attributed to the operator.
+  if (t.startsWith('<channel')) {
+    const envelope = parseChannelEnvelope(t);
+    if (!envelope) return true;
+    return !isAllowedSender(config, envelope.source, envelope.userId);
+  }
   if (INJECTED_EXACT.has(t)) return true;
   // Harness task notifications — Monitor events AND subagent/background-task
   // completions. Live-probed 2026-08-19 (CC 2.1.235): the harness wraps the
@@ -154,8 +173,10 @@ function appendSkillUsage(name: string): void {
 }
 
 // The UserPromptSubmit half, callable in-process by user-prompt-pipeline.ts.
-export function run(prompt: string): void {
-  if (!isRoutinePrompt(prompt)) {
+// `config` feeds the channel allowlist gate only; the pipeline passes its own
+// lazily-read raw config so this module never re-reads it on a hot path.
+export function run(prompt: string, config: Json = null): void {
+  if (!isRoutinePrompt(prompt, config)) {
     // Skill-usage capture is operator-activity only — hermit's own injected
     // slash commands (INJECTED_EXACT) are routine prompts, so gating on the
     // same filter keeps automated heartbeat/session-close/routines fires out
@@ -179,7 +200,15 @@ function main(raw: string): void {
     return;
   }
 
-  run(prompt);
+  // Direct-script path (SessionStart, tests). The pipeline hands run() its own
+  // config; here the read is ours to make — and only worth making for a channel
+  // prompt, the one shape whose verdict depends on it.
+  let config: Json = null;
+  if (prompt.trim().startsWith('<channel')) {
+    try { config = readConfigRaw(AGENT_DIR); } catch { /* fail-open — accept-all */ }
+  }
+
+  run(prompt, config);
 }
 
 // Entry shell only when executed directly — importing this module (the pipeline

--- a/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
@@ -112,7 +112,7 @@ async function main(raw: string): Promise<void> {
   // 1-3. Audit and context. These run on every prompt, including during a
   // shutdown — the operator's message is still recorded and the reply reminder
   // still names the chat to answer on.
-  await stage('record-operator-action', () => { recordOperatorAction(prompt); }, ctx);
+  await stage('record-operator-action', () => { recordOperatorAction(prompt, ctx.config()); }, ctx);
   await stage('prompt-context', promptContext, ctx);
   await stage('channel-reply-reminder', channelReplyReminder, ctx);
 

--- a/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
@@ -112,7 +112,8 @@ async function main(raw: string): Promise<void> {
   // 1-3. Audit and context. These run on every prompt, including during a
   // shutdown — the operator's message is still recorded and the reply reminder
   // still names the chat to answer on.
-  await stage('record-operator-action', () => { recordOperatorAction(prompt, ctx.config()); }, ctx);
+  await stage('record-operator-action',
+    () => { recordOperatorAction(prompt, { envelope: ctx.envelope, config: ctx.config() }); }, ctx);
   await stage('prompt-context', promptContext, ctx);
   await stage('channel-reply-reminder', channelReplyReminder, ctx);
 

--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -90,7 +90,9 @@ After authorization passes, run:
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/record-operator-action.ts --force
 ```
 
-This writes `state/last-operator-action.json` with the current timestamp, resetting the AUTO_CLOSE quiet window (used by both the 12h-inactivity trigger and the daily-midnight lull drain). It also opens `state/operator-turn-open.json`, which defers monitor-mode routines for the rest of this exchange (cleared at Stop). The `UserPromptSubmit` hook deliberately skips `<channel` prompts (it can't see the allowlist); this step is the authorized write site for both. Run it as early as authorization allows — a routine due before it lands can interject mid-exchange.
+This writes `state/last-operator-action.json` with the current timestamp, resetting the AUTO_CLOSE quiet window (used by both the 12h-inactivity trigger and the daily-midnight lull drain). It also opens `state/operator-turn-open.json`, which defers monitor-mode routines for the rest of this exchange (cleared at Stop).
+
+The `UserPromptSubmit` hook already writes both for any `<channel` prompt whose sender clears this channel's `allowed_users` gate — that mechanical write, not this step, is what keeps the clock honest on a channel-only conversation. Run this anyway: it is idempotent, and it covers the turns the hook could not attribute (an envelope it could not parse, or a sender you admitted by some other route). Run it as early as authorization allows.
 
 ## 1e. Chat-ID persistence — hook-owned, nothing to do here
 

--- a/plugins/claude-code-hermit/tests/auto-close.test.ts
+++ b/plugins/claude-code-hermit/tests/auto-close.test.ts
@@ -246,6 +246,14 @@ describe('last-operator-action.json signal', () => {
   const recordHook = (dir: string, stdin: string, args: string[] = []) =>
     runScript('record-operator-action.ts', { stdin, cwd: dir, args });
 
+  // A well-formed inbound envelope — quoted attributes, so parseChannelEnvelope
+  // actually resolves a sender to check against the allowlist.
+  const channelPrompt = (userId: string) =>
+    `<channel source="discord" chat_id="c1" user_id="${userId}">hi</channel>`;
+  const writeAllowlist = (dir: string, allowed: string[]) =>
+    fs.writeFileSync(hermit(dir, 'config.json'),
+      JSON.stringify({ timezone: 'UTC', channels: { discord: { enabled: true, allowed_users: allowed } } }));
+
   // a. precheck: last-operator-action.json 13h ago + fresh SHELL.md mtime → AUTO_CLOSE
   test('precheck: stale last-operator-action (13h) + fresh SHELL.md → AUTO_CLOSE', withTmp(async (dir) => {
     seedPrecheck(dir); // fresh SHELL.md mtime
@@ -359,8 +367,29 @@ describe('last-operator-action.json signal', () => {
     expect(fs.existsSync(lastOp(dir))).toBe(true);
   }));
 
-  // i. hook smoke: channel inbound prompt → file NOT written (channel-responder handles post-auth)
-  test('hook smoke: <channel inbound → file NOT written by hook', withTmp(async (dir) => {
+  // i. hook smoke: channel inbound. Issue #835 — a channel-only conversation used to
+  // leave the clock frozen (the write was delegated to a skill step the model skipped),
+  // so the midnight post-close /clear fired mid-exchange. The hook now applies the same
+  // allowlist gate channel-responder does: allowlisted sender = operator activity,
+  // anyone else still ignored so stranger/bot traffic can't suppress AUTO_CLOSE.
+  test('hook smoke: <channel inbound, no allowlist configured → file IS written', withTmp(async (dir) => {
+    await recordHook(dir, JSON.stringify({ prompt: channelPrompt('u1') }));
+    expect(fs.existsSync(lastOp(dir))).toBe(true);
+  }));
+
+  test('hook smoke: <channel inbound from allowlisted sender → file IS written', withTmp(async (dir) => {
+    writeAllowlist(dir, ['u1']);
+    await recordHook(dir, JSON.stringify({ prompt: channelPrompt('u1') }));
+    expect(fs.existsSync(lastOp(dir))).toBe(true);
+  }));
+
+  test('hook smoke: <channel inbound from non-allowlisted sender → file NOT written', withTmp(async (dir) => {
+    writeAllowlist(dir, ['u1']);
+    await recordHook(dir, JSON.stringify({ prompt: channelPrompt('stranger') }));
+    expect(fs.existsSync(lastOp(dir))).toBe(false);
+  }));
+
+  test('hook smoke: <channel prefix with no parseable envelope → file NOT written', withTmp(async (dir) => {
     await recordHook(dir, '{"prompt":"<channel source=discord chat_id=x>hi</channel>"}');
     expect(fs.existsSync(lastOp(dir))).toBe(false);
   }));
@@ -447,8 +476,20 @@ describe('last-operator-action.json signal', () => {
     expect(fs.existsSync(turnPath(dir))).toBe(false);
   }));
 
-  test('marker: <channel inbound → NOT written', withTmp(async (dir) => {
-    await recordHook(dir, '{"prompt":"<channel source=discord chat_id=x>hi</channel>"}');
+  test('marker: <channel inbound, no allowlist configured → written', withTmp(async (dir) => {
+    await recordHook(dir, JSON.stringify({ prompt: channelPrompt('u1') }));
+    expect(fs.existsSync(turnPath(dir))).toBe(true);
+  }));
+
+  test('marker: <channel inbound from allowlisted sender → written', withTmp(async (dir) => {
+    writeAllowlist(dir, ['u1']);
+    await recordHook(dir, JSON.stringify({ prompt: channelPrompt('u1') }));
+    expect(fs.existsSync(turnPath(dir))).toBe(true);
+  }));
+
+  test('marker: <channel inbound from non-allowlisted sender → NOT written', withTmp(async (dir) => {
+    writeAllowlist(dir, ['u1']);
+    await recordHook(dir, JSON.stringify({ prompt: channelPrompt('stranger') }));
     expect(fs.existsSync(turnPath(dir))).toBe(false);
   }));
 

--- a/plugins/claude-code-hermit/tests/user-prompt-pipeline.test.ts
+++ b/plugins/claude-code-hermit/tests/user-prompt-pipeline.test.ts
@@ -365,6 +365,36 @@ describe('user-prompt-pipeline: fail-open contract', () => {
     expect(fs.existsSync(hermit(wd.dir, 'state', 'operator-turn-open.json'))).toBe(true);
   });
 
+  // Issue #835: a channel-only conversation left last-operator-action.json frozen (the
+  // write was delegated to a channel-responder skill step the model skipped), so the
+  // midnight post-close /clear fired mid-exchange. The pipeline now hands the raw config
+  // to record-operator-action, which applies the same allowed_users gate.
+  test('allowlisted channel sender advances the clock and opens the turn marker', async () => {
+    const wd = setupChannelWorkdir();
+
+    const r = await runScript('user-prompt-pipeline.ts', {
+      stdin: JSON.stringify({ prompt: envelope('any updates?', 'u1') }),
+      cwd: wd.dir,
+    });
+
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(hermit(wd.dir, 'state', 'last-operator-action.json'))).toBe(true);
+    expect(fs.existsSync(hermit(wd.dir, 'state', 'operator-turn-open.json'))).toBe(true);
+  });
+
+  test('non-allowlisted channel sender leaves the clock and turn marker untouched', async () => {
+    const wd = setupChannelWorkdir();
+
+    const r = await runScript('user-prompt-pipeline.ts', {
+      stdin: JSON.stringify({ prompt: envelope('any updates?', 'u2') }),
+      cwd: wd.dir,
+    });
+
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(hermit(wd.dir, 'state', 'last-operator-action.json'))).toBe(false);
+    expect(fs.existsSync(hermit(wd.dir, 'state', 'operator-turn-open.json'))).toBe(false);
+  });
+
   test('empty stdin exits 0 and emits nothing', async () => {
     const wd = setupWorkdir();
     const r = await runScript('user-prompt-pipeline.ts', { stdin: '', cwd: wd.dir });


### PR DESCRIPTION
## Summary

A chat-only conversation never advanced `state/last-operator-action.json`, so the hermit's own operator-activity clock read as silence while the operator was actively talking to it. At midnight the `daily-auto-close` precheck stamped `clear-requested.json`, the watchdog's 10-minute operator-lull gate passed on the stale clock, and `/clear` fired mid-exchange.

The watchdog gate was correct; the clock feeding it was not being written. `record-operator-action.ts` skipped every `<channel` prompt and delegated the write to `channel-responder/SKILL.md` §1d (`--force`) — a skill step the model can silently never reach. The allowlist the hook's comment said it "can't see" already exists as `isAllowedSender()` in `lib/channel-auth.ts`, and the pipeline already parses the envelope and lazily reads config. This wires them together so the write is mechanical instead of model-dependent.

The same clock also feeds the 12h-inactivity auto-close, the midnight `close-now` lull decision, and the context-hygiene clear/compact backoff, so one write site fixes all of them.

## Changes

- `scripts/record-operator-action.ts` — `<channel` prompts are now filtered only when the sender fails the channel's `allowed_users` gate, via the existing `isAllowedSender()` + `parseChannelEnvelope()`. A `<channel` prefix with no parseable envelope keeps the old blanket skip (no identity to attribute). `run()` takes the config; `main()` reads it itself, and only for a channel-shaped prompt.
- `scripts/user-prompt-pipeline.ts` — passes its already-memoized `ctx.config()` into the stage.
- `skills/channel-responder/SKILL.md` — §1d no longer claims to be the only write site; `--force` is documented as the fallback for turns the hook could not attribute.
- Tests — the two contract tests asserting the hook never writes for `<channel` become allowlisted / non-allowlisted / no-allowlist-configured / unparseable-envelope cases, plus two pipeline-level cases on the existing `setupChannelWorkdir` fixture.

Behavior for non-allowlisted senders is unchanged: stranger and bot traffic still cannot suppress AUTO_CLOSE.

## Test plan

- `bun test` from `plugins/claude-code-hermit/` — **4640 pass / 0 fail** across 150 files.
- `bunx tsc --noEmit` from the repo root — **exit 0**.
- The four new hook cases were confirmed **red against the pre-fix script** (142 pass / 4 fail) and green after, so they actually pin the regression.
- Post-release live check, not covered here: send one channel message and confirm `last-operator-action.json` advances with no `record-operator-action.ts --force` call in the transcript.

Closes #835