### PR TITLE
fix(claude-code-hermit): fold legacy judge windows on quiet runs and stop clustering verdicts

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Auto-mode denial diagnostics dedup per tool rather than per tool+input, so a burst of different commands blocked on the same tool sends one message instead of one each; the next window reports how many it absorbed (`(+3 more in the previous 30 min)`).
 - The denial diagnostic follows the normal maintainer-tier routing instead of always falling back to `SHELL.md` Findings: maintainer chat when configured, the primary chat on a `technical` profile without one, Findings on a `non-technical` profile. An unreachable or absent channel now suppresses only the send, so the Findings trail survives a dead bot token.
 
+### Fixed
+- A legacy run-object judge window folds into the 20-verdict ring on any reflect run, not only one that carries verdicts, so a quiet install stops carrying the old structure in `reflection-state.json`.
+- Verdicts from one judge run are interleaved in that window instead of grouped by type, so a run straddling the 20-verdict boundary no longer sheds its accepts first and inflates the `reflection-judge` suppress ratio.
+
 ## [1.2.50] - 2026-08-28
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/update-reflection-state.ts
+++ b/plugins/claude-code-hermit/scripts/update-reflection-state.ts
@@ -213,27 +213,45 @@ const judgeRun = {
 };
 const judgeVerdicts = judgeRun.accept + judgeRun.downgrade + judgeRun.suppress;
 // Only the last WINDOW_VERDICTS characters can survive the slice below, so each letter
-// run is capped there: an absurd count (garbled payload, corrupted on-disk run) would
+// count is capped there: an absurd count (garbled payload, corrupted on-disk run) would
 // otherwise throw RangeError out of String.repeat and abort the whole state write.
 // Capping is lossless — a run longer than the window already drops everything before it.
+// Verdicts inside one judge run are simultaneous (one batch, one judge call), so there is
+// no true order among them. The letters are interleaved largest-remaining-first rather
+// than clustered a...d...s...: a run straddling the window boundary then sheds its verdicts
+// proportionally, instead of always losing its accepts first and inflating the suppress
+// ratio Component Health reads off this window.
 const RING_RE = new RegExp(`^[ads]{1,${WINDOW_VERDICTS}}$`);
