### PR TITLE
fix: stop core hatch from pre-stamping a domain hermit's activation

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The `/hatch` OPERATOR.md questionnaire drops the testing question and asks a single follow-up after the four core ones: CI/CD quirks when a CI config was found, team shape otherwise.
 
 ### Fixed
+- Activating a domain hermit during core `/hatch` no longer pre-stamps its `_hermit_versions` entry, so the domain plugin's own hatch preflight offers the full wizard instead of a misleading re-verify (#902).
 - `/hermit-doctor` and the watchdog now compare a monitor's registration against `state/.boot-id`, so one left behind by a previous boot is reported and re-armed instead of reading healthy on its last pre-crash tick for up to 90 minutes. This also covers routines in `croncreate-fallback` mode, where the boot id is the only available evidence, and interactive (`--no-tmux`) starts now stamp the marker so the check works there too.
 - `/hatch` now supplies a description for every `AskUserQuestion` option in both branches, so the identity batch and the OPERATOR.md questionnaire no longer fail with `Invalid tool parameters`.
 - The tmux next step in `hatch-report.ts` now prefixes `.claude-code-hermit/bin/hermit-start` with `!`, so it can run directly in the current Claude Code session.

--- a/plugins/claude-code-hermit/scripts/hatch-config.ts
+++ b/plugins/claude-code-hermit/scripts/hatch-config.ts
@@ -22,9 +22,9 @@
  * _hermit_versions: the core version is read from THIS script's own plugin.json, never
  * from the answers payload — an operator-supplied version could otherwise advance
  * `_hermit_versions["claude-code-hermit"]` on re-init and erase the upgrade gap
- * hermit-evolve's evolve-plan.ts reads to discover pending migrations. Every entry
- * (core + any activated sibling) is stamped add-if-absent, never bumped — mirrors
- * evolve-finalize.ts's sibling-version contract.
+ * hermit-evolve's evolve-plan.ts reads to discover pending migrations. The core
+ * entry is stamped add-if-absent, never bumped — mirrors evolve-finalize.ts's
+ * sibling-version contract. Domain plugins stamp themselves from their own hatch.
  *
  * Validation: this script does not re-implement answer validation. It overlays by
  * presence (Object.hasOwn, never truthiness, so `remote:false`/`null` apply) and lets
