### PR TITLE
fix(claude-code-hermit): store judge_window as a 20-verdict ring instead of run objects

### DIFF
--- a/plugins/claude-code-hermit/scripts/update-reflection-state.ts
+++ b/plugins/claude-code-hermit/scripts/update-reflection-state.ts
@@ -212,6 +212,15 @@ const judgeRun = {
   suppress: intOf(payload.judge_suppress),
 };
 const judgeVerdicts = judgeRun.accept + judgeRun.downgrade + judgeRun.suppress;
+// Only the last WINDOW_VERDICTS characters can survive the slice below, so each letter
+// run is capped there: an absurd count (garbled payload, corrupted on-disk run) would
+// otherwise throw RangeError out of String.repeat and abort the whole state write.
+// Capping is lossless — a run longer than the window already drops everything before it.
+const RING_RE = new RegExp(`^[ads]{1,${WINDOW_VERDICTS}}$`);
+const letters = (run: Json) =>
+  'a'.repeat(Math.min(intOf(run.accept), WINDOW_VERDICTS)) +
+  'd'.repeat(Math.min(intOf(run.downgrade), WINDOW_VERDICTS)) +
+  's'.repeat(Math.min(intOf(run.suppress), WINDOW_VERDICTS));
 if (judgeVerdicts > 0) {
   const storedRuns = Array.isArray(c.judge_window?.runs) && c.judge_window.runs.every((run: Json) =>
     run && typeof run === 'object' && !Array.isArray(run) &&
@@ -220,12 +229,10 @@ if (judgeVerdicts > 0) {
       typeof run[key] === 'number' && Number.isFinite(run[key]) && run[key] >= 0
     )
   ) ? c.judge_window.runs : [];
-  const priorRing = typeof c.judge_window?.ring === 'string' && /^[ads]{1,20}$/.test(c.judge_window.ring)
+  const priorRing = typeof c.judge_window?.ring === 'string' && RING_RE.test(c.judge_window.ring)
     ? c.judge_window.ring
-    : storedRuns.map((run: Json) =>
-        'a'.repeat(intOf(run.accept)) + 'd'.repeat(intOf(run.downgrade)) + 's'.repeat(intOf(run.suppress))
-      ).join('');
-  const ring = (priorRing + 'a'.repeat(judgeRun.accept) + 'd'.repeat(judgeRun.downgrade) + 's'.repeat(judgeRun.suppress))
+    : storedRuns.map(letters).join('');
+  const ring = (priorRing + letters(judgeRun))
     .slice(-WINDOW_VERDICTS);
   c.judge_window = {
     ring,

--- a/plugins/claude-code-hermit/scripts/update-reflection-state.ts
+++ b/plugins/claude-code-hermit/scripts/update-reflection-state.ts
@@ -168,7 +168,7 @@ try {
 
 const now = new Date().toISOString();
 
-// Retain whole runs covering at least the latest 20 judge verdicts.
+// Ring of the last 20 judge verdicts as a/d/s letters. An old runs array is folded in once.
 const WINDOW_VERDICTS = 20;
 
 const c: Json = (state.counters && typeof state.counters === 'object') ? { ...state.counters } : {};
@@ -220,34 +220,19 @@ if (judgeVerdicts > 0) {
       typeof run[key] === 'number' && Number.isFinite(run[key]) && run[key] >= 0
     )
   ) ? c.judge_window.runs : [];
-  const runs = storedRuns.map((run: Json) => ({
-    at: run.at,
-    accept: intOf(run.accept),
-    downgrade: intOf(run.downgrade),
-    suppress: intOf(run.suppress),
-  }));
-  runs.push(judgeRun);
-
-  let verdicts = runs.reduce((sum: number, run: Json) =>
-    sum + run.accept + run.downgrade + run.suppress, 0);
-  while (runs.length > 1) {
-    const first = runs[0];
-    const firstVerdicts = first.accept + first.downgrade + first.suppress;
-    if (verdicts - firstVerdicts < WINDOW_VERDICTS) break;
-    runs.shift();
-    verdicts -= firstVerdicts;
-  }
-
-  const totals = runs.reduce((sum: Json, run: Json) => ({
-    accept: sum.accept + run.accept,
-    downgrade: sum.downgrade + run.downgrade,
-    suppress: sum.suppress + run.suppress,
-  }), { accept: 0, downgrade: 0, suppress: 0 });
+  const priorRing = typeof c.judge_window?.ring === 'string' && /^[ads]{1,20}$/.test(c.judge_window.ring)
+    ? c.judge_window.ring
+    : storedRuns.map((run: Json) =>
+        'a'.repeat(intOf(run.accept)) + 'd'.repeat(intOf(run.downgrade)) + 's'.repeat(intOf(run.suppress))
+      ).join('');
+  const ring = (priorRing + 'a'.repeat(judgeRun.accept) + 'd'.repeat(judgeRun.downgrade) + 's'.repeat(judgeRun.suppress))
+    .slice(-WINDOW_VERDICTS);
   c.judge_window = {
-    runs,
-    ...totals,
-    verdicts,
-    since: runs[0].at,
+    ring,
+    accept: ring.split('a').length - 1,
+    downgrade: ring.split('d').length - 1,
+    suppress: ring.split('s').length - 1,
+    verdicts: ring.length,
   };
 }
 

--- a/plugins/claude-code-hermit/tests/update-reflection-state-window.test.ts
+++ b/plugins/claude-code-hermit/tests/update-reflection-state-window.test.ts
@@ -182,4 +182,13 @@ describe('update-reflection-state judge window', () => {
     expect(state.counters.judge_downgrade).toBe(5);
     expect(state.counters.judge_suppress).toBe(6);
   }));
