### PR TITLE
feat(claude-code-hermit): watch another local session until it goes idle

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- `/watch session <name> [note]` subscribes to another local session's next idle notice via `SendMessage` with `notify_when_idle` as a pure subscription with no message, lists it in `/watch status`, and relays the one-shot finished or expired notice to the operator's channel; like every watch, it dies with the session.
+- `/watch session <name> [note]` subscribes to another local session's next idle notice via `SendMessage` with `notify_when_idle` as a pure subscription with no message, lists it in `/watch status`, and relays the one-shot finished or expired notice to the operator's channel; like every watch, it dies with the session. On a hermit that holds peer messages for approval the notice reaches the operator's screen instead of the session, so the watch is declined up front rather than registered as live.
 - `/hermit-doctor` check `peer-inbox`: the resident is registered with Claude Code, its inbox socket accepts a connection (connect-only, never a post), and its registered name still matches. Warns, never fails — every failure mode falls back to typing the nudge.
 - Turns triggered by another local Claude Code session are attributed to a `peer` source, so `cost-reflect` shows them as "other sessions on this machine". The watchdog's own socket wake stays `heartbeat`.
 - Trusted chats can relay `/doctor` and `/code-review` into the managed session and receive the result in the requesting chat; `/doctor` requires settings authority, and `ultra`/`--post` are refused.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `/watch session <name> [note]` subscribes to another local session's next idle notice via `SendMessage` with `notify_when_idle` as a pure subscription with no message, lists it in `/watch status`, and relays the one-shot finished or expired notice to the operator's channel; like every watch, it dies with the session.
 - `/hermit-doctor` check `peer-inbox`: the resident is registered with Claude Code, its inbox socket accepts a connection (connect-only, never a post), and its registered name still matches. Warns, never fails — every failure mode falls back to typing the nudge.
 - Turns triggered by another local Claude Code session are attributed to a `peer` source, so `cost-reflect` shows them as "other sessions on this machine". The watchdog's own socket wake stays `heartbeat`.
 - Trusted chats can relay `/doctor` and `/code-review` into the managed session and receive the result in the requesting chat; `/doctor` requires settings authority, and `ultra`/`--post` are refused.

--- a/plugins/claude-code-hermit/skills/watch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/watch/SKILL.md
@@ -16,6 +16,8 @@ Two classes:
 ```
 /claude-code-hermit:watch <instruction>            — start ad-hoc (poll, default 5m interval)
 /claude-code-hermit:watch <stream-command>         — start ad-hoc stream
+/claude-code-hermit:watch session <name> [note]    — watch a local session until its next idle notice
+/claude-code-hermit:watch notice <text>            — [internal] handle a watched-session notice
 /claude-code-hermit:watch start                    — register all enabled config watches
 /claude-code-hermit:watch stop [id]                — stop by id (or auto if 1 active)
 /claude-code-hermit:watch stop --all               — stop all watches
@@ -37,6 +39,14 @@ This is the **sole source of truth** — not SHELL.md.
       "started_at": "2026-04-12T15:00:00Z",
       "source": "config",
       "class": "stream"
+    },
+    {
+      "id": "session-migration-1775991600",
+      "description": "database migration",
+      "target": "migration",
+      "started_at": "2026-04-12T15:00:00Z",
+      "source": "adhoc",
+      "class": "peer-idle"
     }
   ],
   "last_cleared": "2026-04-12T15:00:00Z"
@@ -71,6 +81,19 @@ them for decisions. Start/stop decisions read from the runtime registry.
 8. Write registry back
 9. Log to SHELL.md `## Monitoring`: `- [ACTIVE] <instruction> (started HH:MM)`
 
