### PR TITLE
fix(claude-code-hermit): segment digest turns on the delivered-prompt boundary

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -32,6 +32,7 @@
 - The weekly review runs its topic-page check and channel-log consolidation in one runner dispatch instead of two; the runner files its own memory and topic-page candidates in its isolated context, and the main session only marks the reviewed rows, prunes, and logs one Findings line naming what was filed.
 
 ### Fixed
+- The transcript digest now counts CronCreate, channel and peer turns as boundaries, so `wakes` and `productive_wakes` no longer describe only Monitor-delivered ticks.
 - Proposal acceptance in a later session now remains current: the falsification gate receives `## References`, and a proposal queued as a session task re-verifies its citations against the current tree before any edit, preventing already-shipped or stale work from being implemented.
 - The heartbeat monitor's registration command is rendered from one place, so a symlinked plugin path no longer makes every boot tear down and re-register the monitor as `command-drift`.
 - Cost attribution bills a turn to `heartbeat`, `routine:<id>`, `channel:<kind>` or `peer` only when a wake, envelope or peer post actually delivered that frame, not when a prompt merely mentions one. An operator prompt discussing the heartbeat, a compaction summary quoting a routine id or a `<channel>` envelope, and a subagent completion echoing its own output all bill to `other` now. The prose fallback that minted buckets like `routine:has` from ordinary sentences is gone, as is the `channel:...` bucket that quoted envelopes minted.

