### PR TITLE
feat(claude-code-hermit): sweep RC-gate spawn worktrees automatically

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Automatic silent sweep of dead, clean `.claude/worktrees/bridge-*` worktrees while the routine monitor runs, plus a live-spawn summary from `rc-server status`.
 - `/hermit-doctor` check `peer-inbox`: the resident is registered with Claude Code, its inbox socket accepts a connection (connect-only, never a post), and its registered name still matches. Warns, never fails — every failure mode falls back to typing the nudge.
 - Turns triggered by another local Claude Code session are attributed to a `peer` source, so `cost-reflect` shows them as "other sessions on this machine". The watchdog's own socket wake stays `heartbeat`.
 - Trusted chats can relay `/doctor` and `/code-review` into the managed session and receive the result in the requesting chat; `/doctor` requires settings authority, and `ultra`/`--post` are refused.

--- a/plugins/claude-code-hermit/scripts/rc-server.ts
+++ b/plugins/claude-code-hermit/scripts/rc-server.ts
@@ -12,7 +12,7 @@
 // it stops.
 //
 // Reached via: .claude-code-hermit/bin/hermit-run rc-server <subcommand>
-// Subcommands: start | stop | status | gc
+// Subcommands: start | stop | status | gc | sweep
 //
 // Status is a single one-shot pane capture, never a tail: the server's TUI
 // redraws its status line continuously and floods any log follower.
@@ -64,10 +64,15 @@ function statusFromPane(pane: string): string {
   return 'starting';
 }
 
