### PR TITLE
feat: add a curl bootstrap installer

### DIFF
--- a/.github/workflows/pages-install.yml
+++ b/.github/workflows/pages-install.yml
@@ -1,0 +1,68 @@
+name: Publish installer
+
+# Serves scripts/install.sh at https://gtapps.github.io/claude-code-hermit/install.sh
+#
+# Actions-based deploy rather than a gh-pages orphan branch on purpose: the file
+# people pipe to bash must be the same file reviewed in PRs on main. An orphan
+# branch would let the two drift silently, which is the last place you want drift.
+#
+# Pages is already configured for this repo with build_type=workflow; this
+# workflow only publishes to it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/install.sh'
+      - '.github/workflows/pages-install.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two deploys race; queue instead of cancelling, so a merge train
+# still ends with the newest installer live.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assemble site
+        run: |
+          set -euo pipefail
+          mkdir -p site
+          cp scripts/install.sh site/install.sh
+          # Actions-based Pages does not run Jekyll, but this costs nothing and
+          # removes the question entirely.
+          touch site/.nojekyll
+          cat > site/index.html <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>claude-code-hermit</title>
+          <meta http-equiv="refresh" content="0; url=https://github.com/gtapps/claude-code-hermit">
+          <link rel="canonical" href="https://github.com/gtapps/claude-code-hermit">
+          <p>Redirecting to <a href="https://github.com/gtapps/claude-code-hermit">github.com/gtapps/claude-code-hermit</a>.</p>
+          <p>Installer: <code>curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash</code></p>
+          HTML
+
+      - name: Verify the published file matches the repo
+        run: diff -q scripts/install.sh site/install.sh
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -64,6 +64,12 @@ jobs:
           source "$GITHUB_WORKSPACE/scripts/install.sh"
           load_floors
 
+          # load_floors empties both floors on a failed fetch, and ver_ge treats
+          # an empty floor as 0.0.0 — every comparison below would then pass
+          # vacuously. Fail loudly instead of silently asserting nothing.
+          test -n "$CLAUDE_FLOOR" || { echo "could not read CLAUDE_FLOOR"; exit 1; }
+          test -n "$BUN_FLOOR"    || { echo "could not read BUN_FLOOR"; exit 1; }
+
           cv="$(claude --version | awk '{print $1}')"
           bv="$(bun --version)"
           echo "claude=$cv bun=$bv (floors: $CLAUDE_FLOOR / $BUN_FLOOR)"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,0 +1,96 @@
