### PR TITLE
feat(claude-code-hermit): add a memory-size doctor check

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- New `memory-size` doctor check warns when a project `CLAUDE.md` or `CLAUDE.local.md` reaches 200 lines, or auto-memory `MEMORY.md` reaches 160 lines or 20 KB.
+
 ### Changed
 - Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator`, or `feature-dev`, and no longer seeds their `scheduled_checks` entries — Claude Code's native `Plan`/`Explore` agents, auto-memory, and `/doctor` CLAUDE.md trims cover the same ground, and every loaded skill description is paid on every API call of an always-on hermit. The `scheduled_checks` mechanism itself is unchanged; register any plugin's skill with `/hermit-settings scheduled-checks`.
 - `proposal-act` authors `## Skill Improvement` and `## Skill Draft` bodies in-main from the source brief instead of delegating to `skill-creator`; the falsification gate's read-only pass always uses the native `Plan` agent instead of `feature-dev:code-explorer`.

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -1813,6 +1813,71 @@ function checkModelPricingKnown(p: DoctorPaths = PATHS) {
   }
 }
 
+function checkMemorySize(p: DoctorPaths = PATHS) {
+  const CLAUDE_WARN_LINES = 200;
+  const MEMORY_WARN_LINES = 160;
+  const MEMORY_WARN_BYTES = 20 * 1024;
+  const projectRoot = path.dirname(p.hermitDir);
+
+  // A file saved with a trailing newline (the editor norm) has one more
+  // split() element than `wc -l` counts, which would trip every threshold a
+  // line early. Drop the trailing blank so the count matches what the operator
+  // sees on disk.
+  const countLines = (text: string): number => {
+    const segments = text.split(/\r?\n/);
+    return segments[segments.length - 1] === '' ? segments.length - 1 : segments.length;
+  };
+
+  try {
+    const parts: string[] = [];
+
+    for (const name of ['CLAUDE.md', 'CLAUDE.local.md']) {
+      const filePath = path.join(projectRoot, name);
+      if (!fs.existsSync(filePath)) continue;
+      try {
+        const lines = countLines(fs.readFileSync(filePath, 'utf8'));
+        if (lines >= CLAUDE_WARN_LINES) {
+          parts.push(`${name}: ${lines} lines (>=${CLAUDE_WARN_LINES}); use native /doctor to trim it`);
+        }
+      } catch (e: any) {
+        parts.push(`${name}: unreadable (${e.message})`);
+      }
+    }
+
+    // Same key scheme as lib/cc-compat.ts transcriptDirFor: Claude Code replaces
+    // every non-alphanumeric character, not just '/'. A '/'-only scheme mis-keys
+    // any dotted path — including every worktree under `.claude/worktrees/` —
+    // and the leg below would then read as a permanent, silent "ok".
+    const pathKey = projectRoot.replace(/[^a-zA-Z0-9]/g, '-');
+    const memoryPath = path.join(defaultConfigDir(), 'projects', pathKey, 'memory', 'MEMORY.md');
+    // Auto-memory loads only MEMORY.md's first 200 lines or 25 KB, whichever
+    // comes first, and drops the rest with no notice. The thresholds sit at 80%
+    // of that cap so there is room to consolidate before entries start vanishing.
+    if (fs.existsSync(memoryPath)) {
+      try {
+        const memory = fs.readFileSync(memoryPath, 'utf8');
+        const lines = countLines(memory);
+        const bytes = Buffer.byteLength(memory, 'utf8');
+        const bounds: string[] = [];
+        if (lines >= MEMORY_WARN_LINES) bounds.push(`${lines} lines (>=${MEMORY_WARN_LINES} line threshold)`);
+        if (bytes >= MEMORY_WARN_BYTES) bounds.push(`${(bytes / 1024).toFixed(1)} KB (>=20 KB byte threshold)`);
+        if (bounds.length > 0) {
+          parts.push(`MEMORY.md: ${bounds.join('; ')}; approaching the 200-line / 25 KB hard cap (whichever comes first is silently truncated)`);
+        }
+      } catch (e: any) {
+        parts.push(`MEMORY.md: unreadable (${e.message})`);
+      }
+    }
+
+    if (parts.length > 0) {
+      return { id: 'memory-size', status: 'warn', detail: parts.join('; ') };
+    }
+    return { id: 'memory-size', status: 'ok', detail: 'project CLAUDE files and auto-memory below warning thresholds' };
+  } catch (e: any) {
+    return { id: 'memory-size', status: 'fail', detail: `check failed: ${e.message}` };
+  }
+}
+
 // ----------------- Context scan -----------------
 // Reads the record startup-context.ts writes on every SessionStart: which
 // injected entries (compiled/ bodies, catalog summaries, OPERATOR/SHELL