-/** One-line status derived from a single pane capture. */
+/** Gate status, followed by live spawn worktrees when any can be inspected. */
 function statusLine(): string {
-  if (!sessionAlive()) return 'down';
-  return statusFromPane(capturePane());
+  const status = sessionAlive() ? statusFromPane(capturePane()) : 'down';
+  const worktrees = bridgeWorktrees(repoRoot());
+  if (worktrees.length === 0) return status;
+  const cwds = liveCwds();
+  if (cwds === null) return status;
+  const live = worktrees.filter(({ dir }) => inUse(cwds, dir)).map(({ name }) => name);
+  return `${status}\nspawns: ${live.length} live${live.length ? ` (${live.join(', ')})` : ''}`;
 }
 
 function start(): number {
@@ -179,6 +184,40 @@ function inUse(cwds: Set<string>, dir: string): boolean {
   return false;
 }
 
+function bridgeWorktrees(root: string): Array<{ name: string; dir: string }> {
+  const wtDir = path.join(root, '.claude', 'worktrees');
+  try {
+    // Directories only: a stray `bridge-*` file is not a worktree, and the
+    // automatic sweep would otherwise fail to remove it on every single tick.
+    return fs.readdirSync(wtDir, { withFileTypes: true })
+      .filter(e => e.isDirectory() && e.name.startsWith('bridge-'))
+      .map(e => ({ name: e.name, dir: path.join(wtDir, e.name) }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The unattended sweep leaves worktrees younger than this alone.
+ *
+ * `git worktree add` finishes before the spawned session has chdir-ed into the
+ * new worktree, and in that window the tree is clean and no process holds it —
+ * both of gc's guards pass. That was harmless while gc only ran when the
+ * operator asked for it; on a timer it means a tick can delete a phone spawn
+ * that is still starting, along with its branch. Operator-invoked `gc`/`stop`
+ * keep sweeping everything: they run when the operator knows what is spawning.
+ */
+const AUTO_SWEEP_MIN_AGE_MS = 120_000;
+
+/** Worktree age, from the `.git` file `git worktree add` writes once at creation. */
+function worktreeAgeMs(dir: string): number {
+  try {
+    return Date.now() - fs.statSync(path.join(dir, '.git')).mtimeMs;
+  } catch {
+    return Infinity; // not a worktree we created — no reason to hold the sweep back
+  }
+}
+
 /**
  * Branch checked out in each worktree, by worktree path. Read rather than
  * derived: a worktree's directory name and its branch name are independent, so
@@ -205,17 +244,14 @@ function worktreeBranches(root: string): Map<string, string> {
  * a delete of exactly that. An orphan holding a spawned session's unsaved work
  * is the operator's to resolve; gc reports it and moves on. Committed work is
  * covered separately, by deleting the branch with -d rather than -D.
+ *
+ * `auto` marks the unattended timer sweep (the `sweep` verb): it reports
+ * nothing on success and skips brand-new worktrees, per AUTO_SWEEP_MIN_AGE_MS.
  */
-function gc(): number {
+function gc(auto = false): number {
   const root = repoRoot();
-  const wtDir = path.join(root, '.claude', 'worktrees');
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(wtDir).filter(n => n.startsWith('bridge-'));
-  } catch {
-    return 0; // no worktrees dir → nothing to sweep
-  }
-  if (entries.length === 0) return 0;
+  const worktrees = bridgeWorktrees(root);
+  if (worktrees.length === 0) return 0;
 
   const cwds = liveCwds();
   if (cwds === null) {
@@ -225,12 +261,12 @@ function gc(): number {
 
   const branches = worktreeBranches(root);
   let removed = 0;
-  for (const name of entries) {
-    const dir = path.join(wtDir, name);
+  for (const { name, dir } of worktrees) {
     if (inUse(cwds, dir)) continue;
+    if (auto && worktreeAgeMs(dir) < AUTO_SWEEP_MIN_AGE_MS) continue;
     // Untracked files count: a spawned session's new files are usually the work.
     if (sh('git', ['-C', dir, 'status', '--porcelain']).stdout.trim()) {
-      console.log(`kept ${name} (uncommitted changes)`);
+      if (!auto) console.log(`kept ${name} (uncommitted changes)`);
       continue;
     }
     sh('git', ['-C', root, 'worktree', 'unlock', dir]); // absent lock → non-zero, ignored
@@ -247,7 +283,7 @@ function gc(): number {
     // destroying the commits behind it.
     const branch = branches.get(dir);
     if (branch) sh('git', ['-C', root, 'branch', '-d', branch]);
-    console.log(`removed ${name}`);
+    if (!auto) console.log(`removed ${name}`);
     removed++;
   }
   if (removed) sh('git', ['-C', root, 'worktree', 'prune']);
@@ -270,8 +306,9 @@ function main(argv: string[]): number {
     case 'stop': return stop();
     case 'status': console.log(statusLine()); return 0;
     case 'gc': return gc();
+    case 'sweep': return gc(true);
     default:
-      console.error('Usage: hermit-run rc-server <start|stop|status|gc>');
+      console.error('Usage: hermit-run rc-server <start|stop|status|gc|sweep>');
       return 2;
   }
 }

--- a/plugins/claude-code-hermit/scripts/routine-monitor.sh
+++ b/plugins/claude-code-hermit/scripts/routine-monitor.sh
@@ -16,13 +16,27 @@
 set -u
 INTERVAL="${1:?usage: routine-monitor.sh <interval_seconds> <hermit_state_dir>}"
 RT_DIR="${2:?usage: routine-monitor.sh <interval_seconds> <hermit_state_dir>}"
+# Absolute: the sweep below runs it from inside a `cd` subshell, so a relative
+# $0 (bash scripts/routine-monitor.sh …) would resolve against the wrong dir.
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
 # Array, not a string — see heartbeat-monitor.sh for why.
 if [[ -n "${ROUTINE_DUE_SCRIPT:-}" ]]; then
   DUE=("$ROUTINE_DUE_SCRIPT")
 else
-  DUE=("$(dirname "$0")/routines.ts" due)
+  DUE=("$SCRIPT_DIR/routines.ts" due)
 fi
 fail_count=0
+# Spawn-worktree sweep. The root is the git toplevel, not $RT_DIR/..: rc-server
+# creates and scans worktrees under the repo root, which is only the hermit's
+# project dir when the hermit was hatched there — gating on the wrong dir would
+# silently never sweep. Every SWEEP_EVERY-th poll, not every one: a dirty orphan
+# is kept by design, so an every-poll sweep would cost a bun spawn and a full
+# process scan (lsof over every process on darwin) once a minute for as long as
+# that worktree sits there.
+SWEEP_ROOT="$(cd "$RT_DIR/.." 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)"
+[[ -n "$SWEEP_ROOT" ]] || SWEEP_ROOT="$RT_DIR/.."
+SWEEP_EVERY=10
+sweep_tick=0
 # Emission grammar (this line's "$out" and the ROUTINE_MONITOR_ERROR line below) is
 # load-bearing: record-operator-action.ts isRoutinePrompt() drops these lines;
 # tests/auto-close.test.ts drift guard syncs them.
@@ -36,6 +50,10 @@ while true; do
       echo "ROUTINE_MONITOR_ERROR: routine-due failed (${fail_count} consecutive)"
     fi
   fi
+  if (( sweep_tick % SWEEP_EVERY == 0 )) && compgen -G "$SWEEP_ROOT/.claude/worktrees/bridge-*" >/dev/null; then
+    (cd "$SWEEP_ROOT" && bun "$SCRIPT_DIR/rc-server.ts" sweep) >/dev/null 2>&1 || true
+  fi
+  sweep_tick=$((sweep_tick + 1))
   [[ -n "${ROUTINE_MONITOR_ONCE:-}" ]] && break
   sleep "$INTERVAL"
 done

--- a/plugins/claude-code-hermit/skills/rc-gate/SKILL.md
+++ b/plugins/claude-code-hermit/skills/rc-gate/SKILL.md
@@ -20,7 +20,7 @@ All four are `.claude-code-hermit/bin/hermit-run rc-server <verb>`:
 | Verb | What it does | Output |
 |---|---|---|
 | `start` | opens the gate (tmux session `hermit-rc-gate`), waits for the server | `ready <url>` or a one-line refusal |
-| `status` | one pane read | `down`, `starting` (up but not serving yet), `ready`, or `connected N/32` |
+| `status` | one pane read | `down`, `starting` (up but not serving yet), `ready`, or `connected N/32`; a second `spawns: N live (<names>)` line when spawn worktrees exist |
 | `stop` | closes the gate, then sweeps | `closed` / `down`, plus any removals |
 | `gc` | sweeps worktrees left by archived spawns | one line per worktree removed, or kept because it holds uncommitted work |
 
@@ -42,6 +42,7 @@ account can spawn while the gate is open.
 When `start` refuses with the not-logged-in verdict, that is final. Say it once,
 don't retry, don't propose workarounds.
 
-Run `gc` when the operator mentions leftover or stuck worktrees; `stop` already
-sweeps. A `kept` line means that worktree holds uncommitted work — say it is
-there and let the operator decide, never delete it for them.
+Leftover worktrees are swept automatically while the routine monitor runs. Run
+`gc` for an on-demand sweep that reports `kept`; `stop` already sweeps. A `kept`
+line means that worktree holds uncommitted work: say it is there and let the
+operator decide, never delete it for them.

--- a/plugins/claude-code-hermit/tests/rc-server.test.ts
+++ b/plugins/claude-code-hermit/tests/rc-server.test.ts
@@ -54,6 +54,50 @@ describe('rc-server.ts', () => {
     }
   });
 
+  // The unattended sweep dates a worktree by the `.git` file `worktree add`
+  // writes once, so back-dating that file is how a test says "not brand new".
+  function ageWorktree(wt: string, minutes: number): void {
+    const t = new Date(Date.now() - minutes * 60_000);
+    fs.utimesSync(path.join(wt, '.git'), t, t);
+  }
+
+  it('sweep silently removes an orphaned locked bridge worktree and its branch', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const wt = path.join(wd.dir, '.claude', 'worktrees', 'bridge-sweep123');
+      git(wd.dir, 'worktree', 'add', '-q', '-b', 'cse-session-sweep', wt);
+      git(wd.dir, 'worktree', 'lock', wt);
+      ageWorktree(wt, 10);
+
+      const res = await rcServer(wd.dir, ['sweep']);
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout.trim()).toBe('');
+      expect(fs.existsSync(wt)).toBe(false);
+      expect(git(wd.dir, 'branch', '--list', 'cse-session-sweep').trim()).toBe('');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  // A spawn is clean and unheld for the moment between `git worktree add` and
+  // the session chdir-ing into it. gc runs on a timer now, so that window has to
+  // be safe. The un-aged twin of the `gc removes an orphaned...` case above,
+  // which pins that the operator-invoked verb still sweeps it either way.
+  it('sweep leaves a brand-new worktree alone', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const wt = path.join(wd.dir, '.claude', 'worktrees', 'bridge-fresh999');
+      git(wd.dir, 'worktree', 'add', '-q', '-b', 'cse-session-fresh', wt);
+
+      const res = await rcServer(wd.dir, ['sweep']);
+      expect(res.exitCode).toBe(0);
+      expect(fs.existsSync(wt)).toBe(true);
+      expect(git(wd.dir, 'branch', '--list', 'cse-session-fresh').trim()).not.toBe('');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
   it('gc on a repo with no bridge worktrees is a silent no-op', async () => {
     const wd = setupGitWorkdir();
     try {
@@ -153,6 +197,25 @@ describe('rc-server.ts', () => {
       const res = await rcServer(wd.dir, ['status']);
       expect(res.exitCode).toBe(0);
       expect(res.stdout.trim()).toBe('down');
+    } finally {
+      wd.cleanup();
+    }
+  });
+
+  it('status lists a live bridge worktree', async () => {
+    const wd = setupGitWorkdir();
+    try {
+      const wt = path.join(wd.dir, '.claude', 'worktrees', 'bridge-status456');
+      git(wd.dir, 'worktree', 'add', '-q', '-b', 'cse-session-status', wt);
+
+      const holder = Bun.spawn({ cmd: ['sleep', '30'], cwd: wt });
+      try {
+        const res = await rcServer(wd.dir, ['status']);
+        expect(res.exitCode).toBe(0);
+        expect(res.stdout).toContain('spawns: 1 live (bridge-status456)');
+      } finally {
+        holder.kill();
+      }
     } finally {
       wd.cleanup();
     }

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -13,9 +13,10 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 import { runScript, runProposal, runPinnedScript, PLUGIN_ROOT, SCRIPTS_DIR, MONOREPO_ROOT } from './helpers/run';
-import { setupWorkdir, fixturesDir, withDir, writeConfig, type Workdir } from './helpers/workdir';
+import { setupGitWorkdir, setupWorkdir, fixturesDir, withDir, writeConfig, type Workdir } from './helpers/workdir';
 import { assistantEntry } from './helpers/transcript';
 import { deriveStaleSession, STALE_KEY } from '../scripts/lib/alert-state';
 import { logRoutineEvent } from '../scripts/lib/routines/event';
@@ -2687,6 +2688,32 @@ describe('routine-monitor', () => {
     const r = await rtMonitorOnce('process.stdout.write("");\n');
     r.cleanup();
     expect(r.stdout).toBe('');
+  });
+
+  test('routine-monitor silently sweeps an orphaned locked bridge worktree', async () => {
+    const wd = setupGitWorkdir();
+    const stub = makeRtStub('process.stdout.write("");\n');
+    try {
+      const rtDir = path.join(wd.dir, '.claude-code-hermit');
+      const wt = path.join(wd.dir, '.claude', 'worktrees', 'bridge-monitor');
+      fs.mkdirSync(rtDir, { recursive: true });
+      execFileSync('git', ['-C', wd.dir, 'worktree', 'add', '-q', '-b', 'bridge-monitor', wt]);
+      execFileSync('git', ['-C', wd.dir, 'worktree', 'lock', wt]);
+      // Past the unattended sweep's brand-new grace period (rc-server.ts).
+      const aged = new Date(Date.now() - 10 * 60_000);
+      fs.utimesSync(path.join(wt, '.git'), aged, aged);
+
+      const r = await runBash(RT_MONITOR_SH, {
+        args: ['60', rtDir],
+        env: { ROUTINE_MONITOR_ONCE: '1', ROUTINE_DUE_SCRIPT: stub.path },
+      });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toBe('');
+      expect(fs.existsSync(wt)).toBe(false);
+    } finally {
+      stub.cleanup();
+      wd.cleanup();
+    }
   });
 
   test('routine-monitor (routine-due nonzero exit → ROUTINE_MONITOR_ERROR)', async () => {


### PR DESCRIPTION
## Summary

The RC gate leaves a locked `bridge-*` worktree behind whenever a phone-spawned session is archived. Until now those were only removed when the operator remembered to run `rc-server gc` or `stop`, so on a hermit nobody babysits they just accumulate for as long as the gate stays open. This makes the sweep automatic and silent, and gives `rc-server status` a way to show which spawns are actually live.

## Behavior delta

```
BEFORE: spawn archived ─> locked bridge-* worktree stays ─┬─ operator runs gc/stop ─> swept
                                                          └─ operator forgets ─────> piles up

AFTER:  spawn archived ─> locked bridge-* worktree stays ──> routine-monitor tick sweeps it silently (no hermit turn, no stdout line)
        live or dirty spawn ──────────────────────────────> untouched; gc/stop still report `kept`
        spawn younger than 120s ──────────────────────────> held back; still starting up
        no bridge-* present ──────────────────────────────> glob gate matches nothing, zero bun spawns
        rc-server status ────────────────────────────────> gate line + `spawns: N live (<names>)`
```

## Changes

- **`scripts/rc-server.ts`** — new `sweep` verb dispatching to `gc(auto = true)`: same sweep, no stdout. Worktree listing factored into `bridgeWorktrees()`, shared with `status`, and filtered to directories so a stray `bridge-*` *file* can't be retried forever. `statusLine()` gains a second `spawns: N live (<names>)` line when spawn worktrees exist and liveness is knowable.
- **`scripts/routine-monitor.sh`** — runs `sweep` every 10th poll, glob-guarded so a hermit with no spawn worktrees never spawns a `bun` process. Throttled rather than every-poll because a dirty orphan is kept by design, and an every-poll sweep would cost a process scan (`lsof` over every process on darwin) once a minute for as long as it sits there. `SWEEP_ROOT` is the git toplevel, not the state dir's parent — rc-server creates and scans worktrees under the repo root, which only coincides with the hermit's project dir when the hermit was hatched at the root. `SCRIPT_DIR` is now absolute, since the sweep runs inside a `cd` subshell.
- **120s grace period** (`AUTO_SWEEP_MIN_AGE_MS`) on the automatic sweep only. `git worktree add` returns before the spawned session has chdir-ed in, and in that window the tree is clean and unheld, so both of `gc`'s existing guards pass and a tick could delete a spawn that is still starting. Operator-invoked `gc`/`stop` still sweep everything — the operator knows what is spawning.
- **`skills/rc-gate/SKILL.md`** — `status` row documents the second line; the `gc` paragraph now says leftovers are swept automatically and `gc` is the on-demand sweep that reports `kept`. `sweep` is deliberately not listed as an operator verb.

The monitor's stdout grammar (`ROUTINE_DUE …`, `ROUTINE_MONITOR_ERROR: …`) is unchanged, and `ROUTINE_MONITOR_ONCE=1` still exits after one iteration.

## Test plan

Green:

- `bun test tests/rc-server.test.ts` — 12/12, including a new silent-sweep case and a `sweep leaves a brand-new worktree alone` regression guard for the grace period
- `bun test tests/scripts.test.ts` — 405/405, including a new `routine-monitor` case that runs one iteration against a locked `bridge-*` worktree and asserts empty stdout + worktree gone
- `bun test tests/auto-close.test.ts` — 147/147 (the drift guard on the monitor's emission grammar)
- `bunx tsc` — exit 0; `bash -n scripts/routine-monitor.sh` clean
- Manual, end to end: locked `bridge-probe` worktree + `ROUTINE_MONITOR_ONCE=1 routine-monitor.sh` → no stdout, worktree gone, branch gone, no residue

Full suite on a quiet box: `bun test --parallel --timeout=45000` → **4866 pass, 0 fail** (158 files, 52.6s), `bunx tsc` → exit 0.

Earlier local runs of the full suite were red, but that was contention, not this diff: three concurrent `bun test --parallel` runs from other sessions on the same box (loadavg 80+ on 12 cores) starved it into timeouts in `doctor-*` / `routine-gate` suites this change does not touch, with a different failing set each run. The same suite runs in 52s clean versus 132s under load.
