### PR TITLE
fix(feed-hermit): reconcile fetched sources against the written file, not the agent's reply

### DIFF
--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 
 ### Fixed
-- `feed-brief` Phase 1 now classifies each `web`/`rss` source from the `source-fetcher` agent's written output file, not its one-line reply, so a fabricated or partial success summary no longer misclassifies a failed fetch as `sources_used`/`sources_quiet`. `source-fetcher` reports per-source status derived from what it wrote and never writes to a suffixed variant path.
+- `feed-brief` Phase 1 classifies each `web`/`rss` source from `tmp/feed-source-items-<slot>.json`, not the `source-fetcher` reply, so a fabricated success summary no longer hides a failed fetch.
+- `source-fetcher` reads its output file back before reporting, reports per-source status instead of an aggregate count, and never writes to a suffixed variant path.
 
 ## [0.1.3] - 2026-08-14
 

--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `feed-brief` Phase 1 now classifies each `web`/`rss` source from the `source-fetcher` agent's written output file, not its one-line reply, so a fabricated or partial success summary no longer misclassifies a failed fetch as `sources_used`/`sources_quiet`. `source-fetcher` reports per-source status derived from what it wrote and never writes to a suffixed variant path.
+
 ## [0.1.3] - 2026-08-14
 
 ### Fixed

--- a/plugins/feed-hermit/agents/source-fetcher.md
+++ b/plugins/feed-hermit/agents/source-fetcher.md
@@ -184,7 +184,9 @@ You WRITE your result to the file path supplied in your dispatch prompt. That pa
 tmp/feed-source-items-<slot>.json
 ```
 
-where `<slot>` is the slot name from your dispatch (e.g. `morning`, `evening`). Write to that exact relative path in the project root — never `/tmp/`, never a suffixed variant (`-complete`, `-partial`, or any other name). Use the `Write` tool. Do not also print the JSON back as your reply; your reply is a one-line per-source status derived from the file you just wrote, never an aggregate count you did not read back. If the `Write` itself fails, say so plainly in your reply — do not report success.
+where `<slot>` is the slot name from your dispatch (e.g. `morning`, `evening`). Write to that exact relative path in the project root — never `/tmp/`, never a suffixed variant (`-complete`, `-partial`, or any other name). Use the `Write` tool.
+
+After the `Write`, `Read` that same path back and derive your reply from what the file actually contains — never from what you intended to write. Do not print the JSON back as your reply; reply with one compact line per source, naming that source and its read-back status (`<name>: ok <n> items` / `<name>: failed`), never an aggregate count. If the `Write` fails, or the read-back is missing, unparseable, or does not match what you wrote, say so plainly — do not report success.
 
 Write exactly this JSON shape (valid JSON only, no prose, no code fences inside the file):
 

--- a/plugins/feed-hermit/agents/source-fetcher.md
+++ b/plugins/feed-hermit/agents/source-fetcher.md
@@ -184,7 +184,7 @@ You WRITE your result to the file path supplied in your dispatch prompt. That pa
 tmp/feed-source-items-<slot>.json
 ```
 
-where `<slot>` is the slot name from your dispatch (e.g. `morning`, `evening`). Write to that exact relative path in the project root — never `/tmp/`. Use the `Write` tool. Do not also print the JSON back as your reply; your reply is a one-line confirmation of how many sources succeeded/failed.
+where `<slot>` is the slot name from your dispatch (e.g. `morning`, `evening`). Write to that exact relative path in the project root — never `/tmp/`, never a suffixed variant (`-complete`, `-partial`, or any other name). Use the `Write` tool. Do not also print the JSON back as your reply; your reply is a one-line per-source status derived from the file you just wrote, never an aggregate count you did not read back. If the `Write` itself fails, say so plainly in your reply — do not report success.
 
 Write exactly this JSON shape (valid JSON only, no prose, no code fences inside the file):
 

--- a/plugins/feed-hermit/docs/schema.md
+++ b/plugins/feed-hermit/docs/schema.md
@@ -189,6 +189,11 @@ NOT `/tmp/`). Consumed by `feed-brief` Phase 3. Raw scratch — 3-day retention 
 - Caps/rules: <=20 items per source; `summary` is source-derived or `""`; URLs absolute and
   deduped within a source; continue-on-failure.
 
