### PR TITLE
fix(heartbeat): resolve the default credential-expiry item without a model wake

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `validate-config` warns when `heartbeat-restart` has a non-daily schedule — the anchor's 7-day expiry and 26h age windows assume it fires every day.
 
 ### Changed
+- `heartbeat.ts tick` returns `model` (`heartbeat.model`, `null` preserved) and the heartbeat `run` step dispatches from it instead of a separate config read.
 - `hermit-routines load` now arms the heartbeat monitor alongside the routine one: `arm begin` emits `HB_*` plan lines and `arm commit` takes `--heartbeat <task-id|none>`. The always-on bootstrap, the watchdog and the daily anchor prompt no longer send `/heartbeat start` when a `load` covers it, and `hermit-evolve` skips the post-upgrade reload when `arm check` reports healthy. A heartbeat-only staleness still routes to `/heartbeat start`, and `heartbeat.enabled: false` still keeps it off.
 - `list`, `status`, `stop` and the operational notes moved from `skills/hermit-routines/SKILL.md` to a sibling `reference.md`, off the boot path.
 - `/proposal-act` writes hook and permission entries straight into the hatch-resolved `.claude/settings*.json` with an `Edit`/`Write` call, relying on the seeded native ask for approval instead of the bundled `update-config` skill.
@@ -32,6 +33,7 @@
 - The weekly review runs its topic-page check and channel-log consolidation in one runner dispatch instead of two; the runner files its own memory and topic-page candidates in its isolated context, and the main session only marks the reviewed rows, prunes, and logs one Findings line naming what was filed.
 
 ### Fixed
+- The precheck resolves the default credential-expiry item against `state/doctor-report.json` itself, so a default-checklist hermit reaches `OK` with no model wake while the check is healthy (it previously forced an evaluation once per `clean_recheck_cooldown`).
 - Proposal acceptance in a later session now remains current: the falsification gate receives `## References`, and a proposal queued as a session task re-verifies its citations against the current tree before any edit, preventing already-shipped or stale work from being implemented.
 - The heartbeat monitor's registration command is rendered from one place, so a symlinked plugin path no longer makes every boot tear down and re-register the monitor as `command-drift`.
 - Cost attribution bills a turn to `heartbeat`, `routine:<id>`, `channel:<kind>` or `peer` only when a wake, envelope or peer post actually delivered that frame, not when a prompt merely mentions one. An operator prompt discussing the heartbeat, a compaction summary quoting a routine id or a `<channel>` envelope, and a subagent completion echoing its own output all bill to `other` now. The prose fallback that minted buckets like `routine:has` from ordinary sentences is gone, as is the `channel:...` bucket that quoted envelopes minted.

--- a/plugins/claude-code-hermit/scripts/lib/heartbeat-items.ts
+++ b/plugins/claude-code-hermit/scripts/lib/heartbeat-items.ts
@@ -18,3 +18,19 @@
 export function isProposalScanItem(itemText: string): boolean {
   return /proposals?[\/\s]/i.test(itemText) && /\bproposed\b/i.test(itemText);
 }
+
+// Does a HEARTBEAT.md checklist item represent the default credential-expiry item?
+// Matches the shipped default ("Read `state/doctor-report.json` → the
+// `credential-expiry` check …"): it references doctor-report.json AND the
+// credential-expiry check it reads. A custom item that merely mentions one
+// without the other falls through to the generic alert-based rule (unchanged,
+// conservative).
+//
+// Residual (documented, not eliminated): a compound custom item that DOES contain
+// both `doctor-report.json` and `credential-expiry` plus an unrelated clause is
+// classified here and can reach 'clean' on a healthy report, skipping the
+// unrelated clause's LLM eval. Same residual as isProposalScanItem: prose-matching
+// is retained because hermit-evolve does not migrate operator-edited HEARTBEAT.md.
+export function isCredentialExpiryItem(itemText: string): boolean {
+  return /doctor-report\.json/i.test(itemText) && /credential-expiry/i.test(itemText);
+}

