### PR TITLE
fix(claude-code-hermit): render the heartbeat monitor command from one root

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -32,6 +32,7 @@
 - The weekly review runs its topic-page check and channel-log consolidation in one runner dispatch instead of two; the runner files its own memory and topic-page candidates in its isolated context, and the main session only marks the reviewed rows, prunes, and logs one Findings line naming what was filed.
 
 ### Fixed
+- The heartbeat monitor's registration command is rendered from one place, so a symlinked plugin path no longer makes every boot tear down and re-register the monitor as `command-drift`.
 - The weekly review publishes its artifact page again. The skill named only the config key `weekly_review`, so the render call was guessed and failed on an unknown page id; it now names `artifact.ts render weekly` literally.
 - An always-on session start no longer asks what to work on when no task is known; the session stays idle until the channel, a routine, or a queued task starts the next one.
 - `/hatch` seeds `sessions/SHELL.md` from the template, so a hermit's first boot resumes idle like every later boot instead of opening a task-less `in_progress` session that only the 12h auto-close would clear.

--- a/plugins/claude-code-hermit/scripts/lib/heartbeat/monitor-cmd.ts
+++ b/plugins/claude-code-hermit/scripts/lib/heartbeat/monitor-cmd.ts
@@ -3,9 +3,9 @@
 // Two callers judge whether the live heartbeat monitor is the one the config
 // currently describes: `routines.ts arm anchor` (deciding whether the daily
 // re-arm has anything to do) and `heartbeat.ts start-check` (deciding whether to
-// re-register at all). They must agree byte-for-byte — a second rendering of the
-// command string is a second definition of "healthy", and the two drift the first
-// time an interval or a path changes.
+// re-register at all). The plugin root is module-owned so they agree
+// byte-for-byte: a caller-supplied root is a second definition of "healthy",
+// and the two drift the first time a path is a symlink.
 
 import path from 'node:path';
 import { readJson } from '../cli';
@@ -44,8 +44,10 @@ export function heartbeatInterval(config: Json): number {
   return Math.max(1, Math.round(parseDuration(config?.heartbeat?.every, 30 * 60_000) / 1000));
 }
 
