### PR TITLE
fix(claude-code-hermit): make the docker entrypoint boot-conflict guard reachable

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -26,6 +26,7 @@
 - The denial diagnostic follows the normal maintainer-tier routing instead of always falling back to `SHELL.md` Findings: maintainer chat when configured, the primary chat on a `technical` profile without one, Findings on a `non-technical` profile. An unreachable or absent channel now suppresses only the send, so the Findings trail survives a dead bot token.
 - A legacy run-object judge window folds into the 20-verdict ring on any reflect run, not only one that carries verdicts, so a quiet install stops carrying the old structure in `reflection-state.json`.
 - Verdicts from one judge run are interleaved in that window instead of grouped by type, so a run straddling the 20-verdict boundary no longer sheds its accepts first and inflates the `reflection-judge` suppress ratio.
+- The Docker entrypoint's split-brain boot guard read `runtime.json` from a doubled `.claude-code-hermit/.claude-code-hermit/` path, so it never fired and a container would boot beside a live host instance owning the same state dir. It now refuses that boot as intended, and writes the `.boot-conflict` marker where `hermit-docker up` reads it. `HERMIT_FORCE_BOOT=1` still overrides.
 
 ## [1.2.50] - 2026-08-28
 

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -553,7 +553,7 @@ fi
 # tmux healthcheck) rather than exit, so `restart: unless-stopped` can't loop us.
 # HERMIT_FORCE_BOOT=1 overrides, for split-state recovery.
 if [ "${HERMIT_FORCE_BOOT:-0}" != "1" ]; then
-  _rt="${AGENT_DIR}/.claude-code-hermit/state/runtime.json"
+  _rt="${AGENT_DIR}/state/runtime.json"
   _mode="$(jq -r '.runtime_mode // empty' "$_rt" 2>/dev/null || true)"
   if [ -n "$_mode" ] && [ "$_mode" != "docker" ]; then
     # A cleanly-stopped owner is definitively dead; its frozen runtime_mode and
@@ -563,18 +563,18 @@ if [ "${HERMIT_FORCE_BOOT:-0}" != "1" ]; then
     _fresh=0
     if [ "$_state" != "idle" ] && [ -z "$_done" ]; then
       for _f in state/routine-monitor-liveness.json state/heartbeat-liveness.json state/.heartbeat sessions/.status.json; do
-        if [ -n "$(find "${AGENT_DIR}/.claude-code-hermit/$_f" -mmin -10 2>/dev/null || true)" ]; then _fresh=1; break; fi
+        if [ -n "$(find "${AGENT_DIR}/$_f" -mmin -10 2>/dev/null || true)" ]; then _fresh=1; break; fi
       done
     fi
     if [ "$_fresh" = "1" ]; then
       echo "[docker-entrypoint] BOOT CONFLICT: a live '$_mode' instance owns this project's state dir."
       echo "[docker-entrypoint] Staying inert (no claude started). Stop the other instance, then: hermit-docker restart"
-      printf 'live %s owner detected at boot\n' "$_mode" > "${AGENT_DIR}/.claude-code-hermit/state/.boot-conflict"
+      printf 'live %s owner detected at boot\n' "$_mode" > "${AGENT_DIR}/state/.boot-conflict"
       while true; do sleep 300; done
     fi
   fi
 fi
-rm -f "${AGENT_DIR}/.claude-code-hermit/state/.boot-conflict" 2>/dev/null || true
+rm -f "${AGENT_DIR}/state/.boot-conflict" 2>/dev/null || true
 
 # --- 5. Launch hermit-start ---
 "${AGENT_DIR}/bin/hermit-start" "$@"