+**Maps to daily-archive `sources_skipped`/`sources_quiet` (§2) as:** `status: "failed"`, or a
+`feed-sources.md` source absent from `sources[]` entirely, → `sources_skipped`. `status: "ok"`
+with empty `items[]` → `sources_quiet`. `feed-brief` Phase 1 reconciles against this file, not
+the agent's reply — see `skills/feed-brief/SKILL.md`.
+
 Full contract lives in `agents/source-fetcher.md`.
 
 ---

--- a/plugins/feed-hermit/docs/schema.md
+++ b/plugins/feed-hermit/docs/schema.md
@@ -148,7 +148,8 @@ Skipped sources are included with `items_yielded: 0, items_scored_p1: 0` and the
 ## 5. source-items JSON (fetch scratch)
 
 Written by the `source-fetcher` agent to `tmp/feed-source-items-<slot>.json` (project root,
-NOT `/tmp/`). Consumed by `feed-brief` Phase 3. Raw scratch — 3-day retention (§10).
+NOT `/tmp/`). Read by `feed-brief` Phase 1 (item collection + source reconciliation); the items
+it carries are scored in Phase 3. Raw scratch — 3-day retention (§10).
 
 ```json
 {
@@ -189,10 +190,14 @@ NOT `/tmp/`). Consumed by `feed-brief` Phase 3. Raw scratch — 3-day retention 
 - Caps/rules: <=20 items per source; `summary` is source-derived or `""`; URLs absolute and
   deduped within a source; continue-on-failure.
 
-**Maps to daily-archive `sources_skipped`/`sources_quiet` (§2) as:** `status: "failed"`, or a
-`feed-sources.md` source absent from `sources[]` entirely, → `sources_skipped`. `status: "ok"`
-with empty `items[]` → `sources_quiet`. `feed-brief` Phase 1 reconciles against this file, not
-the agent's reply — see `skills/feed-brief/SKILL.md`.
+**Maps to daily-archive `sources_skipped`/`sources_quiet` (§2), for `web`/`rss` sources only:**
+`status: "failed"` (or any status other than `"ok"`), or such a source absent from `sources[]`
+entirely, → `sources_skipped`; `status: "ok"` with empty `items[]` → `sources_quiet`.
+`chrome`/`reddit`/`reddit-home`/`x` sources never appear here and are classified by
+`feed-brief` Phase 2 instead. A source that yielded items but lost all of them to Phase 3
+scoring is also `sources_quiet` per §2.
+`feed-brief` Phase 1 reconciles against this file, not the agent's reply — see
+`skills/feed-brief/SKILL.md`.
 
 Full contract lives in `agents/source-fetcher.md`.
 

--- a/plugins/feed-hermit/skills/feed-brief/SKILL.md
+++ b/plugins/feed-hermit/skills/feed-brief/SKILL.md
@@ -39,6 +39,17 @@ in the project root (never `/tmp/`). Items are nested under `sources[]`, each it
 `{title, summary, url, published_at, source, section, author}`. No scoring —
 extraction only. After the agent returns, read that file for the collected items.
 
+**Reconcile against the file, not the reply** (mapping owned by `docs/schema.md` §5). The
+agent's one-line reply is a claim; the file is the only truth:
+- File missing or unparseable → every `web`/`rss` source in `feed-sources.md` goes to
+  `sources_skipped` with `items_yielded: 0`. Continue to Phase 2 — do not re-dispatch the agent.
+- A `feed-sources.md` source with no entry in `sources[]` → `sources_skipped`, regardless of
+  what the reply claimed.
+- Entry with `status: "failed"` → `sources_skipped`. Entry with `status: "ok"` and empty
+  `items[]` → `sources_quiet`.
+- Reply count disagrees with the file → the file wins; note the discrepancy in the brief's
+  Source notes.
+
 ### Phase 2 — Chrome, reddit, and X sources
 
 For each source whose type is `chrome`, `reddit`, `reddit-home`, or `x`:

--- a/plugins/feed-hermit/skills/feed-brief/SKILL.md
+++ b/plugins/feed-hermit/skills/feed-brief/SKILL.md
@@ -40,15 +40,19 @@ in the project root (never `/tmp/`). Items are nested under `sources[]`, each it
 extraction only. After the agent returns, read that file for the collected items.
 
 **Reconcile against the file, not the reply** (mapping owned by `docs/schema.md` §5). The
-agent's one-line reply is a claim; the file is the only truth:
+agent's reply is a claim; the file is the only truth. This classifies `web`/`rss` sources only —
+`chrome`/`reddit`/`reddit-home`/`x` sources are absent from `sources[]` by design and are
+classified in Phase 2:
 - File missing or unparseable → every `web`/`rss` source in `feed-sources.md` goes to
-  `sources_skipped` with `items_yielded: 0`. Continue to Phase 2 — do not re-dispatch the agent.
-- A `feed-sources.md` source with no entry in `sources[]` → `sources_skipped`, regardless of
-  what the reply claimed.
-- Entry with `status: "failed"` → `sources_skipped`. Entry with `status: "ok"` and empty
-  `items[]` → `sources_quiet`.
-- Reply count disagrees with the file → the file wins; note the discrepancy in the brief's
-  Source notes.
+  `sources_skipped`. Continue to Phase 2 — do not re-dispatch the agent — and note the wholesale
+  fetch failure in the brief's Source notes.
+- A `web`/`rss` source with no entry in `sources[]` → `sources_skipped`, regardless of what the
+  reply claimed.
+- Entry with `status: "failed"`, or any status other than `"ok"` → `sources_skipped`.
+- Entry with `status: "ok"` and empty `items[]` → `sources_quiet`. An entry that did yield items
+  stays provisional: Phase 6 splits `sources_used` vs `sources_quiet` on what survived Phase 3
+  scoring, so a source whose items were all filtered out still lands in `sources_quiet`.
+- Reply disagrees with the file → the file wins; note the discrepancy in the brief's Source notes.
 
 ### Phase 2 — Chrome, reddit, and X sources
 

--- a/plugins/feed-hermit/tests/skill-structure.test.ts
+++ b/plugins/feed-hermit/tests/skill-structure.test.ts
@@ -118,3 +118,8 @@ test("feed-brief defers the injection rule to its single owner", () => {
   const body = readFileSync(join(ROOT, "skills", "feed-brief", "SKILL.md"), "utf8");
   expect(body).toMatch(/§ Source Fetching[\s\S]{0,60}owns this rule/);
 });
+
+test("feed-brief Phase 1 reconciles the fetch file, not the agent's reply", () => {
+  const body = readFileSync(join(ROOT, "skills", "feed-brief", "SKILL.md"), "utf8");
+  expect(body).toMatch(/Reconcile against the file, not the reply/);
+});


### PR DESCRIPTION
## Summary
`source-fetcher`'s one-line aggregate reply ("N/M sources fetched") was trusted as-is, so a partial fetch failure or a failed `Write` could be reported as success. `feed-brief` Phase 1 now classifies each `web`/`rss` source from the file the agent actually wrote, not its reply.

## Changes
- `skills/feed-brief/SKILL.md` Phase 1: reconciles `sources_skipped`/`sources_quiet` against `tmp/feed-source-items-<slot>.json`, falling back to all-skipped on a missing/unparseable file.
- `agents/source-fetcher.md`: reply must report per-source status derived from the written file, never an unread-back aggregate; a failed `Write` must be reported as failure; never write to a suffixed variant path.
- `docs/schema.md` §5: documents the status → `sources_skipped`/`sources_quiet` mapping as the contract authority.
- `tests/skill-structure.test.ts`: pins the Phase 1 reconciliation clause.
- `CHANGELOG.md`: `[Unreleased] / Fixed` entry.

Closes #844

## Test plan
- `cd plugins/feed-hermit && bun test` — 61 pass, 0 fail (was 59; +2 assertions from the new test).
- `bunx tsc --noEmit` from repo root — clean, no output.
- No runtime code changed (prose/docs/test only), so no live pipeline run was needed to verify; the next real `feed-brief` run exercises it.