@@ -2091,6 +2156,7 @@ async function runAllChecks(p: DoctorPaths = PATHS) {
     checkRawSize(p),
     checkCredentialExpiry(p),
     checkModelPricingKnown(p),
+    checkMemorySize(p),
     checkContextScan(p),
     checkVoiceCarrier(p),
     await checkChannelLiveness(p),
@@ -2218,7 +2284,7 @@ export {
   checkDockerSecurity, checkArchival, checkAutoClose, checkReflectLoop, checkScheduler,
   checkWatchdog, checkContextAge, checkOpusWake, checkRoutineCost, checkHeartbeat, checkRoutineMonitor,
   checkRoutinePrecheck, checkRawSize,
-  checkCredentialExpiry, checkModelPricingKnown, checkContextScan, checkVoiceCarrier, checkChannelLiveness,
+  checkCredentialExpiry, checkModelPricingKnown, checkMemorySize, checkContextScan, checkVoiceCarrier, checkChannelLiveness,
   satisfiesRange, cidrOverlap,
   // Tests build their own paths for a scratch dir; the CLI runs on the argv-derived default.
   resolvePaths,

--- a/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-doctor/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: hermit-doctor
-description: Returns a twenty-seven-check health report on the hermit installation (runtime, config, hooks, state-file integrity, cost, proposals, deps, version currency, permissions, docker, archival, auto-close queue, reflect loop, scheduler, watchdog, context age, opus-wake spend, routine cost, heartbeat, routine monitor, routine precheck, raw storage size, plugin credential expiry, model pricing, channel liveness, context scan, voice carrier). Use when diagnosing an install, before a release, or after suspicious behavior. Activates on messages like "/hermit-doctor", "health check", "diagnose the hermit", "what's wrong", "run diagnostic".
+description: Returns a twenty-eight-check health report on the hermit installation (runtime, config, hooks, state-file integrity, cost, proposals, deps, version currency, permissions, docker, archival, auto-close queue, reflect loop, scheduler, watchdog, context age, opus-wake spend, routine cost, heartbeat, routine monitor, routine precheck, raw storage size, plugin credential expiry, model pricing, memory size, context scan, voice carrier, channel liveness). Use when diagnosing an install, before a release, or after suspicious behavior. Activates on messages like "/hermit-doctor", "health check", "diagnose the hermit", "what's wrong", "run diagnostic".
 ---
 
 # Hermit Doctor
 
-Runs twenty-seven read-only health checks against the current hermit install (`channel-liveness`
+Runs twenty-eight read-only health checks against the current hermit install (`channel-liveness`
 is the only one that performs outbound API calls — see Notes) and surfaces the summary. Safe
 to run at any time. Produces no side effects beyond writing
 `.claude-code-hermit/state/doctor-report.json` and `.claude-code-hermit/state/doctor-alerts.json`,
@@ -35,19 +35,19 @@ The optional flag changes its destination, not whether doctor notifies:
    JSON to stdout. It exits 0 unconditionally — on any internal failure the failing
    check reports `status: "fail"` in its own entry rather than crashing the report.
 
-2. Parse the JSON. For each of the twenty-seven checks in the report (`runtime`, `config`, `hooks`, `state`, `cost`,
+2. Parse the JSON. For each of the twenty-eight checks in the report (`runtime`, `config`, `hooks`, `state`, `cost`,
    `proposals`, `dependencies`, `version-currency`, `permissions`, `docker-security`, `archive`, `auto-close`, `reflect`, `scheduler`, `watchdog`,
-   `context-age`, `opus-wake`, `routine-cost`, `heartbeat`, `routine-monitor`, `routine-precheck`, `raw-size`, `credential-expiry`, `model-pricing-known`, `context-scan`, `voice-carrier`, `channel-liveness`), emit one line using this format:
+   `context-age`, `opus-wake`, `routine-cost`, `heartbeat`, `routine-monitor`, `routine-precheck`, `raw-size`, `credential-expiry`, `model-pricing-known`, `memory-size`, `context-scan`, `voice-carrier`, `channel-liveness`), emit one line using this format:
    - `✓ <id> — <detail>` when `status: ok`
    - `⚠ <id> — <detail>` when `status: warn`
    - `✗ <id> — <detail>` when `status: fail`
 
 3. Append a summary section to `.claude-code-hermit/sessions/SHELL.md` under a new
-   `## Doctor Report (<ts>)` heading. Use the same twenty-seven lines from step 2. Place it
+   `## Doctor Report (<ts>)` heading. Use the same twenty-eight lines from step 2. Place it
    above the `## Monitoring` section so it sits with session-level context, not
    with monitoring chatter.
 
-4. Return the twenty-seven lines to the caller. Cap total output at 30 lines.
+4. Return the twenty-eight lines to the caller. Cap total output at 31 lines.
 
 5. **Escalation.** The script already computed this — do not recompute it, and do not write alert
    state yourself. Read the `escalation` object from the step-1 JSON:
@@ -84,10 +84,10 @@ The optional flag changes its destination, not whether doctor notifies:
 
 ## Silence policy
 
-- If every check is `ok`, return only: `All twenty-seven checks passed.` Do not notify via
+- If every check is `ok`, return only: `All twenty-eight checks passed.` Do not notify via
   channel (Tier 0). Still append to SHELL.md so the run is traceable. Clearing the stale
   `doctor:*` entries is the script's job, not yours — it happens on every run.
-- If any check is `warn` or `fail`, return the full twenty-seven-line summary. Notification is
+- If any check is `warn` or `fail`, return the full twenty-eight-line summary. Notification is
   governed by `escalation.new` (step 5), not a blanket per-run ping: only findings not yet
   confirmed delivered notify the selected route.
 
@@ -119,6 +119,7 @@ The optional flag changes its destination, not whether doctor notifies:
 | `raw-size` | Sums file sizes in `raw/` (plus `raw/.archive/`) and checks `runtime.json.last_raw_archive_at`. | `warn` if `raw/` exceeds 50 MB, or if raw files exist and the archive routine hasn't run in >14 days (or never); `ok` otherwise. |
 | `credential-expiry` | Executes each declared `hermit-meta.json` `credentials[].expiry_probe` (bash, 5s timeout, one-line `OK`/`EXPIRES:<iso>`/`EXPIRED` protocol) — core's own manifest plus every sibling plugin's. Core declares its `setup-token` credential this way, since nothing refreshes a long-lived token and renewal needs a human. Still does not check the Claude Code session's own OAuth *access* token — Claude Code refreshes that silently (~8h cycle, no operator action), so checking it produced false alarms. | `warn` if any credential is EXPIRED or inside its warn window (per-credential `warn_days`, default 7; core's setup-token uses 14), or if a probe times out or prints malformed output; `ok` otherwise (including when no plugin declares a credential). |
 | `model-pricing-known` | Compares `config.model`, each `routines[].model`, and `config.heartbeat.model` against the pricing table (`scripts/lib/pricing.ts`); also scans `.claude/cost-log.jsonl` for the last 7 days (inert today — cost-log model strings are pre-collapsed to `haiku\|sonnet\|opus` before logging, so this only activates once raw model ids persist). | `warn` naming every unpriced model and where it's configured — cost tracking silently falls back to sonnet pricing for unknowns; `ok` if every configured model is known. |
+| `memory-size` | Reads the project's `CLAUDE.md` and `CLAUDE.local.md`, plus its auto-memory `MEMORY.md` under `CLAUDE_CONFIG_DIR/projects/<project-path-key>/memory/`. | `warn` naming any project CLAUDE file at >=200 lines, or when `MEMORY.md` reaches >=160 lines or >=20 KB (ahead of the 200-line / 25 KB hard cap, whichever comes first and is silently truncated); `ok` otherwise, including absent files. |
 | `context-scan` | Reads `state/context-scan.json`, written by `startup-context.ts` on every `SessionStart` — which injected entries (compiled bodies/stubs, catalog summaries, OPERATOR.md/SHELL.md excerpts, last report) tripped the injection-marker scan and were blocked. The scan never mutates files; this check only surfaces its verdict. | `ok` if no record yet or the last scan found nothing; `warn` naming the blocked sources (content stays on disk — inspect or remove the flagged files) if any hit. |
 | `voice-carrier` | Compares `config.json`'s `voice` block against what is actually persisted: the winning `outputStyle` across local, project and user scope (`CLAUDE_CONFIG_DIR`), plus `.claude/output-styles/hermit-voice.md` for a custom voice. Boot re-renders both from config, so a mismatch means the hermit has not restarted since the change, or something outside it holds the key. | `ok` when they agree, or when no voice is configured — whatever style is persisted is then the operator's own and is only reported; `warn` naming both values when they disagree, or when a custom voice's style file is missing. A leftover voice file alongside a built-in voice is inert, not a warning. |
 | `channel-liveness` | For each enabled channel in `config.channels`, resolves its bot token from `<state_dir>/.env` and makes one token-authed liveness call (Telegram `getMe`, Discord `/users/@me`) with a 5s timeout. The only check that leaves the machine. | `ok` if reachable or no channels configured; `warn` if unreachable (timeout/network error) or no token configured; `fail` if the platform rejects the token (401/403 — bot token invalid or revoked). |

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -2258,11 +2258,11 @@ const DOCTOR_CHECK_IDS = [
   'runtime', 'config', 'hooks', 'state', 'cost', 'proposals', 'dependencies', 'version-currency',
   'permissions', 'docker-security', 'archive', 'auto-close', 'reflect', 'scheduler', 'watchdog', 'context-age',
   'opus-wake', 'routine-cost', 'heartbeat', 'routine-monitor', 'routine-precheck', 'raw-size', 'credential-expiry', 'model-pricing-known',
-  'context-scan', 'voice-carrier', 'channel-liveness',
+  'memory-size', 'context-scan', 'voice-carrier', 'channel-liveness',
 ];
 
 describe('doctor report contract (PROP-018 count pin)', () => {
-  test('report emits exactly the 27 pinned check ids, in order', withTmpdir(async (dir) => {
+  test('report emits exactly the 28 pinned check ids, in order', withTmpdir(async (dir) => {
     writeConfig(dir, {});
     const report = await runDoctorCheck(dir);
     expect((report.checks ?? []).map((c: any) => c.id)).toEqual(DOCTOR_CHECK_IDS);
@@ -2282,9 +2282,9 @@ describe('hermit-doctor SKILL.md doc-sync (no drift between JSON checks and docs
     expect(missing).toEqual([]);
   });
 
-  test('counts read twenty-seven, not twenty-six', () => {
-    expect(skill.toLowerCase()).not.toContain('twenty-six');
-    expect(skill.toLowerCase()).toContain('twenty-seven');
+  test('counts read twenty-eight, not twenty-seven', () => {
+    expect(skill.toLowerCase()).not.toContain('twenty-seven');
+    expect(skill.toLowerCase()).toContain('twenty-eight');
   });
 });
 

--- a/plugins/claude-code-hermit/tests/doctor-memory-size.test.ts
+++ b/plugins/claude-code-hermit/tests/doctor-memory-size.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { checkMemorySize, resolvePaths } from '../scripts/doctor-check';
+import { freshDirFactory } from './helpers/workdir';
+
+const PLUGIN_ROOT = path.resolve(import.meta.dir, '..');
+const { freshDir, cleanup } = freshDirFactory('hermit-memory-size-');
+afterAll(cleanup);
+
+type Fixture = {
+  claude?: string;
+  local?: string;
+  memory?: string;
+  memoryAsDir?: boolean;
+  /** Nest the project root under a dotted path, as every git worktree is. */
+  dottedRoot?: boolean;
+};
+
+function lines(count: number, content = 'x'): string {
+  return Array.from({ length: count }, () => content).join('\n');
+}
+
+function scenario({ claude, local, memory, memoryAsDir, dottedRoot }: Fixture) {
+  const projectRoot = dottedRoot
+    ? path.join(freshDir(), '.claude', 'worktrees', 'feat-x')
+    : freshDir();
+  const hermitDir = path.join(projectRoot, '.claude-code-hermit');
+  fs.mkdirSync(hermitDir, { recursive: true });
+
+  if (claude !== undefined) fs.writeFileSync(path.join(projectRoot, 'CLAUDE.md'), claude);
+  if (local !== undefined) fs.writeFileSync(path.join(projectRoot, 'CLAUDE.local.md'), local);
+
+  const configDir = freshDir();
+  // Claude Code's own key scheme: every non-alphanumeric character becomes '-'.
+  const pathKey = projectRoot.replace(/[^a-zA-Z0-9]/g, '-');
+  const memoryPath = path.join(configDir, 'projects', pathKey, 'memory', 'MEMORY.md');
+  if (memory !== undefined || memoryAsDir) {
+    fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
+    if (memoryAsDir) fs.mkdirSync(memoryPath);
+    else fs.writeFileSync(memoryPath, memory!);
+  }
+
+  const prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  try {
+    return checkMemorySize(resolvePaths(hermitDir, PLUGIN_ROOT));
+  } finally {
+    if (prevConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+  }
+}
+
+describe('doctor memory-size check', () => {
+  test('files below every threshold are healthy', () => {
+    const result = scenario({
+      claude: lines(199),
+      local: lines(199),
+      memory: lines(159),
+    });
+
+    expect(result.status).toBe('ok');
+  });
+
+  test('a 250-line CLAUDE.md warns with the file and native trim command', () => {
+    const result = scenario({ claude: lines(250) });
+
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('CLAUDE.md: 250 lines');
+    expect(result.detail).toContain('/doctor');
+  });
+
+  test('a 250-line CLAUDE.local.md warns on its own', () => {
+    const result = scenario({ local: lines(250) });
+
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('CLAUDE.local.md: 250 lines');
+    expect(result.detail).toContain('/doctor');
+  });
+
+  test('a 21 KB, 60-line MEMORY.md warns on the byte bound', () => {
+    const result = scenario({ memory: lines(60, 'x'.repeat(360)) });
+
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('MEMORY.md');
+    expect(result.detail).toContain('20 KB byte threshold');
+    expect(result.detail).not.toContain('line threshold');
+  });
+
+  test('a 170-line, 5 KB MEMORY.md warns on the line bound', () => {
+    const result = scenario({ memory: lines(170, 'x'.repeat(29)) });
+
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('170 lines');
+    expect(result.detail).toContain('160 line threshold');
+    expect(result.detail).not.toContain('byte threshold');
+  });
+
+  // The threshold has to mean what `wc -l` means. A real file ends in a newline,
+  // which a naive split() counts as an extra line and would warn one line early.
+  test('a trailing newline does not inflate the line count', () => {
+    expect(scenario({ claude: lines(199) + '\n' }).status).toBe('ok');
+    expect(scenario({ claude: lines(200) + '\n' }).status).toBe('warn');
+  });
+
+  // Every worktree lives under `.claude/worktrees/`, so a '/'-only path key would
+  // resolve to a directory that never exists and report a permanent false ok.
+  test('a dotted project path still resolves MEMORY.md', () => {
+    const result = scenario({ dottedRoot: true, memory: lines(170) });
+
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('MEMORY.md');
+  });
+
+  test('an absent MEMORY.md with clean CLAUDE files is healthy', () => {
+    const result = scenario({ claude: lines(20), local: lines(20) });
+
+    expect(result.status).toBe('ok');
+  });
+
+  test('an unreadable memory path degrades to warn without losing other findings', () => {
+    const result = scenario({ claude: lines(250), memoryAsDir: true });
+
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('MEMORY.md: unreadable');
+    expect(result.detail).toContain('CLAUDE.md: 250 lines');
+  });
+});

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -1955,14 +1955,14 @@ describe('channel-reply-reminder', () => {
 // -------------------------------------------------------
 
 describe('doctor-check', () => {
-  test('doctor-check (minimal install, 27 checks)', withDir(async (dir) => {
+  test('doctor-check (minimal install, 28 checks)', withDir(async (dir) => {
     seedDoctor(dir,
       '{"agent_name":"test","language":"en","timezone":"UTC","escalation":"balanced","channels":{},"env":{},"heartbeat":{"enabled":true,"active_hours":{"start":"08:00","end":"23:00"}},"routines":[]}');
     const report = await doctorReport(dir);
     expect(report.checks.map((c: any) => c.id)).toEqual([
       'runtime', 'config', 'hooks', 'state', 'cost', 'proposals', 'dependencies', 'version-currency',
       'permissions', 'docker-security', 'archive', 'auto-close', 'reflect', 'scheduler', 'watchdog', 'context-age', 'opus-wake', 'routine-cost', 'heartbeat',
-      'routine-monitor', 'routine-precheck', 'raw-size', 'credential-expiry', 'model-pricing-known', 'context-scan', 'voice-carrier', 'channel-liveness',
+      'routine-monitor', 'routine-precheck', 'raw-size', 'credential-expiry', 'model-pricing-known', 'memory-size', 'context-scan', 'voice-carrier', 'channel-liveness',
     ]);
   }));
 


### PR DESCRIPTION
## Summary

`hermit-doctor` had no check touching the always-loaded memory surface. The motivating case is `MEMORY.md`: auto-memory loads only its first 200 lines or 25 KB and silently drops the rest, so a hermit's own memory-first dedup degrades with no signal at all. This adds a 28th check, `memory-size`, warning at 80% of that cap so there is room to consolidate before entries start vanishing.

The `CLAUDE.md` half is advisory. The 200-line figure is a docs *recommendation*, not a cutoff — Claude Code loads a `CLAUDE.md` in full up to 4 MiB and skips it only above that — so this leg warns and points at native `/doctor`'s trim flow rather than reimplementing grading or reporting a healthy install as broken.

Closes #832.

## Changes

- `scripts/doctor-check.ts` — new `checkMemorySize()`, registered in `runAllChecks()` between `model-pricing-known` and `context-scan`. Warns on either project CLAUDE file at >=200 lines, or `MEMORY.md` at >=160 lines or >=20 KB. Per-file `try/catch` so one unreadable file degrades to a warn instead of collapsing the check, matching the sibling checks' convention.
- `skills/hermit-doctor/SKILL.md` — check count 27 to 28, new table row, output cap 30 to 31 lines.
- `tests/contracts.test.ts`, `tests/hooks.contract.test.ts` — both pinned check-id lists updated (the second one lives inline in the hooks contract test).
- `tests/doctor-memory-size.test.ts` — new, 9 cases.
- `CHANGELOG.md` — one `### Added` bullet.

Two details worth a reviewer's eye:

- **Path key.** The auto-memory key replaces every non-alphanumeric character, not just `/`, matching Claude Code's real scheme (`lib/cc-compat.ts` `transcriptDirFor`). Verified against live `~/.claude/projects/` entries, which key this repo's worktrees as `...-claude-code-hermit--claude-worktrees-...`. A `/`-only key resolves to a directory that never exists, which would have made the `MEMORY.md` leg a permanent silent `ok` for any project under a dotted path — including every git worktree.
- **Line counting.** A trailing newline is not counted as a line, so the threshold means what `wc -l` means rather than firing one line early on every normally-saved file.

Both have regression tests; neither was visible to the original fixtures, which used dot-free temp paths and newline-free strings.

Note: `scripts/docker-preflight.ts:46` carries the same `/`-only key derivation. Pre-existing and left alone here.

## Test plan

- `cd plugins/claude-code-hermit && bun test` → 4642 pass, 0 fail
- `bunx tsc --noEmit` (repo root) → exit 0
- `bun scripts/doctor-check.ts <hermit-dir> | jq '.checks[] | select(.id=="memory-size")'` → emits the new check with live figures in `detail`

Reviewers: the `contracts.test.ts` count pin plus its three doc-sync assertions are the real gate — they fail if any doc or test surface for a new check id is missed.
