### PR TITLE
fix(claude-code-hermit): anchor cost attribution on the delivered sentinel line

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Fixed
 - The heartbeat monitor's registration command is rendered from one place, so a symlinked plugin path no longer makes every boot tear down and re-register the monitor as `command-drift`.
+- Cost attribution bills a turn to `heartbeat` or `routine:<id>` only when a wake actually delivered that sentinel, not when a prompt merely mentions one. An operator prompt discussing the heartbeat, a compaction summary quoting a routine id, and a subagent completion echoing its own output all bill to `other` now. The prose fallback that minted buckets like `routine:has` from ordinary sentences is gone.
 - The weekly review publishes its artifact page again. The skill named only the config key `weekly_review`, so the render call was guessed and failed on an unknown page id; it now names `artifact.ts render weekly` literally.
 - An always-on session start no longer asks what to work on when no task is known; the session stays idle until the channel, a routine, or a queued task starts the next one.
 - `/hatch` seeds `sessions/SHELL.md` from the template, so a hermit's first boot resumes idle like every later boot instead of opening a task-less `in_progress` session that only the 12h auto-close would clear.

--- a/plugins/claude-code-hermit/scripts/cost-tracker.ts
+++ b/plugins/claude-code-hermit/scripts/cost-tracker.ts
@@ -86,11 +86,11 @@ const RE_TOOL_USE_ID = /<tool-use-id>([A-Za-z0-9_-]+)<\/tool-use-id>/;
 // Classify a turn by its delivered prompt, hopping once through a subagent-completion
 // notification to the turn that dispatched it.
 //
-// The prompt-only rule (turnPromptText) is what stops a turn's own tool output from
-// capturing it: classifySource matches `[hermit-routine:<id>]` anywhere in the text it
-// is handed, so scanning the whole turn billed any turn whose tool output merely named
-// a routine — e.g. heartbeat-restart's re-arm, whose CronDelete/CronList output lists
-// concrete routine ids, was billed to whichever routine it happened to print first.
+// The prompt-only rule (turnPromptText) hands classifySource the entry that opened the
+// turn, never the tool_results inside it, so the classifier can anchor on the sentinel
+// line a wake actually delivered. Scanning the whole turn instead billed any turn whose
+// tool output merely named a routine — e.g. heartbeat-restart's re-arm, whose
+// CronDelete/CronList output lists concrete routine ids.
 //
 // `boundaryFound` is false when the walk ran off the start of a truncated tail window;
 // the caller downgrades to 'other' rather than trust a prompt that may belong to an