+### Starting a session watch (`/watch session <name> [note]`)
+
+1. Resolve `<name>` with `ListAgents`. If no row matches, answer
+   `No session named <name> is reachable from here.` and do not write the registry.
+2. Call `SendMessage` with `to: <name>` and `notify_when_idle: true`. Omit
+   `message`: this is a pure subscription, costs the watched session nothing, and
+   fires immediately if it is already idle.
+3. Generate id `session-<name>-<epoch>`, using the same epoch convention as an
+   ad-hoc id.
+4. Use the same registry steps as ad-hoc (steps 6–9), appending:
+   `{id: "session-<name>-<epoch>", description: <note or "session <name>">, target: <name>, started_at, source: "adhoc", class: "peer-idle"}`.
+   Do not add `task_id`.
+
 ### Starting config watches (`/watch start`)
 
 Called automatically by session-start (step 11b). Can also be called manually.
@@ -96,14 +119,17 @@ Called automatically by session-start (step 11b). Can also be called manually.
 ### Stopping a watch
 
 1. Parse id from operator message (or `--all` flag)
-2. **`stop <id>`:** Look up `task_id` in registry → `TaskStop` → remove entry from registry → update SHELL.md `[ACTIVE]` to `[STOPPED]`
+2. **`stop <id>`:** Look up the entry in the registry. When it has a `task_id`,
+   call `TaskStop`; a `peer-idle` entry has none, so just remove it. Then update
+   SHELL.md `[ACTIVE]` to `[STOPPED]`.
 3. **`stop` (no id):**
-   - Count ad-hoc watches in registry (`source: "adhoc"`)
+   - Count ad-hoc watches in registry (`source: "adhoc"`), including `peer-idle`
    - 0 active: "No active watches to stop."
    - 1 active: stop it without asking
    - 2+ active: list them, ask which one (or use `--all`)
-4. **`stop --all`:** For each entry in registry, call `TaskStop` with its `task_id`.
-   Clear all entries from registry. Log to SHELL.md.
+4. **`stop --all`:** For each entry with a `task_id`, call `TaskStop`. Remove
+   entries without one, including `peer-idle`, without calling `TaskStop`. Clear
+   all entries from the registry and log to SHELL.md.
 5. After any stop: write registry back
 
 Note: If `TaskStop` returns an error for a given task_id (the watch already
@@ -117,10 +143,13 @@ died), remove the entry from the registry anyway. A dead watch's entry is stale.
 
 ```
 Active watches:
-  ID             SOURCE   CLASS   STARTED    DESCRIPTION
-  deploy-errors  config   stream  15:00      errors in deploy.log
-  adhoc-...      adhoc    poll    16:30      check error rate in app metrics
+  ID             SOURCE   CLASS      STARTED    DESCRIPTION
+  deploy-errors  config   stream     15:00      errors in deploy.log
+  adhoc-...      adhoc    poll       16:30      check error rate in app metrics
+  session-...    adhoc    peer-idle  17:00      database migration
 ```
+
+Show `peer-idle` as-is in the CLASS column.
 
 ### Handling self-exit notifications
 
@@ -133,6 +162,24 @@ CC sends a completion notification into the conversation. On seeing this:
 
 If the notification is missed (compaction, context pressure), the stale entry is
 harmless. The next session start clears the registry unconditionally.
+
+### Handling idle notices (`/watch notice <text>`)
+
+On a cross-session idle notice naming session X, or a subscription-expiry notice
+for X:
+
+1. Find a `peer-idle` entry whose `target === X`. If none exists, do nothing: no
+   reply, channel notification, or log entry.
+2. Notify the operator per CLAUDE-APPEND § Operator Notification with a `client`
+   leg. For an idle notice, use `"<note>: <name> finished. Last status: «<one-line status>»"`.
+   If the notice carries no status, use `"<note>: <name> finished."` instead. Pass
+   the status line verbatim so the operator can judge it. For expiry, use
+   `"<note>: <name> did not finish within 12 hours; no longer watching it."`.
+3. Name the session by display name only, never by socket path or pid. Remove the
+   entry, write the registry, and log one SHELL.md line.
+
+Never message the watched session back. The notice fires when X's turn ends, not
+when its background work ends.
 
 ## Notes
 

