### PR TITLE
fix(claude-code-hermit): match the switch dialog under chrome, make wedge notices honest

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Fixed
 - The seeded deny on plugin source matched nothing. `Edit(*/.claude/plugins/marketplaces/*)` anchors at the settings file's own directory, so the guard has been inert since it was migrated into `state-templates/deny-patterns.json`. Replaced with `Edit(//**/.claude/plugins/**)`, which covers both install trees for every plugin. The dead spelling, and the `Write` twin older installs still carry beside it, are retired via `HERMIT_OBSOLETE_DENY`.
 - `docs/security.md` said auto mode suspends path rules. It drops execution rules only, and `Read` never reaches the classifier.
+- Cached-context `/model` and `/effort` confirmation matches with chrome below the dialog, so a channel-delivered switch is no longer left unanswered.
+- Wedge notices say the heartbeat is being woken first, that the agent isn't responding only after a failed wake, and send an all-clear on recovery.
+- Stall notices quote the pane's last 8 non-blank rows.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/scripts/confirm-harness-switch.ts
+++ b/plugins/claude-code-hermit/scripts/confirm-harness-switch.ts
@@ -2,7 +2,7 @@
 // Claude processes that command only after the hook returns, so confirmation cannot be
 // observed synchronously inside stop-pipeline.ts.
 
-import { isHarnessSwitchConfirmation } from './lib/harness-command';
+import { HARNESS_CONFIRM_TIMEOUT_MS, isHarnessSwitchConfirmation } from './lib/harness-command';
 import { capturePane, sendEnter, tmuxSessionAlive } from './lib/tmux';
 
 const [sessionName, command] = process.argv.slice(2);