+name: Installer
+
+# Runs scripts/install.sh end to end on clean runners — the only place the
+# "nothing is installed yet" path is actually exercised. Deliberately NOT folded
+# into test-macos-compat.yml: every path filter there is plugins/**, so a change
+# to root scripts/ would never trigger it.
+#
+# macOS is the load-bearing half. The version comparison in install.sh uses awk
+# rather than `sort -V` precisely because BSD userland is where that breaks, and
+# this job is what proves it.
+#
+# No setup-bun and no Claude Code preinstall step: watching the script provision
+# both from nothing is the point. Runners carry no Claude credentials, so this
+# also exercises the logged-out closing state, which is the realistic fresh-VPS
+# path.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/install.sh'
+      - '.github/workflows/test-install.yml'
+  pull_request:
+    paths:
+      - 'scripts/install.sh'
+      - '.github/workflows/test-install.yml'
+  workflow_dispatch:
+
+jobs:
+  install:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    # Generous: a cold `brew install tmux` on a macOS runner is minutes, and the
+    # marketplace clone attempts SSH before falling back to HTTPS.
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run the installer in a scratch project
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/proj" "$RUNNER_TEMP/cfg"
+          cd "$RUNNER_TEMP/proj"
+          CLAUDE_CONFIG_DIR="$RUNNER_TEMP/cfg" \
+            bash "$GITHUB_WORKSPACE/scripts/install.sh" 2>&1 | tee "$RUNNER_TEMP/out.txt"
+
+      # A fresh shell on purpose: the installer's own PATH exports die with it,
+      # which is exactly why the closing block tells the operator to reload.
+      - name: Assert the tools are installed and clear their floors
+        if: '!cancelled()'
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"
+
+          # Source the installer rather than re-typing its ver_ge and floor
+          # parsing, so a fix to either cannot silently drift from what this
+          # assertion checks. main() is guarded, so sourcing defines functions
+          # without re-running the install. load_floors reads the same URL the
+          # installer read, so a floor raised in an unmerged PR cannot fail this
+          # job spuriously.
+          source "$GITHUB_WORKSPACE/scripts/install.sh"
+          load_floors
+
+          cv="$(claude --version | awk '{print $1}')"
+          bv="$(bun --version)"
+          echo "claude=$cv bun=$bv (floors: $CLAUDE_FLOOR / $BUN_FLOOR)"
+
+          ver_ge "$cv" "$CLAUDE_FLOOR"
+          ver_ge "$bv" "$BUN_FLOOR"
+
+      - name: Assert the plugin landed at local scope
+        if: '!cancelled()'
+        run: |
+          set -euo pipefail
+          test -f "$RUNNER_TEMP/proj/.claude/settings.local.json"
+          grep -q 'claude-code-hermit@claude-code-hermit' \
+            "$RUNNER_TEMP/proj/.claude/settings.local.json"
+
+      - name: Assert the closing block told the operator what to run
+        if: '!cancelled()'
+        run: |
+          set -euo pipefail
+          grep -q 'Prerequisites set' "$RUNNER_TEMP/out.txt"
+          grep -q 'claude-code-hermit:hatch' "$RUNNER_TEMP/out.txt"
+
+      - name: Assert a second run is a no-op that still exits 0
+        if: '!cancelled()'
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/proj"
+          CLAUDE_CONFIG_DIR="$RUNNER_TEMP/cfg" \
+            bash "$GITHUB_WORKSPACE/scripts/install.sh" 2>&1 | tee "$RUNNER_TEMP/out2.txt"
+          grep -q 'already registered' "$RUNNER_TEMP/out2.txt"

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Claude Code plugin that turns a Claude Code instance into a 24/7 agent. **Statef
 Setup your agent in any folder, empty or existing project with `/hatch` and shape its identity, priorities, routines, knowledge, autonomy, guardrails and make it yours.
 
 ```
-# Install
-claude plugin marketplace add gtapps/claude-code-hermit
-claude plugin install claude-code-hermit@claude-code-hermit --scope local
+# Install (Linux, macOS, WSL2)
+cd /path/to/your/project
+curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
 
 # Boot Claude Code and run the setup wizard
-/claude-code-hermit:hatch
+claude "/claude-code-hermit:hatch"
 
 # Always-on: pick one
 .claude-code-hermit/bin/hermit-start          # tmux, same machine, no image
@@ -113,15 +113,16 @@ On-demand skills — pullable from the Claude app, your terminal, or a DM:
 
 ## Quick Start
 
-> **Prerequisites:** [Claude Code](https://code.claude.com) v2.1.251+, a Claude plan (Pro, Max, Teams, or Enterprise), and [Bun](https://bun.sh) 1.3+. Linux, macOS, and Windows via WSL2; see [FAQ](plugins/claude-code-hermit/docs/faq.md).
+> **Prerequisites:** a Claude plan (Pro, Max, Teams, or Enterprise). Linux, macOS, or Windows via WSL2; see [FAQ](plugins/claude-code-hermit/docs/faq.md).
 
 ### 1. Install
 
 ```bash
 cd /path/to/your/project   # or any folder — even an empty one
-claude plugin marketplace add gtapps/claude-code-hermit
-claude plugin install claude-code-hermit@claude-code-hermit --scope local
+curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
 ```
+
+Installs [Claude Code](https://code.claude.com) and [Bun](https://bun.sh) if they're missing, adds tmux, registers the marketplace, and installs the plugin for this folder. It stops there and tells you what to run next. Prefer to read it first, or do it by hand? [Manual install](plugins/claude-code-hermit/docs/how-to-use.md#manual-install).
 
 ### 2. Initialize
 

--- a/plugins/claude-code-hermit/README.md
+++ b/plugins/claude-code-hermit/README.md
@@ -19,12 +19,12 @@ Claude Code plugin that turns a Claude Code instance into a 24/7 agent. **Statef
 Setup your agent in any folder, empty or existing project with `/hatch` and shape its identity, priorities, routines, knowledge, autonomy, guardrails and make it yours.
 
 ```
-# Install
-claude plugin marketplace add gtapps/claude-code-hermit
-claude plugin install claude-code-hermit@claude-code-hermit --scope local
+# Install (Linux, macOS, WSL2)
+cd /path/to/your/project
+curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
 
 # Boot Claude Code and run the setup wizard
-/claude-code-hermit:hatch
+claude "/claude-code-hermit:hatch"
 
 # Always-on: pick one
 .claude-code-hermit/bin/hermit-start          # tmux, same machine, no image
@@ -113,15 +113,16 @@ On-demand skills — pullable from the Claude app, your terminal, or a DM:
 
 ## Quick Start
 
