### PR TITLE
fix(claude-code-hermit): re-arm dead monitors while the session rests at idle

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- The watchdog now re-arms a heartbeat or routine Monitor whose liveness has gone stale while the session rests at `idle`, instead of exiting above those tiers. A restart that caught a hermit resting left the daily `heartbeat-restart` anchor as the only recovery, and that anchor dies with the process in the same event, so heartbeat and routines could stay silent for a full day. The wedge nudge and the pane-frozen restart are still suppressed at `idle`.
+
 ### Changed
 - Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator`, or `feature-dev`, and no longer seeds their `scheduled_checks` entries — Claude Code's native `Plan`/`Explore` agents, auto-memory, and `/doctor` CLAUDE.md trims cover the same ground, and every loaded skill description is paid on every API call of an always-on hermit. The `scheduled_checks` mechanism itself is unchanged; register any plugin's skill with `/hermit-settings scheduled-checks`.
 - `proposal-act` authors `## Skill Improvement` and `## Skill Draft` bodies in-main from the source brief instead of delegating to `skill-creator`; the falsification gate's read-only pass always uses the native `Plan` agent instead of `feature-dev:code-explorer`.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 
 ### Fixed
-- The watchdog now re-arms a heartbeat or routine Monitor whose liveness has gone stale while the session rests at `idle`, instead of exiting above those tiers. A restart that caught a hermit resting left the daily `heartbeat-restart` anchor as the only recovery, and that anchor dies with the process in the same event, so heartbeat and routines could stay silent for a full day. The wedge nudge and the pane-frozen restart are still suppressed at `idle`.
+- The watchdog now re-arms a heartbeat or routine Monitor whose liveness has gone stale while the session rests at `idle`, instead of exiting above those tiers — previously heartbeat and routines could stay silent for a full day after a restart caught the hermit resting. The wedge nudge and the pane-frozen restart are still suppressed at `idle`.
+- `/claude-code-hermit:heartbeat stop` now deletes `state/heartbeat-liveness.json` alongside clearing the runtime file, so a stopped heartbeat is no longer re-armed by the watchdog once the leftover liveness timestamp ages out.
 
 ### Changed
 - Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator`, or `feature-dev`, and no longer seeds their `scheduled_checks` entries — Claude Code's native `Plan`/`Explore` agents, auto-memory, and `/doctor` CLAUDE.md trims cover the same ground, and every loaded skill description is paid on every API call of an always-on hermit. The `scheduled_checks` mechanism itself is unchanged; register any plugin's skill with `/hermit-settings scheduled-checks`.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-- The watchdog now re-arms a heartbeat or routine Monitor whose liveness has gone stale while the session rests at `idle`, instead of exiting above those tiers — previously heartbeat and routines could stay silent for a full day after a restart caught the hermit resting. The wedge nudge and the pane-frozen restart are still suppressed at `idle`.
-- `/claude-code-hermit:heartbeat stop` now deletes `state/heartbeat-liveness.json` alongside clearing the runtime file, so a stopped heartbeat is no longer re-armed by the watchdog once the leftover liveness timestamp ages out.
 ### Added
 - New `memory-size` doctor check warns when a project `CLAUDE.md` or `CLAUDE.local.md` reaches 200 lines, or auto-memory `MEMORY.md` reaches 160 lines or 20 KB.
 
@@ -16,6 +13,8 @@
 ### Fixed
 - `sessions/.status.json` no longer carries a resolved (`~` / `[resolved]`) blocker in its `blockers` field, so `bin/hermit-status` stops printing `BLOCKED:` for a blocker the session already cleared. A comment-only blocker bullet no longer leaves a bare `-` there either.
 - Channel messages from a sender that clears `allowed_users` now advance the operator-activity clock from the `UserPromptSubmit` hook, so a chat-only conversation no longer reads as silence to the post-close `/clear`, the 12h auto-close, and the context-hygiene backoff. Other senders are still ignored.
+- The watchdog now re-arms a heartbeat or routine Monitor whose liveness has gone stale while the session rests at `idle`, instead of exiting above those tiers — previously heartbeat and routines could stay silent for a full day after a restart caught the hermit resting. The wedge nudge and the pane-frozen restart are still suppressed at `idle`.
+- `/claude-code-hermit:heartbeat stop` now deletes `state/heartbeat-liveness.json` alongside clearing the runtime file, so a stopped heartbeat is no longer re-armed by the watchdog once the leftover liveness timestamp ages out.
 
 ### Upgrade Instructions
 - **Decide whether to keep the plugins hatch used to recommend.** Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator` or `feature-dev`; Claude Code covers them natively (see `${CLAUDE_PLUGIN_ROOT}/docs/recommended-plugins.md`). Nothing is removed for you. First, unconditionally delete `.claude-code-hermit/.baseline-pending` if it exists. Then inventory: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/settings-edit.ts" .claude-code-hermit/config.json get scheduled_checks` for entries whose `plugin` is `claude-code-setup` or `claude-md-management`; `… get docker.recommended_plugins` for entries naming any of the four; `claude plugin list` for any of the four installed. If all three are empty, skip silently. Otherwise this is the operator's decision with no default: **defer per SKILL.md Step 10** with `options: ["Keep", "Remove"]` and no `on_resolve`; the choice is applied in attended Step 10 only.

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -143,12 +143,12 @@ Steps 1–3 are **scheduler-owned context-hygiene** — the watchdog script runs
 2. If context-clear conditions met (prompt tokens over `watchdog.context_clear_tokens`, always-on, quiescent, operator silent) → send `/clear`, exit.
 3. If routine-hygiene compact conditions met (see `context_hygiene.compact` below) → send `/compact`, exit.
 4. If `enabled: false` → exit (restart/nudge machinery disabled).