@@ -12,8 +12,8 @@ if (!sessionName || (command !== '/model' && command !== '/effort')) {
 
 const configuredTimeout = Number(process.env.HERMIT_HARNESS_CONFIRM_TIMEOUT_MS);
 const timeoutMs = Number.isFinite(configuredTimeout) && configuredTimeout >= 250
-  ? Math.min(configuredTimeout, 5_000)
-  : 5_000;
+  ? Math.min(configuredTimeout, HARNESS_CONFIRM_TIMEOUT_MS)
+  : HARNESS_CONFIRM_TIMEOUT_MS;
 const deadline = Date.now() + timeoutMs;
 
 while (Date.now() < deadline) {
@@ -28,4 +28,5 @@ while (Date.now() < deadline) {
   }
 }
 
+// A zero-turn session or a switch back to the cached model applies inline with no dialog, so none within the ceiling is a normal outcome.
 process.exit(0);

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -222,14 +222,22 @@ export function composeRestartMessage(reason: string, timezone: string, locale: 
   return WATCHDOG[locale].restart(hhmm, cause);
 }
 
-/** Operator-language message for the first tick of a wedge episode. */
-export function composeWedgeMessage(timezone: string, locale: Locale = OPERATOR_LOCALE): string {
-  return WATCHDOG[locale].wedge(nowHHMM(timezone));
+/** Operator-language message for a wedge episode: waking on the first notice, unresponsive after a failed wake. */
+export function composeWedgeMessage(timezone: string, locale: Locale = OPERATOR_LOCALE, escalated = false): string {
+  const hhmm = nowHHMM(timezone);
+  return escalated ? WATCHDOG[locale].wedge(hhmm) : WATCHDOG[locale].wedgeWaking(hhmm);
+}
+
+/** Operator-language all-clear after a wedge episode that reached the notice stage. */
+export function composeWedgeRecoveredMessage(timezone: string, locale: Locale = OPERATOR_LOCALE): string {
+  return WATCHDOG[locale].wedgeRecovered(nowHHMM(timezone));
 }
 
 /** Operator-language message for an un-redirectable stalled question (PROP-024's fail-loud half). */
-export function composeStallQuestionMessage(timezone: string, locale: Locale = OPERATOR_LOCALE): string {
-  return WATCHDOG[locale].stallQuestion(nowHHMM(timezone));
+export function composeStallQuestionMessage(timezone: string, locale: Locale = OPERATOR_LOCALE, paneTail?: string): string {
+  const sentence = WATCHDOG[locale].stallQuestion(nowHHMM(timezone));
+  if (!paneTail) return sentence;
+  return `${sentence}\n\n${paneTail}`;
 }
 
 /** Operator-language message for a session that stopped consuming its queued notifications. */
@@ -369,9 +377,10 @@ function getPaneHash(sessionName: string, world: World = REAL_WORLD): string | n
 //
 // The option label is deliberately NOT constrained to a number: the wizard's selector
 // reads "❯ Continue", and requiring `\d+\.` is exactly why the live wedge went
-// undetected. The pointer glyph also starts the composer prompt ("❯ Try ..."), but a
-// modal replaces the composer rather than rendering above it, so the footer anchor
-// below keeps the composer out of every match.
+// undetected. The pointer glyph also starts the composer prompt ("❯ Try ..."). A
+// modal replaces the composer on a clean pane, but a queued channel message keeps
+// the composer rendered below it (probed CC 2.1.260), so the footer anchor misses
+// that case; the registry leg covers it.
 const PENDING_OPTION_RE = /❯\s+\S/;
 // A dialog footer must terminate the visible pane. All three spellings are
 // load-bearing: AskUserQuestion and permission prompts end "· Esc to cancel", a
@@ -1143,18 +1152,29 @@ async function doNudge(sessionName: string, watchdogState: Json, consecutive: nu
     watchdogState.last_nudge_transport = 'typed';
     sendKeys(sessionName, '/claude-code-hermit:heartbeat run');
   }
-  // One push per wedge episode. Keying on `consecutive === 1` alone re-fires when
-  // the operator-recency guard resets consecutive_stale to 0 mid-episode (an
-  // operator poke isn't a heartbeat recovery); a sticky flag, cleared only when the
-  // heartbeat actually recovers (the fresh-heartbeat branch in main), fixes that.
-  const shouldNotify = !watchdogState.wedge_notified;
-  if (shouldNotify) watchdogState.wedge_notified = true;
+  // First notice of an episode is the waking wording. The stronger "isn't
+  // responding" string fires at most once, and only after the wake has failed
+  // (socket undelivered, or a second stale cycle). Keying on `consecutive === 1`
+  // alone re-fires when the operator-recency guard resets consecutive_stale to 0
+  // mid-episode (an operator poke isn't a heartbeat recovery); sticky flags,
+  // cleared only when the heartbeat actually recovers (the fresh-heartbeat
+  // branch in main), fix that.
+  const wakeFailed = socketUndelivered || consecutive >= 2;
+  let notify: 'waking' | 'escalated' | null = null;
+  if (!watchdogState.wedge_notified) {
+    watchdogState.wedge_notified = true;
+    notify = 'waking';
+  } else if (wakeFailed && !watchdogState.wedge_escalated) {
+    watchdogState.wedge_escalated = true;
+    notify = 'escalated';
+  }
   watchdogState.last_nudge_at = utcStamp();
   writeWatchdogState(watchdogState);
   const via = watchdogState.last_nudge_transport === 'socket' ? 'nudge-socket' : 'nudge';
   appendEvent(via, socketUndelivered ? `stale cycle ${consecutive} — socket undelivered` : `stale cycle ${consecutive}`);
   process.stderr.write(`[watchdog] nudged "${sessionName}" via ${watchdogState.last_nudge_transport} (stale cycle ${consecutive})\n`);
-  if (shouldNotify) pushOperatorMessage(composeWedgeMessage(timezone));
+  if (notify === 'waking') pushOperatorMessage(composeWedgeMessage(timezone));
+  else if (notify === 'escalated') pushOperatorMessage(composeWedgeMessage(timezone, OPERATOR_LOCALE, true));
 }
 
 // --- Monitor-liveness re-arm (step 5) ---
@@ -2139,7 +2159,8 @@ async function main(): Promise<void> {
     const watchdogState = readWatchdogState();
     if (pendingQuestion) {
       if (!watchdogState.stall_question_notified) {
-        pushOperatorMessage(composeStallQuestionMessage(timezone));
+        const paneTail = paneContent !== null ? nonBlankTail(paneContent, 8) : undefined;
+        pushOperatorMessage(composeStallQuestionMessage(timezone, OPERATOR_LOCALE, paneTail));
         appendEvent('stall-question-detected', registryWaiting ? 'pending dialog, session alive — via registry' : 'pending dialog on pane, session alive');
         watchdogState.stall_question_notified = true;
         writeWatchdogState(watchdogState);
@@ -2299,14 +2320,23 @@ async function main(): Promise<void> {
           // genuinely new wedge later can notify again. Clearing last_nudge_at re-arms
           // the nudge throttle for the same reason: a new episode's first probe should
           // fire immediately, not wait out the previous episode's window.
+          const recovered = watchdogState.wedge_notified === true;
           watchdogState.consecutive_stale = 0;
           watchdogState.wedge_notified = false;
+          watchdogState.wedge_escalated = false;
           watchdogState.last_nudge_at = null;
           // Same re-arm, for the transport alternation: the next episode's first
           // probe should try the socket again, not inherit this one's fallback.
           watchdogState.last_nudge_transport = null;
           watchdogState.last_pane_hash = currentPaneHash;
           writeWatchdogState(watchdogState);
+          // Flag cleared before the send, as doNudge does: pushOperatorMessage blocks
+          // for up to 12s, and a tick killed inside that window would otherwise leave
+          // wedge_notified set and repeat the all-clear on the next tick.
+          if (recovered) {
+            pushOperatorMessage(composeWedgeRecoveredMessage(timezone));
+            appendEvent('wedge-recovered', 'heartbeat fresh');
+          }
         }
       }
     }

--- a/plugins/claude-code-hermit/scripts/lib/harness-command.ts
+++ b/plugins/claude-code-hermit/scripts/lib/harness-command.ts
@@ -8,7 +8,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { anchoredPaneTail } from './tmux';
 import { PERMISSION_MODE } from './settings/enums';
 
 type PermissionMode = (typeof PERMISSION_MODE)[number];
@@ -152,7 +151,7 @@ export const COMMAND_MARKER_TTL_SECS = 3600;
  */
 export const SWITCH_VERIFY_TTL_SECS = 86_400;
 export const SKILL_RELAY_TTL_SECS = 600;
-const HARNESS_CONFIRM_TAIL_LINES = 20;
+export const HARNESS_CONFIRM_TIMEOUT_MS = 5_000;
 
 // /advisor has NO entry here on purpose. Upstream: "Enabling or disabling the advisor
 // mid-session does not invalidate your main model's prompt cache" — and live-probed
@@ -177,19 +176,22 @@ const SWITCH_CONFIRMATION_ANCHORS: Record<string, readonly string[]> = {
  * Whitespace is collapsed because the warning wraps according to pane width. The
  * target label is deliberately not matched: a stable model alias such as `opus`
  * renders as a release display name such as "Opus 5", and effort levels may expand.
+ *
+ * Geometry is unnecessary: `capturePane` returns only visible rows, and an
+ * answered dialog is erased from the pane within 1.5s (CC 2.1.260, both
+ * renderers). Chrome under the modal (queued channel banner, composer,
+ * statusLine, mode row, IDE row) therefore cannot be a stale leftover.
  */
 export function isHarnessSwitchConfirmation(command: string, paneContent: string): boolean {
   const commandAnchors = SWITCH_CONFIRMATION_ANCHORS[command];
   if (!commandAnchors) return false;
 
-  const activeTail = anchoredPaneTail(paneContent, HARNESS_CONFIRM_TAIL_LINES, 'No, go back');
-  if (activeTail === null) return false;
-  const tail = activeTail.replace(/\s+/g, ' ');
+  const collapsed = paneContent.replace(/\s+/g, ' ');
 
-  return commandAnchors.every((anchor) => tail.includes(anchor))
-    && tail.includes('Your next response will be slower and use more tokens')
-    && tail.includes('Yes, switch to')
-    && tail.includes('No, go back');
+  return commandAnchors.every((anchor) => collapsed.includes(anchor))
+    && collapsed.includes('Your next response will be slower and use more tokens')
+    && collapsed.includes('Yes, switch to')
+    && collapsed.includes('No, go back');
 }
 
 function markerPath(hermitRoot: string): string {

--- a/plugins/claude-code-hermit/scripts/lib/messages.ts
+++ b/plugins/claude-code-hermit/scripts/lib/messages.ts
@@ -252,7 +252,9 @@ export interface WatchdogMessages {
   restart(hhmm: string, cause: string): string;
   restartCauseNotRunning(): string;
   restartCauseFrozen(): string;
+  wedgeWaking(hhmm: string): string;
   wedge(hhmm: string): string;
+  wedgeRecovered(hhmm: string): string;
   pauseUntilResume(label: string): string;
   pauseUntilDate(label: string, boundary: string): string;
   stallQuestion(hhmm: string): string;
@@ -272,7 +274,9 @@ export const WATCHDOG: Localized<WatchdogMessages> = {
     restart: (hhmm, cause) => `I restarted your agent at ${hhmm} — ${cause}.`,
     restartCauseNotRunning: () => "it wasn't running",
     restartCauseFrozen: () => 'it had frozen',
+    wedgeWaking: (hhmm) => `Your agent's heartbeat hasn't checked in, waking it (${hhmm}).`,
     wedge: (hhmm) => `Your agent hasn't responded in a while — checking on it now (${hhmm}).`,
+    wedgeRecovered: (hhmm) => `Your agent is responding again, nothing to do (${hhmm}).`,
     pauseUntilResume: (label) => `Your agent is paused (${label}) until you resume it.`,
     pauseUntilDate: (label, boundary) => `Your agent is paused (${label}) until ${boundary}.`,
     stallQuestion: (hhmm) =>
@@ -300,7 +304,9 @@ export const WATCHDOG: Localized<WatchdogMessages> = {
     restart: (hhmm, cause) => `Reiniciei o seu agente às ${hhmm} — ${cause}.`,
     restartCauseNotRunning: () => 'não estava a correr',
     restartCauseFrozen: () => 'tinha bloqueado',
+    wedgeWaking: (hhmm) => `O heartbeat do seu agente não fez check-in, estou a acordá-lo (${hhmm}).`,
     wedge: (hhmm) => `O seu agente não responde há algum tempo — estou a verificá-lo agora (${hhmm}).`,
+    wedgeRecovered: (hhmm) => `O seu agente já está a responder, não precisa de fazer nada (${hhmm}).`,
     pauseUntilResume: (label) => `O seu agente está em pausa (${label}) até que a retome.`,
     pauseUntilDate: (label, boundary) => `O seu agente está em pausa (${label}) até ${boundary}.`,
     stallQuestion: (hhmm) =>

--- a/plugins/claude-code-hermit/scripts/lib/prompt-stages/harness-verify.ts
+++ b/plugins/claude-code-hermit/scripts/lib/prompt-stages/harness-verify.ts
@@ -18,7 +18,7 @@
 // the delivery exists, the marker is held and the session is told only that its
 // self-perception may be stale.
 
-import { readSwitchVerify, clearSwitchVerify, renderCommand } from '../harness-command';
+import { readSwitchVerify, clearSwitchVerify, renderCommand, HARNESS_CONFIRM_TIMEOUT_MS } from '../harness-command';
 import { lastAssistantModel } from '../cc-compat';
 import { capturePane, paneModeLine } from '../tmux';
 import type { StageContext, StageResult } from './types';
@@ -30,14 +30,8 @@ import type { StageContext, StageResult } from './types';
  * model, so treating "newer than delivered_at" as "post-switch" would report the old
  * model as authoritative and burn the marker. Holding for the helper's full deadline
  * closes that window at the cost of one extra held prompt at worst.
- *
- * NOTE: this hardcodes the same 5s ceiling confirm-harness-switch.ts caps its own
- * poll at (scripts/confirm-harness-switch.ts:15-16). The two are not wired together —
- * if that cap changes, this grace window silently stops covering it and the stale-
- * answer bug this file exists to fix comes back. Consider exporting the ceiling from
- * lib/harness-command.ts and importing it in both places instead of copying the literal.
  */
-const SWITCH_APPLY_GRACE_MS = 5_000;
+const SWITCH_APPLY_GRACE_MS = HARNESS_CONFIRM_TIMEOUT_MS;
 
 const SESSION_SCOPED = 'This lasts for the current session only — a restart, including one the watchdog performs, puts the session back on the configured permission mode.';
 

--- a/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
+++ b/plugins/claude-code-hermit/tests/harness-command-delivery.test.ts
@@ -22,6 +22,19 @@ re-read on your next message.
   2. No, go back
 `;
 
+// Built from the row inventory in memory cc-switch-modal-pane-geometry: the
+// verbatim 2026-09-04 capture was unavailable. Modal, then queued-channel
+// banner, three composer rows, statusLine, auto-mode row, IDE row.
+const MODEL_SWITCH_PANE_WITH_CHROME = `${MODEL_SWITCH_PANE}
+← discord · alice: follow-up after the switch
+────────────────────────────────────────
+❯
+────────────────────────────────────────
+● sonnet · 42%
+  ⏵⏵ auto mode on (shift+tab to cycle)
+  ⧉  claude-code-hermit
+`;
+
 const EFFORT_SWITCH_PANE = `
 Change effort level?
 Your next response will be slower and use more tokens
@@ -255,13 +268,6 @@ describe('harness-switch confirmation matcher', () => {
     }
   });
 
-  test('rejects stale cached-context prompts above newer pane content and blank rows', () => {
-    const progress = Array.from({ length: 6 }, (_, i) => `running step ${i}...`).join('\n');
-    for (const { command, pane } of SWITCH_CASES) {
-      expect(isHarnessSwitchConfirmation(command, `${pane}\n${progress}${'\n'.repeat(20)}`)).toBe(false);
-    }
-  });
-
   test('rejects unrelated or incomplete dialogs', () => {
     expect(isHarnessSwitchConfirmation('/model', `
 Permission required
@@ -281,14 +287,49 @@ Switch model?
     expect(isHarnessSwitchConfirmation('/clear', MODEL_SWITCH_PANE)).toBe(false);
   });
 
-  test('looks only at the pane tail', () => {
-    for (const { command, pane } of SWITCH_CASES) {
-      expect(isHarnessSwitchConfirmation(command, `${pane}\n${'\n'.repeat(20)}ready`)).toBe(false);
-    }
+  test('accepts a model switch with chrome below the dialog', () => {
+    expect(isHarnessSwitchConfirmation('/model', MODEL_SWITCH_PANE_WITH_CHROME)).toBe(true);
+    expect(isHarnessSwitchConfirmation('/effort', MODEL_SWITCH_PANE_WITH_CHROME)).toBe(false);
+  });
+
+  // The matcher has no geometry condition, so anything visible carrying all five
+  // anchors matches. These two pin where that line actually falls: prose or source
+  // quoting the dialog's headings is rejected because the option rows are missing,
+  // while a verbatim echo of a whole dialog is accepted. The second is a known,
+  // accepted cost of dropping the tail window, not an oversight. Narrow the
+  // anchors rather than restoring geometry if it ever needs closing.
+  test('rejects source or prose quoting only the dialog headings', () => {
+    expect(isHarnessSwitchConfirmation('/model', `
+const SWITCH_CONFIRMATION_ANCHORS: Record<string, readonly string[]> = {
+  '/model': [
+    'Switch model?',
+    'This conversation is cached for the current model.',
+  ],
+`)).toBe(false);
+  });
+
+  test('accepts a verbatim echo of the dialog, geometry being deliberately absent', () => {
+    expect(isHarnessSwitchConfirmation('/model', `
+$ cat pane-capture.txt
+${MODEL_SWITCH_PANE}
+`)).toBe(true);
   });
 });
 
 describe('Stop hook harness-switch delivery', () => {
+  test('model: confirmation with chrome below the dialog still receives Enter', withDir(async (dir) => {
+    seedPendingSwitch(dir, '/model', 'opus');
+    const { bin, log, helperPid } = installFakeTmux(dir, MODEL_SWITCH_PANE_WITH_CHROME, { revealAfterCapture: 2 });
+
+    const result = await drain(dir, bin, CONFIRM_TIMEOUT_MULTI_CAPTURE_MS);
+    await waitForVerifierExit(helperPid);
+
+    expect(result.exitCode).toBe(0);
+    const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
+    expect(calls.filter((line) => line.includes('-l -- /model opus'))).toHaveLength(1);
+    expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(2);
+  }));
+
   for (const { label, command, arg, pane } of SWITCH_CASES) {
     const text = `${command} ${arg}`;
 
@@ -320,20 +361,6 @@ describe('Stop hook harness-switch delivery', () => {
       const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
       expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(1);
       expect(fs.existsSync(hermit(dir, 'state', 'pending-harness-command.json'))).toBe(false);
-    }));
-
-    test(`${label}: stale matching confirmation does not receive an extra Enter`, withDir(async (dir) => {
-      seedPendingSwitch(dir, command, arg);
-      const stalePane = `${pane}\nClaude ready${'\n'.repeat(20)}`;
-      const { bin, log, helperPid } = installFakeTmux(dir, stalePane);
-
-      const result = await drain(dir, bin);
-      await waitForVerifierExit(helperPid);
-
-      expect(result.exitCode).toBe(0);
-      const calls = fs.readFileSync(log, 'utf-8').trim().split('\n');
-      expect(calls.filter((line) => line.includes(`-l -- ${text}`))).toHaveLength(1);
-      expect(calls.filter((line) => line.endsWith(' Enter'))).toHaveLength(1);
     }));
 
     test(`${label}: unrelated dialog is never answered`, withDir(async (dir) => {

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -1705,6 +1705,99 @@ test('no inbox socket in runtime.json → wedge nudge types, exactly as before',
   expect(readJson(state(h, 'watchdog-state.json')).last_nudge_transport).toBe('typed');
 }));
 
+test('5h-stale heartbeat first run pushes waking, not unresponsive', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 1);
+  touchAgo(state(h, '.heartbeat'), 5 * 3600);
+  const stub = startHttpStub();
+  try {
+    const r = await watchdog(h, 'run', { env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(r.exitCode).toBe(0);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].body.text).toContain('waking it');
+    expect(stub.requests[0].body.text).not.toContain("hasn't responded");
+  } finally { stub.stop(); }
+}));
+
+test('second stale run with consecutive_stale 1 due pushes unresponsive once', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 1);
+  touchAgo(state(h, '.heartbeat'), 5 * 3600);
+  fs.writeFileSync(state(h, 'watchdog-state.json'), JSON.stringify({
+    consecutive_stale: 1,
+    wedge_notified: true,
+    last_nudge_at: isoAgo(5),
+  }) + '\n');
+  const stub = startHttpStub();
+  try {
+    const r = await watchdog(h, 'run', { env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(r.exitCode).toBe(0);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].body.text).toContain("hasn't responded");
+    expect(readJson(state(h, 'watchdog-state.json')).wedge_escalated).toBe(true);
+  } finally { stub.stop(); }
+}));
+
+test('stale then fresh heartbeat pushes all-clear', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 1);
+  touchAgo(state(h, '.heartbeat'), 5 * 3600);
+  const stub = startHttpStub();
+  try {
+    const r1 = await watchdog(h, 'run', { env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(r1.exitCode).toBe(0);
+    expect(stub.requests[0].body.text).toContain('waking it');
+
+    touchAgo(state(h, '.heartbeat'), 60);
+    const r2 = await watchdog(h, 'run', { env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(r2.exitCode).toBe(0);
+    expect(stub.requests.some((req) => String(req.body?.text ?? '').includes('responding again'))).toBe(true);
+    expect(fs.readFileSync(eventsFile(h), 'utf-8')).toContain('wedge-recovered');
+  } finally { stub.stop(); }
+}));
+
+test('fresh heartbeat with wedge_notified unset pushes nothing', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 1);
+  touchAgo(state(h, '.heartbeat'), 60);
+  const stub = startHttpStub();
+  try {
+    const r = await watchdog(h, 'run', { env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(r.exitCode).toBe(0);
+    expect(stub.requests).toHaveLength(0);
+    const events = fs.existsSync(eventsFile(h)) ? fs.readFileSync(eventsFile(h), 'utf-8') : '';
+    expect(events).not.toContain('wedge-recovered');
+  } finally { stub.stop(); }
+}));
+
+test('third stale run after escalation pushes nothing', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0);
+  writeFakePgrep(h, 1);
+  touchAgo(state(h, '.heartbeat'), 5 * 3600);
+  fs.writeFileSync(state(h, 'watchdog-state.json'), JSON.stringify({
+    consecutive_stale: 2,
+    wedge_notified: true,
+    wedge_escalated: true,
+    last_nudge_at: isoAgo(5),
+  }) + '\n');
+  const stub = startHttpStub();
+  try {
+    const r = await watchdog(h, 'run', { env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(r.exitCode).toBe(0);
+    expect(stub.requests).toHaveLength(0);
+  } finally { stub.stop(); }
+}));
+
 // A stamped path whose session died takes the socket file with it. Reading the
 // stale value as usable would post into nothing and skip the typed recovery.
 test('stamped socket path no longer exists → falls through to typing', withHermit(async (h) => {
@@ -1755,6 +1848,31 @@ function writeRegistryEntry(h: Hermit, patch: Record<string, unknown> = {}): str
   );
   return configDir;
 }
+
+const MCP_AUTH_PANE = [
+  'Plugin:cloudflare:cloudflare-api MCP Server',
+  'Authentication timeout',
+  '❯ 1. Authenticate',
+  '  2. Disable',
+  '↑/↓ to navigate · Enter to select · Esc to back',
+].join('\n');
+
+test('registry waiting stall notice quotes the pane tail', withHermit(async (h) => {
+  writeConfig(h);
+  configureChannel(h);
+  writeFakeTmux(h, 0, MCP_AUTH_PANE);
+  writeFakePgrep(h, 1);
+  const configDir = writeRegistryEntry(h, { status: 'waiting' });
+  patchRuntime(h, { config_dir: configDir, session_pid: process.pid });
+  const stub = startHttpStub();
+  try {
+    const r = await watchdog(h, 'run', { env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+    expect(r.exitCode).toBe(0);
+    expect(fs.readFileSync(eventsFile(h), 'utf-8')).toContain('stall-question-detected');
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].body.text).toContain('Authentication timeout');
+  } finally { stub.stop(); }
+}));
 
 test('registry says the resident is waiting on a dialog → alert, no nudge', withHermit(async (h) => {
   writeConfig(h, '30m');
@@ -4253,7 +4371,8 @@ describe('composeRestartMessage / composeWedgeMessage / composePauseMessage', ()
   });
 
   test('wedge message names the check-in time', () => {
-    expect(composeWedgeMessage('UTC')).toContain('checking on it now');
+    expect(composeWedgeMessage('UTC')).toContain('waking it');
+    expect(composeWedgeMessage('UTC', 'en', true)).toContain('checking on it now');
   });
 
   test('pause message: indefinite pause has no boundary time', () => {
@@ -4455,10 +4574,14 @@ describe('watchdog message localization', () => {
   });
 
   test('composeWedgeMessage en / pt-PT', () => {
-    expect(composeWedgeMessage('UTC', 'en')).toMatch(
+    expect(composeWedgeMessage('UTC', 'en', true)).toMatch(
       /^Your agent hasn't responded in a while — checking on it now \(\d{2}:\d{2}\)\.$/);
-    expect(composeWedgeMessage('UTC', 'pt-PT')).toMatch(
+    expect(composeWedgeMessage('UTC', 'pt-PT', true)).toMatch(
       /^O seu agente não responde há algum tempo — estou a verificá-lo agora \(\d{2}:\d{2}\)\.$/);
+    expect(composeWedgeMessage('UTC', 'en')).toMatch(
+      /^Your agent's heartbeat hasn't checked in, waking it \(\d{2}:\d{2}\)\.$/);
+    expect(composeWedgeMessage('UTC', 'pt-PT')).toMatch(
+      /^O heartbeat do seu agente não fez check-in, estou a acordá-lo \(\d{2}:\d{2}\)\.$/);
   });
 
   test('composeStallQuestionMessage en / pt-PT', () => {


### PR DESCRIPTION
## Summary

A `/model` or `/effort` switch delivered from a channel could leave the session blocked on its own cached-context dialog. The confirmation matcher required the dialog to occupy the pane tail, but a queued channel banner, the composer, the statusLine and the mode rows render *below* the modal, so the helper never matched and never pressed Enter. One live session sat wedged for 27 minutes.

Geometry was defending nothing: `capturePane` returns only visible rows, and an answered dialog is erased within 1.5s on both renderers (probed on CC 2.1.260), so a stale leftover is not a case that can occur. The matcher now collapses whitespace over the whole capture and requires its five text anchors, with no row-position condition.

The same change makes the watchdog's wedge notices say only what it has actually established, and gives the stall notice enough content to be acted on.

## Behavior delta

```
BEFORE
  /model over channel ─> Stop hook delivers ─> "Switch model?" modal opens
      └─ a channel message is queued ─> chrome renders under the modal
           └─ helper demands the dialog be the last row, never matches, exits quietly
                └─ session blocked until a human presses Enter (27 min live)
  heartbeat stale ─> first nudge ─> "agent hasn't responded" pushed on suspicion
      └─ agent answers in <1s ─> flags reset silently ─> operator never told
  stall detected via registry ─> "waiting on a question" ─> operator asks which question

AFTER
  /model over channel ─> Stop hook delivers ─> modal opens, chrome or not
      └─ helper matches the dialog text wherever it sits ─> Enter sent ─> switch applied
      └─ (no dialog: fresh session or switch back to the cached model) ─> applied inline
  heartbeat stale ─> first nudge ─> "heartbeat hasn't checked in, waking it"
      └─ wake demonstrably failed ─> "agent isn't responding" (once per episode)
      └─ heartbeat fresh again ─> "responding again" all-clear (only if a notice went out)
  stall detected (either leg) ─> notice ends with the pane's last 8 non-blank rows
```

## Changes

- `lib/harness-command.ts`: `isHarnessSwitchConfirmation` drops its tail window; `anchoredPaneTail` and `HARNESS_CONFIRM_TAIL_LINES` leave the file, the former still serving its watchdog caller in `lib/tmux.ts`.
- `HARNESS_CONFIRM_TIMEOUT_MS` gets one exported home in `lib/harness-command.ts`; the helper's poll cap and the verify stage's grace window both read it, replacing two hardcoded `5_000` literals and the comment that flagged the duplication.
- `hermit-watchdog.ts`: a new `wedgeWaking` string is the first notice of an episode; the existing "isn't responding" wording is gated on `socketUndelivered || consecutive >= 2` and pushed at most once, tracked by a new `wedge_escalated` state flag; recovery pushes a `wedgeRecovered` all-clear and appends a `wedge-recovered` event, but only when a notice actually went out.
- `composeStallQuestionMessage` takes an optional pane tail; the watchdog passes `nonBlankTail(paneContent, 8)` on both the pane and the registry leg.
- The comment above `PENDING_OPTION_RE` claiming a modal replaces the composer is corrected: it does on a clean pane, but a queued channel message keeps the composer rendered below it, which is why the footer anchor misses that case and the registry leg covers it.
- en and pt-PT strings for the two new notices.

## Test plan

Ran in the worktree at `395647e3`:

```
0  cd plugins/claude-code-hermit && bun test --timeout=45000
0  bunx tsc
1  cd plugins/claude-code-hermit && grep -c 'anchoredPaneTail' scripts/lib/harness-command.ts
1  cd plugins/claude-code-hermit && grep -c '5_000' scripts/confirm-harness-switch.ts scripts/lib/prompt-stages/harness-verify.ts
1  cd plugins/claude-code-hermit && grep -c 'replaces the composer rather than rendering above it' scripts/hermit-watchdog.ts
```

The three grep rows exit 1 because they print `0`, which is the intended count for each. New coverage: a `MODEL_SWITCH_PANE_WITH_CHROME` fixture (modal, channel banner, composer, statusLine, mode row, IDE row) matching for `/model` and not `/effort`, a delivery test driving fake tmux with it, wedge escalation across three stale runs, the recovery all-clear and its event, and a registry-`waiting` stall whose pushed text carries the MCP auth dialog from the pane.

Two negative tests that encoded the retired tail window were deleted rather than re-tuned, as the plan directed. One replacement pair was added during review: prose or source quoting only the dialog headings is rejected, while a verbatim echo of a whole dialog is accepted and pinned as a known, accepted cost of dropping geometry.

Still to do by hand after merge, outside this change's fence: request `/model sonnet` over the channel with a second message queued behind it and confirm the switch is accepted with no keystroke.

## Blast radius

- **Released surfaces touched:** all five scripts ship in claude-code-hermit v1.3.1 and run on every installed hermit: `hermit-watchdog.ts`, `confirm-harness-switch.ts`, `lib/harness-command.ts`, `lib/messages.ts`, `lib/prompt-stages/harness-verify.ts`.
- **Unreleased surfaces touched:** none. The changelog bullets sit under `[Unreleased]`, so nothing reaches an installed operator until the plugin version is bumped.
- **Downstream operators:** three notices change wording and one is new. A wedge episode now opens with "waking it" instead of asserting the agent is unresponsive, closes with an all-clear, and stall notices carry eight pane rows at maintainer tier. No config change, no new setting, no `### Upgrade Instructions` step.
- **Downstream hermits:** watchdog state gains an optional `wedge_escalated` boolean. State is untyped JSON with a falsy default, so no migration and no compatibility break for a hermit that upgrades mid-episode. The visible behavior change is that a channel-delivered `/model` or `/effort` now completes where it previously wedged the session until a human intervened.
- **Per-actor ledger:** grok implemented all eight plan steps in a worktree at the grounded commit and ran its own cleanup pass, staging and committing nothing. `/code-review high --fix` moved the all-clear's state write ahead of its 12s blocking push so a killed tick cannot double-send, and corrected a doc comment that misdescribed the sticky `wedge_notified` flag. The operator reviewed three remaining findings and took the additive one: a replacement negative test for the geometry-free matcher. Two were declined on the record: quoting raw pane rows to the channel is step 6's intended contract at maintainer tier, and relaxing the footer anchor to close the documented `hasPendingQuestion` blind spot is explicitly out of the plan's scope and risks a false positive that would suppress nudge and restart.
