### PR TITLE
feat(claude-code-hermit): glob targets for /watch session

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Compose and Dockerfile templates are now evolve-managed. Upstream template hunks are merged into the live files while preserving operator customizations, with verified pristine bytes retained as the next 3-way base.
+- `/watch session <name>` accepts a glob (`*`, `?`) to match several local sessions at once, showing each match's live status and asking for one confirmation before subscribing to all of them.
 
 ### Fixed
 - Regenerating Docker scaffolding is no longer the only refresh path for a customized `docker-compose.hermit.yml` or `Dockerfile.hermit`; hermit-evolve reconciles each changed file in place and validates the result before it can be built.

--- a/plugins/claude-code-hermit/skills/watch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/watch/SKILL.md
@@ -14,14 +14,14 @@ Two classes:
 ## Usage
 
 ```
-/claude-code-hermit:watch <instruction>            — start ad-hoc (poll, default 5m interval)
-/claude-code-hermit:watch <stream-command>         — start ad-hoc stream
-/claude-code-hermit:watch session <name> [note]    — watch a local session until its next idle notice
-/claude-code-hermit:watch notice <text>            — [internal] handle a watched-session notice
-/claude-code-hermit:watch start                    — register all enabled config watches
-/claude-code-hermit:watch stop [id]                — stop by id (or auto if 1 active)
-/claude-code-hermit:watch stop --all               — stop all watches
-/claude-code-hermit:watch status                   — list active watches from registry
+/claude-code-hermit:watch <instruction>              — start ad-hoc (poll, default 5m interval)
+/claude-code-hermit:watch <stream-command>           — start ad-hoc stream
+/claude-code-hermit:watch session <name|glob> [note] — watch local session(s) until their next idle notice
+/claude-code-hermit:watch notice <text>              — [internal] handle a watched-session notice
+/claude-code-hermit:watch start                      — register all enabled config watches
+/claude-code-hermit:watch stop [id]                  — stop by id (or auto if 1 active)
+/claude-code-hermit:watch stop --all                 — stop all watches
+/claude-code-hermit:watch status                     — list active watches from registry
 ```
 
 ## Runtime Registry
@@ -87,6 +87,17 @@ them for decisions. Start/stop decisions read from the runtime registry.
    this machine — `notify_when_idle` covers nothing else, so a cloud/remote agent
    or an in-process subagent row does not qualify. If no such row matches, answer
    `No session named <name> is reachable from here.` and do not write the registry.
+
+   **Glob target:** if `<name>` contains `*` or `?`, match it against every
+   `ListAgents` row that already qualifies above, excluding this session and,
+   in a hatched folder, the resident/guest pair. No match: answer
+   `No session matching <name> is reachable from here.` and do not write the
+   registry. One or more matches: show the operator each matched name with the
+   live status its row reports (e.g. `idle`, `busy`, `waiting`, `shell`) and
+   wait for confirmation before doing anything else — an already-idle match
+   fires its notice as soon as it is subscribed. On confirmation, run steps
+   2–5 below once per matched name, each producing its own registry entry. A
+   plain (non-glob) `<name>` skips this branch and needs no confirmation.
 2. Call `SendMessage` with `to: <name>` and `notify_when_idle: true`. Omit
    `message`: this is a pure subscription, costs the watched session nothing, and
    fires immediately if it is already idle.

--- a/plugins/claude-code-hermit/skills/watch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/watch/SKILL.md
@@ -81,23 +81,33 @@ them for decisions. Start/stop decisions read from the runtime registry.
 8. Write registry back
 9. Log to SHELL.md `## Monitoring`: `- [ACTIVE] <instruction> (started HH:MM)`
 
-### Starting a session watch (`/watch session <name> [note]`)
+### Starting a session watch (`/watch session <name|glob> [note]`)
 
-1. Resolve `<name>` with `ListAgents`. The row must be a Claude Code session on
-   this machine — `notify_when_idle` covers nothing else, so a cloud/remote agent
-   or an in-process subagent row does not qualify. If no such row matches, answer
-   `No session named <name> is reachable from here.` and do not write the registry.
+1. If `<name>` contains `*` or `?`, take the **glob branch** below instead of
+   resolving an exact name.
 
-   **Glob target:** if `<name>` contains `*` or `?`, match it against every
-   `ListAgents` row that already qualifies above, excluding this session and,
-   in a hatched folder, the resident/guest pair. No match: answer
+   Otherwise resolve `<name>` with `ListAgents`. The row must be a Claude Code
+   session on this machine — `notify_when_idle` covers nothing else, so a
+   cloud/remote agent or an in-process subagent row does not qualify. If no such
+   row matches, answer `No session named <name> is reachable from here.` and do
+   not write the registry.
+
+   **Glob branch:** match the glob against the session *name* of every
+   `ListAgents` row that qualifies by the same rule — whole name,
+   case-sensitive, matching only the name that opens the row and not its
+   trailing `[ref]`, kind, status, or tmux address. `ListAgents` omits this
+   session from its own listing, so no self-exclusion is needed. Skip a match
+   that already has a live `peer-idle` entry for that target, and say which ones
+   you skipped. No match: answer
    `No session matching <name> is reachable from here.` and do not write the
    registry. One or more matches: show the operator each matched name with the
-   live status its row reports (e.g. `idle`, `busy`, `waiting`, `shell`) and
-   wait for confirmation before doing anything else — an already-idle match
-   fires its notice as soon as it is subscribed. On confirmation, run steps
-   2–5 below once per matched name, each producing its own registry entry. A
-   plain (non-glob) `<name>` skips this branch and needs no confirmation.
+   live status its row reports (`idle`, `busy`, `waiting`, `shell`; some rows
+   carry none, so show the name alone there) and wait for confirmation before
+   doing anything else — an already-idle match fires its notice as soon as it is
+   subscribed. On confirmation, run steps 2–5 below once per matched name, each
+   producing its own registry entry; do step 3's relay check on the first match
+   before subscribing to the rest, and if it comes back operator-only, stop
+   there and decline the whole set rather than subscribing the others.
 2. Call `SendMessage` with `to: <name>` and `notify_when_idle: true`. Omit
    `message`: this is a pure subscription, costs the watched session nothing, and
    fires immediately if it is already idle.


### PR DESCRIPTION
## Summary
`/watch session <name>` required an exact session name, but Claude Code silently renames a session on a name collision, so the operator often cannot know the name to type. This lets `<name>` be a glob (`*`, `?`) matching several local sessions in one command.

## Changes
- Resolve step now matches a glob against qualifying `ListAgents` rows, shows each match with its live status (`idle`/`busy`/`waiting`/`shell`), and asks for one confirmation before subscribing to all of them — an already-idle match fires its notice as soon as it's subscribed, so the operator sees that before it happens.
- On confirmation, existing per-target registration (subscribe + registry entry) runs once per match; no new state shape, no script changes.
- Usage line updated to advertise `<name|glob>`.

## Test plan
- `bun test` in `plugins/claude-code-hermit` — 4886 pass, 0 fail.
- Grep-based verification of each plan step (glob branch present in the session-watch section, usage line updated, CHANGELOG entry added) — all passed.
- Not run: an end-to-end `/probe` of the confirm-and-fan-out flow against live sessions (optional per the plan; left for a follow-up if wanted).