-5. Read `runtime.json`. If explicit shutdown markers are set, the runtime is interactive, or no tmux session is named → exit. `session_state == idle` is supervision-only, not an immediate exit: the alert tiers below still run.
+5. Read `runtime.json`. If explicit shutdown markers are set, the runtime is interactive, or no tmux session is named → exit. `session_state == idle` is supervision-only, not an immediate exit: the alert tiers and the monitor re-arms below still run.
 6. If an active session's tmux session is gone → restart, unless fresh shared-liveness says the process survived without tmux; in that orphan shape, alert and exit instead of starting a duplicate.
 7. If a re-auth relay was spawned or remains active → exit while it owns recovery.
 8. If the captured pane shows a stalled dialog → send one deduplicated operator alert for the episode.
 9. If the transcript ends with an `enqueue` that has not drained for 30 minutes while tmux is alive → send one deduplicated `session-wedged` alert for the episode.
-10. If a dialog is pending, or the session is supervision-only (`idle`) → exit before any tier that sends keystrokes or restarts the session.
+10. If a dialog is pending → exit before any tier that sends keystrokes or restarts the session. A supervision-only (`idle`) session skips step 11's wedge nudge and pane-frozen restart, but still reaches the monitor re-arms in steps 12 and 13 — a hermit rests at `idle`, so that is where a dead Monitor has to be recovered from.
 11. If the heartbeat is stale and the operator is quiet and the pane is frozen for `escalate_after` cycles → restart. Before that threshold: nudge (`/claude-code-hermit:heartbeat run`).
 12. If the in-session 4am `heartbeat-restart` routine missed its fire (last fired > 26h ago) → send-keys re-arm fallback.
 13. If heartbeat or routine Monitor liveness is stale → re-arm the missing monitor.

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -1591,6 +1591,12 @@ async function main(): Promise<void> {
             watchdogState.last_pane_hash = currentPaneHash;
             writeWatchdogState(watchdogState);
             await doRestart(sessionName, 'pane-frozen', runtime, timezone);
+            // doRestart kills the tmux session and spawns a detached replacement, so the
+            // verdict cached at step 3c is stale from here on. Steps 5 and 6 below send
+            // keys into this pane and guard on it: reusing the pre-restart `true` would
+            // inject slash commands into a killed (or still-booting) session and burn the
+            // per-monitor re-arm damper for 6h on a send that never landed.
+            sessionAlive = tmuxSessionAlive(sessionName);
           } else {
             doNudge(sessionName, watchdogState, consecutive, currentPaneHash, timezone, staleThresholdSecs);
           }

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -767,10 +767,10 @@ export function rearmDamperOpen(lastStamp: unknown, world: World = REAL_WORLD): 
  * neither stamps the operator-activity clock). `alreadyRearmed` short-circuits when
  * step 5 already fired doRearm this tick — that re-armed both, nothing left to do.
  */
