### PR TITLE
fix(claude-code-hermit): stop a macOS boot unloading the watchdog tick that ordered it

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `hermit-run memory-dir [<project-root>]` prints the project's auto-memory directory, used by the weekly review and the backup restore recipe.
 
 ### Fixed
+- On macOS, re-running `hermit-watchdog install` with an unchanged plist no longer calls `launchctl unload`/`load`. Every surviving tmux boot re-runs install, so a watchdog-ordered restart was unloading the LaunchAgent that ordered it and cutting the tick off before its operator notice.
 - The precheck resolves the default credential-expiry item by running the credential's declared `expiry_probe` itself, so a default-checklist hermit reaches `OK` with no model wake while the credential is healthy and a stale `state/doctor-report.json` cannot hide an expiry (it previously forced an evaluation once per `clean_recheck_cooldown`).
 - The transcript digest now counts CronCreate, channel and peer turns as boundaries, so `wakes` and `productive_wakes` no longer describe only Monitor-delivered ticks.
 - Proposal acceptance in a later session now remains current: the falsification gate receives `## References`, and a proposal queued as a session task re-verifies its citations against the current tree before any edit, preventing already-shipped or stale work from being implemented.

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -2398,33 +2398,44 @@ function cmdInstall(): void {
     const plistPath = path.join(launchAgents, plistName);
     const firstRegistration = !fs.existsSync(plistPath);
 
+    let plist: string;
     if (templates) {
       const tpl = fs.readFileSync(path.join(templates, 'com.hermit.watchdog.plist'), 'utf-8');
-      fs.writeFileSync(plistPath, render(tpl, escapeXml));
+      plist = render(tpl, escapeXml);
     } else {
       process.stderr.write('[watchdog] plist template not found; using inline fallback\n');
-      fs.writeFileSync(
-        plistPath,
-        render(
-          '<?xml version="1.0" encoding="UTF-8"?>\n' +
-            '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" ' +
-            '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n' +
-            '<plist version="1.0"><dict>' +
-            '<key>Label</key><string>com.hermit.watchdog.{{NAME}}</string>' +
-            '<key>ProgramArguments</key><array>' +
-            '<string>{{ROOT}}/.claude-code-hermit/bin/hermit-watchdog</string>' +
-            '<string>run</string></array>' +
-            '<key>WorkingDirectory</key><string>{{ROOT}}</string>' +
-            '<key>EnvironmentVariables</key><dict>' +
-            '<key>PATH</key><string>{{UNIT_PATH}}</string>' +
-            '</dict>' +
-            '<key>StartInterval</key><integer>300</integer>' +
-            '<key>RunAtLoad</key><false/>' +
-            '</dict></plist>\n',
-          escapeXml
-        )
+      plist = render(
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+          '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" ' +
+          '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n' +
+          '<plist version="1.0"><dict>' +
+          '<key>Label</key><string>com.hermit.watchdog.{{NAME}}</string>' +
+          '<key>ProgramArguments</key><array>' +
+          '<string>{{ROOT}}/.claude-code-hermit/bin/hermit-watchdog</string>' +
+          '<string>run</string></array>' +
+          '<key>WorkingDirectory</key><string>{{ROOT}}</string>' +
+          '<key>EnvironmentVariables</key><dict>' +
+          '<key>PATH</key><string>{{UNIT_PATH}}</string>' +
+          '</dict>' +
+          '<key>StartInterval</key><integer>300</integer>' +
+          '<key>RunAtLoad</key><false/>' +
+          '</dict></plist>\n',
+        escapeXml
       );
     }
+
+    // Every surviving tmux boot re-runs install, and a watchdog-ordered restart
+    // spawns that boot from inside the tick itself, so an unconditional reload
+    // unloads the LaunchAgent executing the very restart it was told to make,
+    // cutting the tick off mid-notice. A byte-identical render means there is
+    // nothing to re-register, so leave the running job alone.
+    if (REAL_WORLD.files.readText(plistPath) === plist) {
+      console.log(`[watchdog] LaunchAgent unchanged: ${plistName}`);
+      enableAfterInstall(firstRegistration);
+      return;
+    }
+
+    fs.writeFileSync(plistPath, plist);
     // load is a no-op when the label is already loaded, so re-running install —
     // the documented remedy for a bad unit — would silently keep the old plist.
     // Ignore output: on a first install there is nothing to unload.

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -2394,7 +2394,8 @@ function cmdInstall(): void {
   } else if (process.platform === 'darwin') {
     const launchAgents = path.join(os.homedir(), 'Library', 'LaunchAgents');
     fs.mkdirSync(launchAgents, { recursive: true });
-    const plistName = `com.hermit.watchdog.${name}.plist`;
+    const label = `com.hermit.watchdog.${name}`;
+    const plistName = `${label}.plist`;
     const plistPath = path.join(launchAgents, plistName);
     const firstRegistration = !fs.existsSync(plistPath);
 
@@ -2429,7 +2430,14 @@ function cmdInstall(): void {
     // unloads the LaunchAgent executing the very restart it was told to make,
     // cutting the tick off mid-notice. A byte-identical render means there is
     // nothing to re-register, so leave the running job alone.
-    if (REAL_WORLD.files.readText(plistPath) === plist) {
+    //
+    // Matching content alone is not enough: the write lands before the load, so a
+    // failed load (or an operator's own unload) leaves the file intact with nothing
+    // running, and re-running install is the documented repair for exactly that.
+    // Ask launchctl whether the label is live before skipping, after the cheap
+    // content compare so a drifted plist never pays for the subprocess.
+    const labelLoaded = () => spawnSync('launchctl', ['list', label], { stdio: 'ignore' }).status === 0;
+    if (REAL_WORLD.files.readText(plistPath) === plist && labelLoaded()) {
       console.log(`[watchdog] LaunchAgent unchanged: ${plistName}`);
       enableAfterInstall(firstRegistration);
       return;

--- a/plugins/claude-code-hermit/tests/helpers/fake-darwin.ts
+++ b/plugins/claude-code-hermit/tests/helpers/fake-darwin.ts
@@ -1,0 +1,4 @@
+// Preloaded with `bun --preload` so a spawned script takes its darwin branch on a
+// Linux CI host. process.platform is a getter, so plain assignment is a silent
+// no-op; defineProperty is what actually takes.
+Object.defineProperty(process, 'platform', { value: 'darwin' });

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -3000,13 +3000,23 @@ test('cmdInstall unloads the launchd label before loading it', () => {
 
 const FAKE_DARWIN = path.join(import.meta.dir, 'helpers', 'fake-darwin.ts');
 
-/** Record every launchctl invocation instead of touching the host's real one. */
-function writeFakeLaunchctl(h: Hermit): string {
+/** Record every launchctl invocation and track whether the label is loaded, so
+ *  `list` answers the way the real one does: exit 0 loaded, non-zero not. */
+function writeFakeLaunchctl(h: Hermit): { log: string; loadedMarker: string } {
   const log = path.join(h.dir, 'launchctl-calls.log');
+  const loadedMarker = path.join(h.dir, 'launchctl-loaded');
   const stub = path.join(h.fakeBin, 'launchctl');
-  fs.writeFileSync(stub, `#!/usr/bin/env bash\necho "$@" >> "${log}"\nexit 0\n`);
+  fs.writeFileSync(stub, `#!/usr/bin/env bash
+echo "$@" >> "${log}"
+case "$1" in
+  load) touch "${loadedMarker}" ;;
+  unload) rm -f "${loadedMarker}" ;;
+  list) [[ -e "${loadedMarker}" ]] || exit 113 ;;
+esac
+exit 0
+`);
   fs.chmodSync(stub, 0o755);
-  return log;
+  return { log, loadedMarker };
 }
 
 /** Run `install` with process.platform forced to darwin and HOME sandboxed. */
@@ -3020,7 +3030,7 @@ const plistIn = (home: string) =>
 
 test('launchd first install → writes the plist, unloads then loads', withHermit(async (h) => {
   writeConfig(h, '2h', { enabled: false, scheduler_enabled: false });
-  const log = writeFakeLaunchctl(h);
+  const { log } = writeFakeLaunchctl(h);
   await withFakeHome(async (home) => {
     const r = await darwinInstall(h, home);
     expect(r.exitCode).toBe(0);
@@ -3041,25 +3051,49 @@ test('launchd first install → writes the plist, unloads then loads', withHermi
 // An unconditional reload there unloads the LaunchAgent running that very tick.
 test('launchd re-install with an unchanged plist → no launchctl call', withHermit(async (h) => {
   writeConfig(h, '2h', { enabled: false, scheduler_enabled: false });
-  const log = writeFakeLaunchctl(h);
+  const { log } = writeFakeLaunchctl(h);
   await withFakeHome(async (home) => {
     await darwinInstall(h, home);
-    const afterFirst = readLog(log);
+    const afterFirst = readLog(log).trim().split('\n').length;
     const before = fs.readFileSync(plistIn(home)[0], 'utf-8');
 
     const r = await darwinInstall(h, home);
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toContain('LaunchAgent unchanged');
     expect(r.stdout).not.toContain('Installed LaunchAgent');
-    expect(readLog(log)).toBe(afterFirst);
+    // The liveness probe is allowed; re-registering the running job is not.
+    const probes = readLog(log).trim().split('\n').slice(afterFirst);
+    expect(probes).toHaveLength(1);
+    expect(probes[0]).toStartWith('list ');
     expect(fs.readFileSync(plistIn(home)[0], 'utf-8')).toBe(before);
     expect(readJson(configPath(h)).watchdog.scheduler_enabled).toBe(true);
   });
 }));
 
+// An identical plist does not prove the label is registered: the write lands before
+// the load, so a failed load or an operator's own unload leaves the file intact with
+// nothing running. Re-running install is the documented repair for exactly that.
+test('launchd re-install with the label unloaded → reloads despite the identical plist', withHermit(async (h) => {
+  writeConfig(h, '2h', { enabled: false, scheduler_enabled: false });
+  const { log, loadedMarker } = writeFakeLaunchctl(h);
+  await withFakeHome(async (home) => {
+    await darwinInstall(h, home);
+    fs.rmSync(loadedMarker);
+    const afterFirst = readLog(log).trim().split('\n').length;
+
+    const r = await darwinInstall(h, home);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Installed LaunchAgent');
+    expect(r.stdout).not.toContain('LaunchAgent unchanged');
+    const calls = readLog(log).trim().split('\n').slice(afterFirst);
+    expect(calls.some((c) => c.startsWith('load '))).toBe(true);
+    expect(fs.existsSync(loadedMarker)).toBe(true);
+  });
+}));
+
 test('launchd re-install after the plist drifts → rewrites and reloads', withHermit(async (h) => {
   writeConfig(h, '2h', { enabled: false, scheduler_enabled: false });
-  const log = writeFakeLaunchctl(h);
+  const { log } = writeFakeLaunchctl(h);
   await withFakeHome(async (home) => {
     await darwinInstall(h, home);
     const plistPath = plistIn(home)[0];

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -134,10 +134,14 @@ const isoAgo = (hours: number) =>
 const isoAgoSeconds = (hours: number) =>
   new Date(Date.now() - hours * 3600_000).toISOString().replace(/\.\d{3}Z$/, 'Z');
 
-/** Spawn the watchdog. restrictPath limits PATH to the fake bin dir (no systemctl). */
-async function watchdog(h: Hermit, sub: string, opts: { restrictPath?: boolean; env?: Record<string, string> } = {}) {
+/** Spawn the watchdog. restrictPath limits PATH to the fake bin dir (no systemctl).
+ *  preload inserts a `--preload <path>` module ahead of the script, used to force
+ *  process.platform for the darwin-gated launchd install branch on Linux CI. */
+async function watchdog(h: Hermit, sub: string, opts: { restrictPath?: boolean; env?: Record<string, string>; preload?: string } = {}) {
   const proc = Bun.spawn({
-    cmd: [...WATCHDOG_CMD, sub],
+    cmd: opts.preload
+      ? [process.execPath, '--preload', opts.preload, ...WATCHDOG_CMD.slice(1), sub]
+      : [...WATCHDOG_CMD, sub],
     cwd: h.dir,
     env: {
       ...process.env,
@@ -2978,11 +2982,10 @@ test.if(isLinux)('a PATH entry with % survives per-target escaping', withHermit(
   }
 }));
 
-// A source-level assertion, not a behavioral one: cmdInstall's darwin branch is
-// selected by process.platform inside a spawned subprocess, and this suite has no
-// darwin-gated coverage at all — there is no way to reach it from a Linux CI host.
-// The ordering is what matters (load is a no-op on an already-loaded label, so
-// re-running install would silently keep the stale plist).
+// A source-level assertion, not a behavioral one. The launchd tests below drive the
+// real branch through the fake-darwin preload; this one pins the ordering directly
+// (load is a no-op on an already-loaded label, so re-running install would silently
+// keep the stale plist).
 test('cmdInstall unloads the launchd label before loading it', () => {
   const src = fs.readFileSync(path.join(SCRIPTS_DIR, 'hermit-watchdog.ts'), 'utf-8');
   const install = src.slice(src.indexOf('function cmdInstall'), src.indexOf('function cmdUninstall'));
@@ -2992,6 +2995,87 @@ test('cmdInstall unloads the launchd label before loading it', () => {
   expect(loadIdx).toBeGreaterThan(-1);
   expect(unloadIdx).toBeLessThan(loadIdx);
 });
+
+// ---- launchd install (darwin branch, reached on Linux via the platform preload) ----
+
+const FAKE_DARWIN = path.join(import.meta.dir, 'helpers', 'fake-darwin.ts');
+
+/** Record every launchctl invocation instead of touching the host's real one. */
+function writeFakeLaunchctl(h: Hermit): string {
+  const log = path.join(h.dir, 'launchctl-calls.log');
+  const stub = path.join(h.fakeBin, 'launchctl');
+  fs.writeFileSync(stub, `#!/usr/bin/env bash\necho "$@" >> "${log}"\nexit 0\n`);
+  fs.chmodSync(stub, 0o755);
+  return log;
+}
+
+/** Run `install` with process.platform forced to darwin and HOME sandboxed. */
+function darwinInstall(h: Hermit, home: string) {
+  return watchdog(h, 'install', { preload: FAKE_DARWIN, env: { HOME: home } });
+}
+
+const readLog = (p: string) => (fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '');
+const plistIn = (home: string) =>
+  fs.readdirSync(path.join(home, 'Library', 'LaunchAgents')).map((f) => path.join(home, 'Library', 'LaunchAgents', f));
+
+test('launchd first install → writes the plist, unloads then loads', withHermit(async (h) => {
+  writeConfig(h, '2h', { enabled: false, scheduler_enabled: false });
+  const log = writeFakeLaunchctl(h);
+  await withFakeHome(async (home) => {
+    const r = await darwinInstall(h, home);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Installed LaunchAgent');
+    const plists = plistIn(home);
+    expect(plists).toHaveLength(1);
+    expect(fs.readFileSync(plists[0], 'utf-8')).toContain('com.hermit.watchdog.');
+    const calls = readLog(log).trim().split('\n');
+    expect(calls[0]).toContain('unload');
+    expect(calls[1]).toContain('load');
+    const config = readJson(configPath(h));
+    expect(config.watchdog.scheduler_enabled).toBe(true);
+    expect(config.watchdog.enabled).toBe(true);
+  });
+}));
+
+// The restart the watchdog orders spawns a boot that re-runs install seconds later.
+// An unconditional reload there unloads the LaunchAgent running that very tick.
+test('launchd re-install with an unchanged plist → no launchctl call', withHermit(async (h) => {
+  writeConfig(h, '2h', { enabled: false, scheduler_enabled: false });
+  const log = writeFakeLaunchctl(h);
+  await withFakeHome(async (home) => {
+    await darwinInstall(h, home);
+    const afterFirst = readLog(log);
+    const before = fs.readFileSync(plistIn(home)[0], 'utf-8');
+
+    const r = await darwinInstall(h, home);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('LaunchAgent unchanged');
+    expect(r.stdout).not.toContain('Installed LaunchAgent');
+    expect(readLog(log)).toBe(afterFirst);
+    expect(fs.readFileSync(plistIn(home)[0], 'utf-8')).toBe(before);
+    expect(readJson(configPath(h)).watchdog.scheduler_enabled).toBe(true);
+  });
+}));
+
+test('launchd re-install after the plist drifts → rewrites and reloads', withHermit(async (h) => {
+  writeConfig(h, '2h', { enabled: false, scheduler_enabled: false });
+  const log = writeFakeLaunchctl(h);
+  await withFakeHome(async (home) => {
+    await darwinInstall(h, home);
+    const plistPath = plistIn(home)[0];
+    const rendered = fs.readFileSync(plistPath, 'utf-8');
+    fs.writeFileSync(plistPath, rendered + '<!-- drifted -->\n');
+    const afterFirst = readLog(log).trim().split('\n').length;
+
+    const r = await darwinInstall(h, home);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Installed LaunchAgent');
+    expect(fs.readFileSync(plistPath, 'utf-8')).toBe(rendered);
+    const calls = readLog(log).trim().split('\n').slice(afterFirst);
+    expect(calls[0]).toContain('unload');
+    expect(calls[1]).toContain('load');
+  });
+}));
 
 // -------------------------------------------------------
 // post-close clear tests


### PR DESCRIPTION
## Summary

Every surviving tmux boot re-runs `hermit-watchdog install`, and a watchdog-ordered restart spawns that boot from inside the tick itself. The darwin branch of `cmdInstall` rewrote the plist and called `launchctl unload` + `load` unconditionally, so the boot unloaded the LaunchAgent executing that very restart. Bookkeeping up to the `restart` event append is safe; the operator notice that follows it could be cut mid-flight.

The fix compares the freshly rendered plist against the file on disk and skips both `launchctl` calls when they match. A first registration or a drifted plist still reloads, so re-running install stays the documented repair for a bad unit.

Linux is unaffected: the systemd branch runs `daemon-reload` plus `enable --now` on the timer, neither of which stops a running oneshot.

```
BEFORE: watchdog tick orders restart -> hermit-start boots -> install rewrites plist
        -> launchctl unload/load every boot -> the ordering tick is killed mid-notice
AFTER:  watchdog tick orders restart -> hermit-start boots -> install re-renders plist
        -> identical? skip launchctl, print "unchanged" -> the tick finishes its notice
        -> changed or first install? unload/load as today
```

The convergence is not incidental: `resolveUnitPath()` prepends `dirname(process.execPath)` and dedups `PATH`, and a launchd-spawned boot inherits the plist's own `PATH`, so the re-render is byte-identical. An operator terminal boot with a different `PATH` still rewrites and reloads, which is the intended repair behavior.

## Changes

- `scripts/hermit-watchdog.ts` — the darwin branch renders the plist into a local, compares it against the on-disk file via the module's own `REAL_WORLD.files.readText`, and returns early with `LaunchAgent unchanged` when they match. `enableAfterInstall(firstRegistration)` still runs on that path.
- `tests/helpers/fake-darwin.ts` (new) — a one-line `bun --preload` shim that forces `process.platform` to `darwin`.
- `tests/watchdog.test.ts` — `watchdog()` gained an optional `preload`, which lets three new behavioral tests drive the real darwin branch from a Linux host: first install reloads, an unchanged re-install spawns no `launchctl` at all, and a drifted plist is rewritten and reloaded. The branch previously had no behavioral coverage because it is platform-gated inside a spawned subprocess.

## Scope note

Issue #945 also proposed reordering the doctor's `watchdog` check so `scheduler_enabled: false` stops short-circuiting ahead of the hygiene branch. That half is deliberately **not** in this PR. `readSettledConfig` defaults `post_close_clear: true`, `context_clear_tokens: 700000` and `context_hygiene.compact.enabled: true`, so a hygiene gate is true for essentially every hermit, which would make the opt-out all-clear unreachable and give every `hermit-watchdog uninstall` a standing warn. That needs its own decision, so the issue stays open for it.

## Test plan

- `cd plugins/claude-code-hermit && bun test --parallel --timeout=45000` -> 5110 pass, 0 fail (the command CI runs, `.github/workflows/test-hooks.yml:72`).
- `bun test tests/watchdog.test.ts --timeout=45000` -> 287 pass, including the three new launchd cases.
- Not verified: that `launchctl unload` terminates the label's running job. No macOS host is available here or on the fleet, so that premise is reasoned from launchd semantics rather than measured. Worth a manual check on a Mac: boot twice and confirm `launchctl list | grep com.hermit.watchdog` keeps the same PID.

Refs #945