### PR TITLE
fix(claude-code-hermit): drop resolved blockers from .status.json

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `proposal-act` authors `## Skill Improvement` and `## Skill Draft` bodies in-main from the source brief instead of delegating to `skill-creator`; the falsification gate's read-only pass always uses the native `Plan` agent instead of `feature-dev:code-explorer`.
 - The first-session baseline audit offer (`.baseline-pending`) is removed along with the plugins it audited.
 
+### Fixed
+- `sessions/.status.json` no longer carries a resolved (`~` / `[resolved]`) blocker in its `blockers` field, so `bin/hermit-status` stops printing `BLOCKED:` for a blocker the session already cleared.
+
 ### Upgrade Instructions
 - **Decide whether to keep the plugins hatch used to recommend.** Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator` or `feature-dev`; Claude Code covers them natively (see `${CLAUDE_PLUGIN_ROOT}/docs/recommended-plugins.md`). Nothing is removed for you. First, unconditionally delete `.claude-code-hermit/.baseline-pending` if it exists. Then inventory: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/settings-edit.ts" .claude-code-hermit/config.json get scheduled_checks` for entries whose `plugin` is `claude-code-setup` or `claude-md-management`; `… get docker.recommended_plugins` for entries naming any of the four; `claude plugin list` for any of the four installed. If all three are empty, skip silently. Otherwise this is the operator's decision with no default: **defer per SKILL.md Step 10** with `options: ["Keep", "Remove"]` and no `on_resolve`; the choice is applied in attended Step 10 only.
   **Keep:** change nothing; tell the operator once that the listed checks keep running and that `/claude-code-hermit:hermit-settings scheduled-checks` disables or removes them later.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -8,7 +8,7 @@
 - The first-session baseline audit offer (`.baseline-pending`) is removed along with the plugins it audited.
 
 ### Fixed
-- `sessions/.status.json` no longer carries a resolved (`~` / `[resolved]`) blocker in its `blockers` field, so `bin/hermit-status` stops printing `BLOCKED:` for a blocker the session already cleared.
+- `sessions/.status.json` no longer carries a resolved (`~` / `[resolved]`) blocker in its `blockers` field, so `bin/hermit-status` stops printing `BLOCKED:` for a blocker the session already cleared. A comment-only blocker bullet no longer leaves a bare `-` there either.
 
 ### Upgrade Instructions
 - **Decide whether to keep the plugins hatch used to recommend.** Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator` or `feature-dev`; Claude Code covers them natively (see `${CLAUDE_PLUGIN_ROOT}/docs/recommended-plugins.md`). Nothing is removed for you. First, unconditionally delete `.claude-code-hermit/.baseline-pending` if it exists. Then inventory: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/settings-edit.ts" .claude-code-hermit/config.json get scheduled_checks` for entries whose `plugin` is `claude-code-setup` or `claude-md-management`; `… get docker.recommended_plugins` for entries naming any of the four; `claude plugin list` for any of the four installed. If all three are empty, skip silently. Otherwise this is the operator's decision with no default: **defer per SKILL.md Step 10** with `options: ["Keep", "Remove"]` and no `on_resolve`; the choice is applied in attended Step 10 only.

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -12,7 +12,7 @@ import { kStr, formatTokens } from './lib/format';
 import { sessionId as ccSessionId, transcriptPath as ccTranscriptPath, readTailLines, entryText, isToolResult, extractUsage, isCompactBoundary, turnPromptText, toolUseNames, costLogPath, hermitDir } from './lib/cc-compat';
 import { costIndexPath, updateCostIndex, readCostIndex, scanCostLogWarnings, buildMainCostRow, buildSubagentCostRow, appendCostRows } from './lib/cost-log';
 import { todayYMD, thisWeekKey, thisMonthYYYYMM, friendlyBoundary } from './lib/time';
-import { extractSection, stripPlaceholders } from './lib/md-write';
+import { extractSection, isResolvedBlockerLine, stripPlaceholders } from './lib/md-write';
 import { mutateOwnedAlerts, budgetAlertsPath } from './lib/alert-state';
 import { readSettledConfig } from './lib/config-read';
 import { setPause, isPaused } from './lib/pause';