--- a/plugins/claude-code-hermit/scripts/lib/heartbeat/precheck.ts
+++ b/plugins/claude-code-hermit/scripts/lib/heartbeat/precheck.ts
@@ -21,7 +21,7 @@ import { currentHHMM, todayYMD, parseDuration } from '../time';
 import { readSettledConfig } from '../config-read';
 import { readAlertState, defaultAlertState, quarantineAlertState, writeAlertState, readMergedAlerts, MICRO_PREFIX, PROPOSAL_PREFIX } from '../alert-state';
 import { readFrontmatter, listProposalFiles } from '../frontmatter';
-import { isProposalScanItem } from '../heartbeat-items';
+import { isProposalScanItem, isCredentialExpiryItem } from '../heartbeat-items';
 import { isPaused } from '../pause';
 import { readMicroProposals } from '../micro-proposals-io';
 import { scanForInjection } from '../injection-scan';
@@ -147,6 +147,23 @@ function resolveMicroPendingScan(dir: string, alertMap: Json): 'clean' | 'evalua
     const entry = alertMap[`${MICRO_PREFIX}${p.id}`];
     if (!entry || !entry.suppressed || (entry.consecutive_clean ?? 0) > 0) return 'evaluate';
   }
+  return 'clean';
+}
+
+// The default HEARTBEAT.md credential-expiry item reads state/doctor-report.json.
+// Resolve it against that report so a healthy check reaches OK without an LLM
+// wake. Fail-open on a missing, unparseable, or incomplete report (parity with
+// today). A lingering alerts[key] on an otherwise-ok check is SKILL.md-owned
+// resolution, so defer. Any other status uses the generic suppressed-entry
+// rule. Read-only, identical under --peek.
+function resolveCredentialExpiryItem(stateDir: string, alerts: Json, key: string): 'clean' | 'evaluate' {
+  const report = readJSON(path.join(stateDir, 'state', 'doctor-report.json'));
+  if (!report || !Array.isArray(report.checks)) return 'evaluate';
+  const check = report.checks.find((c: Json) => c && c.id === 'credential-expiry');
+  if (!check) return 'evaluate';
+  if (check.status === 'ok') return alerts[key] ? 'evaluate' : 'clean';
+  const entry = alerts[key];
+  if (!entry || !entry.suppressed || (entry.consecutive_clean ?? 0) > 0) return 'evaluate';
   return 'clean';
 }
 
@@ -426,8 +443,9 @@ export function runPrecheck(stateDir: string, peek: boolean): string {
   }
 
   // OK fires only when every item in HEARTBEAT.md is satisfied. The default
-  // proposals-scan item is resolved against real proposal frontmatter (so a hermit
-  // with no proposals awaiting review reaches OK without an LLM wake); every other
+  // proposals-scan item is resolved against real proposal frontmatter; the
+  // default credential-expiry item against state/doctor-report.json (so a hermit
+  // whose doctor check is healthy reaches OK without an LLM wake); every other
   // item needs a matching entry in alerts{} that is suppressed (count > 5) and not
   // approaching resolution (consecutive_clean === 0).
   for (const item of checklistItems) {
@@ -437,6 +455,10 @@ export function runPrecheck(stateDir: string, peek: boolean): string {
     }
     const key = normalizeItemKey(item);
     if (!key) return 'EVALUATE';
+    if (isCredentialExpiryItem(item)) {
+      if (resolveCredentialExpiryItem(stateDir, alerts, key) === 'evaluate') return 'EVALUATE';
+      continue;
+    }
     const entry = alerts[key];
     if (!entry || !entry.suppressed || (entry.consecutive_clean ?? 0) > 0) return 'EVALUATE';
   }

--- a/plugins/claude-code-hermit/scripts/lib/heartbeat/tick.ts
+++ b/plugins/claude-code-hermit/scripts/lib/heartbeat/tick.ts
@@ -9,7 +9,8 @@
 // Output (stdout, one JSON line):
 //   {"verdict":"SKIP"|"OK"|"AUTO_CLOSE"|"EVALUATE"|"ALERT",
 //    "reason"?:string, "alert"?:string,
-//    "notifications":[{"text":string,"mark_key"?:string}]}
+//    "notifications":[{"text":string,"mark_key"?:string}],
+//    "model":string|null}
 //
 // Owner contract (write-field split with SKILL.md):
 //   This verb owns: the precheck's own fields (see precheck.ts), runtime.json's