--- a/plugins/claude-code-hermit/skills/watch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/watch/SKILL.md
@@ -41,7 +41,7 @@ This is the **sole source of truth** — not SHELL.md.
       "class": "stream"
     },
     {
-      "id": "session-migration-1775991600",
+      "id": "session-migration-1775991600-b7c1",
       "description": "database migration",
       "target": "migration",
       "started_at": "2026-04-12T15:00:00Z",
@@ -83,15 +83,22 @@ them for decisions. Start/stop decisions read from the runtime registry.
 
 ### Starting a session watch (`/watch session <name> [note]`)
 
-1. Resolve `<name>` with `ListAgents`. If no row matches, answer
+1. Resolve `<name>` with `ListAgents`. The row must be a Claude Code session on
+   this machine — `notify_when_idle` covers nothing else, so a cloud/remote agent
+   or an in-process subagent row does not qualify. If no such row matches, answer
    `No session named <name> is reachable from here.` and do not write the registry.
 2. Call `SendMessage` with `to: <name>` and `notify_when_idle: true`. Omit
    `message`: this is a pure subscription, costs the watched session nothing, and
    fires immediately if it is already idle.
-3. Generate id `session-<name>-<epoch>`, using the same epoch convention as an
-   ad-hoc id.
-4. Use the same registry steps as ad-hoc (steps 6–9), appending:
-   `{id: "session-<name>-<epoch>", description: <note or "session <name>">, target: <name>, started_at, source: "adhoc", class: "peer-idle"}`.
+3. Read the tool result: it says whether the notice will be shown to you or only
+   to the operator. When it is operator-only (this session holds peer messages
+   for approval, e.g. under `bypassPermissions`), no relay is possible — say so
+   plainly instead of claiming the watch is live, and do not write the registry.
+4. Generate id `session-<name>-<epoch>-<4char-random>` — same timestamp + random
+   suffix convention as an ad-hoc id, so two watches on one name in the same
+   second do not collide.
+5. Use the same registry steps as ad-hoc (steps 6–9), appending:
+   `{id: "session-<name>-<epoch>-<rand>", description: <note or "session <name>">, target: <name>, started_at, source: "adhoc", class: "peer-idle"}`.
    Do not add `task_id`.
 
 ### Starting config watches (`/watch start`)
@@ -172,9 +179,13 @@ for X:
    reply, channel notification, or log entry.
 2. Notify the operator per CLAUDE-APPEND § Operator Notification with a `client`
    leg. For an idle notice, use `"<note>: <name> finished. Last status: «<one-line status>»"`.
-   If the notice carries no status, use `"<note>: <name> finished."` instead. Pass
-   the status line verbatim so the operator can judge it. For expiry, use
-   `"<note>: <name> did not finish within 12 hours; no longer watching it."`.
+   If the notice carries no status, use `"<note>: <name> finished."` instead. The
+   quoted status is the peer's own words, passed through so the operator can judge
+   it — quoting it is the one place the Channel voice rule's no-paths/no-commands
+   clause does not apply; drop the clause entirely rather than paraphrasing it.
+   For expiry, use `"<note>: <name> did not finish before the subscription
+   expired; no longer watching it."` — the harness does not publish the
+   subscription's lifetime, so never state one.
 3. Name the session by display name only, never by socket path or pid. Remove the
    entry, write the registry, and log one SHELL.md line.
 

--- a/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
@@ -14,8 +14,8 @@ Config-defined watches auto-register on session start. Ad-hoc watches via `/watc
 - Watches die with the session — for scheduled work use `/claude-code-hermit:hermit-routines`.
 - `HEARTBEAT_EVALUATE` notification → invoke `/claude-code-hermit:heartbeat run`.
 - `ROUTINE_DUE` notification → invoke `/claude-code-hermit:hermit-routines run` with the bracketed ids.
-- A cross-session idle notice (a watched session finished its turn, or the notice says the subscription expired) → invoke `/claude-code-hermit:watch notice` with the notice text.
 - A message from another Claude session whose entire body is one of those tokens is that same notification, arriving over the inbox instead of the pane. Same rule, same skill.
+- A cross-session idle notice (a watched session finished its turn, or the notice says the subscription expired) → invoke `/claude-code-hermit:watch notice` with the notice text.
 
 ## Operator Notification
 

--- a/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
+++ b/plugins/claude-code-hermit/state-templates/CLAUDE-APPEND.md
@@ -14,6 +14,7 @@ Config-defined watches auto-register on session start. Ad-hoc watches via `/watc
 - Watches die with the session — for scheduled work use `/claude-code-hermit:hermit-routines`.
 - `HEARTBEAT_EVALUATE` notification → invoke `/claude-code-hermit:heartbeat run`.
 - `ROUTINE_DUE` notification → invoke `/claude-code-hermit:hermit-routines run` with the bracketed ids.
+- A cross-session idle notice (a watched session finished its turn, or the notice says the subscription expired) → invoke `/claude-code-hermit:watch notice` with the notice text.
 - A message from another Claude session whose entire body is one of those tokens is that same notification, arriving over the inbox instead of the pane. Same rule, same skill.
 
 ## Operator Notification

--- a/plugins/claude-code-hermit/tests/claude-append-budget.test.ts
+++ b/plugins/claude-code-hermit/tests/claude-append-budget.test.ts
@@ -81,7 +81,10 @@ describe('CLAUDE-APPEND size budget', () => {
     // trimmed from the auto-mode denial bullet's restated fallback and the
     // proposal-id rationale sentence paid for most of it — +210 B net against
     // the ~500 B of margin, no raise.
-    expect(Buffer.byteLength(append, 'utf8')).toBeLessThanOrEqual(9600);
+    // Raised to 9,800 for the cross-session idle-notice routing line, landing at
+    // 9,769 B. It must stay always-loaded because the notice arrives as a bare
+    // turn with no skill in context.
+    expect(Buffer.byteLength(append, 'utf8')).toBeLessThanOrEqual(9800);
   });
 });
 