-function maybeMonitorRearm(config: Json, sessionName: string, operatorGraceSecs: number, alreadyRearmed: boolean): void {
+function maybeMonitorRearm(config: Json, sessionName: string, sessionAlive: boolean, operatorGraceSecs: number, alreadyRearmed: boolean): void {
   if (alreadyRearmed) return;
   if (isPaused(HERMIT_ROOT).paused) return;               // no injection while paused (mirrors doNudge)
-  if (!tmuxSessionAlive(sessionName)) return;             // dead session belongs to the doRestart path
+  if (!sessionAlive) return;                              // dead session belongs to the doRestart path
   const opAge = getOperatorLastActionAgeSecs();
   if (opAge !== null && opAge < operatorGraceSecs) return; // operator mid-conversation — back off
 
@@ -1493,8 +1493,11 @@ async function main(): Promise<void> {
   // condition this tier always documented has to actually be tested. 3b needs no equivalent —
   // capturePane returns null on a dead session and the `paneContent !== null` check catches it.
   // Reuses step 3's verdict when it ran; falls back to a fresh check when it didn't —
-  // 'idle' (the path this fix enables) and any other unlisted session_state.
-  if (sessionAlive ?? tmuxSessionAlive(sessionName)) {
+  // 'idle' (the path this fix enables) and any other unlisted session_state. The fallback
+  // is cached back, not discarded: on an idle arc step 3 never ran, so this is the tick's
+  // only has-session call and steps 5 and 6 below reuse it rather than spawning tmux again.
+  sessionAlive = sessionAlive ?? tmuxSessionAlive(sessionName);
+  if (sessionAlive) {
     // `opened_transcript` — the CC transcript UUID that names the .jsonl file.
     // `session_id` is the logical S-NNN arc id and resolves to a path that never exists.
     const transcriptId = typeof runtime.opened_transcript === 'string' ? runtime.opened_transcript : null;
@@ -1526,28 +1529,31 @@ async function main(): Promise<void> {
   // auto-answering a decision that is always the operator's to make.
   if (pendingQuestion) process.exit(0);
 
-  // Supervision-only boundary. Everything below this line sends keystrokes into the pane
-  // (steps 4 and 5) or restarts the session (the pane-frozen path inside step 4, and the
-  // monitor re-arm in step 6) on the watchdog's own initiative. An idle session arc gets
-  // the observe/notify tiers above and never these, which is what keeps "never resurrect a
-  // deliberately-stopped hermit" true now that step 2 no longer exits on it — and a
-  // deliberately-stopped hermit is not merely 'idle' anyway: hermit-stop always stamps
-  // shutdown_completed_at, which step 2 still hard-exits on.
+  // Supervision-only scope. An idle session arc suppresses step 4 — the wedge nudge and the
+  // pane-frozen restart, the two tiers that act on a pane whose intent the watchdog cannot
+  // read. It does NOT suppress the re-arm injections in steps 5 and 6: a hermit rests at
+  // 'idle' between arcs, so that is exactly where a dead heartbeat/routine Monitor has to be
+  // recovered from, and until this it was not — the only recovery was the daily
+  // heartbeat-restart anchor, a CronCreate that dies with the process it was registered in,
+  // i.e. in the same event that kills the monitors. Those steps carry their own guards
+  // (pause, dead tmux, operator-recency, a per-monitor damper) and inject only slash commands
+  // whose skills are stop-then-start idempotent, so a re-arm cannot stack duplicate Monitors.
   //
-  // Step 3's dead-session restart needs no equivalent guard: its state whitelist
+  // "Never resurrect a deliberately-stopped hermit" still holds: hermit-stop stamps
+  // shutdown_completed_at, which step 2 hard-exits on — a stopped hermit is never merely
+  // 'idle'. Step 3's dead-session restart needs no guard either: its state whitelist
   // (in_progress / waiting / suspect_process) already excludes 'idle'.
   //
-  // Step 3a is the one tier above this line that can eventually reach a restart: the
-  // re-auth relay's `finish` verb calls requestRestart() once the operator has completed
-  // the browser sign-in. That is deliberate — an expired setup-token strands a RESTING
-  // hermit just as hard as a working one, and the restart only happens after the operator
-  // acts on the relay's message, so it is operator-initiated, not watchdog-initiated.
-  if (supervisionOnly) process.exit(0);
+  // Step 3a can also reach a restart from an idle arc: the re-auth relay's `finish` verb
+  // calls requestRestart() once the operator has completed the browser sign-in. That is
+  // deliberate — an expired setup-token strands a RESTING hermit just as hard as a working
+  // one, and the restart only follows the operator acting on the relay's message.
 
-  // 4. Wedge detection (only when heartbeat is enabled + within active hours)
+  // 4. Wedge detection (only when heartbeat is enabled + within active hours, and never on an
+  //    idle arc — see the supervision-only scope note above)
   const heartbeatCfg = config?.heartbeat ?? {};
   const heartbeatIsObj = heartbeatCfg && typeof heartbeatCfg === 'object' && !Array.isArray(heartbeatCfg);
-  if (heartbeatIsObj && ('enabled' in heartbeatCfg ? heartbeatCfg.enabled : true)) {
+  if (!supervisionOnly && heartbeatIsObj && ('enabled' in heartbeatCfg ? heartbeatCfg.enabled : true)) {
     const activeHours = heartbeatCfg.active_hours;
     const activeHoursIsObj = activeHours && typeof activeHours === 'object' && !Array.isArray(activeHours);
     if (!activeHoursIsObj || inActiveHours(activeHours, config.timezone ?? 'UTC')) {
@@ -1616,7 +1622,7 @@ async function main(): Promise<void> {
     // Only re-arm when operator is silent (not in the middle of a conversation)
     if (opAge === null || opAge >= operatorGraceSecs) {
       const watchdogState = readWatchdogState();
-      if (rearmDamperOpen(watchdogState.last_rearm_fallback) && tmuxSessionAlive(sessionName)) {
+      if (rearmDamperOpen(watchdogState.last_rearm_fallback) && sessionAlive) {
         doRearm(sessionName, config);
         watchdogState.last_rearm_fallback = utcStamp();
         writeWatchdogState(watchdogState);
@@ -1628,7 +1634,7 @@ async function main(): Promise<void> {
   // 6. Liveness-keyed monitor re-arm: recover a heartbeat/routine Monitor that died
   // mid-session, detected via its stale liveness file rather than step 5's fired-age
   // heuristic (which needs a model-issued 'fired' metric that can be missing).
-  maybeMonitorRearm(config, sessionName, operatorGraceSecs, rearmedThisTick);
+  maybeMonitorRearm(config, sessionName, sessionAlive, operatorGraceSecs, rearmedThisTick);
 }
 
 // --- Install / uninstall ---

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -96,7 +96,7 @@ The monitor's poll interval is fixed at registration from `heartbeat.every`. The
 ### stop
 
 1. Read `state/heartbeat-monitor.runtime.json`. If a `task_id` is present, TaskStop it.
-2. Clear `state/heartbeat-monitor.runtime.json` (write `{}`).
+2. Clear `state/heartbeat-monitor.runtime.json` (write `{}`). Delete `state/heartbeat-liveness.json` if it exists — the cleared runtime file has no `started_at`, so a leftover `last_peek_at` would be trusted as current and read fresh until it ages past the threshold, after which the watchdog re-arms the heartbeat the operator just stopped.
 3. Sweep legacy CronCreate: `CronList` → `CronDelete` any entry whose `prompt` matches `/claude-code-hermit:heartbeat run`. Belt-and-suspenders.
 4. Append to SHELL.md Monitoring: `[HH:MM] Heartbeat: stopped`.
 

--- a/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
@@ -4,7 +4,7 @@ description: Schedules routines via one persistent Monitor subprocess (zero-toke
 ---
 # Routines
 
-Register and manage scheduled routines. Where the Monitor tool is available, all enabled routines except `heartbeat-restart` run from ONE persistent Monitor subprocess that decides eligibility outside the session — a skipped fire costs zero model tokens. `heartbeat-restart` stays a CronCreate **re-arm anchor**: its skill IS `load`, so its daily fire re-arms the monitor and the anchor CronCreate — and, unless `heartbeat.enabled` is explicitly false, restores the heartbeat monitor too (the only heartbeat recovery that reaches a resting session; the watchdog is supervision-only at `idle`). Where Monitor is unavailable (Bedrock/Google Cloud Agent Platform/Foundry, `DISABLE_TELEMETRY`/`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`), `load` falls back to per-routine CronCreates.
+Register and manage scheduled routines. Where the Monitor tool is available, all enabled routines except `heartbeat-restart` run from ONE persistent Monitor subprocess that decides eligibility outside the session — a skipped fire costs zero model tokens. `heartbeat-restart` stays a CronCreate **re-arm anchor**: its skill IS `load`, so its daily fire re-arms the monitor and the anchor CronCreate — and, unless `heartbeat.enabled` is explicitly false, restores the heartbeat monitor too. The watchdog re-arms a monitor whose liveness has gone stale as a second net, on a resting session too. Where Monitor is unavailable (Bedrock/Google Cloud Agent Platform/Foundry, `DISABLE_TELEMETRY`/`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`), `load` falls back to per-routine CronCreates.
 
 ## Usage
 
@@ -75,7 +75,7 @@ Replace `<pluginRoot>`, `<id>`, `<rdw>` (`true`/`false`; default `false`), and `
 ```
 Then read heartbeat.enabled from .claude-code-hermit/config.json: unless it is explicitly false, invoke /claude-code-hermit:heartbeat start to re-register the heartbeat monitor.
 ```
-The condition is checked at fire time, never baked in at registration, so flipping `heartbeat.enabled` takes effect at the next 4am fire. It keeps `false` meaning off (bootstrap and the watchdog's re-arms honour it the same way — see `doRearm` in `hermit-watchdog.ts`), while the daily fire stays the only heartbeat-monitor recovery that reaches a resting session: the watchdog goes supervision-only at `session_state: idle` and never re-arms there, and a healthy hermit rests at `idle` between arcs. An operator with `heartbeat.enabled: false` who wants one for just the current session types `/claude-code-hermit:heartbeat start` themselves.
+The condition is checked at fire time, never baked in at registration, so flipping `heartbeat.enabled` takes effect at the next 4am fire. It keeps `false` meaning off (bootstrap and the watchdog's re-arms honour it the same way — see `doRearm` in `hermit-watchdog.ts`). The daily fire is not the only recovery that reaches a resting session: the watchdog also re-arms a monitor whose liveness file has gone stale, at `session_state: idle` included, which is where a healthy hermit rests between arcs. An operator with `heartbeat.enabled: false` who wants one for just the current session types `/claude-code-hermit:heartbeat start` themselves.
 
 **`reflect_after: true`:** append after the trailing `finish` call (and after the `heartbeat-restart` append if both apply). Skip when `skill` is `claude-code-hermit:reflect` — chaining reflect after reflect is a config foot-gun.
 ```

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -1593,6 +1593,48 @@ test('idle arc + heartbeat-restart missed > 26h → re-arm-fallback', withHermit
   expect(tmuxCalls(h)).toContain('/claude-code-hermit:hermit-routines load');
 }));
 
+// 11g. The re-arm tiers must not reuse a pre-restart aliveness verdict.
+//
+// Step 4's pane-frozen escalation falls through to steps 5 and 6 (doRestart returns, it
+// does not exit). Both guard on `sessionAlive`, which step 3c caches — so the verdict has
+// to be refreshed after the restart killed the pane, or the tick injects slash commands
+// into a session that no longer exists and stamps the 6h per-monitor damper on a send
+// that never landed.
+test('pane-frozen restart → no monitor re-arm into the killed session', withHermit(async (h) => {
+  writeConfig(h);
+  touchAgo(state(h, '.heartbeat'), 6 * 3600);
+  // Stale heartbeat-monitor liveness: step 6 would fire if it trusted the cached verdict.
+  writeState(h, 'heartbeat-monitor.runtime.json', { started_at: isoAgo(9) });
+  writeState(h, 'heartbeat-liveness.json', { last_peek_at: isoAgo(8) });
+
+  const paneContent = 'frozen pane';
+  const frozenHash = crypto.createHash('sha256').update(`${paneContent}\n`).digest('hex');
+  writeState(h, 'watchdog-state.json', {
+    consecutive_stale: 2, last_pane_hash: frozenHash, last_nudge_at: '2026-01-01T00:00:00Z',
+  });
+
+  // tmux stub that actually dies on kill-session, unlike the always-alive writeFakeTmux.
+  const log = path.join(h.dir, 'tmux-calls.log');
+  const deadMarker = path.join(h.dir, 'tmux-dead');
+  const stub = path.join(h.fakeBin, 'tmux');
+  fs.writeFileSync(stub, `#!/usr/bin/env bash
+case "$1" in
+  has-session) [[ -f "${deadMarker}" ]] && exit 1 ; exit 0 ;;
+  capture-pane) echo "${paneContent}" ;;
+  send-keys) echo "send-keys $@" >> "${log}" ;;
+  kill-session) echo "kill-session $@" >> "${log}" ; touch "${deadMarker}" ;;
+esac
+`);
+  fs.chmodSync(stub, 0o755);
+  writeFakePgrep(h, 1);
+
+  const r = await watchdog(h, 'run');
+  expect(r.exitCode).toBe(0);
+  expect(tmuxCalls(h)).toContain('kill-session');
+  expect(tmuxCalls(h)).not.toContain('/claude-code-hermit:heartbeat start');
+  expect(events(h)).not.toContain('monitor-rearm');
+}));
+
 // -------------------------------------------------------
 // 12. checkWatchdog in doctor-check.ts: disabled → ok
 // -------------------------------------------------------

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -1040,8 +1040,11 @@ test('idle arc + DEAD tmux + stale enqueue tail → no wedge event', withHermit(
   } finally { stub.stop(); }
 }));
 
-// The other half of the contract: reaching the alert tiers must NOT hand an idle arc back
-// to the keystroke tiers. "Never resurrect a deliberately-stopped hermit" still holds.
+// The other half of the contract: reaching the alert tiers must NOT hand an idle arc back to
+// the wedge nudge or the pane-frozen restart. "Never resurrect a deliberately-stopped hermit"
+// still holds. The re-arm tiers (steps 5 and 6) DO run at idle — see section 11f — but stay
+// silent here: this fixture writes no monitor liveness, no monitor runtime and no
+// routine-metrics.jsonl, so neither tier has a stale signal to act on.
 test('idle arc + stale heartbeat + monitor down → no nudge, no restart, no keystrokes', withHermit(async (h) => {
   writeConfig(h);
   configureChannel(h);
@@ -1533,6 +1536,61 @@ test('routine monitor in croncreate-fallback mode → no re-arm', withHermit(asy
   const r = await watchdog(h, 'run');
   expect(r.exitCode).toBe(0);
   expect(events(h)).not.toContain('monitor-rearm');
+}));
+
+// 11f. The same re-arms on an IDLE session arc.
+//
+// A hermit rests at 'idle' between arcs, so that is where a Monitor that died has to be
+// recovered from. Before this, the supervision-only cut exited above steps 5 and 6, and the
+// only recovery left was the daily heartbeat-restart anchor — a CronCreate that dies with the
+// process it was registered in, i.e. in the same event that kills the monitors. A restart
+// catching the hermit at 'idle' therefore silenced heartbeat and routines until an operator
+// noticed. Idle still suppresses step 4 (the nudge and the pane-frozen restart); that half of
+// the contract is pinned in section 5b.
+// -------------------------------------------------------
+
+test('idle arc + stale heartbeat liveness → monitor-rearm, heartbeat start injected', withHermit(async (h) => {
+  writeConfig(h);
+  patchRuntime(h, { session_state: 'idle' });
+  writeState(h, 'heartbeat-monitor.runtime.json', { started_at: isoAgo(9) });
+  writeState(h, 'heartbeat-liveness.json', { last_peek_at: isoAgo(8) });
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 1);
+  const r = await watchdog(h, 'run');
+  expect(r.exitCode).toBe(0);
+  expect(events(h)).toContain('monitor-rearm');
+  const calls = tmuxCalls(h);
+  expect(calls).toContain('/claude-code-hermit:heartbeat start');
+  expect(calls).not.toContain('hermit-routines load');
+}));
+
+test('idle arc + stale routine-monitor liveness → monitor-rearm, hermit-routines load injected', withHermit(async (h) => {
+  writeRoutineMonitorConfig(h);
+  patchRuntime(h, { session_state: 'idle' });
+  writeState(h, 'routine-monitor.runtime.json', { started_at: isoAgo(25 / 60), interval: 60, mode: 'monitor' });
+  writeState(h, 'routine-monitor-liveness.json', { last_peek_at: isoAgo(20 / 60) });
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 1);
+  const r = await watchdog(h, 'run');
+  expect(r.exitCode).toBe(0);
+  expect(events(h)).toContain('monitor-rearm');
+  const calls = tmuxCalls(h);
+  expect(calls).toContain('/claude-code-hermit:hermit-routines load');
+  expect(calls).not.toContain('heartbeat start');
+}));
+
+test('idle arc + heartbeat-restart missed > 26h → re-arm-fallback', withHermit(async (h) => {
+  writeConfig(h);
+  patchRuntime(h, { session_state: 'idle' });
+  fs.writeFileSync(state(h, 'routine-metrics.jsonl'), JSON.stringify({
+    ts: isoAgoSeconds(28), routine_id: 'heartbeat-restart', event: 'fired', delivery: 'cron-create',
+  }) + '\n');
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 0);
+  const r = await watchdog(h, 'run');
+  expect(r.exitCode).toBe(0);
+  expect(events(h)).toContain('re-arm-fallback');
+  expect(tmuxCalls(h)).toContain('/claude-code-hermit:hermit-routines load');
 }));
 
 // -------------------------------------------------------


### PR DESCRIPTION
## Summary

A hermit sits at `session_state: idle` between arcs, and the watchdog's supervision-only cut exited above the re-arm tiers there. When the heartbeat and routine Monitors died, the only recovery left was the daily `heartbeat-restart` anchor, a CronCreate that dies with the process it was registered in, i.e. in the very event that kills the monitors. A restart catching the hermit resting could silence heartbeat and routines for a full day, discovered only when the operator noticed the silence.

The fix is a scoping change, not new machinery: the cut now guards step 4 alone.

Closes #834

## Changes

- **`hermit-watchdog.ts`** — dropped the blanket `if (supervisionOnly) process.exit(0)`; step 4's existing condition now carries `!supervisionOnly`. An idle arc still skips the wedge nudge and the pane-frozen restart, but reaches the step 5 re-arm fallback and the step 6 liveness-keyed monitor re-arm. Those already carry every guard this needs (pause, dead tmux, operator-recency, a per-monitor 6h damper) and inject only `hermit-routines load` / `heartbeat start`, both stop-then-start idempotent, so a re-arm cannot stack duplicate Monitors. `hermit-routines load` also re-creates the anchor, covering the case where it vanished too.
- **`hermit-watchdog.ts`** — reaching step 6 on the common idle path exposed a latent double spawn: step 3c asked `tmux has-session` and discarded the verdict, so step 6 asked again. The verdict is now cached into `sessionAlive` and threaded through steps 5 and 6, which is what the comment above step 3 already promised. Without this the change would have doubled per-tick tmux spawns on the path hermits sit in most.
- **`watchdog.test.ts`** — new section 11f pins the idle re-arm contract (stale heartbeat liveness, stale routine-monitor liveness, `heartbeat-restart` missed >26h). Amended the section-5b comment explaining why the existing no-keystrokes test stays silent.
- **`docs/config-reference.md`, `skills/hermit-routines/SKILL.md`** — retired the "the watchdog never re-arms at idle" / "the daily fire is the only recovery that reaches a resting session" claims.

Rejected from the issue's proposed options: a separate idle-only liveness check would duplicate `maybeMonitorRearm`; a `CronList` probe for the anchor is impossible (the watchdog is a Bun process, not the model) and unnecessary since `load` re-creates it; persisting the anchor outside `CronCreate` has no harness mechanism.

## Test plan

- `bun test` from `plugins/claude-code-hermit` — **4636 pass / 0 fail**.
- `bunx tsc --noEmit` from the repo root — **exit 0**.
- Red-first verified: with the `hermit-watchdog.ts` change stashed, the three new section-11f tests fail and the seven existing section-5b idle tests still pass, so they pin the new behavior rather than passing vacuously.
- The section-5b contract (idle raises alerts but sends no keystrokes and never restarts) is unchanged and still green.