### PR TITLE
fix(claude-code-hermit): derive the memory-size KB threshold from its constant

### DIFF
--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -1846,8 +1846,14 @@ function checkMemorySize(p: DoctorPaths = PATHS) {
 
     // Same key scheme as lib/cc-compat.ts transcriptDirFor: Claude Code replaces
     // every non-alphanumeric character, not just '/'. A '/'-only scheme mis-keys
-    // any dotted path — including every worktree under `.claude/worktrees/` —
-    // and the leg below would then read as a permanent, silent "ok".
+    // any path containing a dot or other punctuation (a dotted repo name, a
+    // project under a hidden directory), and the leg below would then read as a
+    // permanent, silent "ok".
+    // Known gap: a doctor run whose project root is a *linked git worktree* finds
+    // nothing here — Claude Code writes transcripts under the worktree's own key
+    // but keeps auto-memory under the main checkout's key, so MEMORY.md never
+    // exists at the worktree key and this leg stays silently "ok". Only affects
+    // hermits driven from a worktree; a normally-installed hermit is unaffected.
     const pathKey = projectRoot.replace(/[^a-zA-Z0-9]/g, '-');
     const memoryPath = path.join(defaultConfigDir(), 'projects', pathKey, 'memory', 'MEMORY.md');
     // Auto-memory loads only MEMORY.md's first 200 lines or 25 KB, whichever
@@ -1860,7 +1866,7 @@ function checkMemorySize(p: DoctorPaths = PATHS) {
         const bytes = Buffer.byteLength(memory, 'utf8');
         const bounds: string[] = [];
         if (lines >= MEMORY_WARN_LINES) bounds.push(`${lines} lines (>=${MEMORY_WARN_LINES} line threshold)`);
-        if (bytes >= MEMORY_WARN_BYTES) bounds.push(`${(bytes / 1024).toFixed(1)} KB (>=20 KB byte threshold)`);
+        if (bytes >= MEMORY_WARN_BYTES) bounds.push(`${(bytes / 1024).toFixed(1)} KB (>=${MEMORY_WARN_BYTES / 1024} KB byte threshold)`);
         if (bounds.length > 0) {
           parts.push(`MEMORY.md: ${bounds.join('; ')}; approaching the 200-line / 25 KB hard cap (whichever comes first is silently truncated)`);
         }

--- a/plugins/claude-code-hermit/tests/doctor-memory-size.test.ts
+++ b/plugins/claude-code-hermit/tests/doctor-memory-size.test.ts
@@ -13,7 +13,7 @@ type Fixture = {
   local?: string;
   memory?: string;
   memoryAsDir?: boolean;
-  /** Nest the project root under a dotted path, as every git worktree is. */
+  /** Nest the project root under a dotted path, e.g. a checkout inside a hidden dir. */
   dottedRoot?: boolean;
 };
 
@@ -23,7 +23,7 @@ function lines(count: number, content = 'x'): string {
 
 function scenario({ claude, local, memory, memoryAsDir, dottedRoot }: Fixture) {
   const projectRoot = dottedRoot
-    ? path.join(freshDir(), '.claude', 'worktrees', 'feat-x')
+    ? path.join(freshDir(), '.local', 'src', 'my.project')
     : freshDir();
   const hermitDir = path.join(projectRoot, '.claude-code-hermit');
   fs.mkdirSync(hermitDir, { recursive: true });
@@ -103,8 +103,9 @@ describe('doctor memory-size check', () => {
     expect(scenario({ claude: lines(200) + '\n' }).status).toBe('warn');
   });
 
-  // Every worktree lives under `.claude/worktrees/`, so a '/'-only path key would
-  // resolve to a directory that never exists and report a permanent false ok.
+  // A '/'-only path key mangles any root holding a dot (a hidden parent dir, a
+  // dotted repo name) and would resolve to a directory that never exists,
+  // reporting a permanent false ok.
   test('a dotted project path still resolves MEMORY.md', () => {
     const result = scenario({ dottedRoot: true, memory: lines(170) });
 


### PR DESCRIPTION
Follow-up to #837, which merged before these review fixes landed.

## What changed

- **`doctor-check.ts`** — the MEMORY.md byte-threshold detail hardcoded `20 KB` while the check compared against `MEMORY_WARN_BYTES`. Changing the constant would have left the operator-facing line describing a threshold that no longer applied. Now interpolated, matching the sibling line one above it.
- **Path-key comments and test fixture** — the regex was justified by "every worktree under `.claude/worktrees/`", but that scenario cannot arise: auto-memory is keyed by the main checkout path, not the worktree cwd, so `MEMORY.md` never exists at a worktree key. The regex itself is correct and stays; the rationale now cites the real motivation (dotted repo names, hidden parent directories), and the test fixture uses `.local/src/my.project` instead.
- A **Known gap** note documents the worktree case explicitly: a doctor run whose project root is a linked git worktree reports `ok` regardless of memory size. Closing it needs git-common-dir resolution, which is a behavior change out of scope here and only affects hermits driven from a worktree.

No CHANGELOG entry: comment/test corrections plus a behaviour-neutral interpolation inside a check that has not shipped yet.

## Verification

- `bun test tests/doctor-memory-size.test.ts` — 9 pass, 0 fail
- `bunx tsc --noEmit` — clean
- Full `bun test` on the pre-rebase branch: 4641 pass, 1 fail (the known snap-tmux `watchdog.test.ts` timeout, green in isolation, unrelated)