### PR TITLE
fix(claude-code-hermit): trap SIGTERM in the inert entrypoint hold and short-circuit hermit-docker down

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Stopping a boot-conflicted (inert) container took ~2 minutes: the entrypoint's inert hold never trapped SIGTERM, and `hermit-docker down` polled the other, live instance's `runtime.json` for 60s. The hold now traps SIGTERM/SIGINT and exits immediately, and `down` short-circuits past the poll when `state/.boot-conflict` is present.
+
 ## [1.2.51] - 2026-08-29
 
 ### Added

--- a/plugins/claude-code-hermit/state-templates/bin/hermit-docker
+++ b/plugins/claude-code-hermit/state-templates/bin/hermit-docker
@@ -225,6 +225,11 @@ case "$CMD" in
     FORCE=false
     [ "${1:-}" = "--force" ] && FORCE=true
 
+    if [ "$FORCE" = false ] && [ -f "$PROJECT_DIR/.claude-code-hermit/state/.boot-conflict" ]; then
+      echo "[hermit] Container is inert (boot conflict) — no session to close."
+      FORCE=true
+    fi
+
     if [ "$FORCE" = false ]; then
       echo "[hermit] Requesting graceful session close..."
       # Split text and Enter into two send-keys calls with a pause — Claude Code's

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -570,7 +570,11 @@ if [ "${HERMIT_FORCE_BOOT:-0}" != "1" ]; then
       echo "[docker-entrypoint] BOOT CONFLICT: a live '$_mode' instance owns this project's state dir."
       echo "[docker-entrypoint] Staying inert (no claude started). Stop the other instance, then: hermit-docker restart"
       printf 'live %s owner detected at boot\n' "$_mode" > "${AGENT_DIR}/state/.boot-conflict"
-      while true; do sleep 300; done
+      # Bash defers a trapped signal until a foreground command returns, and PID 1
+      # has no default signal action. docker stop/compose down do not re-trigger
+      # restart: unless-stopped, so make the sleep interruptible through wait.
+      trap 'echo "[docker-entrypoint] Stop requested while inert — exiting."; exit 0' SIGTERM SIGINT
+      while true; do sleep 300 & wait $! || true; done
     fi
   fi
 fi

--- a/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
+++ b/plugins/claude-code-hermit/tests/docker-baseline-content.test.ts
@@ -295,8 +295,8 @@ describe('Entrypoint: marketplace registration uses list --json, not dir existen
 describe('Entrypoint: §4b boot conflict guard', () => {
   const block = entrypoint.slice(entrypoint.indexOf('# --- 4b.'), entrypoint.indexOf('# --- 5.'));
 
-  // `sleep` is overridden so the guard's `while true; do sleep 300; done` inert
-  // hold terminates: exit 42 means "the guard fired and went inert".
+  // `sleep` is overridden so the inert hold receives the same signal sent by
+  // docker stop and exercises its trap without waiting for the real interval.
   const { freshDir, cleanup } = freshDirFactory('hermit-4b-');
   afterAll(cleanup);
 
@@ -319,16 +319,17 @@ describe('Entrypoint: §4b boot conflict guard', () => {
       }
     }
 
-    // `set -euo pipefail` mirrors the real entrypoint header: without -e, a
-    // future edit that drops an `|| true` would abort the whole entrypoint in
-    // production (container never boots) while still passing here.
-    const script = `set -euo pipefail\nsleep() { exit 42; }\nAGENT_DIR=${JSON.stringify(agentDir)}\n${block}`;
+    // `set -euo pipefail` mirrors the real entrypoint header so the extracted
+    // guard runs under the same shell options as it does in production.
+    const script = `set -euo pipefail\nsleep() { kill -TERM $$; }\nAGENT_DIR=${JSON.stringify(agentDir)}\n${block}`;
     const out = spawnSync('bash', ['-c', script], {
       encoding: 'utf8',
       env: { ...process.env, HERMIT_FORCE_BOOT: opts.forceBoot ?? '0' },
+      timeout: 10_000,
     });
     return {
       status: out.status,
+      signal: out.signal,
       stdout: out.stdout,
       marker: fs.existsSync(path.join(stateDir, '.boot-conflict')),
     };
@@ -342,9 +343,15 @@ describe('Entrypoint: §4b boot conflict guard', () => {
     expect(spawnSync('sh', ['-c', 'command -v jq'], { encoding: 'utf8' }).status).toBe(0);
   });
 
+  test('entrypoint §4b: inert hold traps signals around an interruptible sleep', () => {
+    expect(block).toContain('sleep 300 & wait $!');
+    expect(block.indexOf('trap ')).toBeLessThan(block.indexOf('sleep 300 & wait $!'));
+  });
+
   test('entrypoint §4b: goes inert over a live non-docker owner', () => {
     const r = runGuard({ runtime_mode: 'tmux', session_state: 'active' }, { liveness: 'fresh' });
-    expect(r.status).toBe(42);
+    expect(r.status).toBe(0);
+    expect(r.signal).toBeNull();
     expect(r.stdout).toContain('BOOT CONFLICT');
     expect(r.marker).toBe(true);
   });


### PR DESCRIPTION
## Summary
Stopping a boot-conflicted (inert) hermit container took ~2 minutes: the entrypoint's inert hold never installed a SIGTERM trap, and `hermit-docker down` polled a `runtime.json` belonging to the other, live instance. Both legs now stop promptly.

```
plan ──> BEFORE: boot conflict ─> container inert ─> `hermit-docker down`
           polls other instance's runtime.json for 60s ─> "Timed out" ─>
           compose down ─> SIGTERM absorbed by foreground sleep, no trap ─>
           stop_grace_period 60s ─> SIGKILL (exit 137)                    ≈120s

     ──> AFTER: boot conflict ─> container inert ─> `hermit-docker down`
           sees `.boot-conflict` ─> "no session to close" ─> compose down ─>
           SIGTERM lands in `wait` ─> trap exits 0                          ≈1s
```

## Changes
- `docker-entrypoint.hermit.sh.template`: the §4b inert hold now traps `SIGTERM`/`SIGINT` around a backgrounded `sleep 300 & wait $!`, so a trapped signal isn't deferred behind a foreground sleep.
- `hermit-docker`: `down` short-circuits past the 60s graceful-close poll when `state/.boot-conflict` is present (and `--force` wasn't passed), printing "Container is inert — no session to close" instead.
- `docker-baseline-content.test.ts`: retargets the §4b guard tests at the new hold (signal-based override instead of an `exit 42` stand-in) and adds a static shape assertion so a regression to a foreground sleep is caught even if the trap itself still fires.

## Test plan
- `bunx tsc` — exit 0
- `cd plugins/claude-code-hermit && bun test --parallel --timeout=45000` — 4745 pass, 0 fail

Closes #868