-export function heartbeatCommand(pluginRoot: string, hermitDir: string, config: Json): string {
-  return `bash ${path.join(pluginRoot, 'scripts', 'heartbeat-monitor.sh')} ${heartbeatInterval(config)} ${hermitDir}`;
+const PLUGIN_ROOT = path.resolve(import.meta.dir, '../../..');
+
+export function heartbeatCommand(hermitDir: string, config: Json): string {
+  return `bash ${path.join(PLUGIN_ROOT, 'scripts', 'heartbeat-monitor.sh')} ${heartbeatInterval(config)} ${hermitDir}`;
 }
 
 /**
@@ -53,7 +55,7 @@ export function heartbeatCommand(pluginRoot: string, hermitDir: string, config: 
  * healthy so the daily anchor leaves a deliberately-off heartbeat alone; `start`
  * is an explicit operator act and treats that reason as a re-arm instead.
  */
-export function heartbeatHealth(hermitDir: string, pluginRoot: string, config: Json, nowMs: number): LegHealth {
+export function heartbeatHealth(hermitDir: string, config: Json, nowMs: number): LegHealth {
   if (config?.heartbeat?.enabled === false) return { healthy: true, reason: 'disabled' };
   const runtime = readJson(path.join(hermitDir, 'state', 'heartbeat-monitor.runtime.json'));
   if (!hasStartedRegistration(runtime)) return { healthy: false, reason: 'runtime-missing' };
@@ -62,7 +64,7 @@ export function heartbeatHealth(hermitDir: string, pluginRoot: string, config: J
   }
   const interval = heartbeatInterval(config);
   if (runtime.interval !== interval) return { healthy: false, reason: 'interval-drift' };
-  if (runtime.command !== heartbeatCommand(pluginRoot, hermitDir, config)) {
+  if (runtime.command !== heartbeatCommand(hermitDir, config)) {
     return { healthy: false, reason: 'command-drift' };
   }
   const live = readJson(path.join(hermitDir, 'state', 'heartbeat-liveness.json'));

--- a/plugins/claude-code-hermit/scripts/lib/heartbeat/start.ts
+++ b/plugins/claude-code-hermit/scripts/lib/heartbeat/start.ts
@@ -34,9 +34,6 @@ import { hasStartedRegistration, heartbeatCommand, heartbeatHealth, heartbeatInt
 
 type Json = any;
 
-/** `<pluginRoot>` — this file sits at `<pluginRoot>/scripts/lib/heartbeat/`. */
-const PLUGIN_ROOT = path.resolve(import.meta.dir, '..', '..', '..');
-
 function writeJson(file: string, value: Json): void {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   const tmp = `${file}.${process.pid}.tmp`;
@@ -53,10 +50,9 @@ const livenessPath = (hermitDir: string) =>
  * Side effects and plan lines for one heartbeat re-arm, without the leading
  * `REARM|<reason>` line. Shared by `start-check` and by `routines.ts arm begin`,
  * which prefixes each line with `HB_` — so the two callers can never drift into
- * planning different registrations. `pluginRoot` is caller-supplied because the
- * routine leg resolves its own from argv; `start-check` passes PLUGIN_ROOT.
+ * planning different registrations.
  */
-export function prepareHeartbeatArm(hermitDir: string, config: Json, pluginRoot: string): string[] {
+export function prepareHeartbeatArm(hermitDir: string, config: Json): string[] {
   const runtime = readJson(runtimePath(hermitDir));
   // Same reason as the routine leg: the commit waits for a liveness file to
   // appear, so the outgoing monitor's last tick has to go before the new one spawns
@@ -80,7 +76,7 @@ export function prepareHeartbeatArm(hermitDir: string, config: Json, pluginRoot:
   }
   if (!hasStartedRegistration(runtime)) lines.push('FIRST_START:1');
   lines.push(`INTERVAL:${heartbeatInterval(config)}`);
-  lines.push(`CMD:${heartbeatCommand(pluginRoot, hermitDir, config)}`);
+  lines.push(`CMD:${heartbeatCommand(hermitDir, config)}`);
   return lines;
 }
 
@@ -94,7 +90,6 @@ export function prepareHeartbeatArm(hermitDir: string, config: Json, pluginRoot:
 export async function commitHeartbeatArm(
   hermitDir: string,
   config: Json,
-  pluginRoot: string,
   taskId: string,
 ): Promise<string> {
   const interval = heartbeatInterval(config);
@@ -117,7 +112,7 @@ export async function commitHeartbeatArm(
   writeJson(runtimePath(hermitDir), {
     description: 'heartbeat-monitor',
     task_id: taskId,
-    command: heartbeatCommand(pluginRoot, hermitDir, config),
+    command: heartbeatCommand(hermitDir, config),
     interval,
     started_at: adopt ? peekAt : new Date(nowMs).toISOString(),
     boot_id: readBootId(hermitDir),
@@ -134,7 +129,7 @@ export async function commitHeartbeatArm(
 }
 
 function cmdCheck(hermitDir: string, config: Json): void {
-  const health = heartbeatHealth(hermitDir, PLUGIN_ROOT, config, resolveHermitNowMs());
+  const health = heartbeatHealth(hermitDir, config, resolveHermitNowMs());
   // `disabled` is healthy to the daily anchor, which must leave a deliberately-off
   // heartbeat alone. Reaching `start` at all is an explicit act, so re-arm instead.
   if (health.healthy && health.reason !== 'disabled') {
@@ -142,13 +137,13 @@ function cmdCheck(hermitDir: string, config: Json): void {
     return;
   }
   process.stdout.write(`REARM|${health.reason}\n`);
-  for (const line of prepareHeartbeatArm(hermitDir, config, PLUGIN_ROOT)) {
+  for (const line of prepareHeartbeatArm(hermitDir, config)) {
     process.stdout.write(`${line}\n`);
   }
 }
 
 async function cmdCommit(hermitDir: string, config: Json, taskId: string): Promise<void> {
-  process.stdout.write(`${await commitHeartbeatArm(hermitDir, config, PLUGIN_ROOT, taskId)}\n`);
+  process.stdout.write(`${await commitHeartbeatArm(hermitDir, config, taskId)}\n`);
 }
 
 export async function run(verb: string, args: string[]): Promise<void> {

--- a/plugins/claude-code-hermit/scripts/lib/routines/arm.ts
+++ b/plugins/claude-code-hermit/scripts/lib/routines/arm.ts
@@ -200,7 +200,7 @@ function emitPlan(ctx: Context, result: PlanResult): void {
 function armVerdict(ctx: Context): { line: string; healthy: boolean; paused: boolean } {
   if (isPaused(ctx.hermitDir).paused) return { line: 'SKIP|paused', healthy: false, paused: true };
   const routines = monitorHealth(ctx);
-  const heartbeat = heartbeatHealth(ctx.hermitDir, ctx.pluginRoot, ctx.config, ctx.nowMs);
+  const heartbeat = heartbeatHealth(ctx.hermitDir, ctx.config, ctx.nowMs);
   if (routines.healthy && heartbeat.healthy) {
     return { line: `HEALTHY|${summary(ctx, heartbeat)}`, healthy: true, paused: false };
   }
@@ -231,7 +231,7 @@ function cmdBegin(ctx: Context, flags: string[]): void {
   // Read once for both the HEALTHY short-circuit and the HB_ plan below: heartbeatHealth
   // re-reads two state files plus `.boot-id`, and both sites see identical inputs. Null
   // on `--fallback`, the one path that never plans the heartbeat leg.
-  const heartbeat = fallback ? null : heartbeatHealth(ctx.hermitDir, ctx.pluginRoot, ctx.config, ctx.nowMs);
+  const heartbeat = fallback ? null : heartbeatHealth(ctx.hermitDir, ctx.config, ctx.nowMs);
   if (heartbeat && !reset && heartbeat.healthy && monitorHealth(ctx).healthy) {
     process.stdout.write(`HEALTHY|${summary(ctx, heartbeat)}\n`);
     return;
@@ -245,7 +245,7 @@ function cmdBegin(ctx: Context, flags: string[]): void {
   // the second pass of a load whose first pass already committed the heartbeat, and
   // a `disabled` verdict is healthy — neither emits a plan.
   if (heartbeat && !heartbeat.healthy) {
-    for (const line of prepareHeartbeatArm(ctx.hermitDir, ctx.config, ctx.pluginRoot)) {
+    for (const line of prepareHeartbeatArm(ctx.hermitDir, ctx.config)) {
       process.stdout.write(`HB_${line}\n`);
     }
   }
@@ -292,7 +292,7 @@ function startHeartbeatLeg(ctx: Context, flags: string[]): Promise<string> | nul
   const index = flags.indexOf('--heartbeat');
   const taskId = index === -1 ? '' : (flags[index + 1] ?? '').trim();
   if (!taskId || taskId === 'none') return null;
-  const pending = commitHeartbeatArm(ctx.hermitDir, ctx.config, ctx.pluginRoot, taskId);
+  const pending = commitHeartbeatArm(ctx.hermitDir, ctx.config, taskId);
   // Both monitors are already spawned by the time `commit` runs, so this leg's
   // first-tick wait overlaps the routine leg's instead of following it — up to 10s off
   // every boot that arms both. The awaits below still surface any rejection; this

--- a/plugins/claude-code-hermit/tests/routine-arm.test.ts
+++ b/plugins/claude-code-hermit/tests/routine-arm.test.ts
@@ -265,6 +265,20 @@ test('commit --heartbeat records the heartbeat monitor after the routine leg', a
   expect(runtime).toMatchObject({ task_id: 'hb-new', interval: 1800 });
 });
 
+test('a symlinked plugin root writes the same heartbeat command as start-commit', async () => {
+  const f = fixture();
+  const pluginLink = path.join(f.root, 'plugin-link');
+  fs.symlinkSync(pluginRoot, pluginLink);
+  staleHeartbeat(f);
+  await runScript('routines.ts', { args: ['arm', 'begin', f.hermit, pluginLink] });
+  fs.writeFileSync(path.join(f.state, 'routine-monitor-liveness.json'), JSON.stringify({ last_peek_at: iso() }));
+  fs.writeFileSync(path.join(f.state, 'heartbeat-liveness.json'), JSON.stringify({ last_peek_at: iso(Date.now() + 1000) }));
+
+  await runScript('routines.ts', { args: ['arm', 'commit', f.hermit, pluginLink, 'task-new', '--heartbeat', 'hb-new'] });
+  const checked = await runScript('heartbeat.ts', { args: ['start-check', f.hermit] });
+  expect(checked.stdout).toStartWith('FRESH|interval=1800');
+});
+
 // The two legs are independent: a routine subprocess that never ticked says
 // nothing about whether the heartbeat one did.
 test('a routine fallback still commits the heartbeat leg', async () => {


### PR DESCRIPTION
## Summary

The heartbeat monitor's registration command had two renderers that disagreed on a symlinked plugin path: `heartbeat.ts start-check` derived the plugin root from `import.meta.dir` (which Bun resolves to the realpath), while `routines.ts arm` passed the argv root (the symlink as typed). The two command strings never matched, so `heartbeatHealth` returned `command-drift` on every boot, the monitor was torn down and re-registered, and the 4am arm anchor flipped it back the other way: a perpetual ping-pong plus a false drift signal in `hermit-doctor` and the watchdog on an unchanged install.

`heartbeatCommand` now owns the plugin root as a module constant and takes no root from any caller, so the two readers cannot diverge. Non-symlinked installs behave exactly as before.

Closes #933

## Behavior delta

```
BEFORE  boot on a symlinked plugin path
        hermit-routines load ─> arm commit --heartbeat writes command with the argv root (symlink as typed)
        heartbeat start-check ─> compares against import.meta.dir root (realpath) ─> REARM|command-drift
        ─> TaskStop + Monitor + first-tick wait, every boot; doctor/watchdog show drift on an unchanged install
        (arm anchor at 4am flips it back the other way: perpetual ping-pong)

AFTER   boot on a symlinked plugin path
        hermit-routines load ─> arm commit --heartbeat writes command with the module-owned root
        heartbeat start-check ─> same module-owned root ─> FRESH
        ─> no re-register, no drift signal; non-symlinked installs behave exactly as before
```

## Changes

- `scripts/lib/heartbeat/monitor-cmd.ts` — `heartbeatCommand(hermitDir, config)` renders the script path from a module-owned `PLUGIN_ROOT` (`path.resolve(import.meta.dir, '../../..')`, the derivation already used in `routines/gate.ts`). No caller can pass a root.
- `scripts/lib/heartbeat/monitor-cmd.ts`, `start.ts` — `heartbeatHealth`, `prepareHeartbeatArm` and `commitHeartbeatArm` drop their `pluginRoot` parameter; `start.ts` drops its own `PLUGIN_ROOT` constant.
- `scripts/lib/routines/arm.ts` — the four heartbeat call sites drop the argument. `ctx.pluginRoot` stays for the routine monitor command, `planCron`/`commitCron` and the anchor prompt, which are single-writer and unaffected.
- `tests/routine-arm.test.ts` — new test: `arm begin` + `arm commit --heartbeat` through a symlinked plugin-root argv, then `heartbeat.ts start-check` must return `FRESH|interval=1800`. Fails with `REARM|command-drift` on the unchanged code.
- `CHANGELOG.md` — one `### Fixed` bullet under `[Unreleased]`.

## Test plan

Run from `plugins/claude-code-hermit/`. All six exit 0 on this branch:

```
0  bunx tsc                                    (repo root)
0  bun test --parallel --timeout=45000
0  test "$(grep -c "pluginRoot" scripts/lib/heartbeat/monitor-cmd.ts)" = 0
0  test "$(grep -c "PLUGIN_ROOT" scripts/lib/heartbeat/start.ts)" = 0
0  test "$(grep -c "ctx.pluginRoot" scripts/lib/routines/arm.ts)" = 5
0  test "$(awk '/^## \[Unreleased\]/,/^## \[[0-9]/' CHANGELOG.md | grep -c "symlinked plugin")" = 1
```

Confirmed empirically on Bun 1.4.0 that `import.meta.dir` is realpath-resolved for both the entry module and imported modules when invoked through a symlinked directory, so the new `PLUGIN_ROOT` is genuinely invocation-independent.

## Blast radius

- **Released surfaces touched:** yes. `arm.ts:205,223` in `claude-code-hermit--v1.2.53` already compared `runtime.command` against a render from `ctx.pluginRoot`, so installed operators on a symlinked plugin path already see the drift verdict from the arm anchor.
- **Unreleased surfaces touched:** the write side. `aad80ed4` (PR #930, post-tag) made the routine load arm the heartbeat, which is what turned a once-a-day anchor flip into a per-boot ping-pong. That regression never reached a released version.
- **Downstream operators:** installs whose stored `runtime.command` carries the argv root report `command-drift` exactly once after this ships, re-arm, and self-heal. No config, state-file or CLI change; nothing to do on upgrade.
- **Downstream hermits:** none. No sibling plugin imports these symbols, and no `required_core_version` floor moves.
- **Known gap, deliberately out of scope:** the routine monitor leg (`routineCommand` at `arm.ts:74`, compared in `monitorHealth` at `:115`, hashed into `planCron`'s `promptHash` at `:87`) still renders from the argv root. It only bites when that string varies between boots, and fixing the command string alone would leave the prompt hash inconsistent. Not filed as an issue at the operator's direction.
- **Per-actor ledger:** grok wrote the test and the parameter removal across all five files; `/code-review high --fix` applied no edits and raised one low finding (the routine-leg gap above); the operator decided to skip that finding and to file no follow-up issue.