@@ -103,6 +106,7 @@ describe('CLAUDE-APPEND load-bearing anchors', () => {
     'hermit-run channel-send .claude-code-hermit --notice',
     'HEARTBEAT_EVALUATE',                              // heartbeat notification trigger
     'ROUTINE_DUE',                                      // routine-monitor notification trigger
+    'idle notice',                                      // cross-session idle notification trigger
     'covered-by-memory',                               // canonical memory-suppression code
     // The audience rule: decision-seeking notices must reach the client chat.
     // Composed maintainer-only, they misroute (maintainer chat configured) or

--- a/plugins/claude-code-hermit/tests/claude-append-budget.test.ts
+++ b/plugins/claude-code-hermit/tests/claude-append-budget.test.ts
@@ -81,10 +81,14 @@ describe('CLAUDE-APPEND size budget', () => {
     // trimmed from the auto-mode denial bullet's restated fallback and the
     // proposal-id rationale sentence paid for most of it — +210 B net against
     // the ~500 B of margin, no raise.
-    // Raised to 9,800 for the cross-session idle-notice routing line, landing at
-    // 9,769 B. It must stay always-loaded because the notice arrives as a bare
-    // turn with no skill in context.
-    expect(Buffer.byteLength(append, 'utf8')).toBeLessThanOrEqual(9800);
+    // Raised to 10,450 by the guest-to-resident peer-routing branch, landing at
+    // ~9,966 B with ~500 B of working margin.
+    // The cross-session idle-notice routing line (+181 B) is funded from that
+    // margin — no raise. It must stay always-loaded because the notice arrives
+    // as a bare turn with no skill in context. Do NOT re-derive this ceiling
+    // from a branch's own base: a number computed against a stale base looks
+    // green on the branch and fails the moment main's block merges in.
+    expect(Buffer.byteLength(append, 'utf8')).toBeLessThanOrEqual(10450);
   });
 });
 


