### PR TITLE
feat(hatch): auto-launch the wizard from the installer and render its reports as markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,12 @@ Claude Code plugin that turns a Claude Code instance into a 24/7 agent. **Statef
 
 Setup your agent in any folder, empty or existing project with `/hatch` and shape its identity, priorities, routines, knowledge, autonomy, guardrails and make it yours.
 
-```
-# 1. Install (Linux, macOS, WSL2)
-cd /path/to/your/project
+```bash
+cd /path/to/your/project   # any folder, even an empty one — Linux, macOS, WSL2
 curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
-
-# 2. Boot Claude Code and run the setup wizard
-claude "/claude-code-hermit:hatch"
-
-# 3. Always-on: pick one
-.claude-code-hermit/bin/hermit-start          # tmux, same machine, no image
-/claude-code-hermit:docker-setup              # Docker, isolated, restarts with the daemon
 ```
+
+The installer provisions everything and launches the setup wizard. When it finishes, it hands you the always-on step: `hermit-start` (tmux, same machine) or `/docker-setup` (isolated container).
 
 ---
 
@@ -122,15 +116,31 @@ cd /path/to/your/project   # or any folder — even an empty one
 curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
 ```
 
-Installs [Claude Code](https://code.claude.com) and [Bun](https://bun.sh) if they're missing, adds tmux, registers the marketplace, and installs the plugin for this folder. It stops there and tells you what to run next. Prefer to read it first, or do it by hand? [Manual install](plugins/claude-code-hermit/docs/how-to-use.md#manual-install).
+Installs [Claude Code](https://code.claude.com) and [Bun](https://bun.sh) if they're missing, adds tmux, registers the marketplace, and installs the plugin for this folder — then launches the setup wizard.
 
-### 2. Initialize
+<details>
+<summary>Prefer to do it by hand?</summary>
+
+With Claude Code and Bun already present:
+
+```bash
+cd /path/to/your/project
+claude plugin marketplace add gtapps/claude-code-hermit
+claude plugin install claude-code-hermit@claude-code-hermit --scope local
+claude "/claude-code-hermit:hatch"
+```
+
+Details: [Manual install](plugins/claude-code-hermit/docs/how-to-use.md#manual-install).
+
+</details>
+
+### 2. Hatch
+
+The wizard sets up your agent's identity, scans your folder, generates `OPERATOR.md`, and offers Quick (4 questions) or Advanced (full wizard). Skipped the countdown, or no terminal? Run it yourself:
 
 ```
-claude /claude-code-hermit:hatch
+claude "/claude-code-hermit:hatch"
 ```
-
-The wizard sets up your agent's identity, scans your folder, generates `OPERATOR.md`, and offers Quick (4 questions) or Advanced (full wizard).
 
 > **Just trying it?** After `hatch`, run `.claude-code-hermit/bin/hermit-start --no-tmux` for sessions, routines, heartbeat, and the learning loop without 24/7 autonomy. Run `/claude-code-hermit:channel-setup` first if you want Discord or Telegram.
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changed
 - `/hatch` lists `tmux always-on` before `Docker always-on`, making tmux the pre-selected deployment. Docker still applies the hardened deny-pattern profile when chosen.
-- The `/hatch` channel question labels the no-channel option `Only Claude App` instead of `None`, and says what you still get: push notifications, plus Remote Control if enabled.
+- The `/hatch` channel question asks "How do you want to communicate with your agent?" in both branches, and labels the no-channel option `Claude app (for now)` instead of `None`: push notifications + Remote Control, with Discord/Telegram pairable later.
+- The `/hatch` confirm preview renders as a single markdown table — chosen answers echoed verbatim plus template-derived defaults tagged `(default)` — ending with a `/hermit-settings` pointer. The final report is now minimal: agent-name headline, warn-only disk audit (missing artifacts surface as fixable warnings instead of a full file table), next steps, and a config-reference link.
 - The `/hatch` OPERATOR.md questionnaire drops the testing question and asks a single follow-up after the four core ones: CI/CD quirks when a CI config was found, team shape otherwise.
 
 ### Fixed

--- a/plugins/claude-code-hermit/README.md
+++ b/plugins/claude-code-hermit/README.md
@@ -18,18 +18,12 @@ Claude Code plugin that turns a Claude Code instance into a 24/7 agent. **Statef
 
 Setup your agent in any folder, empty or existing project with `/hatch` and shape its identity, priorities, routines, knowledge, autonomy, guardrails and make it yours.
 
-```
-# Install (Linux, macOS, WSL2)
-cd /path/to/your/project
+```bash
+cd /path/to/your/project   # any folder, even an empty one — Linux, macOS, WSL2
 curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
-
-# Boot Claude Code and run the setup wizard
-claude "/claude-code-hermit:hatch"
-
-# Always-on: pick one
-.claude-code-hermit/bin/hermit-start          # tmux, same machine, no image
-/claude-code-hermit:docker-setup              # Docker, isolated, restarts with the daemon
 ```
+
+The installer provisions everything and launches the setup wizard. When it finishes, it hands you the always-on step: `hermit-start` (tmux, same machine) or `/docker-setup` (isolated container).
 
 ---
 
@@ -122,15 +116,15 @@ cd /path/to/your/project   # or any folder — even an empty one
 curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
 ```
 
-Installs [Claude Code](https://code.claude.com) and [Bun](https://bun.sh) if they're missing, adds tmux, registers the marketplace, and installs the plugin for this folder. It stops there and tells you what to run next. Prefer to read it first, or do it by hand? [Manual install](docs/how-to-use.md#manual-install).
+Installs [Claude Code](https://code.claude.com) and [Bun](https://bun.sh) if they're missing, adds tmux, registers the marketplace, and installs the plugin for this folder — then launches the setup wizard. Prefer to read it first, or do it by hand? [Manual install](docs/how-to-use.md#manual-install).
 
-### 2. Initialize
+### 2. Hatch
+
+The wizard sets up your agent's identity, scans your folder, generates `OPERATOR.md`, and offers Quick (4 questions) or Advanced (full wizard). Skipped the countdown, or no terminal? Run it yourself:
 
 ```
-claude /claude-code-hermit:hatch
+claude "/claude-code-hermit:hatch"
 ```
-
-The wizard sets up your agent's identity, scans your folder, generates `OPERATOR.md`, and offers Quick (4 questions) or Advanced (full wizard).
 
 > **Just trying it?** After `hatch`, run `.claude-code-hermit/bin/hermit-start --no-tmux` for sessions, routines, heartbeat, and the learning loop without 24/7 autonomy. Run `/claude-code-hermit:channel-setup` first if you want Discord or Telegram.
 

--- a/plugins/claude-code-hermit/docs/how-to-use.md
+++ b/plugins/claude-code-hermit/docs/how-to-use.md
@@ -15,7 +15,7 @@ cd /path/to/your/project   # or any folder — even an empty one
 curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
 ```
 
-It installs anything missing, registers the marketplace, installs the plugin for this folder, and stops — printing the exact command to run next. It never runs `/hatch` for you, and it takes no arguments.
+It installs anything missing, registers the marketplace, installs the plugin for this folder, then launches Claude Code with the `/hatch` setup wizard after a short countdown (Ctrl+C skips the launch and prints the command to run instead; so does running without a terminal, e.g. over plain ssh or in CI). It takes no arguments.
 
 To read it before running it:
 

--- a/plugins/claude-code-hermit/scripts/hatch-report.ts
+++ b/plugins/claude-code-hermit/scripts/hatch-report.ts
@@ -27,6 +27,14 @@ import { readConfigRaw } from './lib/config-read';
 
 type Json = any;
 
+// Both renders emit GFM for the model to re-print: the transcript collapses raw
+// Bash output ("Ran 1 shell command"), so the model's own message is the only
+// display surface, and it renders markdown.
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(import.meta.dir, '..');
+const TEMPLATE_PATH = path.join(PLUGIN_ROOT, 'state-templates', 'config.json.template');
+const CONFIG_REFERENCE_URL =
+  'https://github.com/gtapps/claude-code-hermit/blob/main/plugins/claude-code-hermit/docs/config-reference.md';
+
 const DEPLOYMENTS = ['docker', 'tmux', 'interactive'];
 const CLAUDE_MARKER = 'claude-code-hermit: Session Discipline';
 const WORKTREE_MARKER = '# >>> claude-code-hermit';
@@ -76,10 +84,6 @@ export function observe(root: string): Observed {
   };
 }
 
-function line(label: string, value: string): string {
-  return `  ${(label + ':').padEnd(20)}${value}`;
-}
-
 function channelSummary(config: Json): string {
   const channels = config?.channels ?? {};
   const names = Object.keys(channels).filter(k => k !== 'primary');
@@ -88,25 +92,90 @@ function channelSummary(config: Json): string {
   return on.length ? on.join(', ') : `${names.join(', ')} (not enabled)`;
 }
 
+const DEPLOYMENT_LABELS: Record<string, string> = {
+  docker: 'Docker always-on', tmux: 'tmux always-on', interactive: 'Interactive',
+};
+
+const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+// Permissive: an unreadable template degrades the preview to chosen rows
+// only, it never blocks the confirm turn.
+function readTemplate(): Json {
+  return readJson(TEMPLATE_PATH) ?? {};
+}
+
 export function renderConfirm(answers: Json): string {
-  const out: string[] = ['Quick setup will apply:', ''];
-  const identity = [answers.agent_name ?? 'no name', answers.language, answers.timezone]
-    .filter(Boolean).join(', ');
-  out.push(line('Identity', identity + (answers.sign_off ? `, sign-off="${answers.sign_off}"` : '')));
-  out.push(line('Behavior', `idle=${answers.idle_behavior ?? 'discover'}, escalation + remote at template defaults`));
-  out.push(line('Deployment', `${answers.deployment ?? 'interactive'}, permission=${answers.permission_mode ?? 'auto'}`));
-  out.push(line('Channel', answers.channel && answers.channel !== 'none'
-    ? `${answers.channel} (allow-everyone; token + pairing later)` : 'none'));
-  out.push(line('Plugins', answers.plugins?.length ? answers.plugins.join(', ') : 'all recommended'));
-  out.push(line('Routines', answers.routines?.enabled === false
-    ? 'heartbeat re-arm only' : 'morning, evening, heartbeat re-arm'));
-  out.push(line('Visibility', answers.hatch_target === 'committed'
-    ? 'committed files' : '.local files (gitignored)'));
-  if (answers.activated_hermit?.slug) out.push(line('Hermit ext', answers.activated_hermit.slug));
-  if (answers.git_init) out.push(line('Git', 'initialize a local repo here'));
+  const t = readTemplate();
+  const row = (label: string, value: string) => `| **${label}** | ${value} |`;
+  const def = (label: string, value: string) => row(label, `${value} *(default)*`);
+  const out: string[] = ['## Hatch preview', '', '| | |', '|---|---|'];
+
+  // Chosen rows — each echoes a wizard answer verbatim, only when it was given.
+  if (answers.agent_name) {
+    out.push(row('🪪 Name', answers.agent_name
+      + (answers.sign_off ? ` — sign-off "${answers.sign_off}"` : '')));
+  }
+  const locale = [answers.language, answers.timezone].filter(Boolean).join(' · ');
+  if (locale) out.push(row('🌍 Language / Timezone', locale));
+  if (answers.activated_hermit?.slug) out.push(row('🧩 Hermit extension', answers.activated_hermit.slug));
+  if (answers.plugins?.length) out.push(row('🧩 Plugins', answers.plugins.join(' · ')));
+  if (answers.deployment) out.push(row('🚀 Deployment', DEPLOYMENT_LABELS[answers.deployment] ?? answers.deployment));
+  if (answers.channel) {
+    out.push(row('💬 Chat', answers.channel === 'none'
+      ? 'Claude app (for now)' : `${cap(answers.channel)} — pairing comes after setup`));
+  }
+  if (answers.idle_behavior) out.push(row('🧭 Idle', cap(answers.idle_behavior)));
+
+  // Default rows — read live from the same template hatch-config.ts overlays,
+  // so they track the shipped defaults instead of prose that drifts.
+  if (t.model) out.push(def('Model / Effort', `${t.model} · effort ${t.effort ?? 'unset'}`));
+  const permission = answers.permission_mode ?? t.permission_mode;
+  if (permission) {
+    out.push(permission === t.permission_mode
+      ? def('Permission mode', `\`${permission}\``)
+      : row('Permission mode', `\`${permission}\``));
+  }
+  if (t.escalation) out.push(def('Autonomy', `${t.escalation} · remote control ${t.remote ? 'on' : 'off'}`));
+  if (t.heartbeat) {
+    const hours = t.heartbeat.active_hours;
+    out.push(def('Heartbeat', t.heartbeat.enabled
+      ? `every ${t.heartbeat.every}${hours ? `, ${hours.start}–${hours.end}` : ''}, quiet ticks free`
+      : 'off'));
+  }
+  // heartbeat-restart and scheduled-checks are plumbing, not something the
+  // operator would recognize as "a routine that wakes the agent".
+  const infra = (t.routines ?? [])
+    .filter((r: Json) => r.enabled !== false && !['heartbeat-restart', 'scheduled-checks'].includes(r.id))
+    .map((r: Json) => r.id.replace(/-/g, ' '));
+  const briefs = answers.routines?.enabled === false ? [] : ['briefs 08:30 + 22:30'];
+  if (briefs.length || infra.length) out.push(row('Routines', [...briefs, ...infra].join(' · ')));
+  if (t.push_notifications !== undefined) {
+    let notifications = 'push off';
+    if (t.push_notifications) {
+      notifications = 'push on';
+      if (answers.channel && answers.channel !== 'none') {
+        notifications += `, dormant once ${cap(answers.channel)} is paired`;
+      }
+    }
+    out.push(def('Notifications', notifications));
+  }
+  const pages = Object.entries(t.artifacts ?? {})
+    .filter(([k, v]) => ['dashboard', 'proposals', 'weekly_review'].includes(k) && v)
+    .map(([k]) => k.replace('_', ' '));
+  if (pages.length) out.push(def('Artifact pages', pages.join(' · ')));
+  if (t.budget) {
+    const caps = ['daily_usd', 'weekly_usd', 'monthly_usd'].filter(k => t.budget[k] != null);
+    out.push(def('Budget caps', caps.length ? caps.map(k => `${k.replace('_usd', '')} $${t.budget[k]}`).join(' · ') : `none, ${t.budget.action ?? 'alert'}-only`));
+  }
+  if (answers.deployment) {
+    out.push(row('Safety rules', answers.deployment === 'docker'
+      ? 'hardened deny profile (from Docker choice)' : 'minimal deny profile'));
+  }
+  out.push(row('Files', (answers.hatch_target === 'committed' ? 'committed files' : '`.local` (gitignored)')
+    + (answers.git_init ? ' · git repo initialized' : '')));
+
   out.push('');
-  out.push('Nothing has been written yet. Customize restarts the wizard in Advanced;');
-  out.push('your Quick answers will not carry over.');
+  out.push('Nothing has been written yet. Every *(default)* is tunable later with `/hermit-settings`.');
   return out.join('\n');
 }
 
@@ -120,69 +189,54 @@ export function renderFinal(o: Observed, deployment: string): string {
       'Re-run /claude-code-hermit:hatch; nothing below would be accurate.';
   }
 
-  out.push('Autonomous agent initialized.', '');
-  out.push('Identity:');
-  out.push(line('Agent name', c.agent_name ?? 'none'));
-  out.push(line('Language', c.language ?? 'none'));
-  out.push(line('Timezone', c.timezone ?? 'none'));
-  out.push(line('Escalation', c.escalation ?? 'balanced'));
-  out.push(line('Sign-off', c.sign_off ?? 'none'));
-  out.push('');
+  out.push(`## 🐣 ${c.agent_name ?? 'Your agent'} is hatched`);
 
-  out.push('Configured:');
-  out.push(line('Channels', channelSummary(c)));
-  out.push(line('Push notifications', c.push_notifications === false ? 'disabled' : 'enabled'));
-  out.push(line('Heartbeat', c.heartbeat?.enabled ? `every ${c.heartbeat.every}` : 'disabled'));
-  out.push(line('Permission mode', c.permission_mode ?? 'auto'));
-  out.push(line('Routines', `${(c.routines ?? []).length} registered`));
-  out.push(line('Scheduled checks', `${(c.scheduled_checks ?? []).length} registered`));
-  out.push(line('Hermit ext', Object.keys(c._hermit_versions ?? {}).filter(k => k !== 'claude-code-hermit').join(', ') || 'none'));
-  out.push('');
+  // Warn-only disk audit: the happy path shows nothing, but a declined or
+  // failed write surfaces — the operator is still in the hatch session, so the
+  // fix is one message away. (Filesystem-observed, never a remembered file
+  // list; git repo absence is not warned — existing projects legitimately vary.)
+  const missing: string[] = [];
+  if (!o.binScripts.length) missing.push('`.claude-code-hermit/bin/` scripts');
+  if (!o.claudeBlock) missing.push('CLAUDE session-discipline block');
+  if (!o.gitignore) missing.push('`.gitignore` hermit entries');
+  if (!o.worktreeinclude) missing.push('`.worktreeinclude` managed block');
+  if (!o.settingsFile) missing.push('hermit permissions in `.claude/` settings');
+  if (missing.length) {
+    out.push('');
+    for (const m of missing) out.push(`⚠ Not present: ${m} — tell me to fix it and I will.`);
+  }
 
-  // Every row below is a filesystem observation. "Present" rather than
-  // "Created" — this runs after the fact and cannot know who wrote a file, only
-  // that it is there. A declined step correctly reports "not present".
-  out.push('Present on disk:');
-  out.push(line('State dir', `.claude-code-hermit/ (${o.binScripts.length} bin scripts)`));
-  out.push(line('CLAUDE block', o.claudeBlock ?? 'not present'));
-  out.push(line('.gitignore', o.gitignore ? 'hermit entries present' : 'not present'));
-  out.push(line('.worktreeinclude', o.worktreeinclude ? 'managed block present' : 'not present'));
-  out.push(line('Settings', o.settingsFile ?? 'no hermit permissions found'));
-  out.push(line('Target', o.hatchOptions?.target ?? 'not stamped'));
-  out.push(line('Git repo', o.gitRepo ? 'present' : 'not present'));
   out.push('');
-
   // Nothing chains from here — the operator runs each of these. Numbered because
   // the order is load-bearing, closed by a consequence line spelling out what is
   // still not running.
-  out.push('Next steps — nothing is running yet:');
+  out.push('**Next — nothing is running yet:**');
   // Hatch installs the recommended plugins mid-run, and Claude Code only exposes
   // them to the *current* session after a reload — so this line goes first, ahead
   // of anything that would use them.
-  const steps: string[] = ['/reload-plugins                      load newly installed plugins in this session'];
+  const steps: string[] = ['`/reload-plugins` — load newly installed plugins in this session'];
   let consequence: string;
   // The consequence names the step that actually starts something, not "the last
   // step" — on tmux with a channel, pairing comes after the boot, so the hermit is
   // already awake by the time the list ends.
   if (deployment === 'docker') {
-    steps.push('/claude-code-hermit:docker-setup      build and start the container');
+    steps.push('`/claude-code-hermit:docker-setup` — build and start the container');
     consequence = `No container exists until step ${steps.length} finishes.`;
   } else if (deployment === 'tmux') {
     // This is the only shell command here; ! makes it runnable in the current session.
-    steps.push('!.claude-code-hermit/bin/hermit-start boot the always-on session');
+    steps.push('`!.claude-code-hermit/bin/hermit-start` — boot the always-on session');
     consequence = `The hermit is not awake until step ${steps.length} finishes.`;
-    if (channelSummary(c) !== 'none') steps.push('/claude-code-hermit:channel-setup     set the bot token and pair');
+    if (channelSummary(c) !== 'none') steps.push('`/claude-code-hermit:channel-setup` — set the bot token and pair');
   } else {
-    if (channelSummary(c) !== 'none') steps.push('/claude-code-hermit:channel-setup     set the bot token and pair');
-    steps.push('/claude-code-hermit:session           start working');
+    if (channelSummary(c) !== 'none') steps.push('`/claude-code-hermit:channel-setup` — set the bot token and pair');
+    steps.push('`/claude-code-hermit:session` — start working');
     consequence = `No session is open until step ${steps.length} finishes.`;
   }
-  steps.forEach((s, i) => out.push(`  ${i + 1}. ${s}`));
+  steps.forEach((s, i) => out.push(`${i + 1}. ${s}`));
   out.push('');
-  out.push(`  ${consequence}`);
+  out.push(consequence);
   out.push('');
-  out.push('  Anytime: /hermit-settings to change settings, /hermit-evolve after plugin');
-  out.push('  updates, /hermit-doctor to troubleshoot. Refine OPERATOR.md by telling me what changed.');
+  out.push(`Anytime: \`/hermit-settings\` to change settings ([full reference](${CONFIG_REFERENCE_URL})), \`/hermit-evolve\` after plugin updates, \`/hermit-doctor\` to troubleshoot. Refine OPERATOR.md by telling me what changed.`);
 
   return out.join('\n');
 }

