### PR TITLE
feat(claude-code-hermit): make the long-lived setup token optional after login

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New `memory-size` doctor check warns when a project `CLAUDE.md` or `CLAUDE.local.md` reaches 200 lines, or auto-memory `MEMORY.md` reaches 160 lines or 20 KB.
 
 ### Changed
+- `/docker-setup` now asks after a successful container login whether to mint the long-lived setup token or stay on `/login` credentials, in both Quick and Advanced; the Advanced auth prompt is Subscription / API Key, and the manual guide lists `hermit-docker setup-token` as optional.
 - Hatch no longer offers `claude-code-setup`, `claude-md-management`, `skill-creator`, or `feature-dev`, and no longer seeds their `scheduled_checks` entries — Claude Code's native `Plan`/`Explore` agents, auto-memory, and `/doctor` CLAUDE.md trims cover the same ground, and every loaded skill description is paid on every API call of an always-on hermit. The `scheduled_checks` mechanism itself is unchanged; register any plugin's skill with `/hermit-settings scheduled-checks`.
 - `proposal-act` authors `## Skill Improvement` and `## Skill Draft` bodies in-main from the source brief instead of delegating to `skill-creator`; the falsification gate's read-only pass always uses the native `Plan` agent instead of `feature-dev:code-explorer`.
 - The first-session baseline audit offer (`.baseline-pending`) is removed along with the plugins it audited.

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -264,9 +264,11 @@ All state is in `sessions/SHELL.md` on disk. A disconnect loses conversation con
 
 ## 6. Login Renewal
 
-A Docker hermit on subscription auth uses a **long-lived login token** minted with `claude setup-token`. It lasts a year, and because the hermit mints it, the expiry date is known from day one — the CLI itself exposes no expiry surface for these tokens, so the hermit tracks it in `state/setup-token.json`.
+A Docker hermit on subscription auth can hold a **long-lived login token** minted with `claude setup-token` — offered right after login in `/docker-setup`, recommended. It lasts a year, and because the hermit mints it, the expiry date is known from day one — the CLI itself exposes no expiry surface for these tokens, so the hermit tracks it in `state/setup-token.json`. A hermit still on plain `/login` credentials re-authenticates with `hermit-docker login` when they expire, and can convert to a long-lived token at any time with `hermit-docker setup-token`.
 
-Renewal takes one browser tap and needs no server access.
+The rest of this section covers renewal for a hermit holding the long-lived token. A hermit still on plain `/login` credentials re-authenticates from the host with `hermit-docker login` when the session expires instead, or converts once with `hermit-docker setup-token` to switch to the flow below.
+
+For a token-holding hermit, renewal takes one browser tap and needs no server access.
 
 **Two weeks before expiry**, the hermit asks you over your channel. Reply and it sends a one-time sign-in link; open it, send back the code it gives you, and the hermit installs the new token and restarts itself. Doctor's `credential-expiry` check reports the same thing if you'd rather see it there.
 

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -264,9 +264,9 @@ All state is in `sessions/SHELL.md` on disk. A disconnect loses conversation con
 
 ## 6. Login Renewal
 
-A Docker hermit on subscription auth can hold a **long-lived login token** minted with `claude setup-token` — offered right after login in `/docker-setup`, recommended. It lasts a year, and because the hermit mints it, the expiry date is known from day one — the CLI itself exposes no expiry surface for these tokens, so the hermit tracks it in `state/setup-token.json`. A hermit still on plain `/login` credentials re-authenticates with `hermit-docker login` when they expire, and can convert to a long-lived token at any time with `hermit-docker setup-token`.
+A Docker hermit on subscription auth can hold a **long-lived login token** minted with `claude setup-token` — offered right after login in `/docker-setup`, recommended. It lasts a year, and because the hermit mints it, the expiry date is known from day one — the CLI itself exposes no expiry surface for these tokens, so the hermit tracks it in `state/setup-token.json`.
 