@@ -500,7 +500,13 @@ function writeStatusJson(shellContent: string, cumulative: { cost: number; token
 
   const task = stripPlaceholders(taskSection ?? '');
 
-  const blockersText = stripPlaceholders(blockersSection ?? '');
+  // Resolved (`~` / `[resolved]`) entries are dropped, matching the other blocker
+  // surfaces: bin/hermit-status prints this field verbatim as "BLOCKED: …".
+  const blockersText = stripPlaceholders(blockersSection ?? '')
+    .split('\n')
+    .filter(l => !isResolvedBlockerLine(l))
+    .join('\n')
+    .trim();
   const hasBlockers = blockersText.length > 0 && !/^none$/i.test(blockersText);
 
   const statusData = {

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -502,9 +502,11 @@ function writeStatusJson(shellContent: string, cumulative: { cost: number; token
 
   // Resolved (`~` / `[resolved]`) entries are dropped, matching the other blocker
   // surfaces: bin/hermit-status prints this field verbatim as "BLOCKED: …".
+  // The dash filter drops the bare "-" a comment-only bullet leaves behind once
+  // stripPlaceholders runs (startup-context's dropBulletResidue, same shape).
   const blockersText = stripPlaceholders(blockersSection ?? '')
     .split('\n')
-    .filter(l => !isResolvedBlockerLine(l))
+    .filter(l => !isResolvedBlockerLine(l) && !/^\s*-+\s*$/.test(l))
     .join('\n')
     .trim();
   const hasBlockers = blockersText.length > 0 && !/^none$/i.test(blockersText);

--- a/plugins/claude-code-hermit/tests/cost-tracker-status-writer.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-tracker-status-writer.test.ts
@@ -173,4 +173,11 @@ describe('cost-tracker: blockers drops resolved entries', () => {
     const status = await statusFor(['[resolved] cleared blocker']);
     expect(status.blockers).toBeNull();
   });
+
+  // A comment-only bullet leaves a bare "-" once stripPlaceholders removes the
+  // comment; unfiltered it reaches the operator as "BLOCKED: -".
+  test('a comment-only bullet does not leave a bare dash', async () => {
+    const status = await statusFor(['- <!-- resolved: operator supplied the API key -->']);
+    expect(status.blockers).toBeNull();
+  });
 });

--- a/plugins/claude-code-hermit/tests/cost-tracker-status-writer.test.ts
+++ b/plugins/claude-code-hermit/tests/cost-tracker-status-writer.test.ts
@@ -12,7 +12,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { runScript, PLUGIN_ROOT } from './helpers/run';
-import { fixturesDir, writeConfig } from './helpers/workdir';
+import { fixturesDir, freshDirFactory, writeConfig } from './helpers/workdir';
 import { triggerPrompt, assistantEntryFor as assistantEntry } from './helpers/transcript';
 
 describe('cost-tracker: writeStatusJson populates status/task from real state', () => {
@@ -121,5 +121,56 @@ describe('cost-tracker: a ### sub-heading does not hijack the section read', () 
   test('blockers reads the real ## Blockers section, not the ### decoy', () => {
     const status = JSON.parse(fs.readFileSync(statusPath, 'utf-8'));
     expect(status.blockers).toBe('the real blocker');
+  });
+});
+
+// GH #828: the `blockers` field must drop `~`/`[resolved]` entries like every other
+// blocker surface: `bin/hermit-status` prints it verbatim as "BLOCKED: …".
+describe('cost-tracker: blockers drops resolved entries', () => {
+  const { freshDir, cleanup } = freshDirFactory('hermit-cost-resolved-');
+
+  async function statusFor(blockerLines: string[]): Promise<{ blockers: string | null }> {
+    const dir = freshDir();
+    const cchDir = path.join(dir, '.claude-code-hermit');
+    fs.mkdirSync(path.join(cchDir, 'state'), { recursive: true });
+    fs.mkdirSync(path.join(cchDir, 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cchDir, 'state', 'runtime.json'),
+      JSON.stringify({ session_id: 'test-session', session_state: 'in_progress' })
+    );
+    writeConfig(dir, { timezone: null });
+    fs.writeFileSync(path.join(cchDir, 'sessions', 'SHELL.md'), [
+      '# Active Session',
+      '',
+      '## Task',
+      'Real task',
+      '',
+      '## Blockers',
+      ...blockerLines,
+      '',
+      '## Session Summary',
+      '',
+    ].join('\n'));
+    const transcriptPath = path.join(dir, 'transcript.jsonl');
+    fs.writeFileSync(transcriptPath, [
+      triggerPrompt('[hermit-routine:demo] start'),
+      assistantEntry('claude-sonnet-4-6', 1000, 500),
+    ].join('\n') + '\n');
+    const stdin = JSON.stringify({ session_id: 'test-session', transcript_path: transcriptPath });
+    await runScript('cost-tracker.ts', { stdin, cwd: dir, env: { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT } });
+    return JSON.parse(fs.readFileSync(path.join(cchDir, 'sessions', '.status.json'), 'utf-8'));
+  }
+
+  afterAll(cleanup);
+
+  test('a resolved line ahead of an open one yields the open one', async () => {
+    const status = await statusFor(['~ cleared blocker', 'real blocker']);
+    expect(status.blockers).toBe('real blocker');
+  });
+
+  test('only resolved lines yields null', async () => {
+    const status = await statusFor(['[resolved] cleared blocker']);
+    expect(status.blockers).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
`writeStatusJson` in `cost-tracker.ts` wrote the first line of SHELL.md's `## Blockers` into `sessions/.status.json` verbatim, so a blocker already marked `~` or `[resolved]` still surfaced. The issue framed this as latent, but `bin/hermit-status` reads that field and prints it as `BLOCKED: …`, so operators saw a cleared blocker as blocking until SHELL.md was reset.

## Changes
- `writeStatusJson` filters resolved lines with the shared `isResolvedBlockerLine` predicate before picking the first blocker, matching the startup-context and session-archive paths fixed in #827.
- Two new cases in `tests/cost-tracker-status-writer.test.ts`: a resolved line ahead of an open one yields the open one; an all-resolved section yields `null`.
- CHANGELOG `### Fixed` entry under `[Unreleased]`.

## Test plan
- `cd plugins/claude-code-hermit && bun test` → 4635 pass, 0 fail
- `bunx tsc --noEmit` → exit 0
- The two new tests were red before the filter and green after.

Closes #828