### PR TITLE
feat(claude-code-hermit): opt-in docker.fleet_mesh for same-box peers

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `docker.fleet_mesh` shares the session registry, inbox sockets, and a PID namespace between Docker hermits on one box so they can address each other with `ListAgents`/`SendMessage`. Opt-in because it needs two host-created volumes and a PID-namespace holder container that the plugin cannot provision: enable it in `config.json`, then run `/docker-setup` and `hermit-docker update`.
 - `/hermit-doctor` check `peer-inbox`: the resident is registered with Claude Code, its inbox socket accepts a connection (connect-only, never a post), and its registered name still matches. Warns, never fails — every failure mode falls back to typing the nudge.
 - Turns triggered by another local Claude Code session are attributed to a `peer` source, so `cost-reflect` shows them as "other sessions on this machine". The watchdog's own socket wake stays `heartbeat`.
 - Trusted chats can relay `/doctor` and `/code-review` into the managed session and receive the result in the requesting chat; `/doctor` requires settings authority, and `ultra`/`--post` are refused.

--- a/plugins/claude-code-hermit/docs/always-on.md
+++ b/plugins/claude-code-hermit/docs/always-on.md
@@ -105,6 +105,30 @@ Reverse anytime: re-run `/docker-security` and answer No to every prompt, or `rm
 
 ---
 
+## Fleet mesh (opt-in)
+
+Fleet mesh lets Docker hermits on the same host discover and message each other with Claude Code's native `ListAgents` and `SendMessage` tools. Each hermit appears in `ListAgents` under its configured `agent_name`.
+
+Create the shared volumes and PID namespace holder once on the host:
+
+```bash
+docker volume create hermit-fleet-sessions
+docker volume create hermit-fleet-socks
+docker run -d --name hermit-fleet-pidns --restart unless-stopped --init alpine sleep infinity
+```
+
+Set `docker.fleet_mesh` to `true` in each hermit's `.claude-code-hermit/config.json`, re-run `/docker-setup`, then apply the rendered files:
+
+```bash
+.claude-code-hermit/bin/hermit-docker update
+```
+
+Every hermit in the mesh must run as the **same host UID**. The shared socket directory is `0700` and the shared `sessions/` volume is owned by whichever hermit mounted it first, so a hermit started by a different host user cannot read either: Claude Code silently falls back to `/tmp` for its inbox socket and the hermit stays invisible to its peers, with only a `[hermit] Cannot secure socket directory` line in `hermit-docker logs` to say so. Compose reads the UID from `${UID:-1000}` in the launching shell.
+
+The generated Compose file uses `pid: "container:hermit-fleet-pidns"` so peer registry filenames use unique PIDs without exposing host processes. The holder is a hard dependency: if it is removed or recreated, every mesh hermit must be recreated too (`hermit-docker update`), since a container cannot rejoin a namespace that went away. As a manual alternative, replace that line with `pid: host`. Host PID mode removes the holder dependency, but every hermit can then see and signal every process on the host, not only other hermits.
+
+---
+
 ## Managing Your Hermit
 
 | Action    | Command                                                       |

--- a/plugins/claude-code-hermit/docs/config-reference.md
+++ b/plugins/claude-code-hermit/docs/config-reference.md
@@ -513,6 +513,7 @@ Modify with `/hermit-settings scheduled-checks`.
 |-----|------|---------|-------------|
 | `packages` | array | `[]` | System packages (`apt-get`) to install in the Docker image. |
 | `recommended_plugins` | array | `[]` | Plugins to install on container boot. Empty by default — entries are only added when the operator explicitly opts in during `/docker-setup` or `/hermit-settings docker`. |
+| `fleet_mesh` | boolean | `false` | Opt-in, same-box Docker peer discovery and messaging. Requires the two external volumes and the pid namespace holder documented in [Always-On Mode](always-on.md#fleet-mesh-opt-in). Set it in `config.json`, then re-run `/docker-setup`. |
 
 ### `recommended_plugins` entry schema
 

--- a/plugins/claude-code-hermit/docs/docker-security.md
+++ b/plugins/claude-code-hermit/docs/docker-security.md
@@ -37,6 +37,7 @@ The wizard makes the container *meaningfully harder to abuse*. It does not make 
 - **mDNS / `.local`** doesn't resolve through dnsmasq. Services must be referenced by IP address (with a LAN carve-out) rather than `.local` hostnames.
 - **Host-bound services unreachable in bridge+containment mode** — `localhost`/`127.0.0.1` on the host is only reachable when `network_mode: host`. Operators wanting both LAN containment AND host-bound access need to refactor their host service to bind on the bridge IP and add a carve-out for that IP.
 - **Sidecar crash isolates hermit** — because hermit shares hermit-netguard's network namespace, if the sidecar dies hermit loses *all* networking until you bring it back up. The sidecar has `restart: unless-stopped` and a fail-safe entrypoint (loads-rules-or-tail-stay-up rather than crash-loop), but a misconfigured `nftables.conf` can still strand hermit. If this happens, `docker compose -f docker-compose.hermit.yml -f docker-compose.security.yml logs hermit-netguard` will tell you what went wrong.
+- **Fleet mesh weakens sibling isolation.** Every mesh container shares a PID namespace, so it can see and signal every other hermit's processes. The shared `sessions/` volume also holds every hermit's peer auth key, so a compromised hermit can message any sibling. Fleet mesh is for hermits on one host only; `isolatePeerMachines` remains unaffected.
 
 ## How to run it
 

--- a/plugins/claude-code-hermit/scripts/hermit-start.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-start.ts
@@ -168,6 +168,7 @@ const DEFAULT_CONFIG: Json = {
   docker: {
     packages: [],
     recommended_plugins: [],
+    fleet_mesh: false,
   },
   compact: {
     monitoring_threshold: 30,

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -521,6 +521,27 @@ function checkProcessRunning(pattern: string): boolean {
   return spawnSync('pgrep', ['-f', pattern], { stdio: 'ignore' }).status === 0;
 }
 
+/** ERE metacharacter escape, for embedding a literal path in a `pgrep -f` pattern. */
+function ereEscape(literal: string): string {
+  return literal.replace(/[.[\]{}()*+?^$|\\]/g, '\\$&');
+}
+
+/**
+ * True when THIS hermit's heartbeat monitor subprocess is not running.
+ *
+ * Anchored on this hermit's own state dir, not on the bare script name: `pgrep`
+ * scans the whole PID namespace, and `docker.fleet_mesh` hermits deliberately
+ * SHARE one (`pid: container:hermit-fleet-pidns`). A bare `heartbeat-monitor.sh`
+ * match there finds a SIBLING hermit's monitor and reports this hermit's dead
+ * one as alive, permanently suppressing the pane-frozen restart escalation.
+ * The monitor is registered as `bash <script> <interval> $PWD/.claude-code-hermit`
+ * (heartbeat/SKILL.md § start), so the resolved hermit root disambiguates it.
+ */
+function heartbeatMonitorDead(): boolean {
+  const root = ereEscape(path.resolve(HERMIT_ROOT));
+  return !checkProcessRunning(`heartbeat-monitor\\.sh .*${root}`);
+}
+
 /**
  * True if the `daily-auto-close` routine's next fire is within `windowSecs` of now.
  * The post-close /clear (maybePostCloseClear) already resets context for free right
@@ -1882,7 +1903,7 @@ async function main(): Promise<void> {
             process.exit(0);
           }
 
-          const monitorDead = !checkProcessRunning('heartbeat-monitor.sh');
+          const monitorDead = heartbeatMonitorDead();
 
           const prevHash = watchdogState.last_pane_hash;
           const paneFrozen =

--- a/plugins/claude-code-hermit/scripts/lib/config-read.ts
+++ b/plugins/claude-code-hermit/scripts/lib/config-read.ts
@@ -80,7 +80,7 @@ const TABLE: Record<string, Spec> = {
   boot_skill: str(null),
   shutdown_skill: str(null),
   scheduled_checks: arr,
-  docker: shape({ packages: arr, recommended_plugins: arr }),
+  docker: shape({ packages: arr, recommended_plugins: arr, fleet_mesh: bool(false) }),
   compact: shape({
     monitoring_threshold: num(30),
     monitoring_keep: num(20),

--- a/plugins/claude-code-hermit/scripts/render-docker-templates.ts
+++ b/plugins/claude-code-hermit/scripts/render-docker-templates.ts
@@ -22,7 +22,8 @@
  *       },
  *       "agentHookProfile": "strict",
  *       "networkMode": "bridge" | "host",
- *       "gitIdentityMount": true
+ *       "gitIdentityMount": true,
+ *       "fleetMesh": true            // optional; absent == false
  *     }
  *   channels.envLines / volumeLines carry the line BODY (the text after
  *   `      - `); this script owns the compose indentation.
@@ -58,6 +59,7 @@ interface Inputs {
   agentHookProfile: string;
   networkMode: 'bridge' | 'host';
   gitIdentityMount: boolean;
+  fleetMesh?: boolean;
 }
 
 function packagesBlock(packages: string[]): string {
@@ -79,8 +81,22 @@ function indentedLines(bodies: string[]): string {
 export function render(inputs: Inputs): { dockerfile: string; compose: string } {
   const packages = inputs.packages ?? [];
   const channels = inputs.channels ?? {};
-  const envLines = channels.envLines ?? [];
-  const volumeLines = channels.volumeLines ?? [];
+  // envLines/volumeLines feed the CHANNEL_ENV_LINES and CHANNEL_VOLUME_LINES
+  // placeholders, which are really just "extra env/volume lines" despite the
+  // channel-specific name — fleet mesh reuses them instead of adding its own.
+  const envLines = [
+    ...(channels.envLines ?? []),
+    ...(inputs.fleetMesh ? ['XDG_RUNTIME_DIR=/run/hermit-fleet'] : []),
+  ];
+  const volumeLines = [
+    ...(channels.volumeLines ?? []),
+    ...(inputs.fleetMesh
+      ? [
+          'hermit-fleet-sessions:/home/claude/.claude/sessions',
+          'hermit-fleet-socks:/run/hermit-fleet',
+        ]
+      : []),
+  ];
 
   const dockerfileTemplate = fs.readFileSync(
     path.join(TEMPLATES_DIR, 'Dockerfile.hermit.template'), 'utf8');
@@ -113,6 +129,16 @@ export function render(inputs: Inputs): { dockerfile: string; compose: string } 
   const networkModeLine = inputs.networkMode === 'host'
     ? '    # WARNING: host networking exposes all host-local services to the container.\n    network_mode: host'
     : '';
+  // FLEET_MESH_PID_LINE shares a template line with NETWORK_MODE_LINE, so it
+  // carries its own leading newline — but only when NETWORK_MODE_LINE is
+  // non-empty, otherwise the default bridge case gains a stray blank line.
+  const fleetMeshPidLine = inputs.fleetMesh
+    ? `${networkModeLine ? '\n' : ''}    pid: "container:hermit-fleet-pidns"`
+    : '';
+  // Appended straight after "claude-config:" on the same template line.
+  const fleetMeshVolumeDeclarations = inputs.fleetMesh
+    ? '\n  hermit-fleet-sessions:\n    external: true\n  hermit-fleet-socks:\n    external: true'
+    : '';
 
   const compose = renderTemplate(composeTemplate, {
     AUTH_ENV_LINE: authEnvLine,
@@ -120,6 +146,8 @@ export function render(inputs: Inputs): { dockerfile: string; compose: string } 
     CHANNEL_VOLUME_LINES: indentedLines(volumeLines),
     AGENT_HOOK_PROFILE: inputs.agentHookProfile,
     NETWORK_MODE_LINE: networkModeLine,
+    FLEET_MESH_PID_LINE: fleetMeshPidLine,
+    FLEET_MESH_VOLUME_DECLARATIONS: fleetMeshVolumeDeclarations,
   });
 
   return { dockerfile, compose };

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -128,6 +128,7 @@ The render script derives every `{{PLACEHOLDER}}` internally and fails loud (wri
 - `agentHookProfile` — always `"strict"` for Docker (enforces `always_on` deny patterns inside the container).
 - `networkMode` — `docker.network_mode` (`"bridge"` or `"host"`, Step 2).
 - `gitIdentityMount` — the Step 1 preflight `gitconfigExists`. When **false**, the `.gitconfig` bind-mount is dropped and you must add to the summary: "No ~/.gitconfig found — git commits inside the container will have no author identity. Create one on the host and re-run docker-setup, or set git config manually inside the container."
+- `fleetMesh` - read `docker.fleet_mesh` from the project's `.claude-code-hermit/config.json`; absent means `false`. Never ask interactively. When true, tell the operator that the two external volumes and the `hermit-fleet-pidns` holder in `docs/always-on.md` must exist before `hermit-docker up`.
 
 ### 5. Auto-memory seed
 
@@ -311,7 +312,8 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/render-docker-templates.ts <PROJECT_ROOT> <<'H
   "channels": { "envLines": [...], "volumeLines": [...] },
   "agentHookProfile": "strict",
   "networkMode": "bridge" | "host",
-  "gitIdentityMount": true | false
+  "gitIdentityMount": true | false,
+  "fleetMesh": true | false
 }
 HERMIT_RENDER_JSON
 ```