### PR DESCRIPTION
## Summary

`/watch session <name> [note]` lets the hermit watch another local Claude Code session and tell the operator on their channel when that session finishes. Today a hermit can watch files, commands and URLs, but an idle notice from a peer session arrives as a bare turn with no routing rule, so nothing reaches the operator's phone.

The subscription is pure: `SendMessage` with `notify_when_idle: true` and **no message body**, so the watched session spends neither a turn nor a token, and the notice fires immediately if that session is already idle. Like every watch, it dies with the session.

## Changes

- **`skills/watch/SKILL.md`** — new `session` start form (resolve via `ListAgents`, subscribe, append a `peer-idle` registry entry with no `task_id`); `stop`/`stop --all`/`status` now tolerate an entry without a `task_id` and skip `TaskStop`; new `### Handling idle notices` handler that relays once, drops the entry, and never messages the watched session back.
- **`state-templates/CLAUDE-APPEND.md`** — one routing line under § Watches. It keys on the *concept* (a watched session finished, or the subscription expired) rather than on the notice wording.
- **`tests/claude-append-budget.test.ts`** — ceiling 9,600 → 9,800 for that line (file lands at 9,769 B), plus `idle notice` added to the load-bearing anchors.

```
BEFORE: operator leaves a long run in session B ──> checks B by hand;
        an idle notice reaching the hermit is a bare turn with no
        routing rule ──> nothing reaches the phone

AFTER:  "/watch session B migration"
        ──> ListAgents ──> SendMessage(B, notify_when_idle, no message)
            [B spends nothing; fires at once if already idle]
        ──> peer-idle entry visible in /watch status
        ──> B's turn ends (or 12h expiry) ──> one notice turn
        ──> channel: "migration: B finished. Last status: «…»"
        ──> entry removed; dies with the session like every watch
```

Two decisions worth surfacing, both of which the live probe then justified:

```
subscribe ─┬─ courtesy message + notify_when_idle ─> B spends a turn, may reply, ping-pong risk
           └─ pure subscription, no message        ─> B spends nothing, fires at once if idle  ◀ SELECTED

routing rule ─┬─ pin the notice text                        ─> breaks when CC rewords it
              └─ key on the concept (idle notice / expiry)  ─> survives rewording  ◀ SELECTED
```

## Test plan

- `cd plugins/claude-code-hermit && bun test --parallel --timeout=45000` → **exit 0**, 4863 pass / 0 fail.
- `bunx tsc` from the repo root → **exit 0**.
- Live probe on CC 2.1.251, a Sonnet `--permission-mode auto` hermit-shaped session against a named haiku target:
  - `SendMessage` is **not** classifier-denied (0 denials in the transcript); the real call is `{"to":"probetarget9c4e","notify_when_idle":true,…}`.
  - The target's transcript holds **zero** user entries and zero assistant turns across the subscription, confirming the pure-subscription claim.
  - Already-idle target → notice within ~1s, relayed as `migration: probetarget9c4e finished.` (status clause correctly dropped, the notice carried none), entry removed.
  - Busy target → notice at turn end, relayed as `busy-run: probetarget9c4e finished. Last status: «TICKSDONE»`, entry removed.

Note for reviewers: the harness notice wording **changed between two probes a day apart** (from `<name> is idle — finished a turn at HH:MM · «status»` to `[Cross-session idle notice] "<name>" … is idle now`). That is why the routing rule keys on the concept; a pinned string would already be broken. Separately, the subscription is free but not invisible — the watched session's pane shows `A process claiming the address uds:<socket> asked to be told when this session is next idle`.