-The rest of this section covers renewal for a hermit holding the long-lived token. A hermit still on plain `/login` credentials re-authenticates from the host with `hermit-docker login` when the session expires instead, or converts once with `hermit-docker setup-token` to switch to the flow below.
+The rest of this section covers renewal for a hermit holding that token. A hermit still on plain `/login` credentials gets none of it: nothing warns ahead of expiry and the channel relay below never fires. When the credentials lapse the container blocks at boot, prints the `hermit-docker login` instruction to its own log, and exits after ten minutes, so the first sign is the hermit going quiet. Re-authenticate from the host with `hermit-docker login`, or convert once with `hermit-docker setup-token` to switch to the flow below.
 
 For a token-holding hermit, renewal takes one browser tap and needs no server access.
 

--- a/plugins/claude-code-hermit/docs/security.md
+++ b/plugins/claude-code-hermit/docs/security.md
@@ -243,7 +243,7 @@ Hermit does not probe for or configure Claude Code's native bash sandbox (`sandb
 
 ## Login Token Handling
 
-Docker hermits on subscription auth hold a long-lived `setup-token`. Renewal relays through the operator's chat channel, so it's worth being precise about what crosses that channel and what doesn't.
+Docker hermits on subscription auth can hold a long-lived `setup-token` (offered right after login in `/docker-setup`; a hermit that declines stays on its `/login` credentials and none of the below applies). Renewal relays through the operator's chat channel, so it's worth being precise about what crosses that channel and what doesn't.
 
 **Crosses the channel:** the one-time OAuth sign-in URL, and the short-lived login code the operator pastes back. Both are single-use and worthless once the flow completes. On an install with a `maintainer_channel_id` configured, the URL is routed to the maintainer chat (via `channel-send.ts --tier maintainer`, marked sensitive so it is not written to the searchable channel log) rather than the primary client chat; the operator still pastes the code back through the primary DM chat, which remains the only inbound surface.
 

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -419,7 +419,7 @@ Re-run /claude-code-hermit:docker-setup any time you want guided help.
 
 **Post-login decision — mint or keep `/login`:** ask immediately after the login above succeeds. The attended login is still required first — the first-launch wizard demands an interactive login and will not accept the env token (confirmed live), and initial setup is attended anyway.
 