--- a/plugins/claude-code-hermit/state-templates/config.json.template
+++ b/plugins/claude-code-hermit/state-templates/config.json.template
@@ -40,7 +40,8 @@
   "scheduled_checks": [],
   "docker": {
     "packages": [],
-    "recommended_plugins": []
+    "recommended_plugins": [],
+    "fleet_mesh": false
   },
   "compact": {
     "monitoring_threshold": 30,

--- a/plugins/claude-code-hermit/state-templates/docker/Dockerfile.hermit.template
+++ b/plugins/claude-code-hermit/state-templates/docker/Dockerfile.hermit.template
@@ -24,12 +24,15 @@ ARG HOST_UID=1000
 ARG CLAUDE_CODE_VERSION=latest
 ARG BUN_VERSION=1.4.0
 RUN userdel -r ubuntu 2>/dev/null; \
-    useradd -m -s /bin/bash -u ${HOST_UID} claude
+    useradd -m -s /bin/bash -u ${HOST_UID} claude && \
+    mkdir -p /run/hermit-fleet && \
+    chown claude:claude /run/hermit-fleet && \
+    chmod 0700 /run/hermit-fleet
 
 USER claude
 
-# Pre-create the config dir so the named volume inherits claude ownership on first mount
-RUN mkdir -p /home/claude/.claude
+# Pre-create the config dirs so named volumes inherit claude ownership on first mount
+RUN mkdir -p /home/claude/.claude/sessions
 
 # Install npm globals as claude user so Claude Code can self-update without sudo
 ENV NPM_CONFIG_PREFIX=/home/claude/.npm-global

--- a/plugins/claude-code-hermit/state-templates/docker/docker-compose.hermit.yml.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-compose.hermit.yml.template
@@ -31,7 +31,7 @@ services:
       # guard for split-state recovery (HERMIT_FORCE_BOOT=1 hermit-docker up).
       - HERMIT_FORCE_BOOT=${HERMIT_FORCE_BOOT:-0}
 {{AUTH_ENV_LINE}}{{CHANNEL_ENV_LINES}}
-{{NETWORK_MODE_LINE}}
+{{NETWORK_MODE_LINE}}{{FLEET_MESH_PID_LINE}}
     # Defense in depth — rationale and override path: run /claude-code-hermit:docker-security.
     cap_drop:
       - ALL
@@ -73,4 +73,4 @@ services:
       start_period: 30s
 
 volumes:
-  claude-config:
+  claude-config:{{FLEET_MESH_VOLUME_DECLARATIONS}}

--- a/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
+++ b/plugins/claude-code-hermit/state-templates/docker/docker-entrypoint.hermit.sh.template
@@ -569,6 +569,14 @@ if [ "${HERMIT_FORCE_BOOT:-0}" != "1" ]; then
 fi
 rm -f "${AGENT_DIR}/state/.boot-conflict" 2>/dev/null || true
 
+# Keep Claude Code on the configured inbox socket directory. It rejects
+# group- or world-writable directories and otherwise silently falls back to /tmp.
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  if ! mkdir -p "$XDG_RUNTIME_DIR" 2>/dev/null || ! chmod 0700 "$XDG_RUNTIME_DIR" 2>/dev/null; then
+    printf '[hermit] Cannot secure socket directory %s; fix with: docker volume rm hermit-fleet-socks, then hermit-docker up\n' "$XDG_RUNTIME_DIR" >&2
+  fi
+fi
+
 # --- 4c. Operator sidecar: pre-launch ---
 export HERMIT_ENTRY_PHASE=pre-launch
 if [ -f "${PROJECT_DIR}/docker-entrypoint.hermit-local.sh" ]; then . "${PROJECT_DIR}/docker-entrypoint.hermit-local.sh"; fi

--- a/plugins/claude-code-hermit/tests/render-docker-templates.test.ts
+++ b/plugins/claude-code-hermit/tests/render-docker-templates.test.ts
@@ -103,6 +103,27 @@ describe('render-docker-templates.ts', () => {
     expect(compose(hostDir)).toContain('network_mode: host');
   });
 
+  test('fleet mesh wiring is present only when explicitly enabled', async () => {
+    const absentDir = freshDir();
+    await render(absentDir);
+    expect(compose(absentDir)).not.toContain('hermit-fleet');
+
+    const disabledDir = freshDir();
+    await render(disabledDir, { fleetMesh: false });
+    expect(compose(disabledDir)).not.toContain('hermit-fleet');
+
+    const enabledDir = freshDir();
+    await render(enabledDir, { fleetMesh: true });
+    const enabledCompose = compose(enabledDir);
+    expect(enabledCompose).toContain('pid: "container:hermit-fleet-pidns"');
+    expect(enabledCompose).toContain('XDG_RUNTIME_DIR=/run/hermit-fleet');
+    expect(enabledCompose).toMatch(/^ {6}- hermit-fleet-sessions:\/home\/claude\/\.claude\/sessions$/m);
+    expect(enabledCompose).toMatch(/^ {6}- hermit-fleet-socks:\/run\/hermit-fleet$/m);
+    expect(enabledCompose.match(/^ {4}external: true$/gm)).toHaveLength(2);
+    expect(enabledCompose).not.toMatch(/\{\{[A-Z][A-Z0-9_]*\}\}/);
+    expect(dockerfile(enabledDir)).toBe(dockerfile(disabledDir));
+  });
+
   test('api-key auth adds ANTHROPIC_API_KEY env line; oauth does not', async () => {
     const keyDir = freshDir();
     await render(keyDir, { auth: 'api-key' });


### PR DESCRIPTION
## Summary

Docker hermits running on the same host could not see or message each other. Each container kept its own session registry and inbox socket dir, so `ListAgents` in one hermit never listed the others and `SendMessage` had no address to target. Sharing those dirs by hand does not fix it either: every container runs `claude` as pid 7, and the registry filenames are pid-keyed, so the entries overwrite each other.

This adds an opt-in `docker.fleet_mesh` key that renders a compose file wiring the shared state and a dedicated pid namespace.

## Behavior delta

```
BEFORE  two hermit stacks on one host
        ──> each container has its own session registry and socket dir
        ──> ListAgents in hermit A never lists hermit B; SendMessage has no address
        ──> sharing the dirs by hand collides: both claude processes are pid 7,
            so <pid>.json overwrites the other's entry

AFTER   docker.fleet_mesh: true, plus the two volumes and the pidns holder
        ──> every mesh container writes its registry entry to the shared
            sessions volume and its inbox socket to /run/hermit-fleet
        ──> all mesh containers share one pid namespace, so pids are unique
            and registry filenames never collide
        ──> ListAgents in A lists B by its agent_name; SendMessage delivers

fleet_mesh false or absent ──> rendered files byte-identical to today
```

## The decision a reviewer will ask about

```
how do pids become unique across containers?
  ├─> pid: host
  │     ──> unique pids, but every hermit sees and can signal every host process
  ├─> pid: "container:hermit-fleet-pidns"                          ◀ SELECTED
  │     ──> unique pids inside one hermit-only namespace, at the cost of
  │         one extra holder container the operator creates once
  └─> stagger launches and handle the collision
        ──> filenames stay pid-keyed, so a restart can still collide
```

Opt-in rather than default-on for two reasons: it needs two host-created volumes and a holder container the plugin cannot provision, and it deliberately weakens isolation between sibling hermits.

## Changes

- `docker.fleet_mesh` declared in the config template and documented in the config reference, defaulting to `false`
- `render-docker-templates.ts` takes an optional `fleetMesh` input and renders the two mounts, `XDG_RUNTIME_DIR`, the `pid:` key, and the two `external: true` volume declarations
- Dockerfile pre-creates `/home/claude/.claude/sessions` and `/run/hermit-fleet` with `claude` ownership so empty named volumes inherit it on first mount
- Entrypoint enforces `0700` on the socket dir before `hermit-start`, since Claude Code silently falls back to `/tmp` on a group- or world-writable one
- `/docker-setup` reads the key from `config.json` and never asks for it interactively
- Setup steps, the same-host-UID requirement, and the isolation trade documented in `always-on.md` and `docker-security.md`

## Two changes outside the original scope, both required

- **`hermit-start.ts` and `lib/config-read.ts`** register the new key. The template-parity tests make the `config.json.template` change impossible to land green without them.
- **`hermit-watchdog.ts`** anchors its heartbeat-monitor `pgrep` on this hermit's own state dir. A bare `pgrep -f heartbeat-monitor.sh` scans the whole pid namespace, which mesh containers now share by design, so it matched a *sibling's* monitor and reported a dead local one as alive. That permanently suppresses the pane-frozen restart escalation, which is exactly the recovery path a wedged hermit depends on. Shipping the mesh without this fix would ship that regression.

## Test plan

Run from the repo root:

```bash
bun install --frozen-lockfile && bunx tsc
cd plugins/claude-code-hermit && bun test --timeout=45000
```

Both green as of this branch: `tsc` exit 0, suite 4863 pass / 0 fail across 158 files. Also verified serially and under `--parallel` to rule out contention flakes.

New unit coverage asserts the three render modes (key absent, `false`, `true`), that the enabled compose carries the pid key, the env line, both mounts at the exact indent, and two `external: true` declarations, and that the Dockerfile output does not depend on the flag.

**Not covered by tests, needs a Docker host before merge:** two real containers built with `fleetMesh: true`, sharing the two volumes and the `hermit-fleet-pidns` holder. Expect `pidDomain` identical in both registry entries, each hermit listing the other in `ListAgents`, a restart yielding a new pid with no `<pid>.json` overwrite, `SendMessage` delivering, and no socket-dir refusal in the debug log.