@@ -40,10 +41,11 @@ type TickResult = {
   reason?: string;
   alert?: string;
   notifications: Notification[];
+  model: string | null;
 };
 
 /** Split the precheck's one-line grammar into the JSON fields the skill branches on. */
-function parseVerdict(raw: string): TickResult {
+function parseVerdict(raw: string): Omit<TickResult, 'model'> {
   if (raw.startsWith('SKIP|')) return { verdict: 'SKIP', reason: raw.slice(5), notifications: [] };
   if (raw.startsWith('ALERT|')) return { verdict: 'ALERT', alert: raw.slice(6), notifications: [] };
   return { verdict: raw, notifications: [] };
@@ -105,12 +107,19 @@ async function composeBudgetAlerts(hermitDir: string, config: Json, out: Notific
 
 export async function run(args: string[]): Promise<void> {
   const hermitDir = args[0];
+  // Settled once, shared by the model field and the bookkeeping below. Settling
+  // preserves an explicit `heartbeat.model: null` (the skill reads it as "inherit
+  // the session model") while folding absent/""/wrong-typed to 'haiku'; the
+  // reader never writes and never throws.
+  const config = readSettledConfig(hermitDir);
   // Mutating precheck, exactly once — before anything below can throw, so a tick
   // is never double-counted by a retry.
-  const result = parseVerdict(runPrecheck(hermitDir, false));
+  const result: TickResult = {
+    ...parseVerdict(runPrecheck(hermitDir, false)),
+    model: config.heartbeat.model,
+  };
 
   try {
-    const config = readSettledConfig(hermitDir);
     const nowMs = resolveHermitNowMs();
 
     if (result.verdict === 'AUTO_CLOSE') {

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -30,7 +30,7 @@ This subcommand is the handler for `HEARTBEAT_EVALUATE` notifications emitted by
    ```
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/heartbeat.ts tick .claude-code-hermit
    ```
-   It prints one JSON line: `{"verdict", "reason"?, "alert"?, "notifications":[{"text","mark_key"?}]}`. The verdict is the precheck's; the `notifications` array is every deterministic pre-dispatch finding — a waiting-timeout that already fired, and each un-notified budget alert, composed and ready to send. The tick applied the runtime.json transition and wrote any Monitoring line it owed. Sending is yours.
+   It prints one JSON line: `{"verdict", "reason"?, "alert"?, "notifications":[{"text","mark_key"?}], "model"}`. The verdict is the precheck's; the `notifications` array is every deterministic pre-dispatch finding — a waiting-timeout that already fired, and each un-notified budget alert, composed and ready to send. `model` is the settled `heartbeat.model` — `"haiku"` when absent or malformed, an explicit `null` preserved. The tick applied the runtime.json transition and wrote any Monitoring line it owed. Sending is yours.
 2. Branch on `verdict`:
    - `SKIP` → emit `HEARTBEAT_SKIP (<reason>)`. No channel notification. No SHELL.md write. Stop.
    - `OK` → emit `HEARTBEAT_OK`. Stop.
@@ -50,7 +50,7 @@ This subcommand is the handler for `HEARTBEAT_EVALUATE` notifications emitted by
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/cost-tracker.ts --mark-budget-notified <mark_key>
    ```
    Marking before a confirmed send would silently swallow the alert; that is why the tick leaves `notified` untouched and cost-tracker stays the sole writer of `budget-alerts.json`. An empty array is the common case — continue to step 4 either way.
-4. **Read `heartbeat.model` from `.claude-code-hermit/config.json`** (default `"haiku"` when the key is absent). **Dispatch via the Agent tool** (`subagent_type: "claude-code-hermit:skill-eval-runner"`) to run the report-only evaluation. Pass the `model` param per the resolved value: a concrete string (`"haiku"`/`"sonnet"`/`"opus"`) → `model: "<that value>"`; explicit `null` → **omit the `model` param entirely** so the subagent inherits the session model. This runs the evaluation in a fresh ~40k context instead of the main session's 200k–500k inherited context — the eval reads only files and needs none of that history. Instructions for the subagent:
+4. **Take `model` from the step 1 tick JSON.** **Dispatch via the Agent tool** (`subagent_type: "claude-code-hermit:skill-eval-runner"`) to run the report-only evaluation. Pass the `model` param from that field: a string → `model: "<that value>"`; `null` → **omit the `model` param entirely** so the subagent inherits the session model. This runs the evaluation in a fresh ~40k context instead of the main session's 200k–500k inherited context — the eval reads only files and needs none of that history. Instructions for the subagent:
    > Read `${CLAUDE_PLUGIN_ROOT}/skills/heartbeat/reference.md` for the complete evaluation instructions. Execute the evaluation steps in that file against `.claude-code-hermit/` in the current project directory, using the file paths described there. Return the JSON object exactly as specified in reference.md § Return Schema (no prose). Do NOT write any files or send any notifications — the calling session handles all writes and notifications.
 
    Receive the structured JSON back from the subagent.

--- a/plugins/claude-code-hermit/tests/heartbeat-default-scan.test.ts
+++ b/plugins/claude-code-hermit/tests/heartbeat-default-scan.test.ts
@@ -17,7 +17,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { runScript, PLUGIN_ROOT } from './helpers/run';
-import { isProposalScanItem } from '../scripts/lib/heartbeat-items';
+import { isProposalScanItem, isCredentialExpiryItem } from '../scripts/lib/heartbeat-items';
 
 const hermit = (dir: string, ...p: string[]) => path.join(dir, '.claude-code-hermit', ...p);
 
@@ -32,6 +32,13 @@ const TODAY = new Intl.DateTimeFormat('en-CA', { timeZone: 'UTC' }).format(new D
 const HEARTBEAT_DEFAULT =
   '# Heartbeat Checklist\n\n## Standing Checks\n' +
   '- Review `proposals/` for any with `status: proposed` needing operator review.\n';
+
+// Template line 6 verbatim. Tests 1–18 reach OK against HEARTBEAT_DEFAULT (proposal
+// scan only); adding this bullet would force EVALUATE until doctor-report.json is
+// healthy, so the credential matrix uses HEARTBEAT_BOTH instead.
+const CREDENTIAL_BULLET =
+  '- Read `state/doctor-report.json` → the `credential-expiry` check; if its status is warn or fail, tell the operator which credential needs re-auth and name the plugin\'s reauth skill from the report detail.';
+const HEARTBEAT_BOTH = HEARTBEAT_DEFAULT + CREDENTIAL_BULLET + '\n';
 
 // clean_recheck_cooldown: null disables the damper so these tests isolate the
 // item-loop resolution (the damper has its own coverage in auto-close.test.ts).
@@ -48,6 +55,7 @@ interface Fixture {
   noProposalsDir?: boolean;  // don't create proposals/ at all (ENOENT readdir path)
   proposalsAsFile?: boolean; // proposals is a regular file, not a dir (ENOTDIR readdir path)
   microCorrupt?: boolean;    // micro-proposals.json present but unparseable (#764)
+  doctorReport?: object | 'missing' | 'corrupt';
 }
 
 function build(fix: Fixture): string {
@@ -87,7 +95,26 @@ function build(fix: Fixture): string {
       JSON.stringify({ pending: ids.map(id => ({ id, status: 'pending', tier: 1 })) }),
     );
   }
+  if (fix.doctorReport === 'corrupt') {
+    fs.writeFileSync(hermit(dir, 'state', 'doctor-report.json'), '{"ts":');
+  } else if (fix.doctorReport && fix.doctorReport !== 'missing') {
+    const given = fix.doctorReport as { ts?: string; checks?: unknown[] };
+    const report = Array.isArray(given.checks)
+      ? { ts: given.ts ?? NOW, ...given }
+      : { ts: NOW, checks: [{ id: 'credential-expiry', detail: '', ...given }] };
+    fs.writeFileSync(hermit(dir, 'state', 'doctor-report.json'), JSON.stringify(report));
+  }
   return dir;
+}
+
+// Mirrors precheck.ts normalizeItemKey: checklist:<first 8 alphanumerics of the bullet>.
+function checklistKey(itemText: string): string {
+  const text = itemText
+    .replace(/^[-*+]\s*(\[.\]\s*)?/, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+    .slice(0, 8);
+  return `checklist:${text}`;
 }
 
 async function verdict(dir: string, peek = false, now = NOW): Promise<string> {
@@ -254,6 +281,66 @@ describe('default proposal-scan resolution', () => {
   });
 });
 
+describe('default credential-expiry resolution', () => {
+  const both = { heartbeat: HEARTBEAT_BOTH };
+  const credKey = checklistKey(CREDENTIAL_BULLET);
+
+  test('1. status ok, no alerts → OK', async () => {
+    const dir = build({ ...both, doctorReport: { status: 'ok' } });
+    expect(await verdict(dir)).toBe('OK');
+  });
+
+  test('2. status warn, no alerts → EVALUATE', async () => {
+    const dir = build({ ...both, doctorReport: { status: 'warn' } });
+    expect(await verdict(dir)).toBe('EVALUATE');
+  });
+
+  test('3. status fail, entry suppressed with consecutive_clean: 0 → OK', async () => {
+    const dir = build({
+      ...both,
+      doctorReport: { status: 'fail' },
+      alertState: { alerts: { [credKey]: { suppressed: true, consecutive_clean: 0, count: 6 } } },
+    });
+    expect(await verdict(dir)).toBe('OK');
+  });
+
+  test('4. status ok, lingering checklist key → EVALUATE', async () => {
+    expect(credKey).toBe('checklist:readstat');
+    const dir = build({
+      ...both,
+      doctorReport: { status: 'ok' },
+      alertState: { alerts: { [credKey]: { suppressed: true, consecutive_clean: 0, count: 6 } } },
+    });
+    expect(await verdict(dir)).toBe('EVALUATE');
+  });
+
+  test('5. report missing → EVALUATE', async () => {
+    const dir = build({ ...both, doctorReport: 'missing' });
+    expect(await verdict(dir)).toBe('EVALUATE');
+  });
+
+  test('6. report unparseable → EVALUATE', async () => {
+    const dir = build({ ...both, doctorReport: 'corrupt' });
+    expect(await verdict(dir)).toBe('EVALUATE');
+  });
+
+  test('7. report present but no credential-expiry entry in checks → EVALUATE', async () => {
+    const dir = build({
+      ...both,
+      doctorReport: { checks: [{ id: 'runtime', status: 'ok', detail: 'ok' }] },
+    });
+    expect(await verdict(dir)).toBe('EVALUATE');
+  });
+
+  test('8. --peek variant of case 1 → OK and alert-state.json unchanged', async () => {
+    const dir = build({ ...both, doctorReport: { status: 'ok' } });
+    const p = hermit(dir, 'state', 'alert-state.json');
+    const before = fs.readFileSync(p, 'utf8');
+    expect(await verdict(dir, true)).toBe('OK');
+    expect(fs.readFileSync(p, 'utf8')).toBe(before);
+  });
+});
+
 // Coherence guard: the whole optimization hinges on isProposalScanItem matching
 // the item shipped in HEARTBEAT.md.template. If a future template reword drops the
 // `proposed` keyword (or the `proposals/` reference), the classifier stops matching
@@ -269,5 +356,15 @@ describe('shipped HEARTBEAT.md.template ↔ classifier coherence', () => {
     const proposalItem = bullets.find(l => /proposals/i.test(l));
     expect(proposalItem).toBeDefined();
     expect(isProposalScanItem(proposalItem!)).toBe(true);
+  });
+
+  test('the shipped default credential-expiry item matches isCredentialExpiryItem', () => {
+    const tpl = fs.readFileSync(
+      path.join(PLUGIN_ROOT, 'state-templates', 'HEARTBEAT.md.template'), 'utf8',
+    );
+    const bullets = tpl.split('\n').map(l => l.trim()).filter(l => /^[-*+]\s/.test(l));
+    const credentialItem = bullets.find(l => /doctor-report/i.test(l));
+    expect(credentialItem).toBeDefined();
+    expect(isCredentialExpiryItem(credentialItem!)).toBe(true);
   });
 });

--- a/plugins/claude-code-hermit/tests/heartbeat-tick.test.ts
+++ b/plugins/claude-code-hermit/tests/heartbeat-tick.test.ts
@@ -102,7 +102,7 @@ describe('heartbeat tick', () => {
 
   test('JSON shape: verdict always present, reason only on SKIP, alert only on ALERT', async () => {
     const ok = await tick(fixture());
-    expect(ok).toEqual({ verdict: 'OK', notifications: [] });
+    expect(ok).toEqual({ verdict: 'OK', notifications: [], model: 'haiku' });
 
     const skip = await tick(fixture({ checklist: null }));
     expect(skip.verdict).toBe('SKIP');
@@ -222,6 +222,33 @@ describe('heartbeat tick', () => {
     const hermit = fixture();
     await tick(hermit);
     expect(monitoring(hermit)).toEqual([]);
+  });
+
+  test('model: a string heartbeat.model passes through', async () => {
+    const hermit = fixture({
+      config: { timezone: 'UTC', heartbeat: { every: '30m', active_hours: ALWAYS_ON, model: 'sonnet' } },
+    });
+    expect((await tick(hermit)).model).toBe('sonnet');
+  });
+
+  test('model: explicit null stays null', async () => {
+    const hermit = fixture({
+      config: { timezone: 'UTC', heartbeat: { every: '30m', active_hours: ALWAYS_ON, model: null } },
+    });
+    expect((await tick(hermit)).model).toBeNull();
+  });
+
+  test('model: absent key defaults to haiku', async () => {
+    expect((await tick(fixture())).model).toBe('haiku');
+  });
+
+  // "" is not "inherit the session model" — only an explicit null is. Settling folds
+  // it to the default, so the skill never dispatches the Agent tool with model: "".
+  test('model: empty string settles to haiku, not through', async () => {
+    const hermit = fixture({
+      config: { timezone: 'UTC', heartbeat: { every: '30m', active_hours: ALWAYS_ON, model: '' } },
+    });
+    expect((await tick(hermit)).model).toBe('haiku');
   });
 });
 


### PR DESCRIPTION
## Summary

The shipped default `HEARTBEAT.md` checklist could never reach `OK` on its own. Its `credential-expiry` bullet had no `alerts{}` entry, so the precheck fell through to the generic rule and emitted `EVALUATE` once per `clean_recheck_cooldown`. The model then woke, read `state/doctor-report.json`, found `status: ok`, and returned an empty finding list. On the fleet that is 2-5 wakes a day of pure token cost on a hermit with nothing wrong with it.

The precheck now reads that report itself. While the check is healthy the item resolves deterministically and the tick emits `OK`, which `heartbeat-monitor.sh` already drops silently. Zero model tokens.

Separately, `heartbeat.ts tick` now carries `model` in its JSON line so the heartbeat `run` step dispatches from it instead of doing its own `config.json` read, dropping one full-context API call from every waking tick.

Closes #917.

## Behavior delta

```
BEFORE: monitor poll ─> precheck: credential item has no alerts{} entry ─> EVALUATE
        ─> model wakes (tick, config read, Agent, alert-state ≈ 5 calls × context)
        ─> haiku reads doctor-report.json, finds status ok, returns firing: []
        ─> repeats once per clean_recheck_cooldown (≈2–5 wakes/day, default checklist)

AFTER:  monitor poll ─> precheck reads doctor-report.json itself
        ├─ credential-expiry ok, no lingering alert ─> OK, no emission, zero model tokens
        └─ warn/fail, report missing, or alert lingering ─> EVALUATE as today
           ─> model wakes: tick (carries model), Agent, alert-state ≈ 4 calls
```

## Changes

- `scripts/lib/heartbeat-items.ts` — `isCredentialExpiryItem()`, sibling to `isProposalScanItem()`. Prose-matched on both `doctor-report.json` and `credential-expiry`, with the same documented residual: `hermit-evolve` does not migrate operator-edited `HEARTBEAT.md`, so prose matching is retained deliberately.
- `scripts/lib/heartbeat/precheck.ts` — `resolveCredentialExpiryItem()`, consulted in the checklist loop before the generic rule. Read-only, identical under `--peek`, gate order above the loop untouched.
- `scripts/lib/heartbeat/tick.ts` — `model` on `TickResult`, from a single settled config read hoisted to the top of `run()` and shared with the bookkeeping that already needed it.
- `skills/heartbeat/SKILL.md` — step 4 takes `model` from the step 1 tick JSON; the `config.json` read is gone.
- Tests — an 8-case resolution matrix pinning fail-open on every degraded input, a template ↔ classifier coherence test, and four `model` cases.

**Fail-open is the design.** A missing report, an unparseable one, one with no `credential-expiry` entry, or any non-`ok` status all return `EVALUATE`, which is exactly what happens today. The change can only remove a wake that was already going to conclude "nothing wrong"; it can never suppress one that would have found something.

A lingering `alerts[checklist:readstat]` entry on an otherwise-`ok` check also defers to `EVALUATE`, because resolving that entry is `alert-state`-owned. It drains in two ticks (`alert-state.ts:262` deletes at `consecutive_clean >= 2`), so it is bounded, not a wake loop.

## Review note: one plan contract was amended

`/code-review high --fix` falsified the implementation plan's step 4. The plan mandated reading `heartbeat.model` with `readConfigRaw` "because `readSettledConfig` coerces `null` to `haiku`". It does not — `settleValue` (`scripts/lib/config-read.ts:168`) early-returns on `raw === null` for every non-container spec, precisely to preserve explicit-null semantics. The hand-rolled reader bought nothing and was strictly worse on one input: `"model": ""` passed through as `""`, which is not a member of the Agent tool's model enum, so the dispatch would error and that tick would produce no evaluation at all.

The settled read is now used and `""` folds to `"haiku"`. Observable behavior for a string, an explicit `null`, and an absent key is identical either way. Pinned by a regression test. The plan file was amended to record the corrected contract before this was committed.

## Test plan

Run inside `plugins/claude-code-hermit` (the CI spine, `.github/workflows/test-hooks.yml:72-73`):

```
cd plugins/claude-code-hermit && bun test --parallel --timeout=45000
```

Re-run against this commit: **5094 pass, 0 fail, exit 0**. `bunx tsc --noEmit` exit 0.

The plan's closing verification, re-run after the final commit:

| exit | command | result |
|---|---|---|
| 0 | `bun test --parallel --timeout=45000` | 5094 pass / 0 fail |
| 0 | `grep -c "export function isCredentialExpiryItem" scripts/lib/heartbeat-items.ts` | `1` |
| 1 | `grep -c 'Read \`heartbeat.model\` from' skills/heartbeat/SKILL.md` | `0` — the stated pass condition |
| 0 | `grep -c 'tick\` returns \`model' CHANGELOG.md` | `1` |

## Blast radius

- **Released surfaces touched:** the precheck's `OK` gate and the `heartbeat.ts tick` JSON contract, both shipped through v1.2.53. `TickResult` gains a field; no existing field changed shape, so a consumer reading only `verdict`/`notifications` is unaffected.
- **Unreleased surfaces touched:** `CHANGELOG.md` `[Unreleased]` only. No `plugin.json` version bump, no `marketplace.json` entry, no `required_core_version` change.
- **Downstream operators:** nothing reaches them from this merge. `/plugin update` fires only on a `version` change, so this sits on `main` until a release cuts it.
- **Downstream hermits, once released:** a hermit still on the shipped default `HEARTBEAT.md` stops waking for the credential item while its doctor check is healthy — that is the whole point, and it is the only behavior change they will notice. A hermit whose `HEARTBEAT.md` was operator-edited such that the bullet no longer names both `doctor-report.json` and `credential-expiry` falls through to the unchanged generic rule. A hermit whose `doctor` routine has never run has no `state/doctor-report.json` and fails open to `EVALUATE`, exactly as today. No state file is written or migrated, so a downgrade is clean.
- **Per-actor ledger:**
  - *grok* (`/delegate-plan`, headless in a worktree at the grounded SHA) — all six plan steps: the predicate, the resolver, the tick field, the SKILL.md rewrite, the tests, the changelog bullets.
  - *code-review high --fix* — found and fixed the `readConfigRaw` finding described above; added the `model: ""` regression test; corrected step 1's SKILL.md wording to say *settled*.
  - *operator* — approved replacing the plan's `readConfigRaw` mechanism with `readSettledConfig` and amending the plan file to match.