--- a/plugins/claude-code-hermit/scripts/hatch-report.ts
+++ b/plugins/claude-code-hermit/scripts/hatch-report.ts
@@ -106,7 +106,10 @@ function readTemplate(): Json {
 
 export function renderConfirm(answers: Json): string {
   const t = readTemplate();
-  const row = (label: string, value: string) => `| **${label}** | ${value} |`;
+  // Free-text answers (Other) can carry `|` or newlines, which would split the
+  // GFM table into extra cells/rows — neutralize just those two.
+  const cell = (v: string) => v.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+  const row = (label: string, value: string) => `| **${label}** | ${cell(value)} |`;
   const def = (label: string, value: string) => row(label, `${value} *(default)*`);
   const out: string[] = ['## Hatch preview', '', '| | |', '|---|---|'];
 
@@ -147,7 +150,8 @@ export function renderConfirm(answers: Json): string {
   const infra = (t.routines ?? [])
     .filter((r: Json) => r.enabled !== false && !['heartbeat-restart', 'scheduled-checks'].includes(r.id))
     .map((r: Json) => r.id.replace(/-/g, ' '));
-  const briefs = answers.routines?.enabled === false ? [] : ['briefs 08:30 + 22:30'];
+  const briefs = answers.routines?.enabled === false ? []
+    : [`briefs ${answers.routines?.morning_time ?? '08:30'} + ${answers.routines?.evening_time ?? '22:30'}`];
   if (briefs.length || infra.length) out.push(row('Routines', [...briefs, ...infra].join(' · ')));
   if (t.push_notifications !== undefined) {
     let notifications = 'push off';
@@ -196,7 +200,13 @@ export function renderFinal(o: Observed, deployment: string): string {
   // fix is one message away. (Filesystem-observed, never a remembered file
   // list; git repo absence is not warned — existing projects legitimately vary.)
   const missing: string[] = [];
-  if (!o.binScripts.length) missing.push('`.claude-code-hermit/bin/` scripts');
+  // Compare against the shipped template set, not just "empty": a partial
+  // scaffold (missing hermit-run, hermit-update, ...) must surface too.
+  // Operator add-ons in bin/ are fine — only absences are reported.
+  let expectedBin: string[] = [];
+  try { expectedBin = fs.readdirSync(path.join(PLUGIN_ROOT, 'state-templates', 'bin')); } catch { /* no template dir — skip the check */ }
+  const missingBin = expectedBin.filter(b => !o.binScripts.includes(b));
+  if (missingBin.length) missing.push(`\`.claude-code-hermit/bin/\` scripts (${missingBin.join(', ')})`);
   if (!o.claudeBlock) missing.push('CLAUDE session-discipline block');
   if (!o.gitignore) missing.push('`.gitignore` hermit entries');
   if (!o.worktreeinclude) missing.push('`.worktreeinclude` managed block');

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -146,12 +146,12 @@ questions: [
   {
     header: "Channels",
     question: "How do you want to communicate with your agent?",
-    options: [{ label: "Discord", description: "Communicate with your agent via Discord" }, { label: "Telegram", description: "Communicate with your agent via Telegram" }, { label: "Only Claude App", description: "Communicate only via Claude App and Remote Control" }]
+    options: [{ label: "Discord", description: "Communicate with your agent via Discord" }, { label: "Telegram", description: "Communicate with your agent via Telegram" }, { label: "Claude app (for now)", description: "Push notifications + Remote Control. Pair Discord or Telegram anytime later." }]
   }
 ]
 ```
 
-- **If Only Claude App:** record `channels: {}`. Proceed to Phase 5. Do not ask channel follow-ups.
+- **If Claude app (for now):** record `channels: {}`. Proceed to Phase 5. Do not ask channel follow-ups.
 - **If Discord or Telegram:** create a channel entry under the `channels` object (e.g., `channels.discord`). Boot script maps the key to the full plugin identifier. Then ask follow-ups below.
 - Channel plugins require Bun and manual setup (bot creation, token, pairing). After saving the preference to `config.json`, note:
 
@@ -657,12 +657,12 @@ questions: [
     ]
   },
   {
-    header: "Channel",
-    question: "Notification channel?",
+    header: "Chat",
+    question: "How do you want to communicate with your agent?",
     options: [
-      { label: "Only Claude App", description: "No chat channel — push notifications, plus Remote Control if you enabled it" },
-      { label: "Discord", description: "Send notifications through Discord" },
-      { label: "Telegram", description: "Send notifications through Telegram" }
+      { label: "Claude app (for now)", description: "Push notifications + Remote Control. Pair Discord or Telegram anytime later." },
+      { label: "Discord", description: "Communicate with your agent via Discord" },
+      { label: "Telegram", description: "Communicate with your agent via Telegram" }
     ]
   },
   {
@@ -676,7 +676,7 @@ questions: [
 ]
 ```
 
-Record `sign_off`, `deployment` (one of `docker` / `tmux` / `interactive`), `channel` (one of `none` / `discord` / `telegram`), `idle_behavior` (one of `discover` / `wait`). Map the labels to those values — **"Only Claude App" is `none`**, not the label text; downstream code (the confirm bundle, Step 5's `channels` overlay) compares against the sentinel.
+Record `sign_off`, `deployment` (one of `docker` / `tmux` / `interactive`), `channel` (one of `none` / `discord` / `telegram`), `idle_behavior` (one of `discover` / `wait`). Map the labels to those values — **"Claude app (for now)" is `none`**, not the label text; downstream code (the confirm bundle, Step 5's `channels` overlay) compares against the sentinel.
 
 `push_notifications` is left at the template default (`true`) — no follow-up question. Push is dormant whenever a channel is reachable (the runtime guard in CLAUDE-APPEND.md sends channel-first) and fires only as fallback when a channel is unreachable or absent.
 
@@ -749,7 +749,7 @@ Print its output verbatim. It reads the written `config.json`, the stamped `hatc
 
 `--deployment` is the one thing it cannot read: Quick Turn 3 asks for it and nothing persists it. On the Advanced branch, pass the deployment the operator described, or `interactive` if they didn't say.
 
-**Quick-mode report adjustment**: add one line above the report confirming Turn 3's deployment + channel (Quick never showed them back). Keep the script's own output — including the "Next steps" and "Anytime:" blocks — exactly as printed: it is the operator's handoff, and nothing runs on its own after this.
+Keep the script's own output — including the "Next" and "Anytime:" blocks — exactly as printed: it is the operator's handoff, and nothing runs on its own after this. (Deployment and channel were already shown back in the Turn 5 confirm preview; no extra line needed here.)
 
 ---
 

--- a/plugins/claude-code-hermit/tests/hatch-report.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-report.test.ts
@@ -63,41 +63,38 @@ function hatched(o: HatchedOpts = {}): string {
 }
 
 describe('final reports disk truth, not a remembered file list', () => {
-  test('a fully-completed hatch reports every artifact present', () => {
+  test('a fully-completed hatch shows no warnings and names the agent', () => {
     const root = hatched({ claudeTarget: 'CLAUDE.local.md', gitignore: true, worktreeinclude: true, settings: 'local', git: true });
     const out = renderFinal(observe(root), 'docker');
-    expect(out).toContain('CLAUDE.local.md');
-    expect(out).toContain('hermit entries present');
-    expect(out).toContain('managed block present');
-    expect(out).toContain('.claude/settings.local.json');
-    expect(out).toContain('Git repo:');
+    expect(out).toContain('Atlas is hatched');
+    expect(out).not.toContain('Not present');
   });
 
-  test('a declined .gitignore append reports as not present, never as created', () => {
-    const root = hatched({ claudeTarget: 'CLAUDE.local.md', gitignore: false, settings: 'local' });
+  test('a declined .gitignore append surfaces as a warning, never as created', () => {
+    const root = hatched({ claudeTarget: 'CLAUDE.local.md', gitignore: false, worktreeinclude: true, settings: 'local' });
     const out = renderFinal(observe(root), 'interactive');
-    expect(out).toMatch(/\.gitignore:\s+not present/);
+    expect(out).toMatch(/Not present:.*\.gitignore/);
     expect(out).not.toContain('Created');
   });
 
-  test('a declined .worktreeinclude reports as not present', () => {
-    const root = hatched({ worktreeinclude: false, settings: 'local' });
-    expect(renderFinal(observe(root), 'tmux')).toMatch(/\.worktreeinclude:\s+not present/);
+  test('a declined .worktreeinclude surfaces as a warning', () => {
+    const root = hatched({ claudeTarget: 'CLAUDE.md', gitignore: true, worktreeinclude: false, settings: 'local' });
+    expect(renderFinal(observe(root), 'tmux')).toMatch(/Not present:.*\.worktreeinclude/);
   });
 
-  test('a declined permissions merge reports no hermit permissions found', () => {
-    const root = hatched({ settings: null });
-    expect(renderFinal(observe(root), 'tmux')).toContain('no hermit permissions found');
+  test('a declined permissions merge surfaces as a warning', () => {
+    const root = hatched({ claudeTarget: 'CLAUDE.md', gitignore: true, worktreeinclude: true, settings: null });
+    expect(renderFinal(observe(root), 'tmux')).toMatch(/Not present:.*permissions/);
   });
 
-  test('a skipped git init reports no repo', () => {
-    const root = hatched({ git: false });
-    expect(renderFinal(observe(root), 'interactive')).toMatch(/Git repo:\s+not present/);
+  test('a skipped git init is not warned about', () => {
+    const root = hatched({ claudeTarget: 'CLAUDE.md', gitignore: true, worktreeinclude: true, settings: 'local', git: false });
+    expect(renderFinal(observe(root), 'interactive')).not.toContain('Not present');
   });
 
-  test('a "keep" on the CLAUDE block still finds the existing marker', () => {
-    const root = hatched({ claudeTarget: 'CLAUDE.md' });
-    expect(renderFinal(observe(root), 'tmux')).toContain('CLAUDE.md');
+  test('a "keep" on the CLAUDE block still finds the existing marker (no warning)', () => {
+    const root = hatched({ claudeTarget: 'CLAUDE.md', gitignore: true, worktreeinclude: true, settings: 'local' });
+    expect(renderFinal(observe(root), 'tmux')).not.toMatch(/Not present:.*CLAUDE/);
   });
 
   test('an aborted hatch (no config.json) reports failure, not success', () => {
@@ -105,7 +102,7 @@ describe('final reports disk truth, not a remembered file list', () => {
     fs.mkdirSync(path.join(root, '.claude-code-hermit'), { recursive: true });
     const out = renderFinal(observe(root), 'docker');
     expect(out).toContain('did not complete');
-    expect(out).not.toContain('Autonomous agent initialized');
+    expect(out).not.toContain('is hatched');
   });
 });
 
@@ -138,26 +135,34 @@ describe('final next-steps keys off deployment', () => {
   test('CLI final exits 0 and prints the report', async () => {
     const r = await runScript('hatch-report.ts', { args: ['final', hatched(), '--deployment', 'tmux'] });
     expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('Autonomous agent initialized');
+    expect(r.stdout).toContain('is hatched');
   });
 });
 
 describe('confirm previews intent, before anything is written', () => {
-  test('renders the operator choices and says nothing is written yet', () => {
+  test('renders the operator choices verbatim and says nothing is written yet', () => {
     const out = renderConfirm({
       agent_name: 'Atlas', language: 'pt', timezone: 'Europe/Lisbon',
       deployment: 'docker', channel: 'discord', hatch_target: 'local',
     });
     expect(out).toContain('Atlas');
-    expect(out).toContain('docker');
-    expect(out).toContain('discord');
+    expect(out).toContain('Docker always-on');
+    expect(out).toContain('Discord — pairing comes after setup');
     expect(out).toContain('Nothing has been written yet');
   });
 
-  test('a skipped agent name does not render as undefined', () => {
+  test('defaults come from the shipped template, tagged as defaults', () => {
+    const out = renderConfirm({ deployment: 'tmux' });
+    // sonnet is the template's model; a template change should change this test's
+    // fixture expectation only via the template itself.
+    expect(out).toMatch(/Model \/ Effort.*sonnet.*\(default\)/);
+    expect(out).toMatch(/Permission mode.*auto.*\(default\)/);
+  });
+
+  test('a skipped agent name renders no Name row and never "undefined"', () => {
     const out = renderConfirm({ language: 'en', deployment: 'tmux' });
     expect(out).not.toContain('undefined');
-    expect(out).toContain('no name');
+    expect(out).not.toContain('Name');
   });
 
   test('CLI confirm reads the payload from stdin', async () => {

--- a/plugins/claude-code-hermit/tests/hatch-report.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-report.test.ts
@@ -31,7 +31,9 @@ function hatched(o: HatchedOpts = {}): string {
   const hermit = path.join(root, '.claude-code-hermit');
   fs.mkdirSync(path.join(hermit, 'state'), { recursive: true });
   fs.mkdirSync(path.join(hermit, 'bin'), { recursive: true });
-  for (const b of ['hermit-start', 'hermit-stop', 'hermit-status']) {
+  // The full shipped set: renderFinal warns on any template bin script that is
+  // absent, so a fixture with a partial set would read as a broken scaffold.
+  for (const b of fs.readdirSync(path.join(import.meta.dir, '..', 'state-templates', 'bin'))) {
     fs.writeFileSync(path.join(hermit, 'bin', b), '#!/bin/sh\n');
   }
   fs.writeFileSync(path.join(hermit, 'config.json'), JSON.stringify({
@@ -85,6 +87,12 @@ describe('final reports disk truth, not a remembered file list', () => {
   test('a declined permissions merge surfaces as a warning', () => {
     const root = hatched({ claudeTarget: 'CLAUDE.md', gitignore: true, worktreeinclude: true, settings: null });
     expect(renderFinal(observe(root), 'tmux')).toMatch(/Not present:.*permissions/);
+  });
+
+  test('a partial bin scaffold names the missing scripts', () => {
+    const root = hatched({ claudeTarget: 'CLAUDE.md', gitignore: true, worktreeinclude: true, settings: 'local' });
+    fs.rmSync(path.join(root, '.claude-code-hermit', 'bin', 'hermit-run'));
+    expect(renderFinal(observe(root), 'tmux')).toMatch(/Not present:.*bin.*hermit-run/);
   });
 
   test('a skipped git init is not warned about', () => {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,12 +5,14 @@
 #   curl -fsSL https://gtapps.github.io/claude-code-hermit/install.sh | bash
 #
 # Provisions what a bare box needs (Claude Code, Bun, tmux), registers the
-# marketplace and installs the plugin at local scope in the current directory,
-# then stops. It does NOT run /hatch: that is an interactive model turn with no
-# non-interactive equivalent.
+# marketplace and installs the plugin at local scope in the current directory.
+# When a controlling terminal is available it then launches Claude Code with
+# /hatch after a short countdown (Ctrl+C falls back to printed instructions);
+# without one (CI, ssh without -t, provisioning) it prints the instructions.
 #
 # No flags, no prompts by design. Under `curl | bash` the script itself is on
-# stdin, so any `read` would either hang or eat script text.
+# stdin, so any `read` from stdin would either hang or eat script text — which
+# is why the launch redirects claude's stdin from /dev/tty instead.
 #
 # Kept bash 3.2 compatible: macOS ships bash 3.2 as /bin/bash, so no associative
 # arrays, no `readarray`, no `${var^^}`.
@@ -275,6 +277,35 @@ closing_block() {
   rule
 }
 
+# The countdown launch needs two things: /dev/tty must open (no controlling
+# terminal in CI / `ssh host 'curl|bash'` / provisioning), and stdout or stderr
+# must still be a terminal (CI pipes both through tee, and a runner where
+# /dev/tty happens to open must not hang on an interactive claude).
+can_launch() {
+  { : </dev/tty; } 2>/dev/null || return 1
+  [ -t 1 ] || [ -t 2 ]
+}
+
+hatch_countdown() {
+  printf '\n'
+  rule
+  say "Prerequisites set. Time to hatch your agent."
+  if [ "$CLAUDE_WAS_INSTALLED" = "1" ]; then
+    say "(afterwards, open a new shell so 'claude' is on your PATH)"
+  fi
+  if ! has_credentials; then
+    say "(you'll be asked to log in first)"
+  fi
+  printf '\n'
+  trap 'printf "\n"; trap - INT; closing_block; exit 0' INT
+  printf '  Launching Claude Code in 3… '
+  sleep 1; printf '2… '
+  sleep 1; printf '1…   (Ctrl+C to do it later)\n'
+  sleep 1
+  trap - INT
+  exec claude "/claude-code-hermit:hatch" </dev/tty
+}
+
 # ------------------------------------------------------------------- main ----
 
 main() {
@@ -289,7 +320,11 @@ main() {
   ensure_tmux
   install_plugin
 
-  closing_block
+  if [ ! -f ".claude-code-hermit/config.json" ] && can_launch; then
+    hatch_countdown
+  else
+    closing_block
+  fi
 }
 
 # Guarded so CI can `source` this file to reuse ver_ge and load_floors without

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -278,12 +278,13 @@ closing_block() {
 }
 
 # The countdown launch needs two things: /dev/tty must open (no controlling
-# terminal in CI / `ssh host 'curl|bash'` / provisioning), and stdout or stderr
-# must still be a terminal (CI pipes both through tee, and a runner where
-# /dev/tty happens to open must not hang on an interactive claude).
+# terminal in CI / `ssh host 'curl|bash'` / provisioning), and stdout must
+# still be a terminal — claude's interactive UI writes to fd 1, so a
+# redirected run (`bash install.sh > install.log`, `... | tee`) must take the
+# printed fallback instead of streaming a TUI into the file.
 can_launch() {
   { : </dev/tty; } 2>/dev/null || return 1
-  [ -t 1 ] || [ -t 2 ]
+  [ -t 1 ]
 }
 
 hatch_countdown() {


### PR DESCRIPTION
## Summary
Closes the drop-off between `curl | bash` and the first `/hatch`: when a terminal is available the installer now launches Claude Code with the setup wizard itself after a 3-2-1 countdown. The wizard's two operator-facing summaries move from plain padded text to compact markdown the model re-prints: the confirm preview becomes a single table (chosen answers echoed verbatim, template-derived defaults tagged `(default)`), and the final report shrinks to what the preview couldn't know — warn-only disk audit, next steps, and a config-reference link.

```
BEFORE: curl | bash ─> prints "run claude /hatch" ─> operator types it ─> wizard
AFTER:  curl | bash ─> 3…2…1 ─> wizard                        (tty available)
                    └─> prints instructions (unchanged)        (Ctrl+C / no tty)
```

## Changes
- `scripts/install.sh`: `can_launch` guard (must open `/dev/tty` AND have a tty on stdout/stderr, so CI and `ssh host 'curl|bash'` keep the printed fallback), countdown with an INT trap that falls back to the closing block, conditional login/PATH notes, `exec claude "/claude-code-hermit:hatch" </dev/tty`. Already-hatched folders still get `hermit-update` and never launch.
- `hatch-report.ts confirm`: single GFM table; every row is either a wizard answer echoed verbatim or a value read live from `config.json.template` (no hand-maintained defaults prose), ending with a `/hermit-settings` pointer.
- `hatch-report.ts final`: agent-name headline, filesystem-observed warnings only when an artifact is missing (declined steps stay visible, happy path stays silent), deployment-branched next steps, config-reference link. Git-repo absence is no longer reported — existing projects legitimately vary.
- `skills/hatch/SKILL.md`: Quick channel question aligned with Advanced ("How do you want to communicate with your agent?"), no-channel option relabeled `Claude app (for now)`, obsolete step-10 instruction dropped.
- Docs: README hero collapses to the one install command with a collapsible manual-install block; `how-to-use.md` no longer claims the installer "never runs /hatch".

Design constraint behind the markdown move: probed live on Claude Code 2.1.252 — the interactive transcript collapses a Bash call's stdout to "Ran 1 shell command", so script-side chrome (ANSI included) is invisible; the model's re-printed markdown is the only reliable display surface.

## Test plan
- `bun test` (core suite): 4920 pass, including the rewritten `tests/hatch-report.test.ts` (warn-only audit, template-derived defaults, verbatim-answer rows).
- `bash -n scripts/install.sh` clean; the no-tty path is exercised by the existing `test-install.yml` workflow (runners have no controlling terminal, so the countdown never fires there and the closing-block asserts still hold).
- Both renders exercised manually via `bun hatch-report.ts confirm|final` against a fixture project (docker + tmux branches).