+
+  test('an absurd verdict count caps the ring instead of aborting the state write', withTmp(async (stateFile) => {
+    const state = await runPayload(stateFile, { judge_accept: 1e11, judge_suppress: 4 });
+    const window = state.counters.judge_window;
+
+    expect(window.ring).toBe('a'.repeat(16) + 'ssss');
+    expect(window).toMatchObject({ accept: 16, downgrade: 0, suppress: 4, verdicts: 20 });
+    expect(typeof state.counters.last_run_at).toBe('string');
+  }));
 });

--- a/plugins/claude-code-hermit/tests/update-reflection-state-window.test.ts
+++ b/plugins/claude-code-hermit/tests/update-reflection-state-window.test.ts
@@ -35,30 +35,23 @@ async function runPayload(stateFile: string, payload: Record<string, unknown>) {
 }
 
 describe('update-reflection-state judge window', () => {
-  test('first verdict-bearing run creates the window with derived sums and since', withTmp(async (stateFile) => {
+  test('first verdict-bearing run creates a letter ring with derived counts', withTmp(async (stateFile) => {
     const state = await runPayload(stateFile, { judge_accept: 2, judge_downgrade: 1, judge_suppress: 3 });
     const window = state.counters.judge_window;
 
-    expect(window.runs).toHaveLength(1);
-    expect(window.runs[0]).toEqual({
-      at: window.runs[0].at,
-      accept: 2,
-      downgrade: 1,
-      suppress: 3,
-    });
-    expect(Number.isNaN(Date.parse(window.runs[0].at))).toBe(false);
+    expect(window.ring).toBe('aadsss');
     expect(window).toMatchObject({ accept: 2, downgrade: 1, suppress: 3, verdicts: 6 });
-    expect(window.since).toBe(window.runs[0].at);
+    expect(window).not.toHaveProperty('runs');
+    expect(window).not.toHaveProperty('since');
   }));
 
   test('a zero-verdict run preserves an existing window and does not create one when absent', withTmp(async (stateFile) => {
     const existingWindow = {
-      runs: [{ at: '2026-08-01T00:00:00.000Z', accept: 3, downgrade: 1, suppress: 2 }],
+      ring: 'aaadss',
       accept: 3,
       downgrade: 1,
       suppress: 2,
       verdicts: 6,
-      since: '2026-08-01T00:00:00.000Z',
     };
     writeState(stateFile, { counters: { judge_window: existingWindow } });
 
@@ -70,21 +63,22 @@ describe('update-reflection-state judge window', () => {
     expect(absent.counters).not.toHaveProperty('judge_window');
   }));
 
-  test('trimming keeps whole runs and never takes the remainder below 20 verdicts', withTmp(async (stateFile) => {
+  test('trimming keeps exactly the last 20 verdicts', withTmp(async (stateFile) => {
     for (let run = 0; run < 3; run += 1) {
       await runPayload(stateFile, { judge_accept: 8 });
     }
     const initialWindow = readState(stateFile).counters.judge_window;
-    expect(initialWindow.runs).toHaveLength(3);
-    expect(initialWindow.verdicts).toBe(24);
+    expect(initialWindow.ring.length).toBe(20);
+    expect(initialWindow.verdicts).toBe(20);
 
     await runPayload(stateFile, { judge_accept: 8 });
     const window = readState(stateFile).counters.judge_window;
-    expect(window.runs).toHaveLength(3);
-    expect(window.verdicts).toBe(24);
+    expect(window.ring.length).toBe(20);
+    expect(window.verdicts).toBe(20);
+    expect(window.ring).toBe('a'.repeat(20));
   }));
 
-  test('reported sums equal the surviving runs after the window advances', withTmp(async (stateFile) => {
+  test('reported counts equal per-letter tallies of the ring', withTmp(async (stateFile) => {
     const payloads = [
       { judge_accept: 8 },
       { judge_downgrade: 5, judge_suppress: 3 },
@@ -94,13 +88,11 @@ describe('update-reflection-state judge window', () => {
     for (const payload of payloads) await runPayload(stateFile, payload);
 
     const window = readState(stateFile).counters.judge_window;
-    const sums = window.runs.reduce((total: any, run: any) => ({
-      accept: total.accept + run.accept,
-      downgrade: total.downgrade + run.downgrade,
-      suppress: total.suppress + run.suppress,
-    }), { accept: 0, downgrade: 0, suppress: 0 });
-    expect(window).toMatchObject(sums);
-    expect(window.verdicts).toBe(sums.accept + sums.downgrade + sums.suppress);
+    expect(window.ring).toMatch(/^[ads]{1,20}$/);
+    expect(window.accept).toBe(window.ring.split('a').length - 1);
+    expect(window.downgrade).toBe(window.ring.split('d').length - 1);
+    expect(window.suppress).toBe(window.ring.split('s').length - 1);
+    expect(window.verdicts).toBe(window.ring.length);
   }));
 
   test('cumulative judge tallies keep growing past the window totals', withTmp(async (stateFile) => {
@@ -119,13 +111,14 @@ describe('update-reflection-state judge window', () => {
     writeState(stateFile, { counters: { judge_window: 'malformed' } });
     const state = await runPayload(stateFile, { judge_accept: 1, judge_suppress: 2 });
 
-    expect(state.counters.judge_window.runs).toHaveLength(1);
+    expect(state.counters.judge_window.ring).toBe('ass');
     expect(state.counters.judge_window).toMatchObject({
       accept: 1,
       downgrade: 0,
       suppress: 2,
       verdicts: 3,
     });
+    expect(state.counters.judge_window).not.toHaveProperty('runs');
   }));
 
   test('--reset-counters clears the judge window and stamps judge_since', withTmp(async (stateFile) => {
@@ -153,5 +146,40 @@ describe('update-reflection-state judge window', () => {
     const counters = readState(stateFile).counters;
     expect(counters).not.toHaveProperty('judge_window');
     expect(typeof counters.judge_since).toBe('string');
+  }));
+
+  test('an on-disk runs window folds into the ring without resetting', withTmp(async (stateFile) => {
+    writeState(stateFile, {
+      counters: {
+        judge_accept: 6,
+        judge_downgrade: 3,
+        judge_suppress: 3,
+        judge_window: {
+          runs: [
+            { at: '2026-08-01T00:00:00.000Z', accept: 4, downgrade: 2, suppress: 0 },
+            { at: '2026-08-02T00:00:00.000Z', accept: 2, downgrade: 1, suppress: 3 },
+          ],
+          accept: 6,
+          downgrade: 3,
+          suppress: 3,
+          verdicts: 12,
+          since: '2026-08-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    const state = await runPayload(stateFile, { judge_accept: 5, judge_downgrade: 2, judge_suppress: 3 });
+    const window = state.counters.judge_window;
+    const expected = ('aaaadd' + 'aadsss' + 'aaaaaddsss').slice(-20);
+    expect(window.ring).toBe(expected);
+    expect(window.accept).toBe(expected.split('a').length - 1);
+    expect(window.downgrade).toBe(expected.split('d').length - 1);
+    expect(window.suppress).toBe(expected.split('s').length - 1);
+    expect(window.verdicts).toBe(expected.length);
+    expect(window).not.toHaveProperty('runs');
+    expect(window).not.toHaveProperty('since');
+    expect(state.counters.judge_accept).toBe(11);
+    expect(state.counters.judge_downgrade).toBe(5);
+    expect(state.counters.judge_suppress).toBe(6);
   }));
 });


### PR DESCRIPTION
## Summary
`reflection-state.json`'s `counters.judge_window` kept up to 20 pretty-printed run objects to track the last 20 judge verdicts; six skills `Read` the state file whole, so that structure carried ~850 resident tokens of detail nothing reads. This replaces it with a fixed-length string ring: each run appends its verdicts as `a`/`d`/`s` letters, the ring is trimmed to the last 20 characters, and the accept/downgrade/suppress/verdicts counts are derived from the ring instead of stored redundantly.

An on-disk window still in the old `runs` shape is folded into the ring on the next run (flattened in order, then trimmed) rather than reset, so the migration doesn't clear an active judge flag.

Closes #849.

## Changes
- `scripts/update-reflection-state.ts`: replace the run-object window builder with a string-ring builder; migrate a legacy `runs`-shaped window into the ring on read.
- `tests/update-reflection-state-window.test.ts`: rewrite the window tests for ring semantics and add a migration test for the legacy `runs` shape.

## Test plan
- `cd plugins/claude-code-hermit && bun test` — 4684 pass, 0 fail
- `bunx tsc` — exit 0
- Live shape check: drove 25 verdict-bearing runs through the script on a scratch state file — `judge_window.ring.length === 20`, `verdicts === 20`, no `runs`/`since` keys, file at 28 lines (was ~150)