-> **Prerequisites:** [Claude Code](https://code.claude.com) v2.1.251+, a Claude plan (Pro, Max, Teams, or Enterprise), and [Bun](https://bun.sh) 1.3+. Linux, macOS, and Windows via WSL2; see [FAQ](docs/faq.md).
+> **Prerequisites:** a Claude plan (Pro, Max, Teams, or Enterprise). Linux, macOS, or Windows via WSL2; see [FAQ](docs/faq.md).
 
 ### 1. Install
 
 ```bash
 cd /path/to/your/project   # or any folder — even an empty one
-claude plugin marketplace add gtapps/claude-code-hermit
-claude plugin install claude-code-hermit@claude-code-hermit --scope local
+curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
 ```
+
+Installs [Claude Code](https://code.claude.com) and [Bun](https://bun.sh) if they're missing, adds tmux, registers the marketplace, and installs the plugin for this folder. It stops there and tells you what to run next. Prefer to read it first, or do it by hand? [Manual install](docs/how-to-use.md#manual-install).
 
 ### 2. Initialize
 

--- a/plugins/claude-code-hermit/docs/how-to-use.md
+++ b/plugins/claude-code-hermit/docs/how-to-use.md
@@ -2,7 +2,9 @@
 
 ## Prerequisites
 
-[Claude Code](https://code.claude.com) v2.1.251+ and a paid Claude plan (Pro, Max, Teams, or Enterprise). **Bun** ≥1.3; the hooks and scripts are TypeScript run directly by `bun`. Optional: **tmux** for always-on mode.
+A paid Claude plan (Pro, Max, Teams, or Enterprise). Linux, macOS, or Windows via WSL2.
+
+The installer below provisions the rest: [Claude Code](https://code.claude.com) v2.1.251+, **Bun** ≥1.3 (the hooks and scripts are TypeScript run directly by `bun`), and **tmux** for always-on mode.
 
 ---
 
@@ -10,9 +12,32 @@
 
 ```bash
 cd /path/to/your/project   # or any folder — even an empty one
+curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
+```
+
+It installs anything missing, registers the marketplace, installs the plugin for this folder, and stops — printing the exact command to run next. It never runs `/hatch` for you, and it takes no arguments.
+
+To read it before running it:
+
+```bash
+curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh -o install.sh
+less install.sh
+bash install.sh
+```
+
+### Manual install
+
+The installer is a convenience, not a requirement. With Claude Code and Bun already present:
+
+```bash
+cd /path/to/your/project
 claude plugin marketplace add gtapps/claude-code-hermit
 claude plugin install claude-code-hermit@claude-code-hermit --scope local
 ```
+
+`--scope local` keeps the hermit personal to this folder rather than committing it to the repo for everyone. `/hatch` asks the shared-vs-personal question separately.
+
+> **Upgrading is not a second `curl`.** Once installed, use `.claude-code-hermit/bin/hermit-update` (local/tmux), `.claude-code-hermit/bin/hermit-docker update` (Docker), or `claude plugin update claude-code-hermit@claude-code-hermit --scope local`. Re-running the installer is harmless but moves nothing.
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,7 +103,10 @@ load_floors() {
 
 # ------------------------------------------------------------ claude code ----
 
-claude_version() { claude --version 2>/dev/null | awk '{print $1}'; }
+# `|| true` inside the pipeline: with `set -o pipefail` a claude that exists but
+# errors (stale npm wrapper, missing node) would otherwise abort the whole
+# installer at the assignment below, silently and with no message.
+claude_version() { { claude --version 2>/dev/null || true; } | awk '{print $1}'; }
 
 ensure_claude() {
   if ! command -v claude >/dev/null 2>&1; then
@@ -120,6 +123,8 @@ ensure_claude() {
 
   local v
   v="$(claude_version)"
+  [ -n "$v" ] \
+    || die "'claude' is on PATH but 'claude --version' failed. Repair or reinstall Claude Code, then re-run: https://code.claude.com/docs/en/setup"
   if [ -n "$CLAUDE_FLOOR" ] && ! ver_ge "$v" "$CLAUDE_FLOOR"; then
     work "claude" "$v is below $CLAUDE_FLOOR, updating..."
     claude update >/dev/null 2>&1 || true
@@ -134,16 +139,24 @@ ensure_claude() {
 
 ensure_bun() {
   local v=""
-  command -v bun >/dev/null 2>&1 && v="$(bun --version 2>/dev/null)"
+  # `|| true`: the assignment follows the final `&&`, so `set -e` applies to it.
+  # A bun on PATH that errors (broken shim, missing glibc) would otherwise abort
+  # the installer with no output at all.
+  command -v bun >/dev/null 2>&1 && v="$(bun --version 2>/dev/null || true)"
 
   if [ -z "$v" ] || { [ -n "$BUN_FLOOR" ] && ! ver_ge "$v" "$BUN_FLOOR"; }; then
     work "bun" "installing..."
     curl -fsSL --max-time 20 https://bun.sh/install | bash >/dev/null 2>&1 \
-      || die "Bun install failed. Install it manually, then re-run: https://bun.sh"
+      || die "Bun install failed. It needs 'unzip', which minimal images often lack. Install unzip, or install Bun manually, then re-run: https://bun.sh"
     export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
     export PATH="$BUN_INSTALL/bin:$PATH"
     v="$(bun --version 2>/dev/null || true)"
     [ -n "$v" ] || die "Bun installed but 'bun' is not on PATH. Open a new shell and re-run."
+    # Same re-verification ensure_claude does: an install that exits 0 without
+    # replacing a below-floor bun must not be reported as success.
+    if [ -n "$BUN_FLOOR" ] && ! ver_ge "$v" "$BUN_FLOOR"; then
+      die "Bun $v is still below the required $BUN_FLOOR after install. Install it manually, then re-run: https://bun.sh"
+    fi
   fi
   ok "bun" "$v"
 }
@@ -159,28 +172,33 @@ ensure_tmux() {
     return
   fi
 
-  local sudo=""
-  if [ "$(id -u)" != "0" ]; then
-    if command -v sudo >/dev/null 2>&1; then
-      sudo="sudo"
-    else
-      warn "tmux" "not installed and no sudo; install it yourself for the tmux always-on path"
-      return
-    fi
-  fi
-
-  work "tmux" "installing..."
+  # brew is checked before the sudo gate: it never needs root, so a box with
+  # Homebrew but no `sudo` binary should still get tmux.
   if command -v brew >/dev/null 2>&1; then
+    work "tmux" "installing..."
     brew install tmux >/dev/null 2>&1 || true
-  elif command -v apt-get >/dev/null 2>&1; then
-    $sudo apt-get update -qq >/dev/null 2>&1 || true
-    $sudo apt-get install -y tmux >/dev/null 2>&1 || true
-  elif command -v dnf >/dev/null 2>&1; then
-    $sudo dnf install -y tmux >/dev/null 2>&1 || true
-  elif command -v apk >/dev/null 2>&1; then
-    $sudo apk add tmux >/dev/null 2>&1 || true
-  elif command -v pacman >/dev/null 2>&1; then
-    $sudo pacman -S --noconfirm tmux >/dev/null 2>&1 || true
+  else
+    local sudo=""
+    if [ "$(id -u)" != "0" ]; then
+      if command -v sudo >/dev/null 2>&1; then
+        sudo="sudo"
+      else
+        warn "tmux" "not installed and no sudo; install it yourself for the tmux always-on path"
+        return
+      fi
+    fi
+
+    work "tmux" "installing..."
+    if command -v apt-get >/dev/null 2>&1; then
+      $sudo apt-get update -qq >/dev/null 2>&1 || true
+      $sudo apt-get install -y tmux >/dev/null 2>&1 || true
+    elif command -v dnf >/dev/null 2>&1; then
+      $sudo dnf install -y tmux >/dev/null 2>&1 || true
+    elif command -v apk >/dev/null 2>&1; then
+      $sudo apk add tmux >/dev/null 2>&1 || true
+    elif command -v pacman >/dev/null 2>&1; then
+      $sudo pacman -S --noconfirm tmux >/dev/null 2>&1 || true
+    fi
   fi
 
   if command -v tmux >/dev/null 2>&1; then
@@ -193,12 +211,16 @@ ensure_tmux() {
 # ------------------------------------------------------------------ plugin ----
 
 install_plugin() {
-  if claude plugin marketplace list 2>/dev/null | grep -q 'claude-code-hermit'; then
+  # Anchored to the marketplace-name line ("  > claude-code-hermit"). A bare
+  # substring match also hits the "Source: GitHub (owner/claude-code-hermit)"
+  # line, so a fork registered under a different marketplace name would skip the
+  # add and then fail the install below on an unregistered marketplace id.
+  if claude plugin marketplace list 2>/dev/null | grep -qE 'claude-code-hermit[[:space:]]*$'; then
     ok "marketplace" "$MARKETPLACE (already registered)"
   else
     work "marketplace" "adding $MARKETPLACE..."
     claude plugin marketplace add "$MARKETPLACE" >/dev/null 2>&1 \
-      || die "Could not add the marketplace. Check network access to github.com and re-run."
+      || die "Could not add the marketplace. It clones over git, so this needs 'git' installed and network access to github.com. On macOS a missing Xcode CLT makes git prompt instead of run."
     ok "marketplace" "$MARKETPLACE"
   fi
 
@@ -236,18 +258,20 @@ closing_block() {
 
   say "Prerequisites set. Time to hatch your agent:"
   printf '\n'
+  # Not mutually exclusive: a Claude Code this script just installed is by
+  # definition logged out, so the fresh-install path needs the login line too.
   if [ "$CLAUDE_WAS_INSTALLED" = "1" ]; then
     say "    exec \$SHELL"
-    say "    claude \"/claude-code-hermit:hatch\""
-    printf '\n'
-    say "The first reloads your shell so \`claude\` is on PATH."
-  elif ! has_credentials; then
-    say "    claude          # not logged in on this machine? /login first"
-    say "    claude \"/claude-code-hermit:hatch\""
-  else
-    say "    claude \"/claude-code-hermit:hatch\""
   fi
+  if ! has_credentials; then
+    say "    claude          # not logged in on this machine? /login first"
+  fi
+  say "    claude \"/claude-code-hermit:hatch\""
   printf '\n'
+  if [ "$CLAUDE_WAS_INSTALLED" = "1" ]; then
+    say "The first reloads your shell so \`claude\` is on PATH."
+    printf '\n'
+  fi
   rule
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+#
+# claude-code-hermit bootstrap.
+#
+#   curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
+#
+# Provisions what a bare box needs (Claude Code, Bun, tmux), registers the
+# marketplace and installs the plugin at local scope in the current directory,
+# then stops. It does NOT run /hatch: that is an interactive model turn with no
+# non-interactive equivalent.
+#
+# No flags, no prompts by design. Under `curl | bash` the script itself is on
+# stdin, so any `read` would either hang or eat script text.
+#
+# Kept bash 3.2 compatible: macOS ships bash 3.2 as /bin/bash, so no associative
+# arrays, no `readarray`, no `${var^^}`.
+
+set -euo pipefail
+
+MARKETPLACE="gtapps/claude-code-hermit"
+PLUGIN="claude-code-hermit@claude-code-hermit"
+META_URL="https://raw.githubusercontent.com/gtapps/claude-code-hermit/main/plugins/claude-code-hermit/.claude-plugin/hermit-meta.json"
+DOCS_URL="https://github.com/gtapps/claude-code-hermit#quick-start"
+
+CLAUDE_WAS_INSTALLED=0   # set when we install Claude Code fresh; drives the closing block
+
+# ---------------------------------------------------------------- output ----
+
+say()  { printf '  %s\n' "$*"; }
+ok()   { printf '  \033[32m+\033[0m %-12s %s\n' "$1" "$2"; }
+work() { printf '  \033[34m>\033[0m %-12s %s\n' "$1" "$2"; }
+warn() { printf '  \033[33m!\033[0m %-12s %s\n' "$1" "$2"; }
+die()  { printf '\n  \033[31mx\033[0m %s\n\n' "$*" >&2; exit 1; }
+
+# ------------------------------------------------------------- versioning ----
+
+# ver_ge A B -> exit 0 when A >= B. awk rather than `sort -V`, which BSD sort on
+# macOS does not reliably provide. Non-numeric trailers are tolerated: awk's
+# `+ 0` turns "251 (Claude" into 251.
+ver_ge() {
+  awk -v a="$1" -v b="$2" 'BEGIN {
+    na = split(a, A, "."); nb = split(b, B, ".")
+    for (i = 1; i <= 3; i++) {
+      x = (i <= na) ? A[i] + 0 : 0
+      y = (i <= nb) ? B[i] + 0 : 0
+      if (x > y) exit 0
+      if (x < y) exit 1
+    }
+    exit 0
+  }'
+}
+
+# Pull one "key": ">=X.Y.Z" out of hermit-meta.json and reduce it to X.Y.Z.
+# No jq dependency: the file is small, flat and machine-written.
+meta_floor() {
+  printf '%s' "$1" \
+    | sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | tr -cd '0-9.'
+}
+
+# ---------------------------------------------------------------- platform ----
+
+detect_platform() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os" in
+    Linux|Darwin) ;;
+    *) die "Unsupported platform: $os. Linux, macOS and Windows via WSL2 only. See $DOCS_URL" ;;
+  esac
+  case "$arch" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) die "Unsupported architecture: $arch. x64 and arm64 only. See $DOCS_URL" ;;
+  esac
+  if [ "$os" = "Linux" ] && grep -qi microsoft /proc/version 2>/dev/null; then
+    PLATFORM="wsl2-$arch"
+  else
+    PLATFORM="$(printf '%s' "$os" | tr 'A-Z' 'a-z')-$arch"
+  fi
+}
+
+# ------------------------------------------------------------------ floors ----
+
+# Read the version floors from the plugin's own manifest so this script cannot
+# drift from what doctor-check.ts enforces. A failed fetch is not fatal: absent
+# tools are installed at latest, which clears any floor. An already-present but
+# stale tool then goes uncaught here and is caught later by /hermit-doctor.
+load_floors() {
+  local meta
+  CLAUDE_FLOOR=""
+  BUN_FLOOR=""
+  if meta="$(curl -fsSL --max-time 20 "$META_URL" 2>/dev/null)"; then
+    CLAUDE_FLOOR="$(meta_floor "$meta" min_claude_code_version)"
+    BUN_FLOOR="$(meta_floor "$meta" required_bun_version)"
+  fi
+  if [ -z "$CLAUDE_FLOOR" ] || [ -z "$BUN_FLOOR" ]; then
+    warn "floors" "could not read version floors, skipping version checks"
+    CLAUDE_FLOOR=""
+    BUN_FLOOR=""
+  fi
+}
+
+# ------------------------------------------------------------ claude code ----
+
+claude_version() { claude --version 2>/dev/null | awk '{print $1}'; }
+
+ensure_claude() {
+  if ! command -v claude >/dev/null 2>&1; then
+    work "claude" "installing..."
+    curl -fsSL --max-time 20 https://claude.ai/install.sh | bash >/dev/null 2>&1 \
+      || die "Claude Code install failed. Install it manually, then re-run: https://code.claude.com/docs/en/setup"
+    export PATH="$HOME/.local/bin:$PATH"
+    CLAUDE_WAS_INSTALLED=1
+    command -v claude >/dev/null 2>&1 \
+      || die "Claude Code installed but 'claude' is not on PATH. Open a new shell and re-run."
+    ok "claude" "$(claude_version)"
+    return
+  fi
+
+  local v
+  v="$(claude_version)"
+  if [ -n "$CLAUDE_FLOOR" ] && ! ver_ge "$v" "$CLAUDE_FLOOR"; then
+    work "claude" "$v is below $CLAUDE_FLOOR, updating..."
+    claude update >/dev/null 2>&1 || true
+    v="$(claude_version)"
+    ver_ge "$v" "$CLAUDE_FLOOR" \
+      || die "Claude Code $v is below the required $CLAUDE_FLOOR and 'claude update' did not move it. Update manually, then re-run: https://code.claude.com/docs/en/setup"
+  fi
+  ok "claude" "$v"
+}
+
+# -------------------------------------------------------------------- bun ----
+
+ensure_bun() {
+  local v=""
+  command -v bun >/dev/null 2>&1 && v="$(bun --version 2>/dev/null)"
+
+  if [ -z "$v" ] || { [ -n "$BUN_FLOOR" ] && ! ver_ge "$v" "$BUN_FLOOR"; }; then
+    work "bun" "installing..."
+    curl -fsSL --max-time 20 https://bun.sh/install | bash >/dev/null 2>&1 \
+      || die "Bun install failed. Install it manually, then re-run: https://bun.sh"
+    export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+    v="$(bun --version 2>/dev/null || true)"
+    [ -n "$v" ] || die "Bun installed but 'bun' is not on PATH. Open a new shell and re-run."
+  fi
+  ok "bun" "$v"
+}
+
+# ------------------------------------------------------------------- tmux ----
+
+# Best-effort: tmux is only needed for the tmux always-on path. The Docker path
+# and `hermit-start --no-tmux` do not use it, so a box without sudo gets a
+# warning rather than a failed install.
+ensure_tmux() {
+  if command -v tmux >/dev/null 2>&1; then
+    ok "tmux" "$(tmux -V 2>/dev/null | awk '{print $2}')"
+    return
+  fi
+
+  local sudo=""
+  if [ "$(id -u)" != "0" ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo="sudo"
+    else
+      warn "tmux" "not installed and no sudo; install it yourself for the tmux always-on path"
+      return
+    fi
+  fi
+
+  work "tmux" "installing..."
+  if command -v brew >/dev/null 2>&1; then
+    brew install tmux >/dev/null 2>&1 || true
+  elif command -v apt-get >/dev/null 2>&1; then
+    $sudo apt-get update -qq >/dev/null 2>&1 || true
+    $sudo apt-get install -y tmux >/dev/null 2>&1 || true
+  elif command -v dnf >/dev/null 2>&1; then
+    $sudo dnf install -y tmux >/dev/null 2>&1 || true
+  elif command -v apk >/dev/null 2>&1; then
+    $sudo apk add tmux >/dev/null 2>&1 || true
+  elif command -v pacman >/dev/null 2>&1; then
+    $sudo pacman -S --noconfirm tmux >/dev/null 2>&1 || true
+  fi
+
+  if command -v tmux >/dev/null 2>&1; then
+    ok "tmux" "$(tmux -V 2>/dev/null | awk '{print $2}')"
+  else
+    warn "tmux" "install failed; needed only for the tmux always-on path"
+  fi
+}
+
+# ------------------------------------------------------------------ plugin ----
+
+install_plugin() {
+  if claude plugin marketplace list 2>/dev/null | grep -q 'claude-code-hermit'; then
+    ok "marketplace" "$MARKETPLACE (already registered)"
+  else
+    work "marketplace" "adding $MARKETPLACE..."
+    claude plugin marketplace add "$MARKETPLACE" >/dev/null 2>&1 \
+      || die "Could not add the marketplace. Check network access to github.com and re-run."
+    ok "marketplace" "$MARKETPLACE"
+  fi
+
+  work "plugin" "installing at local scope..."
+  claude plugin install "$PLUGIN" --scope local >/dev/null 2>&1 \
+    || die "Plugin install failed. Re-run, or install by hand: claude plugin install $PLUGIN --scope local"
+  ok "plugin" "claude-code-hermit ($(pwd))"
+}
+
+# ------------------------------------------------------------ closing block ----
+
+# Credential detection is best-effort. On macOS Claude Code may hold credentials
+# in the Keychain rather than on disk, so a false "not logged in" is possible;
+# the wording below is written to stay true either way.
+has_credentials() {
+  [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && return 0
+  [ -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json" ] && return 0
+  return 1
+}
+
+rule() { printf '  \033[2m%s\033[0m\n' "─────────────────────────────────────────────────"; }
+
+closing_block() {
+  printf '\n'
+  rule
+
+  if [ -f ".claude-code-hermit/config.json" ]; then
+    say "Prerequisites set. This folder is already hatched, so update instead:"
+    printf '\n'
+    say "    .claude-code-hermit/bin/hermit-update"
+    printf '\n'
+    rule
+    return
+  fi
+
+  say "Prerequisites set. Time to hatch your agent:"
+  printf '\n'
+  if [ "$CLAUDE_WAS_INSTALLED" = "1" ]; then
+    say "    exec \$SHELL"
+    say "    claude \"/claude-code-hermit:hatch\""
+    printf '\n'
+    say "The first reloads your shell so \`claude\` is on PATH."
+  elif ! has_credentials; then
+    say "    claude          # not logged in on this machine? /login first"
+    say "    claude \"/claude-code-hermit:hatch\""
+  else
+    say "    claude \"/claude-code-hermit:hatch\""
+  fi
+  printf '\n'
+  rule
+}
+
+# ------------------------------------------------------------------- main ----
+
+main() {
+  printf '\n  \033[1mclaude-code-hermit\033[0m\n\n'
+
+  detect_platform
+  ok "platform" "$PLATFORM"
+
+  load_floors
+  ensure_claude
+  ensure_bun
+  ensure_tmux
+  install_plugin
+
+  closing_block
+}
+
+# Guarded so CI can `source` this file to reuse ver_ge and load_floors without
+# re-running the install. Under `curl | bash` BASH_SOURCE is unset and both
+# sides resolve to "bash", so the installer still runs.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary

Gives hermit a one-line install, like openclaw and hermes have. The gap it closes is not the pipe, it's the Prerequisites line: today a fresh box is told to go install Claude Code, then Bun, then tmux, and come back.

Hermit is not a runtime, so this is deliberately **not** the equivalent of their installers. Theirs provision Node/Python, clone a repo, set up a venv and configure an LLM provider; `claude plugin install` already is that. What was missing is the layer underneath, making a bare VPS ready for it. So this is a bootstrap that stops at `/hatch`, which is an interactive model turn with no non-interactive equivalent.

```
cd /path/to/your/project
curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
```

## Behavior delta

```
BEFORE                                        AFTER

Fresh box                                     Fresh box
  │                                             │
  ├─ read Prerequisites:                        │
  │    install Claude Code  ─┐                  │
  │    install Bun          ─┼─ 3 detours       │
  │    install tmux         ─┘                  │
  ▼                                             ▼
cd project                                    cd project
  │                                             │
  ├─ claude plugin marketplace add …            ├─ curl …/install.sh | bash
  ├─ claude plugin install … --scope local      │    ├ claude / bun / tmux ensured
  │    └ dropping --scope local silently        │    ├ marketplace + plugin, local scope
  │      installs for every project             │    └ prints the exact next command
  ▼                                             ▼
claude "/hatch"                               claude "/hatch"

Prerequisites line: 3 things to install       Prerequisites line: a Claude plan
```

## Changes

**`scripts/install.sh`** (new, root-scope tooling alongside `test-all.sh`)

Detects platform, reads the version floors, ensures Claude Code / Bun / tmux, registers the marketplace, installs the plugin at local scope in the current directory, prints a closing block, exits 0. Re-running is a no-op.

**`.github/workflows/pages-install.yml`** (new) — publishes the script from `main` via an Actions-based Pages deploy, so the file people pipe to bash is the one reviewed in PRs. Pages is already configured on the repo with `build_type=workflow`.

**`.github/workflows/test-install.yml`** (new) — runs the installer end to end on clean `ubuntu-latest` and `macos-latest`. macOS is the load-bearing half: BSD userland is where the version comparison would break.

**Docs** — `README.md`, `plugins/claude-code-hermit/README.md`, `plugins/claude-code-hermit/docs/how-to-use.md`. Both READMEs lead with the curl line; `how-to-use.md` keeps the two-command form as a documented **Manual install** so nobody is forced through a pipe, and states that upgrades go through `hermit-update`, not a second curl.

No CHANGELOG entry: root-scope plus docs-only per `CLAUDE.md`.

## Decisions

```
Q1  Hand off by exec'ing into the hatch session?
     ├─ exec claude "/hatch" ──> saves one paste; breaks under curl|bash
     │                           (stdin is the pipe), and in CI, Docker RUN,
     │                           non-tty ssh
     └─ print the command   ──>  ◀ SELECTED  exit 0 means provisioned; the
                                 PATH reload surfaces immediately, not later

Q2  Expose --scope as a flag?
     ├─ --scope flag       ──> asks the question hatch already asks, before
     │                         the person has context for it
     ├─ default to project ──> commits plugin enablement to git; every
     │                         teammate cloning the repo boots a hermit
     └─ hardcode local     ──>  ◀ SELECTED  hatch's hatch_target question
                                owns the shared-vs-personal axis

Q3  Flags at all?
     ├─ --runtime/--dir/--ref/--dry-run ──> four decisions asked at step 1
     │                                      that belong at step 3, or never
     └─ zero flags                      ──>  ◀ SELECTED  tmux best-effort
                                             always, cwd is the target
```

Other decisions worth surfacing for review:

- **No prompts, no arguments.** Under `curl | bash` the script itself is on stdin, so any `read` would hang or eat script text.
- **Floors are read from `hermit-meta.json` at runtime**, never hardcoded, so the script cannot drift from `doctor-check.ts`. A failed fetch is non-fatal: absent tools install at latest, which clears any floor.
- **`awk`, not `sort -V`.** BSD sort on macOS is exactly where that breaks. The comparator was unit-tested across 13 cases including the `2.1.251 (Claude` trailer that `claude --version` actually emits.
- **Credentials detected by file presence, not `claude auth status`** — that command is offline and reports `loggedIn: true` for a dead token, so it would wave through a box that then fails at hatch. Detection is best-effort (macOS may use the Keychain), so the logged-out wording stays true either way.
- **bash 3.2 compatible** — macOS ships 3.2 as `/bin/bash`.

## Verification

Probed live on CC 2.1.251 **before** building, since the whole design rests on it. With stdin as a pipe, an isolated `CLAUDE_CONFIG_DIR` and a never-trusted scratch dir: `claude plugin marketplace add` and `claude plugin install --scope local` both exit 0 with **no tty, no credentials and no workspace-trust prompt**, and with SSH broken (`GIT_SSH_COMMAND=/bin/false`, simulating a fresh VPS) the clone prints `SSH clone failed, retrying with HTTPS` and succeeds.

Run locally against a scratch project:

- End-to-end run exits 0; `.claude/settings.local.json` gets `claude-code-hermit@claude-code-hermit`
- Second run exits 0 and reports the marketplace as `already registered`
- 3 of 4 closing states exercised live (ready / logged-out / already-hatched). The fourth needs a box without Claude Code, which the new CI job covers
- `source install.sh` defines `ver_ge` and `load_floors` and produces no installer output, so the CI assertion reuses the real implementation instead of a hand-copied duplicate
- Version comparator: 13/13
- Both workflows parse

## Note for the reviewer: the test spine is red, and it is not this PR

`bun run test` fails on one Home Assistant test:

```
claude-code-homeassistant-hermit FAIL 55s
  (fail) golden corpus: oversized entity list with one sensitive id blocks identically [5001.92ms]
  ^ this test timed out after 5000ms.     Expected: 2   Received: -1
```

Confirmed pre-existing rather than assumed:

- HA suite alone: **676 pass, 0 fail**, 30.3s
- Under `test-all.sh` parallel load: fails, reproducibly
- **Stashed every change in this PR and ran the spine on the clean base commit: identical failure**

It is CPU contention during `test-all.sh`'s parallel phase, which that script's own comments already flag for these gate-corpus tests. CI does not hit it (`test-ha.yml` runs HA alone, `test-macos-compat.yml` runs serial). Worth its own issue, not a fix folded in here.

## Follow-ups, deliberately out of scope

- No Windows `.ps1`; WSL2 is the documented Windows story
- Extension plugins (dev, HA, fitness, feed, forge, scribe) stay post-hatch
- Docker is verified, never installed