--- a/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
@@ -504,9 +504,9 @@ function isSkillInjection(entry: Json): boolean {
  * and return THAT entry's text alone.
  *
  * Returning only the boundary entry — never the intervening tool_results — is the
- * point: `classifySource` matches its markers anywhere in the text it is given, so
- * concatenating the walked entries lets any tool output that merely *mentions* a
- * routine id capture the whole turn's cost.
+ * point: `classifySource` anchors on the sentinel line the boundary entry delivered, so
+ * concatenating the walked entries would put a tool_result's own text where that line
+ * belongs and let any output that merely *mentions* a routine id capture the turn's cost.
  *
  * `boundaryFound` is false when the walk ran off the start of `lines` without
  * finding a prompt — the caller uses that to detect a truncated tail window that

--- a/plugins/claude-code-hermit/scripts/lib/trigger-source.ts
+++ b/plugins/claude-code-hermit/scripts/lib/trigger-source.ts
@@ -10,40 +10,72 @@ import { normalizeChannelSource } from './channel-envelope';
 
 type Json = any;
 
-// Classify a turn's trigger source from the text of its triggering entry (or the
-// scanned text of its entries). Only the marker-driven sources below are claimed;
-// everything else is 'other' (the non-scheduled bucket, typically the largest in
-// practice). Routine ids are validated only for presence/uniqueness in config —
-// the strict charset here ([A-Za-z0-9._-]+) is the classifier's own gate, and it
-// rejects skill-template noise ([hermit-routine:*], <id> placeholders) that
-// appears in tool_result entries when routines register.
+// Reduce a prompt to the sentinel line a wake actually delivered. Three frames carry
+// one, and nothing else does:
+//   Monitor event      <task-notification>…<event>SENTINEL</event>…</task-notification>
+//                      (heartbeat-monitor.sh, lib/routines/due.ts)
+//   Peer socket post   "Another Claude session sent a message:\n<cross-session-message …>
+//                      SENTINEL</cross-session-message>…" ("Message from @<name>" for a
+//                      named peer; the watchdog's wedge wake arrives this way,
+//                      hermit-watchdog.ts WEDGE_WAKE_TOKEN)
+//   CronCreate prompt  the bare prompt itself, "[hermit-routine:<id>] Run: …"
+//                      (lib/routines/arm.ts renderAnchorPrompt)
+// Everything else — an operator prompt, a compaction-continuation summary, a subagent
+// completion quoting its own output — reduces to its own trimmed text, where an
+// anchored match then fails. A subagent completion has no <event> body at all, so it
+// reduces to '' and can never be claimed.
+function sentinelLine(text: string): string {
+  const t = text.trim();
+  if (t.startsWith('<task-notification')) {
+    const event = t.match(/<event>([\s\S]*?)<\/event>/);
+    return event ? event[1].trim() : '';
+  }
+  if (t.startsWith('Another Claude session sent a message') || t.startsWith('Message from @')) {
+    const nl = t.indexOf('\n');
+    const body = nl === -1 ? '' : t.slice(nl + 1).trim();
+    // The harness wraps a socket post in <cross-session-message from=… from-name=…
+    // from-mode=…> and appends a trailer after the close tag (verified against live
+    // transcripts). The sentinel is that element's body, so unwrap it — otherwise the
+    // watchdog's wedge wake reads as the wrapper text and never matches.
+    const inner = body.match(/^<cross-session-message\b[^>]*>([\s\S]*?)<\/cross-session-message>/);
+    return inner ? inner[1].trim() : body;
+  }
+  return t;
+}
+
+// Classify a turn's trigger source from the text of its triggering entry. Only the
+// marker-driven sources below are claimed; everything else is 'other' (the
+// non-scheduled bucket, typically the largest in practice).
+//
+// Anchored on the delivered sentinel line, never containment: an operator prompt that
+// merely discusses the heartbeat, or a compaction summary that quotes a routine id,
+// was billed as a wake under the old containment rules, and the prose fallback minted
+// buckets like `routine:has` from ordinary sentences. record-operator-action.ts matches
+// the same sentinels anchored at the live input boundary; this is that grammar applied
+// to retrospective cost attribution.
+//
+// Routine ids are validated only for presence/uniqueness in config — the strict charset
+// here ([A-Za-z0-9._-]+) is the classifier's own gate, and it rejects skill-template
+// noise ([hermit-routine:*], <id> placeholders).
 function classifySource(triggerText: string): string {
   if (!triggerText) return 'other';
-  if (triggerText.includes('HEARTBEAT_EVALUATE') ||
-      triggerText.includes('/claude-code-hermit:heartbeat run')) {
-    return 'heartbeat';
-  }
+  const line = sentinelLine(triggerText);
+  if (line === 'HEARTBEAT_EVALUATE') return 'heartbeat';
   // Monitor co-fire: a ROUTINE_DUE line naming ≥2 distinct routine ids means one wake turn
   // ran multiple routines. Attribute the shared turn to a synthetic `routine:multi` bucket
   // rather than mis-charging the whole turn to the first id (which would inflate that
   // routine's per-run cost and mask the others in the doctor's routine-cost check).
-  // Anchored to the ROUTINE_DUE line — NOT the whole turn — so heartbeat-restart's re-arm,
-  // whose `load` step's CronDelete output surfaces [hermit-routine:*] markers, never trips it.
-  const routineDue = triggerText.match(/ROUTINE_DUE((?:\s+\[hermit-routine:[A-Za-z0-9._-]+\])+)/);
+  const routineDue = line.match(/^ROUTINE_DUE((?:\s+\[hermit-routine:[A-Za-z0-9._-]+\])+)/);
   if (routineDue) {
     const ids = new Set([...routineDue[1].matchAll(/\[hermit-routine:([A-Za-z0-9._-]+)\]/g)].map((m) => m[1]));
     if (ids.size >= 2) return 'routine:multi';
     if (ids.size === 1) return `routine:${[...ids][0].slice(0, 64)}`;
   }
-  // Strict charset — must match a real routine id, never a placeholder or glob
-  const routineMatch = triggerText.match(/\[hermit-routine:([A-Za-z0-9._-]+)\]/);
+  // CronCreate-delivered routine: the id opens the prompt. Strict charset — must match a
+  // real routine id, never a placeholder or glob.
+  const routineMatch = line.match(/^\[hermit-routine:([A-Za-z0-9._-]+)\]/);
   // Length-cap to 64 chars so ids can't overflow markdown table cells
   if (routineMatch) return `routine:${routineMatch[1].slice(0, 64)}`;
-  // log-event fallback: present in tool_result when the skill fires the marker.
-  // Both spellings are matched — the old `log-routine-event.sh <id>` form still
-  // appears in historic transcripts that cost attribution replays.
-  const logMatch = triggerText.match(/(?:log-routine-event\.sh|routines\.ts log-event)\s+([A-Za-z0-9._-]+)/);
-  if (logMatch) return `routine:${logMatch[1].slice(0, 64)}`;
   // Inbound-channel envelope (see lib/channel-envelope.ts): source is plugin-qualified
   // on the wire (e.g. `plugin:discord:discord`, `plugin:voice:voice`). Bucket by the
   // bare server name via normalizeChannelSource — the same normalizer the auth/config

--- a/plugins/claude-code-hermit/scripts/record-operator-action.ts
+++ b/plugins/claude-code-hermit/scripts/record-operator-action.ts
@@ -131,10 +131,10 @@ function isRoutinePrompt(prompt: string, channel?: ChannelGateInputs): boolean {
   // Monitor emissions in bare form. Deliberately anchored, NOT containment: this
   // is a live input boundary where a false positive silences an AUTO_CLOSE, so an
   // operator prompt that merely quotes a sentinel must still count as activity
-  // (pinned in tests/auto-close.test.ts). lib/trigger-source.ts matches the same
-  // grammar by containment — that is retrospective cost attribution over stored
-  // transcripts, a different boundary with a different failure cost, and is not
-  // precedent here.
+  // (pinned in tests/auto-close.test.ts). lib/trigger-source.ts anchors the same
+  // grammar too, on the sentinel line a wake delivered; it stays a separate boundary
+  // (retrospective cost attribution over stored transcripts, different failure cost),
+  // so keep both in sync deliberately rather than treating either as precedent.
   //   heartbeat-monitor.sh:38-43 → "HEARTBEAT_EVALUATE" (bare) | "HEARTBEAT_ERROR: <detail>"
   //   lib/routines/due.ts        → "ROUTINE_DUE [hermit-routine:<id>] ..."
   //   routine-monitor.sh:36      → "ROUTINE_MONITOR_ERROR: <detail>"

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -3818,20 +3818,39 @@ describe('cost-tracker classifySource / resolveTurnSource', () => {
     expect(typeof resolveTurnSource).toBe('function');
   });
 
-  // classifySource: heartbeat marker
-  test('cost-tracker: classifySource(HEARTBEAT_EVALUATE) = heartbeat', () => {
-    expect(classifySource('some prefix HEARTBEAT_EVALUATE rest')).toBe('heartbeat');
+  // Real delivery shapes. A wake reaches the classifier as one of three frames; a sentinel
+  // sitting anywhere else in a prompt is prose an operator (or a compaction summary) wrote,
+  // and must never be billed as a wake. The Monitor envelope below is a verbatim copy of the
+  // live shape (heartbeat-monitor.sh / lib/routines/due.ts emit into it).
+  const envelope = (event: string) =>
+    `<task-notification>\n<task-id>b0u6x5fhf</task-id>\n<summary>Monitor event: "heartbeat-monitor"</summary>\n<event>${event}</event>\nIf this event is something the user would act on now, send a PushNotification.\n</task-notification>`;
+
+  // classifySource: heartbeat marker — only as the delivered sentinel line
+  test('cost-tracker: classifySource(bare HEARTBEAT_EVALUATE) = heartbeat', () => {
+    expect(classifySource('HEARTBEAT_EVALUATE')).toBe('heartbeat');
   });
-  test('cost-tracker: classifySource(heartbeat run) = heartbeat', () => {
-    expect(classifySource('/claude-code-hermit:heartbeat run')).toBe('heartbeat');
+  test('cost-tracker: classifySource(Monitor envelope HEARTBEAT_EVALUATE) = heartbeat', () => {
+    expect(classifySource(envelope('HEARTBEAT_EVALUATE'))).toBe('heartbeat');
+  });
+  test('cost-tracker: classifySource(HEARTBEAT_EVALUATE mid-prose) = other', () => {
+    expect(classifySource('some prefix HEARTBEAT_EVALUATE rest')).toBe('other');
+  });
+  // The manual slash command arrives as a <command-message>/<command-args> frame, never as
+  // this literal, so the old containment rule only ever matched operators discussing it.
+  test('cost-tracker: classifySource(heartbeat run literal) = other', () => {
+    expect(classifySource('/claude-code-hermit:heartbeat run')).toBe('other');
   });
 
-  // classifySource: routine marker
+  // classifySource: routine marker — CronCreate delivers it as the prompt's first line
   test('cost-tracker: classifySource([hermit-routine:daily]) = routine:daily', () => {
     expect(classifySource('[hermit-routine:daily]')).toBe('routine:daily');
   });
-  test('cost-tracker: classifySource([hermit-routine:cortex-refresh]) = routine:cortex-refresh', () => {
-    expect(classifySource('text [hermit-routine:cortex-refresh] more text')).toBe('routine:cortex-refresh');
+  test('cost-tracker: classifySource(CronCreate prompt) = routine:<id>', () => {
+    expect(classifySource('[hermit-routine:heartbeat-restart]\nRun: bun /p/scripts/routines.ts arm anchor'))
+      .toBe('routine:heartbeat-restart');
+  });
+  test('cost-tracker: classifySource([hermit-routine:x] mid-prose) = other', () => {
+    expect(classifySource('text [hermit-routine:cortex-refresh] more text')).toBe('other');
   });
 
   // classifySource: monitor co-fire → routine:multi (ROUTINE_DUE line naming ≥2 distinct ids)
@@ -3841,16 +3860,43 @@ describe('cost-tracker classifySource / resolveTurnSource', () => {
   test('cost-tracker: classifySource(ROUTINE_DUE with 1 id) = routine:<id>', () => {
     expect(classifySource('ROUTINE_DUE [hermit-routine:reflect]')).toBe('routine:reflect');
   });
-  // Anchoring guard: a heartbeat turn whose tool output surfaces multiple [hermit-routine:*]
-  // markers (heartbeat-restart's re-arm CronDelete output) but has NO ROUTINE_DUE line must
-  // stay heartbeat — never routine:multi.
-  test('cost-tracker: classifySource(heartbeat + stray routine markers, no ROUTINE_DUE) = heartbeat', () => {
-    expect(classifySource('HEARTBEAT_EVALUATE — CronDelete [hermit-routine:reflect] [hermit-routine:doctor]')).toBe('heartbeat');
+  test('cost-tracker: classifySource(envelope ROUTINE_DUE with 1 id) = routine:<id>', () => {
+    expect(classifySource(envelope('ROUTINE_DUE [hermit-routine:reflect]'))).toBe('routine:reflect');
   });
-  // A turn with stray markers but no ROUTINE_DUE line falls through to the generic first-match
-  // path (not routine:multi) — preserves pre-existing single-fire attribution.
-  test('cost-tracker: classifySource(2 markers, no ROUTINE_DUE line) = first id, not multi', () => {
-    expect(classifySource('load done: CronDelete [hermit-routine:reflect] [hermit-routine:doctor]')).toBe('routine:reflect');
+  test('cost-tracker: classifySource(envelope ROUTINE_DUE with 2 ids) = routine:multi', () => {
+    expect(classifySource(envelope('ROUTINE_DUE [hermit-routine:weekly-review] [hermit-routine:doctor]')))
+      .toBe('routine:multi');
+  });
+  // Trailing prose after the ids is part of the delivered line and must not break the match.
+  test('cost-tracker: classifySource(ROUTINE_DUE with trailing text) = routine:<id>', () => {
+    expect(classifySource('ROUTINE_DUE [hermit-routine:daily-brief] fired')).toBe('routine:daily-brief');
+  });
+  // Anchoring guard: a heartbeat turn whose tool output surfaces multiple [hermit-routine:*]
+  // markers (heartbeat-restart's re-arm CronDelete output) is not a delivered sentinel line
+  // at all — neither heartbeat nor routine:multi.
+  test('cost-tracker: classifySource(heartbeat + stray routine markers, no ROUTINE_DUE) = other', () => {
+    expect(classifySource('HEARTBEAT_EVALUATE — CronDelete [hermit-routine:reflect] [hermit-routine:doctor]')).toBe('other');
+  });
+  test('cost-tracker: classifySource(2 stray markers, no ROUTINE_DUE line) = other', () => {
+    expect(classifySource('load done: CronDelete [hermit-routine:reflect] [hermit-routine:doctor]')).toBe('other');
+  });
+
+  // Negatives drawn from the live transcripts that motivated the anchoring: a long operator
+  // prompt naming the sentinel deep in its text, a subagent completion whose <result> quotes
+  // it (no <event> body), and the retired log-event prose fallback.
+  test('cost-tracker: classifySource(long prompt naming sentinel mid-text) = other', () => {
+    const long = `${'x'.repeat(1200)} HEARTBEAT_EVALUATE ${'y'.repeat(4000)}`;
+    expect(classifySource(long)).toBe('other');
+  });
+  test('cost-tracker: classifySource(subagent completion quoting sentinel) = other', () => {
+    const done = '<task-notification>\n<task-id>a8e283fde</task-id>\n<tool-use-id>toolu_01RH</tool-use-id>\n<status>completed</status>\n<result>ran HEARTBEAT_EVALUATE for [hermit-routine:reflect]</result>\n</task-notification>';
+    expect(classifySource(done)).toBe('other');
+  });
+  test('cost-tracker: classifySource(log-routine-event prose) = other', () => {
+    expect(classifySource('ran log-routine-event.sh has fired')).toBe('other');
+  });
+  test('cost-tracker: classifySource(routines.ts log-event prose) = other', () => {
+    expect(classifySource('then routines.ts log-event which errored')).toBe('other');
   });
 
   // classifySource: no marker → other
@@ -3909,6 +3955,16 @@ describe('cost-tracker classifySource / resolveTurnSource', () => {
   // nudge is double-counted as peer traffic.
   test('cost-tracker: classifySource(peer frame carrying HEARTBEAT_EVALUATE) = heartbeat', () => {
     expect(classifySource('Another Claude session sent a message:\nHEARTBEAT_EVALUATE')).toBe('heartbeat');
+  });
+  // The live frame wraps the posted body in <cross-session-message …> and appends a
+  // trailer, so the sentinel is never the whole remainder. Copied from a real transcript.
+  test('cost-tracker: classifySource(live wedge-wake frame) = heartbeat', () => {
+    const frame = 'Another Claude session sent a message:\n<cross-session-message from="uds:/run/user/1000/cc-socks/4112470.sock" from-name="watchdog" from-mode="prompting">\nHEARTBEAT_EVALUATE\n</cross-session-message>\n\nThis came from another Claude session.';
+    expect(classifySource(frame)).toBe('heartbeat');
+  });
+  test('cost-tracker: classifySource(live peer frame with prose body) = peer', () => {
+    const frame = 'Another Claude session sent a message:\n<cross-session-message from="uds:/run/user/1000/cc-socks/4112470.sock" from-name="scout" from-mode="prompting">\nGUEST_REPORT: ran the tests, all green.\n</cross-session-message>\n\nThis came from another Claude session.';
+    expect(classifySource(frame)).toBe('peer');
   });
   test('cost-tracker: classifySource(peer frame carrying ROUTINE_DUE) = routine:<id>', () => {
     expect(classifySource('Another Claude session sent a message:\nROUTINE_DUE [hermit-routine:daily-brief]'))

--- a/plugins/claude-code-hermit/tests/transcript-digest.test.ts
+++ b/plugins/claude-code-hermit/tests/transcript-digest.test.ts
@@ -8,7 +8,8 @@
 //
 // Fixture entry shapes mirror real CC transcripts (verified live, CC 2.1.214):
 //   - wake trigger: user entry, string content, no isMeta (Monitor task-notification
-//     carries "HEARTBEAT_EVALUATE"; slash form carries "<command-name>/…heartbeat run…")
+//     carries "<event>HEARTBEAT_EVALUATE</event>"; a CronCreate routine prompt opens
+//     with "[hermit-routine:<id>]")
 //   - rejection carrier: user tool_result with is_error:true + top-level toolDenialKind
 //   - compact_boundary: {type:'system', subtype:'compact_boundary'}
 
@@ -306,8 +307,16 @@ describe('digestLines — wake classification (trigger entry only)', () => {
   test('Monitor task-notification HEARTBEAT_EVALUATE is a wake', () => {
     expect(wakesOf([triggerEntry('<task-notification>\n<event>HEARTBEAT_EVALUATE</event>\n</task-notification>')])).toBe(1);
   });
-  test('command-wrapped /…heartbeat run is a wake', () => {
-    expect(wakesOf([triggerEntry('<command-message>heartbeat</command-message>\n<command-name>/claude-code-hermit:heartbeat run</command-name>')])).toBe(1);
+  // A manually typed slash command is operator activity, not a scheduler wake —
+  // isWakeSource is defined as "a non-operator scheduler prompt". It also never had the
+  // shape this fixture used: live transcripts carry `<command-name>/claude-code-hermit:heartbeat`
+  // with the subcommand in a separate `<command-args>`, so the old containment rule matched
+  // this synthetic string and nothing real.
+  test('command-wrapped manual heartbeat run is NOT a wake', () => {
+    expect(wakesOf([triggerEntry('<command-message>claude-code-hermit:heartbeat</command-message>\n<command-name>/claude-code-hermit:heartbeat</command-name>\n<command-args>run</command-args>')])).toBe(0);
+  });
+  test('CronCreate routine prompt is a wake', () => {
+    expect(wakesOf([triggerEntry('[hermit-routine:heartbeat-restart]\nRun: bun /p/scripts/routines.ts arm anchor')])).toBe(1);
   });
   test('ROUTINE_DUE marker is a wake', () => {
     expect(wakesOf([triggerEntry('ROUTINE_DUE [hermit-routine:daily-brief] due now')])).toBe(1);


### PR DESCRIPTION
## Summary

`classifySource` matched `HEARTBEAT_EVALUATE` and `[hermit-routine:<id>]` by containment anywhere in a turn's prompt, so any prompt that merely *discussed* a wake was billed as one. It now reduces a prompt to the sentinel line a wake actually delivered before matching, which is the anchored grammar `record-operator-action.ts` already used at the live input boundary.

Measured on this repo's own stored transcripts: 10 operator/compaction prompts and 11 subagent completions were billed to `heartbeat`, against 10 genuine Monitor ticks. A prose fallback matching `log-routine-event.sh <word>` also minted buckets from ordinary sentences, which is why `routine:has`, `routine:which`, `routine:27` and a dozen more are sitting in `state/cost-index.json`.

## Behavior delta

```
BEFORE: prompt anywhere-contains HEARTBEAT_EVALUATE ─────────────────────────> cost row: heartbeat
        prompt anywhere-contains [hermit-routine:x] ─────────────────────────> cost row: routine:x
        prompt anywhere-contains "log-routine-event.sh has" ────────────────> cost row: routine:has
        subagent completion whose <result> quotes the sentinel ─────────────> cost row: heartbeat

AFTER:  Monitor envelope <event>HEARTBEAT_EVALUATE</event> ──────────────────> heartbeat
        Monitor envelope <event>ROUTINE_DUE [hermit-routine:a] …</event> ───> routine:a | routine:multi
        CronCreate prompt opening "[hermit-routine:x] Run: …" ──────────────> routine:x
        peer frame wrapping HEARTBEAT_EVALUATE in <cross-session-message> ──> heartbeat
        operator/compaction prose naming a sentinel mid-text ───────────────> other
        subagent completion quoting a sentinel ─────────────────────────────> other
        "log-routine-event.sh <word>" in prose ─────────────────────────────> other
```

## Changes

- **`scripts/lib/trigger-source.ts`** — new private `sentinelLine()` reduces a prompt to the line a wake delivered: the `<event>` body of a Monitor `<task-notification>`, the `<cross-session-message>` body of a peer socket post, or the prompt's own text. `heartbeat` now requires that line to equal `HEARTBEAT_EVALUATE`; routine matching is anchored with `^`. The `log-event` prose fallback and the `/claude-code-hermit:heartbeat run` literal are deleted. Channel and peer rules and their ordering are unchanged.
- **`scripts/cost-tracker.ts`, `scripts/lib/cc-compat.ts`, `scripts/record-operator-action.ts`** — comment-only. All three described the classifier as matching by containment, which this change makes false.
- **`tests/scripts.test.ts`, `tests/transcript-digest.test.ts`** — the containment cases become `other`; positives added for each real delivery shape, plus negatives for a long prose prompt, a subagent completion, and the retired fallback.
- **`scripts/lib/routines/gate.ts`, `tests/contracts.test.ts`** — comment-only, same class: one described the classifier as scanning the whole prompt, the other referenced the deleted `log-routine-event.sh` fallback as if live.

### Why `SOURCE_ATTRIBUTION_VERSION` stays at 2

Not because the polluted rows age out on their own. They do for `routines.ts health`, whose `scanRoutineCostWindow` is 7-day scoped, but not for the doctor: `doctor-check.ts:2028` uses `scanRoutineLedger`, which is lifetime-scoped and filtered only on `version === 2`. The real reason is that the doctor never reads the affected buckets.

`checkRoutineCost` looks up `routine:<id>` for **configured, enabled** routines only (`doctor-check.ts:2044`). Every mis-attribution this PR removes landed either in the `heartbeat` bucket, which is never keyed, or in unconfigured `routine:<word>` artifacts, which `tests/contracts.test.ts:3040` already pins as ignored.

Verified against the live 9810-row cost log:

- No v2 row in any bucket the doctor reads is mis-attributed. Each configured routine's v2 rows sit on its cron anchor (`heartbeat-restart` 03:24-03:32 UTC, `pipeline-digest` 08:00-08:01 UTC).
- The ledger verdict is identical with and without the bad rows: worst routine $2.208/run against a $2.915 threshold → `ok`.
- The `routine:has` / `routine:which` / `routine:27` buckets are all **pre-v2**. The v2 epoch is the same commit as the prompt-only `turnPromptText` fix (27676a7c), so a v2 row is by construction classified from a boundary prompt and the prose fallback could never reach it. They survive in `state/cost-index.json`'s `by_source`, which filters no version at all — a bump would not clear a single one.
- A bump *would* drop all four routines below `MIN_RUNS = 3`, blinding `checkRoutineCost` for roughly 3-7 days and zeroing routine-health $/run for a full 7-day window, to discard data it never consults.

Residual risk, for the record: a v2 row billed by containment to a *configured* routine id would be permanent. The replay found two prompts of that shape (compaction summaries quoting `[hermit-routine:heartbeat-restart]` and `[hermit-routine:pipeline-digest]`) that happened to produce no billed row. Anchoring closes that going forward.

The reasoning is now recorded at the constant in `scripts/lib/cost-log.ts` so the next reader does not have to re-derive it.

## Two test fixtures encoded shapes that never occur live

Both were corrected against real transcripts, and the second one caught a regression this PR would otherwise have shipped.

1. A manual heartbeat slash command was modelled with its subcommand inlined into `<command-name>`. The harness actually splits it into a separate `<command-args>`, so the old literal never matched a real manual run. A typed slash command is operator activity, not a scheduler wake, so it is no longer counted as one in the digest.
2. The peer frame was modelled with a bare body. The harness actually wraps a socket post in `<cross-session-message from=… from-name=… from-mode=…>` and appends a trailer. Without unwrapping that element, the watchdog's wedge wake would have regressed from `heartbeat` to `peer`.
3. The CronCreate wake fixture omitted `isMeta`, which is set in 12/12 real samples. `digestLines` gates on `isTurnTrigger`, whose `isMeta !== true` guard means a real CronCreate prompt never reaches `classifySource` and is not counted as a wake — so the test was green only on a shape that cannot occur. It is now pinned at 0 with the field set, recording the gap; #939 fixes the segmentation and flips it back. The channel fixture gets the same field (74/74 live), and the skill-injection fixture now uses array content, which is what `isSkillInjection` actually keys on and what 592/600 live entries carry.

## Test plan

- `bun test --parallel --timeout=45000` in `plugins/claude-code-hermit` → 5077 pass, 0 fail
- `bunx tsc` → exit 0
- Read-only replay of the new classifier over this machine's stored transcripts: prose-billed and subagent-billed wakes both drop to 0, while the 10 Monitor heartbeat events, 32 `ROUTINE_DUE` events and 12 CronCreate prompts all still classify as wakes.

Follow-up review also anchored the `channel` and `peer` matchers, which the first pass left on containment: a compaction summary quoting a `<channel>` envelope billed to that channel (4 live turns) and prose containing `source="..."` minted a `channel:...` bucket (6 rows). The peer case also suppressed `resolveTurnSource`'s dispatch hop, which only runs on `other`, losing the dispatching routine's cost on 5 turns. Delta after both: `peer` 72→67, `channel:discord` 90→86, `channel:...` 6→0, every `heartbeat`/`routine:*` count unchanged.

Closes #934

