### PR TITLE
fix(claude-code-hermit): keep .jsonl ledgers out of doctor's permissions check

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## [Unreleased]
 
-### Upgrade Instructions
-1. Tighten permissions on existing JSONL ledgers so the widened doctor check does not report them as world-readable: `find .claude-code-hermit/state -name '*.jsonl' -exec chmod 600 {} +`. Use `find`, not `chmod .../*.jsonl`: an unmatched glob is passed through literally and exits non-zero, which would fail this step on an install that has no ledgers yet.
-
 ### Added
 - `hermit-doctor` gains a `classifier-denials` check reading a rolling 7 days of auto-mode denials, with the program name for shell commands. It stays `ok` below a reporting floor (under 3 denials, no cluster past 1) since ambient denials are expected under auto mode, `warn`s at or above it, and `fail`s when 3 or more land inside any 10-minute span. Clustering is cross-tool. The row is tagged `tier: maintainer` in the doctor JSON and travels only on the maintainer leg of doctor's notice, so a client chat never sees it.
 
@@ -12,7 +9,7 @@
 - `hermit-doctor` sends one two-leg notice on every run and `--maintainer` no longer changes the route, which `channel-send` resolves from the install's own config: a technical install with no maintainer chat gets the full summary in its primary chat, a non-technical one gets the plain summary there and the technical detail in `SHELL.md` Findings.
 - `reflect`'s `skill-correction:*` route with no procedure brief now always emits a `## Skill Improvement` candidate carrying no `source_artifact:`, and `skill-preference:*` does the same whenever `.claude/skills/<name>/SKILL.md` exists or `<plugin>:<name>` is in the available-skills list (an unreadable list still yields a plain candidate). Whether the target is an editable override, a plugin skill, or gone is decided once by `proposal-act` at accept.
 - The `PermissionDenied` hook records each denial as one line in `state/permission-denied-events.jsonl` (timestamp, tool, shell program name) for doctor's `classifier-denials` check; tool input never leaves the ledger. `state/permission-denied-alerts.json` is now keyed by tool with an open-window record, and entries in the previous tool+input hash shape are dropped on first read. Lines that cannot be read back as a denial are counted in the doctor row rather than silently skipped.
-- `state/*.jsonl` ledgers are created 0600 rather than at the process umask, and doctor's `permissions` and `state` checks now cover `.jsonl` as well as `.json` (a JSONL file is validated per line, with a torn trailing line tolerated).
+- `state/*.jsonl` ledgers are created 0600 rather than at the process umask, and doctor's `state` check now covers `.jsonl` as well as `.json` (validated per line, with a torn trailing line tolerated). The `permissions` check still looks only at `config.json`, `state/*.json` and `proposals/`: the ledgers carry no secrets, so inspecting them would warn on every install upgraded from before the 0600 default.
 
 ### Fixed
 - `rc-server gc` collects orphaned bridge worktrees on macOS. `liveCwds()` read `/proc`, which does not exist there, so it returned null and the GC refused to collect anything; it now reads process cwds through `lsof -n -P` on darwin, bounded at 5s. A missing `lsof`, or a timeout that leaves a partial listing, returns null rather than a short set, so the GC skips instead of treating the processes `lsof` had not reached as dead and deleting a live worktree.