@@ -151,22 +151,16 @@ if (Object.hasOwn(answers, 'routines')) {
 config._hermit_versions =
   config._hermit_versions && typeof config._hermit_versions === 'object' ? config._hermit_versions : {};
 
-function stampIfAbsent(key: string, version: string): void {
-  if (!Object.hasOwn(config._hermit_versions, key)) config._hermit_versions[key] = version;
+if (!Object.hasOwn(config._hermit_versions, 'claude-code-hermit')) {
+  config._hermit_versions['claude-code-hermit'] = coreVersion;
 }
-
-stampIfAbsent('claude-code-hermit', coreVersion);
 if (Object.hasOwn(answers, 'activated_hermit') && answers.activated_hermit) {
-  // slug/version are hand-built by the model from detected_hermits + the sibling's
-  // plugin.json — refuse a malformed pair rather than stamp `_hermit_versions["undefined"]`
-  // (which evolve-plan.ts would then treat as a real sibling) or an undefined value
-  // (which JSON.stringify silently drops, desyncing the written file from validate()).
-  const { slug, version } = answers.activated_hermit;
+  // slug is hand-built by the model from detected_hermits — refuse a malformed
+  // slug rather than let hatch-report.ts render an undefined Hermit-ext name.
+  // A stray `version` key (older skill text) is ignored; domain plugins stamp
+  // `_hermit_versions` from their own hatch.
+  const { slug } = answers.activated_hermit;
   if (typeof slug !== 'string' || !slug) die('activated_hermit.slug must be a non-empty string');
-  if (typeof version !== 'string' || !version) {
-    die(`activated_hermit.version must be a non-empty string (slug "${slug}")`);
-  }
-  stampIfAbsent(slug, version);
 }
 
 // --- boot_skill: only touched when a hermit was (re)activated this run ---

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -100,7 +100,7 @@ If the list is non-empty:
 - If the operator selects one: record the full entry from `detected_hermits` as `activated_hermit` (carries `plugin`, `id`, `marketplace_name`, `installPath`).
   - Read `<activated_hermit.installPath>/state-templates/CLAUDE-APPEND.md` and append it to the target project's CLAUDE.md (after the core append in step 5).
   - Read `<activated_hermit.installPath>/.claude-plugin/hermit-meta.json`: if it declares a `hermit.boot_skill` field (e.g. `"/claude-code-homeassistant-hermit:ha-boot"`), record it for step 5 to write as `boot_skill` in `config.json`. This replaces the default `/claude-code-hermit:session` bootstrap so the domain hermit's custom boot logic fires on every always-on launch. If the field is absent, leave `boot_skill` unset (core behavior).
-  - Read `<activated_hermit.installPath>/.claude-plugin/plugin.json` for its `version` field — this, together with `activated_hermit.plugin` (as `slug`) and the `boot_skill` above, is what Step 5 sends as `activated_hermit` in the `hatch-config.ts` answers payload.
+  - Step 5 sends `activated_hermit.plugin` as `slug` together with the `boot_skill` above in the `hatch-config.ts` answers payload. Do not read the sibling's `plugin.json` version — core does not stamp `_hermit_versions` for an activated hermit.
 - If the list is empty or the operator declines: skip.
 
 ### 4. Setup wizard
@@ -251,7 +251,7 @@ with the answers payload as JSON on stdin. The script reads the template (or, on
 ```json
 {
   "project_name": "<project directory name, fresh hatch only>",
-  "activated_hermit": { "slug": "<plugin>", "version": "<sibling's plugin.json version>", "boot_skill": "<hermit.boot_skill from hermit-meta.json, or null>" },
+  "activated_hermit": { "slug": "<plugin>", "boot_skill": "<hermit.boot_skill from hermit-meta.json, or null>" },
   "agent_name": "...", "language": "...", "timezone": "...", "sign_off": "...",
   "escalation": "...", "remote": true, "idle_behavior": "...",
   "permission_mode": "...",
@@ -264,7 +264,7 @@ with the answers payload as JSON on stdin. The script reads the template (or, on
 - **Phase 3** → `escalation`, `remote`, `idle_behavior`.
 - **Phase 4** → `channels.<name>`: `enabled`, `allowed_users` (omit if the operator skipped access control), `morning_brief_time` (omit if declined; on re-init, send it as `null` to turn off a brief the operator previously enabled). The script fills in `dm_channel_id: null`, `default_chat_id: null`, and `state_dir: .claude.local/channels/<name>` on first creation and preserves all three (plus any other channel it doesn't recognize, `channels.primary`, and third-party `marketplace` channels) on re-init merge. Do **not** include `push_notifications` in the payload — the script never touches it; it stays at the template default (`true`) or, on re-init, whatever value is already on disk. The runtime channel-first/push-fallback guard in CLAUDE-APPEND.md already prevents double-notification.
 - **Phase 5** → `permission_mode`, `routines` (morning/evening only — `heartbeat-restart` and the other infrastructure routines are already in the template and are never touched by this payload).
-- **Step 3 hermit activation** → `activated_hermit`. `version` is read from `<activated_hermit.installPath>/.claude-plugin/plugin.json`; `boot_skill` is read from `<activated_hermit.installPath>/.claude-plugin/hermit-meta.json`'s `hermit.boot_skill` field (or `null` if absent).
+- **Step 3 hermit activation** → `activated_hermit`. `slug` is `activated_hermit.plugin`; `boot_skill` is read from `<activated_hermit.installPath>/.claude-plugin/hermit-meta.json`'s `hermit.boot_skill` field (or `null` if absent).
 
 **Re-initialization** is `--reinit` on the same call — the script reads the existing config as its base (never the template), so any field the payload doesn't mention (custom operator keys, `push_notifications`, `docker`, `monitors`, ...) survives untouched, `_hermit_versions` entries are never advanced (only added if a slug is newly absent), and `scheduled_checks`/`channels`/`routines` are reconciled/merged by id rather than replaced wholesale. `shutdown_skill` is never written by this script — leave it `null`; the operator sets it via config edit if they run always-on services that need stopping on full close.
 
@@ -595,7 +595,7 @@ Replaces Steps 3-4 with batched turns + confirm; resumes shared Steps 5-9 after 
 
 Only fires if `detected_hermits` from Step 1.5 is non-empty. Same prompt shape as Step 3 of the Advanced branch — uses the cached candidate list, does not re-glob. If multiple hermits detected, list all + Skip. If none, this turn is skipped entirely.
 
-If a hermit is selected: record the full entry from `detected_hermits` as `activated_hermit` (carries `plugin`, `id`, `marketplace_name`, `installPath`). Read `<activated_hermit.installPath>/state-templates/CLAUDE-APPEND.md` and stash for Step 6's CLAUDE.md append. Read `<activated_hermit.installPath>/.claude-plugin/hermit-meta.json` for the `hermit.boot_skill` field and `<activated_hermit.installPath>/.claude-plugin/plugin.json` for its `version`; stash both for Step 5's `hatch-config.ts` answers payload.
+If a hermit is selected: record the full entry from `detected_hermits` as `activated_hermit` (carries `plugin`, `id`, `marketplace_name`, `installPath`). Read `<activated_hermit.installPath>/state-templates/CLAUDE-APPEND.md` and stash for Step 6's CLAUDE.md append. Read `<activated_hermit.installPath>/.claude-plugin/hermit-meta.json` for the `hermit.boot_skill` field; stash it for Step 5's `hatch-config.ts` answers payload.
 
 ### Quick Turn 2 — Identity batch (one `AskUserQuestion`, 3 questions)
 
@@ -755,7 +755,7 @@ Print its output verbatim. It reads the written `config.json`, the stamped `hatc
 
 ### Hand off pending domain hatches
 
-Applies on **both** Quick and Advanced paths and is the **last** action of the skill. After the report, build the pending set from `detected_hermits` (Step 1.5). A sibling is **pending** when a file exists at `<installPath>/skills/hatch/SKILL.md` and its `plugin` was **not** already present in `config.json._hermit_versions` when Step 1 read the config. A hermit activated in Step 3 is always pending: Step 5 stamps its version into `_hermit_versions` without ever running its wizard, so never filter it out on that stamp.
+Applies on **both** Quick and Advanced paths and is the **last** action of the skill. After the report, build the pending set from `detected_hermits` (Step 1.5). A sibling is **pending** when a file exists at `<installPath>/skills/hatch/SKILL.md` and its `plugin` was **not** already present in `config.json._hermit_versions` when Step 1 read the config. An activated hermit is never stamped by core, so the generic rule covers it.
 
 For each pending sibling, print the block below with its `plugin` field substituted for `<slug>` — the bare plugin name, not `id`, which carries an `@marketplace` suffix. Repeat the complete block once per pending sibling. Do not invoke the Skill tool. If none are pending, stop after the report.
 

--- a/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
@@ -38,7 +38,7 @@ describe('hatch-config.ts', () => {
     const answers = {
       project_name: 'my-project',
       activated_hermit: {
-        slug: 'claude-code-dev-hermit', version: '9.9.9',
+        slug: 'claude-code-dev-hermit',
         boot_skill: '/claude-code-dev-hermit:dev-boot',
       },
       agent_name: 'Aria', language: 'en', timezone: 'Europe/London', sign_off: 'Aria out.',
@@ -56,7 +56,7 @@ describe('hatch-config.ts', () => {
       agent_name: 'Aria', language: 'en', timezone: 'Europe/London', sign_off: 'Aria out.',
       escalation: 'balanced', operator_profile: 'technical', remote: true, idle_behavior: 'discover', permission_mode: 'auto',
       boot_skill: '/claude-code-dev-hermit:dev-boot',
-      _hermit_versions: { 'claude-code-hermit': CORE_VERSION, 'claude-code-dev-hermit': '9.9.9' },
+      _hermit_versions: { 'claude-code-hermit': CORE_VERSION },
       routines: [
         ...template.routines,
         { id: 'morning', schedule: '30 8 * * *', skill: 'claude-code-hermit:brief --morning', enabled: true, run_during_waiting: true },
@@ -116,7 +116,7 @@ describe('hatch-config.ts', () => {
       agent_name: 'Aria2',
       routines: { enabled: true, morning_time: '09:00', evening_time: '21:00' },
       channels: { discord: { allowed_users: ['999'] } },
-      activated_hermit: { slug: 'claude-code-dev-hermit', version: '2.0.0', boot_skill: '/claude-code-dev-hermit:dev-boot' },
+      activated_hermit: { slug: 'claude-code-dev-hermit', boot_skill: '/claude-code-dev-hermit:dev-boot' },
     };
     const r = await runHatchConfig(dir, answers, true);
     expect(r.exitCode).toBe(0);
@@ -126,9 +126,9 @@ describe('hatch-config.ts', () => {
     expect(out.foo_custom).toBe(true);
     expect(out.push_notifications).toBe(false);
 
-    // _hermit_versions: not advanced, new sibling added since it was absent
+    // _hermit_versions: not advanced; activated sibling is not stamped by core
     expect(out._hermit_versions['claude-code-hermit']).toBe('1.0.0');
-    expect(out._hermit_versions['claude-code-dev-hermit']).toBe('2.0.0');
+    expect(out._hermit_versions['claude-code-dev-hermit']).toBeUndefined();
 
     // channels: discord field-merged (dm_channel_id preserved, allowed_users updated),
     // mycustom + primary fully preserved
@@ -222,18 +222,31 @@ describe('hatch-config.ts', () => {
     expect(fs.readFileSync(path.join(hermit, 'config.json'), 'utf8')).toBe(malformed);
   });
 
-  test('malformed activated_hermit (missing slug or version) is refused, no file written', async () => {
+  test('malformed activated_hermit (missing or empty slug) is refused, no file written', async () => {
     for (const activated_hermit of [
       { version: '1.2.3' },                       // missing slug
-      { slug: 'x' },                              // missing version
       { slug: '', version: '1.2.3' },             // empty slug
-      { slug: 'x', version: 42 },                 // non-string version
     ]) {
       const dir = freshDir();
       const r = await runHatchConfig(dir, { project_name: 'x', activated_hermit });
       expect(r.exitCode).not.toBe(0);
       expect(fs.existsSync(configPathFor(dir))).toBe(false);
     }
+  });
+
+  test('activated_hermit with a stray version key is tolerated and not stamped', async () => {
+    const dir = freshDir();
+    const r = await runHatchConfig(dir, {
+      project_name: 'x',
+      activated_hermit: {
+        slug: 'claude-code-dev-hermit', version: '9.9.9',
+        boot_skill: '/claude-code-dev-hermit:dev-boot',
+      },
+    });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(fs.readFileSync(configPathFor(dir), 'utf8'));
+    expect(out._hermit_versions).toEqual({ 'claude-code-hermit': CORE_VERSION });
+    expect(out.boot_skill).toBe('/claude-code-dev-hermit:dev-boot');
   });
 
   test('null channels payload is refused cleanly, not crashed', async () => {


### PR DESCRIPTION
## Summary
Activating a domain hermit during core `/hatch` pre-stamped its `_hermit_versions` entry before the domain plugin's own hatch wizard ever ran. That made the domain plugin's hatch preflight return `verify` instead of `full`, so operators silently skipped the wizard steps that actually configure the install.

## Changes
- `hatch-config.ts`: core activation now writes `boot_skill` (and the CLAUDE block) only — it no longer stamps `_hermit_versions[<slug>]`. The domain hatch's own completion step remains the sole writer of that stamp.
- `skills/hatch/SKILL.md`: dropped the sibling `plugin.json` version read from the activation payload/prose, and replaced the special-cased "always pending" note with the generic pending rule (pending = has a hatch skill and is absent from `_hermit_versions`).
- `tests/hatch-config-contract.test.ts`: updated fixtures/assertions to match — fresh-hatch and re-init cases no longer expect a stamp for the activated sibling; a stray `version` key is now tolerated and ignored rather than rejected.
- `CHANGELOG.md`: one line under `[Unreleased] / Fixed`.

## Test plan
- `cd plugins/claude-code-hermit && bun test` — 4919 pass, 0 fail.
- `bunx tsc` (repo-wide) — exit 0.

Closes #902