-const letters = (run: Json) =>
-  'a'.repeat(Math.min(intOf(run.accept), WINDOW_VERDICTS)) +
-  'd'.repeat(Math.min(intOf(run.downgrade), WINDOW_VERDICTS)) +
-  's'.repeat(Math.min(intOf(run.suppress), WINDOW_VERDICTS));
-if (judgeVerdicts > 0) {
-  const storedRuns = Array.isArray(c.judge_window?.runs) && c.judge_window.runs.every((run: Json) =>
-    run && typeof run === 'object' && !Array.isArray(run) &&
-    typeof run.at === 'string' && !Number.isNaN(Date.parse(run.at)) &&
-    ['accept', 'downgrade', 'suppress'].every((key) =>
-      typeof run[key] === 'number' && Number.isFinite(run[key]) && run[key] >= 0
-    )
-  ) ? c.judge_window.runs : [];
-  const priorRing = typeof c.judge_window?.ring === 'string' && RING_RE.test(c.judge_window.ring)
-    ? c.judge_window.ring
-    : storedRuns.map(letters).join('');
-  const ring = (priorRing + letters(judgeRun))
-    .slice(-WINDOW_VERDICTS);
+const letters = (run: Json) => {
+  const left: Record<string, number> = {
+    a: Math.min(intOf(run.accept), WINDOW_VERDICTS),
+    d: Math.min(intOf(run.downgrade), WINDOW_VERDICTS),
+    s: Math.min(intOf(run.suppress), WINDOW_VERDICTS),
+  };
+  let out = '';
+  for (let remaining = left.a + left.d + left.s; remaining > 0; remaining -= 1) {
+    const ch = ['a', 'd', 's'].filter((k) => left[k] > 0)
+      .reduce((best, k) => (left[k] > left[best] ? k : best));
+    left[ch] -= 1;
+    out += ch;
+  }
+  return out;
+};
+
+const storedRuns = Array.isArray(c.judge_window?.runs) && c.judge_window.runs.every((run: Json) =>
+  run && typeof run === 'object' && !Array.isArray(run) &&
+  typeof run.at === 'string' && !Number.isNaN(Date.parse(run.at)) &&
+  ['accept', 'downgrade', 'suppress'].every((key) =>
+    typeof run[key] === 'number' && Number.isFinite(run[key]) && run[key] >= 0
+  )
+) ? c.judge_window.runs : [];
+const isRing = typeof c.judge_window?.ring === 'string' && RING_RE.test(c.judge_window.ring);
+const priorRing = isRing ? c.judge_window.ring : storedRuns.map(letters).join('');
+// A zero-verdict run still folds a legacy runs-shaped window into the ring: a quiet install
+// can go a long time without another verdict, and the point of the ring is to stop carrying
+// that structure in a file six skills Read whole.
+if (judgeVerdicts > 0 || (!isRing && priorRing.length > 0)) {
+  const ring = (priorRing + letters(judgeRun)).slice(-WINDOW_VERDICTS);
   c.judge_window = {
     ring,
     accept: ring.split('a').length - 1,

--- a/plugins/claude-code-hermit/tests/update-reflection-state-window.test.ts
+++ b/plugins/claude-code-hermit/tests/update-reflection-state-window.test.ts
@@ -39,7 +39,7 @@ describe('update-reflection-state judge window', () => {
     const state = await runPayload(stateFile, { judge_accept: 2, judge_downgrade: 1, judge_suppress: 3 });
     const window = state.counters.judge_window;
 
-    expect(window.ring).toBe('aadsss');
+    expect(window.ring).toBe('sasads');
     expect(window).toMatchObject({ accept: 2, downgrade: 1, suppress: 3, verdicts: 6 });
     expect(window).not.toHaveProperty('runs');
     expect(window).not.toHaveProperty('since');
@@ -111,7 +111,7 @@ describe('update-reflection-state judge window', () => {
     writeState(stateFile, { counters: { judge_window: 'malformed' } });
     const state = await runPayload(stateFile, { judge_accept: 1, judge_suppress: 2 });
 
-    expect(state.counters.judge_window.ring).toBe('ass');
+    expect(state.counters.judge_window.ring).toBe('sas');
     expect(state.counters.judge_window).toMatchObject({
       accept: 1,
       downgrade: 0,
@@ -170,7 +170,7 @@ describe('update-reflection-state judge window', () => {
 
     const state = await runPayload(stateFile, { judge_accept: 5, judge_downgrade: 2, judge_suppress: 3 });
     const window = state.counters.judge_window;
-    const expected = ('aaaadd' + 'aadsss' + 'aaaaaddsss').slice(-20);
+    const expected = ('aaadad' + 'sasads' + 'aaasadsads').slice(-20);
     expect(window.ring).toBe(expected);
     expect(window.accept).toBe(expected.split('a').length - 1);
     expect(window.downgrade).toBe(expected.split('d').length - 1);
@@ -183,11 +183,35 @@ describe('update-reflection-state judge window', () => {
     expect(state.counters.judge_suppress).toBe(6);
   }));
 
+  test('a zero-verdict run folds a legacy runs window into the ring', withTmp(async (stateFile) => {
+    writeState(stateFile, {
+      counters: {
+        judge_window: {
+          runs: [
+            { at: '2026-08-01T00:00:00.000Z', accept: 4, downgrade: 2, suppress: 0 },
+            { at: '2026-08-02T00:00:00.000Z', accept: 2, downgrade: 1, suppress: 3 },
+          ],
+          accept: 6,
+          downgrade: 3,
+          suppress: 3,
+          verdicts: 12,
+          since: '2026-08-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    const window = (await runPayload(stateFile, {})).counters.judge_window;
+    expect(window.ring).toBe('aaadad' + 'sasads');
+    expect(window).toMatchObject({ accept: 6, downgrade: 3, suppress: 3, verdicts: 12 });
+    expect(window).not.toHaveProperty('runs');
+    expect(window).not.toHaveProperty('since');
+  }));
+
   test('an absurd verdict count caps the ring instead of aborting the state write', withTmp(async (stateFile) => {
     const state = await runPayload(stateFile, { judge_accept: 1e11, judge_suppress: 4 });
     const window = state.counters.judge_window;
 
-    expect(window.ring).toBe('a'.repeat(16) + 'ssss');
+    expect(window.ring).toBe('a'.repeat(12) + 'asasasas');
     expect(window).toMatchObject({ accept: 16, downgrade: 0, suppress: 4, verdicts: 20 });
     expect(typeof state.counters.last_run_at).toBe('string');
   }));


### PR DESCRIPTION
## Summary
Follow-up to the 20-verdict judge ring shipped in 1.2.50, addressing two review comments left on #851 after it merged. Both describe real behavior; one is fixed as proposed, the other is fixed differently than proposed.

**Migration never ran on quiet installs.** The legacy `runs` to ring fold sat inside the `judgeVerdicts > 0` guard, so an install whose reflect runs produce no verdicts kept the old run-object window indefinitely, which is exactly the structure the ring existed to stop carrying in a file six skills `Read` whole. The fold now runs whenever an unmigrated window is on disk, verdicts or not. (Impact was token weight only, not correctness: the old shape carried `accept`/`downgrade`/`suppress`/`verdicts` at the top level too, so the Component Health flag still read it fine.)

**Clustered letters biased the suppress ratio.** `letters()` emitted each run as `a...d...s...` blocks, so a run straddling the 20-character boundary always lost its accepts first, systematically inflating the suppress ratio Component Health reads. Verdicts inside one judge run are simultaneous (one batch, one call), so any intra-run order is invented; clustering just made the invention directional. Interleaving largest-remaining-first sheds a boundary run's verdicts proportionally instead.

Not taken: the review's suggestion to pass an ordered verdict sequence from the caller. There is no order to pass, and encoding candidate-batch position as chronology would cost a model-composed payload string in `reflect/SKILL.md` for fabricated precision.

## Changes
- `scripts/update-reflection-state.ts`: hoist `storedRuns`/`priorRing` out of the verdict guard and widen it to `judgeVerdicts > 0 || (!isRing && priorRing.length > 0)`; rewrite `letters()` to interleave largest-remaining-first. The per-type `WINDOW_VERDICTS` cap is unchanged and stays lossless for the surviving tail.
- `tests/update-reflection-state-window.test.ts`: update the four pinned ring literals for interleaved output, add a test that a legacy `runs` window folds on a zero-verdict run.

## Test plan
- `cd plugins/claude-code-hermit && bun test` - 4697 pass, 0 fail
- `bunx tsc` - exit 0
- Ring literals recomputed independently rather than hand-derived, then pinned in the tests; counts (`accept`/`downgrade`/`suppress`/`verdicts`) are unchanged by interleaving in every existing case, including the absurd-count cap test.