--- a/plugins/claude-code-hermit/scripts/doctor-check.ts
+++ b/plugins/claude-code-hermit/scripts/doctor-check.ts
@@ -682,7 +682,12 @@ function checkPermissions(p: DoctorPaths = PATHS) {
     const looseFiles: string[] = [];
     const targets: string[] = [configPath];
     if (fs.existsSync(stateDir)) {
-      for (const f of globDir(stateDir, /\.jsonl?$/)) targets.push(f);
+      // `.json` only. The append-only `.jsonl` ledgers are created 0600 by
+      // lib/append-jsonl.ts and hatch-scaffold.ts, but they carry no secrets
+      // (timestamps, counts, tool and program names), so inspecting pre-existing
+      // ones would warn on every install upgraded from before that default and
+      // buy a chmod migration for a finding with no operational consequence.
+      for (const f of globDir(stateDir, /\.json$/)) targets.push(f);
     }
     for (const target of targets) {
       if (!fs.existsSync(target)) continue;

--- a/plugins/claude-code-hermit/scripts/hatch-scaffold.ts
+++ b/plugins/claude-code-hermit/scripts/hatch-scaffold.ts
@@ -150,8 +150,7 @@ for (const jsonl of [
 ]) {
   const dest = path.join(hermit, 'state', jsonl);
   // 0600, not the umask default a bare writeFileSync would leave: these ledgers
-  // carry channel and user IDs, and doctor's `permissions` check reports any
-  // world-readable state file.
+  // carry channel and user IDs.
   seedIfAbsent(dest, () => fs.writeFileSync(dest, '', { mode: 0o600 }));
 }
 // state/pending-close.json: deliberately never created.

--- a/plugins/claude-code-hermit/scripts/lib/append-jsonl.ts
+++ b/plugins/claude-code-hermit/scripts/lib/append-jsonl.ts
@@ -26,9 +26,9 @@ function appendJsonlLine(filePath: string, eventJson: string): string | null {
 /**
  * Create the ledger at 0600 if it does not exist yet. Rows across these files carry
  * channel and user IDs, tool names and command programs, and `fs.appendFileSync`
- * would otherwise leave a new file at the process umask (0644 under the usual 022)
- * — which doctor's `permissions` check reports as world-readable. Defined here so
- * every JSONL writer inherits it instead of each remembering the openSync dance.
+ * would otherwise leave a new file at the process umask (0644 under the usual 022).
+ * Defined here so every JSONL writer inherits it instead of each remembering the
+ * openSync dance.
  */
 function ensureLedgerFile(filePath: string): void {
   try {

--- a/plugins/claude-code-hermit/tests/doctor-classifier-denials.test.ts
+++ b/plugins/claude-code-hermit/tests/doctor-classifier-denials.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
-import { checkClassifierDenials, checkStateFiles, resolvePaths } from '../scripts/doctor-check';
+import { checkClassifierDenials, checkPermissions, checkStateFiles, resolvePaths } from '../scripts/doctor-check';
 import { freshDirFactory } from './helpers/workdir';
 
 const PLUGIN_ROOT = path.resolve(import.meta.dir, '..');
@@ -215,5 +215,35 @@ describe('doctor state check — JSONL validation', () => {
       '{torn\n' + JSON.stringify({ ts: '2026-08-28T11:00:00Z' }) + '\n',
     );
     expect(result.status).toBe('fail');
+  });
+});
+
+describe('doctor permissions check — .jsonl ledgers are out of scope', () => {
+  /** Seed state/ with the given files at the given modes and run the permissions check. */
+  function permsScenario(files: Record<string, number>) {
+    const projectRoot = freshDir();
+    const hermitDir = path.join(projectRoot, '.claude-code-hermit');
+    const stateDir = path.join(hermitDir, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(hermitDir, 'config.json'), '{}', { mode: 0o600 });
+    for (const [name, mode] of Object.entries(files)) {
+      const dest = path.join(stateDir, name);
+      fs.writeFileSync(dest, name.endsWith('.jsonl') ? '' : '{}');
+      fs.chmodSync(dest, mode);
+    }
+    return checkPermissions(resolvePaths(hermitDir, PLUGIN_ROOT));
+  }
+
+  test('a world-readable .jsonl ledger does not warn', () => {
+    // 0644 is what every install upgraded from before the 0600 default still has.
+    const result = permsScenario({ 'usage-metrics.jsonl': 0o644, 'alert-state.json': 0o600 });
+    expect(result.status).toBe('ok');
+  });
+
+  test('a world-readable .json state file still warns', () => {
+    const result = permsScenario({ 'usage-metrics.jsonl': 0o644, 'alert-state.json': 0o644 });
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('alert-state.json');
+    expect(result.detail).not.toContain('usage-metrics.jsonl');
   });
 });


### PR DESCRIPTION
## Summary

Widening doctor's `permissions` check from `state/*.json` to `state/*.jsonl?` was a side effect of #859, not something #853 asked for. Every ledger written before 0600 became the default is `0644`/`0664` on disk, so on the next `/hermit-doctor` run every upgraded install would report `warn: world-readable: usage-metrics.jsonl, …` — and the `### Upgrade Instructions` chmod step existed only to clear a warning the same release had introduced.

The ledgers hold timestamps, token counts, tool names and command program names. Credentials live in `<state_dir>/.env`, which the check never looked at. So the finding had no operational consequence, and doctor is report-only by design, which means the widening could never self-heal: it needed a migration on every install, forever.

## Changes

- `checkPermissions` goes back to `config.json`, `state/*.json` and `proposals/`. A comment records why `.jsonl` is deliberately out of scope, so this is not re-widened by the next person who notices the ledgers are unlisted.
- The `[Unreleased]` `### Upgrade Instructions` section is removed (it held only that step), and the `### Changed` bullet now says what remains true: ledgers are created 0600, and the `state` check covers `.jsonl`.
- Two regression tests: a world-readable `.jsonl` ledger reports `ok`; a world-readable `.json` state file still warns and names itself.
- The two comments that justified 0600 with "doctor's `permissions` check reports it" now just state the reason the mode is right.

Kept deliberately: 0600-on-create in `lib/append-jsonl.ts` and `hatch-scaffold.ts`, the `state` check's per-line JSONL validation (the torn-write detection #860 was closed on), the advisory lock, and the whole `classifier-denials` feature.

## Behavior delta

```
BEFORE: hermit upgrades ─> doctor stats state/*.jsonl ─> pre-existing ledgers are 0644
                       ─> permanent `warn` until hermit-evolve runs the chmod migration

AFTER:  hermit upgrades ─> doctor stats config.json + state/*.json + proposals/
                       ─> no new finding, no migration
                       ─> new ledgers still 0600; `state` still validates .jsonl per line
```

## Test plan

- `bunx tsc` — exit 0
- `cd plugins/claude-code-hermit && bun test --parallel --timeout=45000` — 4744 pass, 0 fail (run twice, both green)
- `diff -r .claude/skills/simplify plugins/claude-code-hermit/skills/simplify` — exit 0
- A sweep for text still claiming the `permissions` check covers `.jsonl`, or referencing the deleted migration, found none; `skills/hermit-doctor/SKILL.md` already documented `state/*.json`.