-Ask with `AskUserQuestion` (header: `"Login token"`) — **Mint a long-lived token** (Recommended; a one-year token stored only on the container's config volume, never printed or written to `.env`, renews over the chat channel with no server access) / **Keep /login credentials** (server access needed again when they expire; `hermit-docker setup-token` converts at any time).
+Ask with `AskUserQuestion` (header: `"Login token"`) — **Mint a long-lived token** (Recommended; a one-year token stored only on the container's config volume, never printed or written to `.env`, renews over the chat channel with no server access) / **Keep /login credentials** (no expiry warning and no channel renewal; when they lapse the hermit goes quiet and you fix it from the box, `hermit-docker setup-token` converts at any time).
 
 **Mint a long-lived token:**
 1. Tell them: "One more step and this hermit never needs server access again. Run:"
@@ -430,7 +430,7 @@ Ask with `AskUserQuestion` (header: `"Login token"`) — **Mint a long-lived tok
 2. Ask with `AskUserQuestion` (header: `"Token"`) — `"Done"` / `"Failed"`. On `"Failed"`, the hermit still works on the `/login` credentials from the previous step; tell the operator that plainly and that they can retry `hermit-docker setup-token` any time. Do not block setup on it.
 3. On success, note for the summary: renewal is due in a year, the hermit will ask over the channel two weeks ahead, and it takes one browser tap with no server access.
 
-**Keep /login credentials:** no `setup-token` command, no restart. Note for the summary: the hermit runs on the `/login` credentials from above and will need server access again when they expire; convert to a long-lived token any time with `.claude-code-hermit/bin/hermit-docker setup-token`. Continue to first-run acceptance.
+**Keep /login credentials:** no `setup-token` command, no restart. Note for the summary, plainly, because this is the trade they just made: the hermit runs on the `/login` credentials from above, doctor's `credential-expiry` check has nothing to probe in this mode and the watchdog's channel re-auth relay only arms for token holders, so when the credentials lapse the container blocks at boot and exits after ten minutes with no notice on the channel. Watch for the hermit going quiet, then re-run `.claude-code-hermit/bin/hermit-docker login` from the box, or convert to a long-lived token any time with `.claude-code-hermit/bin/hermit-docker setup-token`. Continue to first-run acceptance.
 
 **First-run acceptance (workspace trust + bypass mode):** Before asking the operator to attach, verify the tmux session exists inside the container (the entrypoint may still be installing plugins):
 ```

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -58,7 +58,7 @@ questions: [
 ]
 ```
 
-**Quick-mode contract — security non-negotiables.** Quick mode never bulk-accepts third-party plugins, never weakens the safelist, never skips the public-repo pre-flight, and never bypasses the write-time assertion. Those gates exist because that's the line where defaults stop being safe. Quick only auto-defaults the choices that have one obviously-correct answer (auth, networking, build-now) and the SAFE plugin batch (claude-plugins-official + gtapps/* — already vetted by the safelist).
+**Quick-mode contract — security non-negotiables.** Quick mode never bulk-accepts third-party plugins, never weakens the safelist, never skips the public-repo pre-flight, and never bypasses the write-time assertion. Those gates exist because that's the line where defaults stop being safe. Quick only auto-defaults the choices that have one obviously-correct answer (auth, networking, build-now) and the SAFE plugin batch (claude-plugins-official + gtapps/* — already vetted by the safelist). Minting the long-lived setup token is never one of those auto-defaulted choices — in both Quick and Advanced it's a post-login question at Step 8.
 
 Branch on the choice for the rest of the skill:
 - **Advanced** → run today's flow unchanged from Step 2.
@@ -66,7 +66,7 @@ Branch on the choice for the rest of the skill:
 
 ### 2. Ask operator and analyze project
 
-**Quick:** silently apply `auth = setup-token`, `docker.network_mode = "bridge"`. Skip the `AskUserQuestion` below. Continue at the project-dependencies scan below.
+**Quick:** silently apply `auth = oauth-token`, `docker.network_mode = "bridge"`. Skip the `AskUserQuestion` below. Continue at the project-dependencies scan below.
 
 **Advanced:** ask auth method and networking in a single `AskUserQuestion` call:
 
@@ -76,8 +76,7 @@ questions: [
     header: "Auth",
     question: "Authentication method for the container?",
     options: [
-      { label: "Subscription token", description: "Mint a 1-year login token — renews over chat, no server access needed (recommended)" },
-      { label: "Subscription login", description: "Run claude /login inside the container — needs server access again when it expires" },
+      { label: "Subscription", description: "Log in inside the container — the long-lived setup token is offered right after login (recommended)" },
       { label: "API Key", description: "Set ANTHROPIC_API_KEY in .env — bills per token instead of using a subscription" }
     ],
   },
@@ -92,7 +91,7 @@ questions: [
 ]
 ```
 
-Record networking choice as `docker.network_mode` (`"bridge"` or `"host"`).
+Record auth choice as `auth = oauth-token` for Subscription, `auth = api-key` for API Key. Record networking choice as `docker.network_mode` (`"bridge"` or `"host"`).
 
 **Project dependencies scan:** Scan for signals that suggest extra system packages:
    - `package.json` native addons (sqlite3, sharp, canvas, bcrypt, etc.)
@@ -120,7 +119,7 @@ Do NOT set `AGENT_HOOK_PROFILE` in `config.json` `env` — leave it unset. The s
 The render script derives every `{{PLACEHOLDER}}` internally and fails loud (writes nothing) if any survives. Assemble this input object as choices resolve, to be piped on stdin at Step 7b.6:
 
 - `packages` — the finalized `docker.packages` array (Step 7b.packages). Empty array → no project-package layer.
-- `auth` — `"setup-token"`, `"oauth-token"`, or `"api-key"` (Step 2). Both subscription modes add no auth env line — their credential lives on the named volume (`.hermit-setup-token` for token mode, `.credentials.json` for `/login` mode). The setup-token deliberately never goes in `.env`: compose applies `env_file` only at container creation, so an `.env`-stored token would force a host-side recreate on every renewal.
+- `auth` — `"oauth-token"` for subscription, or `"api-key"` (Step 2). The mint-or-keep decision at Step 8 does not affect rendering — both subscription outcomes render as `oauth-token` and add no auth env line, since their credential lives on the named volume (`.hermit-setup-token` if minted, `.credentials.json` otherwise). The setup-token deliberately never goes in `.env`: compose applies `env_file` only at container creation, so an `.env`-stored token would force a host-side recreate on every renewal.
 - `channels` — `{ envLines: [...], volumeLines: [...] }`, one entry per enabled channel (Step 7). Pass the line **bodies** (the script owns the `      - ` indent):
   - env body: `<VAR>_STATE_DIR=${PWD}/.claude.local/channels/<plugin>` (VAR = `DISCORD` / `TELEGRAM`)
   - volume body: `${PWD}/.claude.local/channels/<plugin>:/home/claude/.claude/channels/<plugin>` (keeps channel writes inside the project tree — no permission prompts under `bypassPermissions`)
@@ -147,7 +146,7 @@ Only the top-level project memory is seeded — not agent-scoped memories at `<p
    ANTHROPIC_API_KEY=your-api-key-here
    ```
    If already present, leave it — note for step 8.
-   **If setup-token or oauth:** No auth var needed in `.env`. Check whether `ANTHROPIC_API_KEY` is set (non-empty) in `.env`. If so, warn and ask with `AskUserQuestion` (header: "API key"): **Yes — comment out** (prefix with # to disable it) / **No — keep** (container will run in API key mode).
+   **If subscription (oauth):** No auth var needed in `.env`. Check whether `ANTHROPIC_API_KEY` is set (non-empty) in `.env`. If so, warn and ask with `AskUserQuestion` (header: "API key"): **Yes — comment out** (prefix with # to disable it) / **No — keep** (container will run in API key mode).
    Also remove any `CLAUDE_CODE_OAUTH_TOKEN` line you find in `.env` — this is not a preference. A token stored there is baked in at container creation, so renewing it would require recreating the container from the host, which is exactly the manual access token mode exists to remove. The hermit stores it on the config volume and exports it at process start instead.
 3. Ensure `.env` is listed in both `.gitignore` and `.dockerignore` (create the files if needed, append if missing).
 4. **Deny patterns:** Merge the `default` deny set into the target settings file.
@@ -307,7 +306,7 @@ Now that `docker.packages` (Step 7b.packages), channel state dirs (Step 7), and 
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/render-docker-templates.ts <PROJECT_ROOT> <<'HERMIT_RENDER_JSON'
 {
   "packages": [...],
-  "auth": "setup-token" | "oauth-token" | "api-key",
+  "auth": "oauth-token" | "api-key",
   "channels": { "envLines": [...], "volumeLines": [...] },
   "agentHookProfile": "strict",
   "networkMode": "bridge" | "host",
@@ -369,7 +368,7 @@ Manual deployment guide
 2. (Subscription auth only) From a second terminal, complete login:
    .claude-code-hermit/bin/hermit-docker login
 
-   Then, in token mode, mint the long-lived token:
+   Then, optionally (recommended), mint the long-lived token so future renewals need only a browser tap and no server access — skip it and you'll re-run `hermit-docker login` from a terminal when the `/login` credentials expire:
    .claude-code-hermit/bin/hermit-docker setup-token
 
 3. Accept first-run prompts (press Ctrl+B D to detach when done):
@@ -405,7 +404,7 @@ Re-run /claude-code-hermit:docker-setup any time you want guided help.
    - **Port conflict** → `ss -tlnp | grep <port>` finds what's using the published port
    **Do not continue to Login / Workspace trust / Channel pairing while the container is down — stop here and ask the operator to fix and re-run the skill.**
 
-**Login (subscription auth only — both `setup-token` and `oauth-token`):** If operator chose either subscription mode, proceed only once the container is confirmed running. Guide them through login:
+**Login (subscription auth only):** If operator chose subscription auth, proceed only once the container is confirmed running. Guide them through login:
 1. Tell them: "The container is waiting for you to log in. Run this from another terminal:"
    ```
    .claude-code-hermit/bin/hermit-docker login
@@ -418,8 +417,11 @@ Re-run /claude-code-hermit:docker-setup any time you want guided help.
    - **Credentials not written** → `docker compose exec -T hermit ls /home/claude/.claude/.credentials.json` (should exist after login); missing = named volume not mounted — check `docker-compose.hermit.yml` volume entry
    Then **stop** — operator re-runs `/claude-code-hermit:docker-setup` after resolving the issue.
 
-**Mint the long-lived token (`setup-token` mode only):** run immediately after the login above succeeds. The attended login is still required first — the first-launch wizard demands an interactive login and will not accept the env token (confirmed live), and initial setup is attended anyway.
+**Post-login decision — mint or keep `/login`:** ask immediately after the login above succeeds. The attended login is still required first — the first-launch wizard demands an interactive login and will not accept the env token (confirmed live), and initial setup is attended anyway.
 
+Ask with `AskUserQuestion` (header: `"Login token"`) — **Mint a long-lived token** (Recommended; a one-year token stored only on the container's config volume, never printed or written to `.env`, renews over the chat channel with no server access) / **Keep /login credentials** (server access needed again when they expire; `hermit-docker setup-token` converts at any time).
+
+**Mint a long-lived token:**
 1. Tell them: "One more step and this hermit never needs server access again. Run:"
    ```
    .claude-code-hermit/bin/hermit-docker setup-token
@@ -427,6 +429,8 @@ Re-run /claude-code-hermit:docker-setup any time you want guided help.
    It prints a sign-in link, takes the code back, writes the token to the container's config volume, and restarts the hermit. The token is never printed and never stored in `.env`.
 2. Ask with `AskUserQuestion` (header: `"Token"`) — `"Done"` / `"Failed"`. On `"Failed"`, the hermit still works on the `/login` credentials from the previous step; tell the operator that plainly and that they can retry `hermit-docker setup-token` any time. Do not block setup on it.
 3. On success, note for the summary: renewal is due in a year, the hermit will ask over the channel two weeks ahead, and it takes one browser tap with no server access.
+
+**Keep /login credentials:** no `setup-token` command, no restart. Note for the summary: the hermit runs on the `/login` credentials from above and will need server access again when they expire; convert to a long-lived token any time with `.claude-code-hermit/bin/hermit-docker setup-token`. Continue to first-run acceptance.
 
 **First-run acceptance (workspace trust + bypass mode):** Before asking the operator to attach, verify the tmux session exists inside the container (the entrypoint may still be installing plugins):
 ```
@@ -561,7 +565,7 @@ You're all set! Your hermit is live and running autonomously.
   .claude-code-hermit/bin/hermit-docker attach    — connect to tmux session
   .claude-code-hermit/bin/hermit-docker bash      — shell into container
   .claude-code-hermit/bin/hermit-docker login     — subscription login (first boot)
-  .claude-code-hermit/bin/hermit-docker setup-token — mint/renew the long-lived login token
+  .claude-code-hermit/bin/hermit-docker setup-token — (optional) mint/renew the long-lived login token
   .claude-code-hermit/bin/hermit-docker logs -f   — follow logs
   .claude-code-hermit/bin/hermit-docker restart   — restart container
   .claude-code-hermit/bin/hermit-docker update    — rebuild image + update plugins (durable pin move) + auto-evolve


### PR DESCRIPTION
## Summary
`/docker-setup` no longer commits to minting the long-lived `setup-token` at Step 2's auth choice. The Advanced auth prompt collapses to Subscription/API Key, and the mint-or-keep decision moves to a post-login question in both Quick and Advanced, so operators can stay on `/login` credentials if they don't want a year-long token minted immediately.

## Changes
- Step 2 auth prompt: three options (Subscription token / Subscription login / API Key) become two (Subscription / API Key); Quick defaults to `auth = oauth-token`.
- Step 8: after a successful container login, an `AskUserQuestion` asks Mint a long-lived token (recommended) vs Keep `/login` credentials. The existing mint flow is unchanged when chosen; the Keep branch skips straight to first-run acceptance with no `setup-token` command and no restart.
- Manual deployment guide and command reference describe `hermit-docker setup-token` as optional.
- `docs/always-on-ops.md` § 6 softens to describe the token as something a hermit *can* hold, and scopes the renewal paragraphs to token-holding hermits.
- CHANGELOG entry under `[Unreleased] → Changed`.

## Test plan
- `cd plugins/claude-code-hermit && bun test` — 4674 pass, 0 fail.
- `bunx tsc` from repo root — clean (no `.ts` touched).
- Closing-verification grep for stale `setup-token`/three-way-auth vocabulary in `SKILL.md` — no matches.
- Read `### 8. Guided deployment` top to bottom: the Keep-credentials path reaches first-run acceptance with no `setup-token` command or restart in between.

Closes #829