### PR TITLE
chore: add GitHub issue forms and a contributing entry point

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: 🐛 Bug Report
-description: Report a bug in a claude-code-hermit plugin
+description: Report a Bug
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: 🐛 Bug Report
+description: Report a bug in a claude-code-hermit plugin
+labels:
+  - bug
+body:
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: Paste the output of `claude --version` and `claude plugin list`
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What Happened?
+      description: Describe what went wrong
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What Should Happen?
+      description: Describe the expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Numbered steps someone else can follow
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Messages/Logs
+      description: Any relevant error output, stack traces, or logs (optional)
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discord Community
+    url: https://discord.gg/54sJqAxhUh
+    about: Install help, always-on ops, plugin authoring, and design discussion
+  - name: 📖 Documentation
+    url: https://github.com/gtapps/claude-code-hermit#documentation
+    about: Setup guides, always-on operations, security, and cost

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's wrong or missing? What are you trying to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who else does this affect? Effort vs. benefit (optional)
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing to claude-code-hermit
 
+## Filing an Issue
+
+Bugs and ideas go through the [issue forms](https://github.com/gtapps/claude-code-hermit/issues/new/choose). Questions and install help are faster in [Discord](https://discord.gg/54sJqAxhUh).
+
+The rest of this guide is for code changes.
+
 ## Design Constraints
 
 These are non-negotiable. Read them before making any changes.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Many operators run several hermits in parallel — one per domain. Each one is a
 
 ## Community
 
-Join the [`claude-code-hermit` Discord community](https://discord.gg/54sJqAxhUh) for install help, always-on ops, plugin authoring, bug triage, and proposal/design discussion. Confirmed bugs and roadmap decisions should still move back to GitHub so they remain searchable and reviewable.
+Join the [`claude-code-hermit` Discord community](https://discord.gg/54sJqAxhUh) for install help, always-on ops, plugin authoring, bug triage, and proposal/design discussion. Confirmed bugs and roadmap decisions should still move back to GitHub so they remain searchable and reviewable. See [CONTRIBUTING.md](CONTRIBUTING.md) for filing an issue or opening a PR.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds a GitHub issue-filing front door for outside contributors. The repo had none: `.github/` was workflows-only, and `CONTRIBUTING.md` (code-contribution focused) was unreachable from the README.

## Changes
- `.github/ISSUE_TEMPLATE/bug_report.yml` — labels `[bug]`; required fields for versions (`claude --version` + `claude plugin list`), what happened, expected behavior, and reproduction steps; optional logs.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — labels `[enhancement]`; Problem / Proposed Solution / Impact, mirroring the shape `proposal-create` already emits and `hermit-scribe` already files.
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues disabled; contact links to Discord and the README docs section.
- `CONTRIBUTING.md` — new "Filing an Issue" section pointing bugs/ideas at the forms and questions at Discord.
- `README.md` — Community section now links `CONTRIBUTING.md`.

No PR template: `anthropics/claude-code` ships none either, and `dev-hermit`'s `/dev-pr` appends any found project template verbatim below its own assembled body, so an empty skeleton there would duplicate every generated PR.

No CHANGELOG entry — root-scope/docs-only per repo convention.

## Test plan
- All three new YAML files parsed clean with Ruby's `YAML.load_file` (no pyyaml available locally).
- Not yet verified in the GitHub UI — after merge, open `.../issues/new/choose` and confirm both forms + contact links render, and that required-field validation blocks empty submission.