--- a/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
@@ -300,17 +300,32 @@ describe('Entrypoint: §4b boot conflict guard', () => {
   const { freshDir, cleanup } = freshDirFactory('hermit-4b-');
   afterAll(cleanup);
 
-  function runGuard(runtime: object, opts: { freshLiveness?: boolean } = {}) {
+  function runGuard(
+    runtime: object,
+    opts: { liveness?: 'fresh' | 'stale'; forceBoot?: string } = {},
+  ) {
     const agentDir = path.join(freshDir(), '.claude-code-hermit');
     const stateDir = path.join(agentDir, 'state');
     fs.mkdirSync(stateDir, { recursive: true });
     fs.writeFileSync(path.join(stateDir, 'runtime.json'), JSON.stringify(runtime));
-    if (opts.freshLiveness) fs.writeFileSync(path.join(stateDir, '.heartbeat'), '');
+    if (opts.liveness) {
+      const beat = path.join(stateDir, '.heartbeat');
+      fs.writeFileSync(beat, '');
+      // The guard's window is `find -mmin -10`; backdate 20min for the "stale
+      // signal reads as unknown, so boot" branch.
+      if (opts.liveness === 'stale') {
+        const old = new Date(Date.now() - 20 * 60_000);
+        fs.utimesSync(beat, old, old);
+      }
+    }
 
-    const script = `set -uo pipefail\nsleep() { exit 42; }\nAGENT_DIR=${JSON.stringify(agentDir)}\n${block}`;
+    // `set -euo pipefail` mirrors the real entrypoint header: without -e, a
+    // future edit that drops an `|| true` would abort the whole entrypoint in
+    // production (container never boots) while still passing here.
+    const script = `set -euo pipefail\nsleep() { exit 42; }\nAGENT_DIR=${JSON.stringify(agentDir)}\n${block}`;
     const out = spawnSync('bash', ['-c', script], {
       encoding: 'utf8',
-      env: { ...process.env, HERMIT_FORCE_BOOT: '0' },
+      env: { ...process.env, HERMIT_FORCE_BOOT: opts.forceBoot ?? '0' },
     });
     return {
       status: out.status,
@@ -319,21 +334,46 @@ describe('Entrypoint: §4b boot conflict guard', () => {
     };
   }
 
+  // The guard reads runtime.json through jq. Without it every `jq` call fails,
+  // `_mode` comes back empty and the guard silently self-skips — which is the
+  // exact shape of the bug under test, so assert the dependency explicitly
+  // rather than let its absence read as a logic regression.
+  test('entrypoint §4b: jq is available to run the guard', () => {
+    expect(spawnSync('sh', ['-c', 'command -v jq'], { encoding: 'utf8' }).status).toBe(0);
+  });
+
   test('entrypoint §4b: goes inert over a live non-docker owner', () => {
-    const r = runGuard({ runtime_mode: 'tmux', session_state: 'active' }, { freshLiveness: true });
+    const r = runGuard({ runtime_mode: 'tmux', session_state: 'active' }, { liveness: 'fresh' });
     expect(r.status).toBe(42);
     expect(r.stdout).toContain('BOOT CONFLICT');
     expect(r.marker).toBe(true);
   });
 
   test('entrypoint §4b: boots over a cleanly-stopped owner', () => {
-    const r = runGuard({ runtime_mode: 'tmux', session_state: 'idle' }, { freshLiveness: true });
+    const r = runGuard({ runtime_mode: 'tmux', session_state: 'idle' }, { liveness: 'fresh' });
     expect(r.status).toBe(0);
     expect(r.marker).toBe(false);
   });
 
   test('entrypoint §4b: boots when the recorded owner is docker', () => {
     const r = runGuard({ runtime_mode: 'docker' });
+    expect(r.status).toBe(0);
+    expect(r.marker).toBe(false);
+  });
+
+  // Stale-is-unknown is the guard's only protection against refusing every boot
+  // after an unclean host exit (runtime.json frozen at active, owner long gone).
+  test('entrypoint §4b: boots when the liveness signal is stale', () => {
+    const r = runGuard({ runtime_mode: 'tmux', session_state: 'active' }, { liveness: 'stale' });
+    expect(r.status).toBe(0);
+    expect(r.marker).toBe(false);
+  });
+
+  test('entrypoint §4b: HERMIT_FORCE_BOOT=1 overrides a live owner', () => {
+    const r = runGuard(
+      { runtime_mode: 'tmux', session_state: 'active' },
+      { liveness: 'fresh', forceBoot: '1' },
+    );
     expect(r.status).toBe(0);
     expect(r.marker).toBe(false);
   });

--- a/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
@@ -7,13 +7,14 @@
 //
 // Usage: bun test tests/docker-baseline-content.test.ts   (from the plugin root)
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import { PLUGIN_ROOT } from './helpers/run';
+import { freshDirFactory } from './helpers/workdir';
 import { getSessionName } from '../scripts/lib/tmux';
 
 const dockerfile = fs.readFileSync(
@@ -279,5 +280,61 @@ describe('Entrypoint: marketplace registration uses list --json, not dir existen
     expect(entrypoint).toContain('already enabled');
     // No enable site silently swallows failures via `|| true` anymore.
     expect(entrypoint).not.toMatch(/plugin enable[^\n]*\|\| true/);
+  });
+});
+
+// -------------------------------------------------------
+// Entrypoint §4b: the container-side split-brain boot guard.
+// hermit-start's own shouldRefuseBoot self-skips inside a container, so this
+// block is the only guard against booting a container over a live host hermit.
+// It shipped reading runtime.json from a doubled AGENT_DIR path, so jq always
+// came back empty and the whole block was unreachable (GH #863). A content
+// assertion on the path would not catch a later logic break, so this extracts
+// the real block and runs it.
+// -------------------------------------------------------
+describe('Entrypoint: §4b boot conflict guard', () => {
+  const block = entrypoint.slice(entrypoint.indexOf('# --- 4b.'), entrypoint.indexOf('# --- 5.'));
+
+  // `sleep` is overridden so the guard's `while true; do sleep 300; done` inert
+  // hold terminates: exit 42 means "the guard fired and went inert".
+  const { freshDir, cleanup } = freshDirFactory('hermit-4b-');
+  afterAll(cleanup);
+
+  function runGuard(runtime: object, opts: { freshLiveness?: boolean } = {}) {
+    const agentDir = path.join(freshDir(), '.claude-code-hermit');
+    const stateDir = path.join(agentDir, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'runtime.json'), JSON.stringify(runtime));
+    if (opts.freshLiveness) fs.writeFileSync(path.join(stateDir, '.heartbeat'), '');
+
+    const script = `set -uo pipefail\nsleep() { exit 42; }\nAGENT_DIR=${JSON.stringify(agentDir)}\n${block}`;
+    const out = spawnSync('bash', ['-c', script], {
+      encoding: 'utf8',
+      env: { ...process.env, HERMIT_FORCE_BOOT: '0' },
+    });
+    return {
+      status: out.status,
+      stdout: out.stdout,
+      marker: fs.existsSync(path.join(stateDir, '.boot-conflict')),
+    };
+  }
+
+  test('entrypoint §4b: goes inert over a live non-docker owner', () => {
+    const r = runGuard({ runtime_mode: 'tmux', session_state: 'active' }, { freshLiveness: true });
+    expect(r.status).toBe(42);
+    expect(r.stdout).toContain('BOOT CONFLICT');
+    expect(r.marker).toBe(true);
+  });
+
+  test('entrypoint §4b: boots over a cleanly-stopped owner', () => {
+    const r = runGuard({ runtime_mode: 'tmux', session_state: 'idle' }, { freshLiveness: true });
+    expect(r.status).toBe(0);
+    expect(r.marker).toBe(false);
+  });
+
+  test('entrypoint §4b: boots when the recorded owner is docker', () => {
+    const r = runGuard({ runtime_mode: 'docker' });
+    expect(r.status).toBe(0);
+    expect(r.marker).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The Docker entrypoint's §4b split-brain guard has never executed. It read `runtime.json` from `${AGENT_DIR}/.claude-code-hermit/state/runtime.json`, but `AGENT_DIR` already ends in `.claude-code-hermit`, so the path resolved to `<project>/.claude-code-hermit/.claude-code-hermit/state/runtime.json` and never existed. `jq` returned empty, `[ -n "$_mode" ]` was always false, and the whole block was unreachable: no liveness scan, no `BOOT CONFLICT` message, no `.boot-conflict` marker, no inert hold.

The consequence is that a container boots happily on top of a live host tmux hermit owning the same state dir, which is the exact split-brain the guard was written to prevent. Most likely to bite on a first containerized boot, since the documented migration path is just "run `/docker-setup` in the existing project". `HERMIT_FORCE_BOOT` existing to override the guard is what makes its deadness visible as a bug.

## Changes

```
BEFORE: docker up -> §4b reads <proj>/.claude-code-hermit/.claude-code-hermit/state/runtime.json
                     -> jq finds nothing -> guard skipped -> claude starts beside the live host hermit

AFTER:  docker up -> §4b reads <proj>/.claude-code-hermit/state/runtime.json
                     |- tmux owner, not idle, liveness <10 min -> BOOT CONFLICT, marker written, inert hold
                     |- tmux owner but idle / shutdown_completed_at set -> boots
                     |- runtime_mode=docker -> boots
                     `- HERMIT_FORCE_BOOT=1 -> boots (unchanged)
```

- `state-templates/docker/docker-entrypoint.hermit.sh.template`: drop the doubled `.claude-code-hermit/` segment at all four occurrences in §4b, matching the correct form `cleanup()` already uses on the same variable.
- `tests/docker-baseline-content.test.ts`: new `Entrypoint: §4b boot conflict guard` block. Nothing in `tests/` covered §4b, which is why a path typo in a guard that only runs on a contended boot went unnoticed.
- `CHANGELOG.md`: `[Unreleased]` / `### Fixed` bullet.

Two details worth a reviewer's attention:

- **The marker was doubly unreachable.** `state-templates/bin/hermit-docker` reads `.boot-conflict` from the correct un-doubled path, so even if the guard had fired, `hermit-docker up` would never have reported it. Same one-line fix covers both ends.
- **The test is behavioral, not a string assertion.** It extracts the real §4b block from the template and runs it under `bash` against a fixture state dir, with `sleep()` overridden to `exit 42` so the inert hold terminates. A `grep`-style assertion on the path would have caught this typo but not a future logic break in the same block, which is the class of defect that went unnoticed here.

Introduced with the guard itself, so no released version has ever had working protection. Existing operators pick the fix up on their next `hermit-evolve`, which treats the deployed entrypoint as manifest-managed and `bootCritical`; no `### Upgrade Instructions` step needed.

## Test plan

- New case verified **red before the fix** (`expect(r.status).toBe(42)` received `0`, proving the guard was dead) and green after.
- `bun test tests/docker-baseline-content.test.ts` from `plugins/claude-code-hermit`: 36 pass, 0 fail.
- `bun test --parallel --timeout=45000` (the CI spine, `.github/workflows/test-hooks.yml`): **4741 pass, 0 fail** across 153 files.
- `bunx tsc --noEmit` from the repo root: clean.
- `bash -n` on the template: exit 0.

Closes #863