--- a/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cc-compat.ts
@@ -458,27 +458,13 @@ function extractUsage(entry: Json): { inputTokens: number; cacheWriteTokens: num
 }
 
 /**
- * A turn-opening user entry: a real triggering prompt, not a tool_result
- * carrier and not a mid-turn skill-expansion injection. The `isMeta !== true`
- * guard is load-bearing: CC emits `isMeta:true` user entries mid-turn (e.g.
- * "Base directory for this skill: …") which are NOT turn boundaries — treating
- * them as boundaries splits a turn before its later tool calls land.
- * @param {object} entry
- * @returns {boolean}
- */
-function isTurnTrigger(entry: Json): boolean {
-  return entry.type === 'user' && !isToolResult(entry) && entry.isMeta !== true;
-}
-
-/**
  * A structured mid-turn injection — CC writes skill bodies and similar scaffolding
  * as `isMeta:true` user entries. `isMeta` alone cannot discriminate these from real
  * prompts: routine wakes (`[hermit-routine:<id>] …`) and inbound channel envelopes
- * (`<channel source="…">`) are ALSO `isMeta:true`. That is why `isTurnTrigger` (whose
- * `isMeta` guard is correct for *usage* segmentation) must not be used to find the
- * prompt that classifies a turn's cost — it would skip the marker-bearing entries
- * themselves. Measured on live hermit transcripts: skipping the injections recovers 77
- * real routine/channel prompts that they would otherwise shadow.
+ * (`<channel source="…">`) are ALSO `isMeta:true`. That is why a bare `isMeta !== true`
+ * guard must not be used to find the prompt that opens a turn — it would skip the
+ * marker-bearing entries themselves. Measured on live hermit transcripts: skipping the
+ * injections recovers 77 real routine/channel prompts that they would otherwise shadow.
  *
  * TWO shapes, both scaffolding:
  *   - ARRAY content — the skill body itself, written on first invocation.
@@ -496,6 +482,22 @@ function isTurnTrigger(entry: Json): boolean {
 function isSkillInjection(entry: Json): boolean {
   if (entry.isMeta !== true) return false;
   return Array.isArray(entry.message?.content) || entry.turnCompanion === true;
+}
+
+/**
+ * A turn-opening user entry: the delivered prompt itself, not a tool_result carrier
+ * and not a structured mid-turn injection. This is the boundary both consumers of
+ * turn segmentation share — `turnPromptText` (which prompt classifies the turn) and
+ * transcript-digest's turn counter — so they cannot drift apart on what a turn is.
+ *
+ * NOTE for cost-tracker: its usage walks (`sumTurnUsage`, the agent-usage scan) use a
+ * deliberately looser boundary (`user && !isToolResult`). Tightening those would move
+ * billed amounts, not just labels — don't "align" them without re-measuring totals.
+ * @param {object} entry
+ * @returns {boolean}
+ */
+function isTurnBoundary(entry: Json): boolean {
+  return entry.type === 'user' && !isToolResult(entry) && !isSkillInjection(entry);
 }
 
 /**
@@ -520,7 +522,7 @@ function turnPromptText(lines: string[], billedIndex: number): { text: string; b
   for (let j = billedIndex - 1; j >= 0; j--) {
     try {
       const prev = JSON.parse(lines[j]);
-      if (prev.type === 'user' && !isToolResult(prev) && !isSkillInjection(prev)) {
+      if (isTurnBoundary(prev)) {
         return { text: entryText(prev), boundaryFound: true, index: j };
       }
     } catch {}
@@ -707,7 +709,7 @@ export {
   entryText,
   isToolResult,
   extractUsage,
-  isTurnTrigger,
+  isTurnBoundary,
   isSkillInjection,
   turnPromptText,
   isCompactBoundary,

--- a/plugins/claude-code-hermit/scripts/transcript-digest.ts
+++ b/plugins/claude-code-hermit/scripts/transcript-digest.ts
@@ -36,7 +36,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   entryText,
-  isTurnTrigger,
+  isTurnBoundary,
   isCompactBoundary,
   toolUseNames,
   classifyToolResults,
@@ -68,8 +68,9 @@ function isProductiveTool(name: string): boolean {
 }
 
 // classifySource returns 'heartbeat' | 'routine:<id>' | 'routine:multi' |
-// 'channel:<kind>' | 'other'. A wake is a non-operator scheduler prompt:
-// heartbeat or routine. channel:* (inbound operator DM) and other are not wakes.
+// 'channel:<kind>' | 'peer' | 'other'. A wake is a non-operator scheduler prompt:
+// heartbeat or routine. channel:* (inbound operator DM), peer (another local
+// session's post) and other are not wakes.
 function isWakeSource(source: string): boolean {
   return source === 'heartbeat' || source.startsWith('routine:');
 }
@@ -173,7 +174,7 @@ function digestLines(lines: string[], cutoffMs: number): FileDigest {
 
     if (isCompactBoundary(entry)) { d.compactions++; continue; }
 
-    if (isTurnTrigger(entry)) {
+    if (isTurnBoundary(entry)) {
       flushTurn();
       turnOpen = true;
       turnIsWake = isWakeSource(classifySource(entryText(entry)));

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -4052,7 +4052,8 @@ describe('cost-tracker classifySource / resolveTurnSource', () => {
   });
 
   // An isMeta entry with STRING content IS a real delivered prompt — the live shape of a
-  // routine wake. Skipping it (as isTurnTrigger would) loses the attribution entirely.
+  // routine wake. Skipping it (as a bare `isMeta !== true` guard would) loses the
+  // attribution entirely.
   test('cost-tracker: an isMeta string-content routine prompt still classifies', () => {
     const lines = [
       JSON.stringify({ type: 'user', isMeta: true, message: { content: '[hermit-routine:morning] First run: log-routine-event.sh morning started' } }),

--- a/plugins/claude-code-hermit/tests/transcript-digest.test.ts
+++ b/plugins/claude-code-hermit/tests/transcript-digest.test.ts
@@ -7,13 +7,13 @@
 // no load-time side effects, so direct import is safe and deterministic).
 //
 // Fixture entry shapes mirror real CC transcripts (verified live, CC 2.1.214):
-//   - wake trigger: user entry, string content. Only the Monitor task-notification
-//     frame ("<event>HEARTBEAT_EVALUATE</event>") arrives WITHOUT isMeta. Surveyed over
-//     287 stored transcripts, the other three delivery frames are isMeta:true in every
-//     sample: CronCreate "[hermit-routine:<id>]" 12/12, channel envelopes 74/74, peer
-//     posts 40/40. digestLines gates on isTurnTrigger, whose `isMeta !== true` guard
-//     therefore drops them before they reach classifySource — see #939. The fixtures
-//     below encode that gap rather than papering over it.
+//   - turn boundary: user entry, string content, not a tool_result and not a skill
+//     injection. Monitor HEARTBEAT_EVALUATE arrives without isMeta; CronCreate
+//     "[hermit-routine:<id>]", channel envelopes, and peer posts arrive isMeta:true.
+//     digestLines opens a turn on cc-compat's isTurnBoundary — the same predicate
+//     turnPromptText walks back to (user && !isToolResult && !isSkillInjection) — then
+//     classifySource decides whether that turn is a wake. CronCreate is a wake;
+//     channel and peer are not.
 //   - skill injection: isMeta:true with ARRAY content (592/600 live samples); the bare
 //     string-content form is pre-2.1.202 and no longer emitted.
 //   - rejection carrier: user tool_result with is_error:true + top-level toolDenialKind
@@ -333,20 +333,21 @@ describe('digestLines — wake classification (trigger entry only)', () => {
   test('command-wrapped manual heartbeat run is NOT a wake', () => {
     expect(wakesOf([triggerEntry('<command-message>claude-code-hermit:heartbeat</command-message>\n<command-name>/claude-code-hermit:heartbeat</command-name>\n<command-args>run</command-args>')])).toBe(0);
   });
-  // classifySource does call this a wake, but the digest never asks it: a live CronCreate
-  // routine prompt is isMeta:true (12/12 in stored transcripts) and isTurnTrigger's
-  // `isMeta !== true` guard drops it before classification. Pinned at 0 to record the gap
-  // — #939 fixes the segmentation, and flips this back to 1.
-  test('CronCreate routine prompt is dropped by the isMeta gate (#939)', () => {
-    expect(wakesOf([triggerEntry('[hermit-routine:heartbeat-restart]\nRun: bun /p/scripts/routines.ts arm anchor', { isMeta: true })])).toBe(0);
+  // Live CronCreate routine prompts are isMeta:true. The boundary predicate still
+  // opens a turn; classifySource then counts it as a wake.
+  test('CronCreate routine prompt is a wake (#939)', () => {
+    expect(wakesOf([triggerEntry('[hermit-routine:heartbeat-restart]\nRun: bun /p/scripts/routines.ts arm anchor', { isMeta: true })])).toBe(1);
   });
   test('ROUTINE_DUE marker is a wake', () => {
     expect(wakesOf([triggerEntry('ROUTINE_DUE [hermit-routine:daily-brief] due now')])).toBe(1);
   });
-  // isMeta:true live (74/74), so this is 0 twice over: dropped by the gate, and not a wake
-  // to classifySource either. Stays correct once #939 lands.
+  // isMeta:true live. The envelope now opens a turn; classifySource still does not
+  // count it as a wake.
   test('inbound channel prompt is NOT a wake', () => {
     expect(wakesOf([triggerEntry('<channel source="plugin:discord:discord" user="u">hi</channel>', { isMeta: true })])).toBe(0);
+  });
+  test('inbound peer prompt is NOT a wake', () => {
+    expect(wakesOf([triggerEntry('Another Claude session sent a message:\n<cross-session-message from="x">hi</cross-session-message>', { isMeta: true })])).toBe(0);
   });
   test('plain operator prompt is NOT a wake', () => {
     expect(wakesOf([triggerEntry('please refactor the parser')])).toBe(0);
@@ -366,6 +367,15 @@ describe('digestLines — wake classification (trigger entry only)', () => {
     ], OPEN);
     expect(d.wakes).toBe(1);
     expect(d.productiveWakes).toBe(1);
+  });
+  test('channel envelope after a heartbeat does not credit the Write to the wake', () => {
+    const d = digestLines([
+      triggerEntry('HEARTBEAT_EVALUATE'),
+      triggerEntry('<channel source="plugin:discord:discord" user="u">hi</channel>', { isMeta: true }),
+      assistantToolUse('u1', 'Write'),
+    ], OPEN);
+    expect(d.wakes).toBe(1);
+    expect(d.productiveWakes).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

`digestLines` gated turn boundaries on `isTurnTrigger`, whose `isMeta !== true` guard drops exactly the frames that mark a wake. Live, CronCreate routine prompts, channel envelopes and peer posts are all `isMeta:true`, so none of them opened a turn: `heartbeat-restart`'s daily fire was never counted, and Discord work following a heartbeat credited that heartbeat as productive.

Both consumers of turn segmentation now share one exported `isTurnBoundary` in `cc-compat.ts`, so cost attribution and wake counting cannot drift on what a turn is.

Closes #939

## Behavior delta

```
BEFORE:  Monitor tick ──> turn opens ──> counted as wake
         CronCreate fire ─┐
         channel envelope ├─> isMeta:true ──> no boundary ──> folded into whichever
         peer message ────┘                                   turn was still open

AFTER:   Monitor tick ────┐
         CronCreate fire ─┤
         channel envelope ├─> boundary ──> classifySource ──> wake counted iff a
         peer message ────┘                                  scheduler prompt
         skill-body injection (isMeta + array content, or turnCompanion) ──> still
         no boundary, still lands in classifyToolResults
```

## Changes

- `scripts/lib/cc-compat.ts` — new exported `isTurnBoundary` (`user && !isToolResult && !isSkillInjection`), consumed by both `turnPromptText` and `digestLines`. `isTurnTrigger` deleted: this change removed its last caller, and its docblock asserted the `isMeta !== true` guard was load-bearing for turn boundaries, the exact claim the fix disproves. A note on the new predicate records that `cost-tracker`'s usage walks deliberately keep the looser `user && !isToolResult` boundary, since tightening those would move billed amounts rather than labels.
- `scripts/transcript-digest.ts` — the boundary gate calls the shared predicate; the `isWakeSource` comment now lists `peer`, which became reachable with this change.
- `tests/transcript-digest.test.ts` — the CronCreate case flips from a pinned `0` to `1`; new cases for a peer frame (0 wakes) and for a channel envelope arriving after a `HEARTBEAT_EVALUATE` (`wakes: 1, productiveWakes: 0`). Header and comments now describe the behavior rather than the gap.
- `tests/scripts.test.ts` — one comment updated to name the bare guard instead of the deleted function.

## Test plan

Closing verification, all exit 0 in the branch worktree after the final commit:

```
0  cd plugins/claude-code-hermit && test "$(grep -rl isTurnTrigger scripts/ tests/ | wc -l)" = 0
0  cd plugins/claude-code-hermit && test "$(grep -c 'isTurnBoundary' scripts/lib/cc-compat.ts)" = 3
0  cd plugins/claude-code-hermit && bun test tests/transcript-digest.test.ts
0  cd plugins/claude-code-hermit && bun test --parallel --timeout=45000     # 5083 pass / 0 fail
0  bunx tsc
```

Measured against 80 real local transcripts: old predicate gives 12 wakes / 1 productive, new gives 17 / 4, and the five newly counted wakes are exactly the `[hermit-routine:heartbeat-restart]` anchor prompts. No compaction-summary, channel or peer entry is misclassified as a wake.

**Known, deliberately unfixed:** the boundary predicate also admits `isMeta:true` scaffolding entries (`<local-command-caveat>`, `[Cross-session delivery notice]`); one arriving mid-wake flushes the turn, so a later `Write` is not credited and `productive_wakes` undercounts. Parity with `turnPromptText` is the design, and the measured impact on the same 80-transcript corpus is zero (17 wakes / 4 productive with and without an exclusion list).

## Blast radius

- **Released surfaces touched:** none. Both `scripts/transcript-digest.ts` and `scripts/lib/cc-compat.ts` already carry unreleased changes since `claude-code-hermit--v1.2.53`, so this lands in the same unreleased window.
- **Unreleased surfaces touched:** `claude-code-hermit` only — `scripts/lib/cc-compat.ts` (exported API: `isTurnTrigger` removed, `isTurnBoundary` added), `scripts/transcript-digest.ts`, and the two test files. In-repo consumers of the digest (`cost-tracker.ts`, `observations.ts`, `lib/trigger-source.ts`, the `reflect` and `hatch` skills) are unchanged and green.
- **Downstream operators:** wake accounting changes value, not shape. `wakes` and `productive_wakes` rise for any hermit whose scheduler fires through CronCreate; a hermit driven only by Monitor ticks sees no change. Nothing in the digest's output schema moves, so no operator action is required on update.
- **Downstream hermits:** none depend on `isTurnTrigger` — cross-plugin imports of core are forbidden by repo convention and no sibling references it. Fleet hermits pick this up on the next `/plugin update` after the version bump.
- **Per-actor ledger:** executor `grok` wrote the three-file change (`transcript-digest.ts` gate + local closure, the test flips and two new cases, the CHANGELOG bullet); `/code-review high --fix` hoisted the predicate into `cc-compat.ts`, deleted the orphaned `isTurnTrigger`, corrected the `isWakeSource` and docblock comments, and measured the 80-transcript before/after; the operator approved reversing the plan's original scope fence (which had required `isTurnTrigger` stay exported) and approved leaving the scaffolding finding unfixed. The plan file was amended to record both decisions before the commit.
