### PR TITLE
feat(claude-code-hermit): classify API failures from the StopFailure hook

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `StopFailure` hook stamping the turn's typed failure category to `state/stop-failure.json`, which the watchdog's API-failure notice now classifies from when the stamp is newer than the transcript; the transcript scan stays the fallback.
 - `Read(//**/.claude/plugins/**/claude-code-hermit/**)` in the sealed allow-list, so a hermit reading its own installed docs, skills and templates no longer raises a permission prompt on unattended paths like `hermit-evolve`. One rule covers both trees a plugin runs from, the marketplace clone and the versioned cache, and names `claude-code-hermit` in the plugin slot so the grant survives a fork whose marketplace declares another name.
 - Contract test over every sealed path rule: a `Read`/`Edit` pattern that reads as filesystem-wide but is not (a bare `*` or `**` first segment, or a single leading `/`) now fails CI unless it carries a `//` or `~/` anchor.
 - `docs/security.md` notes what to copy when the config directory is not `~/.claude`, such as a profile install at `~/.claude-work`, and records that `//**/` is the spelling that works on Windows, WSL, macOS and Linux alike.

--- a/plugins/claude-code-hermit/docs/architecture.md
+++ b/plugins/claude-code-hermit/docs/architecture.md
@@ -112,6 +112,7 @@ Skills are namespaced `/claude-code-hermit:*`; the full set is listed in the plu
 | Session evaluator   | Stop         | standard+ | Validates SHELL.md quality, detects zombie/stale/bloat |
 | PermissionDenied notify | PermissionDenied | all | Maintainer diagnostic (tool + reason), one 30-min window per tool with a suppressed count; maintainer chat, else primary chat on a technical profile, else Findings; no client message |
 | Stop pipeline       | Stop         | all       | Cost tracking, session diff, evaluation, heartbeat |
+| StopFailure stamp   | StopFailure  | all       | Records the turn's typed upstream failure to `state/stop-failure.json`; the watchdog classifies from it and notifies |
 | Precompact stamp    | PreCompact   | all       | Breadcrumb in SHELL.md before `/compact` (manual or auto); watchdog's emergency `/clear` flushes the same breadcrumb separately since PreCompact never fires on `/clear` |
 
 Hermits may add hooks at `strict` (e.g., git-push-guard). Profile-gated hooks check `AGENT_HOOK_PROFILE` internally and return early when the active profile doesn't match.
@@ -201,6 +202,7 @@ One writer per state file. No shared mutation bus. (Exception: `state/micro-prop
 | `state/heartbeat-liveness.json` | heartbeat-monitor.sh (every poll iteration)         | doctor-check.ts (heartbeat liveness check), heartbeat status  |
 | `state/cc-stop-snapshot.json`  | stop-pipeline.ts only                               | doctor-check.ts (scheduler/background-task health check)      |
 | `state/operator-turn-open.json` | user-prompt-pipeline.ts (opens at hook exit for a kept, non-blocked prompt, via record-operator-action.ts `openTurnMarker`) + record-operator-action.ts `--force`; stop-pipeline.ts (clears at Stop — the only deleter) | routines.ts due + lib/heartbeat/precheck.ts, both via lib/auto-close.ts `operatorTurnOpen` (defer gate, 60-min TTL backstop against a marker orphaned by a failed Stop) |
+| `state/stop-failure.json`      | stop-failure-stamp.ts (writer), stop-pipeline.ts (deleter — cleared on the next healthy, non-guest Stop) | hermit-watchdog.ts (upstream API failure tier, preferred over the transcript scan while the stamp is the newer of the two) |
 | `state/pending-close-drain.json` | lib/auto-close.ts `stampDrainCooldown`, called by routines.ts due and lib/heartbeat/precheck.ts (non-peek only) | the same two drainers (shared backoff before re-emitting a queued close: 30 min for the routine poll, halved by the heartbeat drainer once `heartbeat.every` reaches 30 min) |
 | `state/.heartbeat`             | heartbeat-touch.ts only                             | heartbeat (detect activity gaps)                              |
 | `state/.lifecycle.lock`        | hermit-start.ts only                                | hermit-stop.ts (cleanup)                                      |

--- a/plugins/claude-code-hermit/hooks/hooks.json
+++ b/plugins/claude-code-hermit/hooks/hooks.json
@@ -179,6 +179,20 @@
         "description": "Stop pipeline: cost tracking, session diff, evaluation, heartbeat"
       }
     ],
+    "StopFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/stop-failure-stamp.ts"],
+            "timeout": 10
+          }
+        ],
+        "description": "Stamp the typed upstream failure the watchdog classifies from"
+      }
+    ],
     "SubagentStop": [
       {
         "matcher": "",

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -500,11 +500,10 @@ const API_UNAVAILABLE_RE = /API Error:.*(529 Overloaded|500 Internal server erro
 
 export type ApiFailureVerdict = { kind: 'usage-limit'; resetAt: string | null } | { kind: 'api-unavailable' };
 
-/** Verdict on the newest assistant record in a transcript tail, or null when it isn't
- *  a recognised upstream API failure (including: no failure, an auth failure, or a
- *  healthy record newer than any failure). Mirrors classifyQueueTail's tolerant JSONL
- *  scan — a truncated first line from the byte-bounded tail read is expected. */
-export function classifyApiFailureTail(tailText: string): ApiFailureVerdict | null {
+/** Newest assistant record in a transcript tail, with its parsed timestamp, or null
+ *  when the tail carries none. Mirrors classifyQueueTail's tolerant JSONL scan — a
+ *  truncated first line from the byte-bounded tail read is expected. */
+function newestAssistantRecord(tailText: string): { rec: Json; ts: number } | null {
   let newest: { rec: Json; ts: number } | null = null;
   for (const line of tailText.split('\n')) {
     if (!line.includes('"role":"assistant"')) continue;
@@ -515,19 +514,60 @@ export function classifyApiFailureTail(tailText: string): ApiFailureVerdict | nu
     if (Number.isNaN(ts)) continue;
     if (newest === null || ts >= newest.ts) newest = { rec, ts };
   }
-  if (newest === null) return null;
-  const rec = newest.rec;
+  return newest;
+}
+
+/** Usage-limit verdict for a rendered failure message, or null when it carries no limit
+ *  line. The line and its reset clause read the same whichever source supplied the text,
+ *  a synthetic transcript record or the StopFailure stamp's last assistant message. */
+function matchUsageLimit(text: string): ApiFailureVerdict | null {
+  if (!USAGE_LIMIT_RE.test(text)) return null;
+  const reset = text.match(USAGE_LIMIT_RESET_RE);
+  return { kind: 'usage-limit', resetAt: reset?.[1]?.trim() || null };
+}
+
+/** Verdict on one assistant record, or null when it isn't a recognised upstream API
+ *  failure. Separate from classifyApiFailureTail so the 3d tier, which already holds
+ *  the newest record, does not rescan the tail to reach it. */
+function verdictFromAssistantRecord(rec: Json): ApiFailureVerdict | null {
   if (rec.isApiErrorMessage !== true || rec.message?.model !== '<synthetic>') return null;
 
   const content = rec.message?.content;
   const text = Array.isArray(content) && content[0]?.type === 'text' ? String(content[0].text ?? '') : '';
 
-  if (USAGE_LIMIT_RE.test(text)) {
-    const reset = text.match(USAGE_LIMIT_RESET_RE);
-    return { kind: 'usage-limit', resetAt: reset?.[1]?.trim() || null };
-  }
+  const usageLimit = matchUsageLimit(text);
+  if (usageLimit) return usageLimit;
   if (API_UNAVAILABLE_RE.test(text)) return { kind: 'api-unavailable' };
   return null; // auth failure or an unrecognised synthetic record — not this tier's job
+}
+
+/** Verdict on the newest assistant record in a transcript tail, or null when it isn't
+ *  a recognised upstream API failure (including: no failure, an auth failure, or a
+ *  healthy record newer than any failure). */
+export function classifyApiFailureTail(tailText: string): ApiFailureVerdict | null {
+  const newest = newestAssistantRecord(tailText);
+  return newest === null ? null : verdictFromAssistantRecord(newest.rec);
+}
+
+/** Verdict on a `state/stop-failure.json` stamp (stop-failure-stamp.ts's record of a
+ *  StopFailure payload), or null when its category isn't this tier's — an auth failure,
+ *  a model error, or no `error` at all.
+ *
+ *  The typed category replaces the structural gate the transcript path needs: only CC
+ *  fires StopFailure, so there is no quoted-text case to defend against here. The live
+ *  payload key is `error` (probed on CC 2.1.261); the docs spell it `error_type`, and a
+ *  payload carrying only that classifies as null — the transcript tail stays the
+ *  fallback, so an upstream rename degrades to today's behavior rather than to silence.
+ *  `rate_limit` covers both a usage lockout and upstream throttling, so it is the one
+ *  category still split on text. */
+export function classifyStopFailureStamp(stamp: Json): ApiFailureVerdict | null {
+  const error = stamp?.error;
+  if (error === 'rate_limit') {
+    const text = typeof stamp.last_assistant_message === 'string' ? stamp.last_assistant_message : '';
+    return matchUsageLimit(text) ?? { kind: 'api-unavailable' };
+  }
+  if (error === 'overloaded' || error === 'server_error') return { kind: 'api-unavailable' };
+  return null;
 }
 
 /** Tail of the active session's transcript, or null when it can't be located/read.
@@ -672,6 +712,13 @@ function readWatchdogState(world: World = REAL_WORLD): Json {
     return { consecutive_stale: 0, last_pane_hash: null, last_nudge_at: null };
   }
   return data;
+}
+
+/** The StopFailure stamp, or null when absent/unreadable. Written by
+ *  stop-failure-stamp.ts, deleted by stop-pipeline.ts on the next healthy Stop. */
+function readStopFailureStamp(world: World = REAL_WORLD): Json | null {
+  const data = world.files.readJson(path.join(world.paths.stateDir, 'stop-failure.json'));
+  return data && typeof data === 'object' && !Array.isArray(data) ? data : null;
 }
 
 function writeWatchdogState(state: Json, world: World = REAL_WORLD): void {
@@ -2216,7 +2263,27 @@ async function main(): Promise<void> {
     // an operator watching from Discord can tell "Claude is down" from "my agent is
     // broken". Reuses the same tail read above; auth failures return null here and
     // are left to the lapsed-login/env-auth tiers so one event isn't notified twice.
-    const apiFailure = tail === null ? null : classifyApiFailureTail(tail);
+    //
+    // Two sources, newest wins. CC's StopFailure hook stamps the typed `error` for the
+    // turn that just failed, which is the category itself rather than a regex over
+    // rendered text — but only while a session is alive to fire hooks, so the transcript
+    // scan stays the source for a dead-session post-mortem and for any episode that
+    // predates the stamp.
+    const stamp = readStopFailureStamp();
+    const stampAt = stamp ? Date.parse(String(stamp.at ?? '')) : NaN;
+    const newestRecord = tail === null ? null : newestAssistantRecord(tail);
+    // Compared at whole-second granularity: `at` is a localISOStamp (seconds), while a
+    // transcript record carries milliseconds and CC writes that record just BEFORE firing
+    // the hook (22ms earlier when probed). A strict `>` on the truncated value therefore
+    // loses the same-second tie the stamp always creates, and the stamp path would only
+    // ever win when the record and the hook straddle a second boundary. The cost is up to
+    // one second of ambiguity in the other direction, far below any real episode gap.
+    const stampIsNewer = !Number.isNaN(stampAt)
+      && (newestRecord === null || stampAt + 999 >= newestRecord.ts);
+    let apiFailure: ApiFailureVerdict | null;
+    if (stampIsNewer) apiFailure = classifyStopFailureStamp(stamp);
+    else if (newestRecord === null) apiFailure = null;
+    else apiFailure = verdictFromAssistantRecord(newestRecord.rec);
     if (apiFailure) {
       if (!watchdogState.api_failure_notified_at) {
         pushOperatorMessage(composeApiFailureMessage(apiFailure, timezone));

--- a/plugins/claude-code-hermit/scripts/stop-failure-stamp.ts
+++ b/plugins/claude-code-hermit/scripts/stop-failure-stamp.ts
@@ -1,0 +1,58 @@
+// stop-failure-stamp.ts — StopFailure hook
+//
+// Claude Code fires StopFailure when a turn ends in an upstream failure instead
+// of an assistant reply. The payload carries a typed `error` (the live key; the
+// docs spell it `error_type`), so this is the one place the failure category is
+// known rather than inferred from rendered error text.
+//
+// The hook only records. It writes state/stop-failure.json and stops there: the
+// watchdog owns the notification, and stop-pipeline.ts deletes the stamp on the
+// next healthy Stop. Guest sessions write nothing, the same residency gate every
+// other state-writing hook applies — one hermit folder, one resident writer.
+//
+// Fail-open and side-effect-only: every path exits 0 with empty stdout.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { hermitDir, sessionId } from './lib/cc-compat';
+import { isGuest } from './lib/guest-marker';
+import { runHook } from './lib/hook-input';
+import { localISOStamp } from './lib/time';
+
+type Json = any;
+
+// The message is a diagnostic aid for the classifier's usage-limit text match,
+// not a transcript; CC's limit lines are far shorter than this.
+const MESSAGE_MAX_LEN = 300;
+
+function main(payload: Json): void {
+  // Only a genuine StopFailure payload stamps, the same gate precompact-stamp.ts
+  // applies: these scripts are reachable through the wildcarded `bun */scripts/*.ts*`
+  // grant, and a hand-fed `{"error":"rate_limit"}` would otherwise push the watchdog
+  // into notifying the operator about an outage that never happened.
+  if (payload.hook_event_name !== 'StopFailure') return;
+
+  const stateDir = path.join(hermitDir(), 'state');
+  if (isGuest(stateDir, sessionId(payload))) return;
+
+  const stamp = {
+    error: payload.error,
+    session_id: sessionId(payload),
+    at: localISOStamp(),
+    last_assistant_message: typeof payload.last_assistant_message === 'string'
+      ? payload.last_assistant_message.slice(0, MESSAGE_MAX_LEN)
+      : null,
+  };
+
+  // tmp+rename so the watchdog never reads a half-written stamp. No mkdir: an
+  // absent state/ is a worktree projection or a folder that was never hatched,
+  // and creating it there is what lib/cc-compat.ts's projection check forbids.
+  const file = path.join(stateDir, 'stop-failure.json');
+  try {
+    const tmp = file + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(stamp) + '\n', 'utf-8');
+    fs.renameSync(tmp, file);
+  } catch { /* fail-open */ }
+}
+
+runHook(main);

--- a/plugins/claude-code-hermit/scripts/stop-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/stop-pipeline.ts
@@ -18,6 +18,7 @@ const STATE_DIR = path.join(HERMIT_DIR, 'state');
 const HEARTBEAT_FILE = path.join(STATE_DIR, '.heartbeat');
 const SNAPSHOT_FILE = path.join(STATE_DIR, 'cc-stop-snapshot.json');
 const TURN_FILE = path.join(STATE_DIR, 'operator-turn-open.json');
+const STOP_FAILURE_FILE = path.join(STATE_DIR, 'stop-failure.json');
 
 async function main(): Promise<void> {
   // Read stdin once
@@ -48,6 +49,11 @@ async function main(): Promise<void> {
   // the starvation class issue #617 fixed, just time-bounded.
   if (!guest) {
     try { fs.unlinkSync(TURN_FILE); } catch {}
+    // A Stop at all means the turn produced an assistant reply, so any stamp
+    // stop-failure-stamp.ts left behind describes an episode that is over. Cleared
+    // here, ahead of the stages, for the same reason the marker above is: a stage
+    // that throws must not strand it and keep the watchdog classifying from it.
+    try { fs.unlinkSync(STOP_FAILURE_FILE); } catch {}
   }
 
   const profile = (process.env.AGENT_HOOK_PROFILE || 'standard').trim().toLowerCase();

--- a/plugins/claude-code-hermit/tests/hooks.contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hooks.contract.test.ts
@@ -18,6 +18,7 @@ import { setupWorkdir, setupGitWorkdir, fixturesDir, type Workdir } from './help
 import { triggerPrompt } from './helpers/transcript';
 import { cidrOverlap } from '../scripts/doctor-check';
 import { unconsolidated, dbExists } from '../scripts/lib/channel-log';
+import { markGuest } from '../scripts/lib/guest-marker';
 
 // ---------- small local helpers ----------
 
@@ -474,6 +475,29 @@ describe('stop-pipeline', () => {
     });
     expect(r.exitCode).toBe(0);
     expect(fs.existsSync(hermit(dir, 'state', 'operator-turn-open.json'))).toBe(false);
+  }));
+
+  // A Stop means the turn recovered, so the StopFailure stamp is stale by
+  // definition — same clear-before-the-stages placement as the marker above.
+  test('stop-pipeline clears stop-failure.json even when a preceding stage fails', withGitDir(async (dir) => {
+    write(hermit(dir, 'state', 'stop-failure.json'), '{"error":"rate_limit","at":"2026-05-20T09:00:00+0000"}');
+    const r = await runScript('stop-pipeline.ts', {
+      stdin: stopHookInput(dir), cwd: dir, env: PIPE_ENV,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(hermit(dir, 'state', 'stop-failure.json'))).toBe(false);
+  }));
+
+  // A guest never touches resident state: the resident's own Stop is what clears
+  // the stamp, and a guest deleting it would blind the watchdog mid-episode.
+  test('stop-pipeline leaves stop-failure.json in place for a guest session', withGitDir(async (dir) => {
+    write(hermit(dir, 'state', 'stop-failure.json'), '{"error":"rate_limit","at":"2026-05-20T09:00:00+0000"}');
+    markGuest(hermit(dir, 'state'), 'test-session-001');
+    const r = await runScript('stop-pipeline.ts', {
+      stdin: stopHookInput(dir), cwd: dir, env: PIPE_ENV,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(hermit(dir, 'state', 'stop-failure.json'))).toBe(true);
   }));
 
   test('stop-pipeline (malformed stdin) still clears operator-turn-open.json, fail-open', withDir(async (dir) => {

--- a/plugins/claude-code-hermit/tests/stop-failure-stamp.test.ts
+++ b/plugins/claude-code-hermit/tests/stop-failure-stamp.test.ts
@@ -1,0 +1,90 @@
+// Contract tests for scripts/stop-failure-stamp.ts, the StopFailure hook that
+// records CC's typed failure category for the watchdog to classify from.
+// Exercised as a subprocess (stdin in, state file + exit code out), the same
+// boundary Claude Code sees. The hook records only: every case exits 0 with
+// empty stdout, and nothing is sent anywhere.
+
+import { describe, test, expect } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { runScript } from './helpers/run';
+import { withDir } from './helpers/workdir';
+import { markGuest } from '../scripts/lib/guest-marker';
+
+const stateFile = (dir: string) => path.join(dir, '.claude-code-hermit', 'state', 'stop-failure.json');
+const readStamp = (dir: string) => JSON.parse(fs.readFileSync(stateFile(dir), 'utf8'));
+
+// Captured live (tmux probe, CC 2.1.261). The key is `error`, not the `error_type`
+// the docs list, and `error_details` is absent — both pinned here on purpose.
+const STOP_FAILURE_PAYLOAD = {
+  hook_event_name: 'StopFailure',
+  error: 'model_not_found',
+  session_id: '63d3ccda-cd07-4fd0-a88c-e56ac4ca311a',
+  last_assistant_message: "There's an issue with the selected model (not-a-real-model-xyz). It may not exist or you may not have access to it. Run /model to pick a different model.",
+};
+
+const run = (dir: string, stdin: string) =>
+  runScript('stop-failure-stamp.ts', { stdin, cwd: dir });
+
+describe('stop-failure-stamp', () => {
+  test('a resident session stamps exactly the four contract fields', withDir(async (dir) => {
+    const r = await run(dir, JSON.stringify(STOP_FAILURE_PAYLOAD));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('');
+
+    const stamp = readStamp(dir);
+    expect(Object.keys(stamp).sort()).toEqual(['at', 'error', 'last_assistant_message', 'session_id']);
+    expect(stamp.error).toBe('model_not_found');
+    expect(stamp.session_id).toBe(STOP_FAILURE_PAYLOAD.session_id);
+    expect(stamp.last_assistant_message).toBe(STOP_FAILURE_PAYLOAD.last_assistant_message);
+    // The watchdog compares this against the newest transcript record, so it has
+    // to parse — localISOStamp's offset has no colon, which Date.parse still takes.
+    expect(Number.isNaN(Date.parse(stamp.at))).toBe(false);
+  }));
+
+  // Residency gate: one hermit folder, one writer. A guest stamping here would
+  // hand the watchdog a failure from a session it does not supervise.
+  test('a guest session writes nothing', withDir(async (dir) => {
+    markGuest(path.join(dir, '.claude-code-hermit', 'state'), STOP_FAILURE_PAYLOAD.session_id);
+
+    const r = await run(dir, JSON.stringify(STOP_FAILURE_PAYLOAD));
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(stateFile(dir))).toBe(false);
+  }));
+
+  test('the message is bounded at 300 characters', withDir(async (dir) => {
+    const long = 'x'.repeat(500);
+    const r = await run(dir, JSON.stringify({ ...STOP_FAILURE_PAYLOAD, last_assistant_message: long }));
+    expect(r.exitCode).toBe(0);
+    expect(readStamp(dir).last_assistant_message).toBe('x'.repeat(300));
+  }));
+
+  test('a payload without a message stamps null rather than dropping the field', withDir(async (dir) => {
+    const { last_assistant_message, ...rest } = STOP_FAILURE_PAYLOAD;
+    const r = await run(dir, JSON.stringify(rest));
+    expect(r.exitCode).toBe(0);
+    expect(readStamp(dir).last_assistant_message).toBeNull();
+  }));
+
+  // These scripts are reachable through the wildcarded `bun */scripts/*.ts*` grant,
+  // so a payload that isn't a genuine StopFailure must not manufacture an outage the
+  // watchdog then notifies the operator about.
+  test('a payload that is not a StopFailure event writes nothing', withDir(async (dir) => {
+    const r = await run(dir, JSON.stringify({ ...STOP_FAILURE_PAYLOAD, hook_event_name: 'Stop' }));
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(stateFile(dir))).toBe(false);
+  }));
+
+  test('malformed stdin writes nothing and still exits 0', withDir(async (dir) => {
+    const r = await run(dir, '{broken');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(stateFile(dir))).toBe(false);
+  }));
+
+  test('empty stdin writes nothing and still exits 0', withDir(async (dir) => {
+    const r = await run(dir, '');
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(stateFile(dir))).toBe(false);
+  }));
+});

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -17,7 +17,7 @@ import { runScript, SCRIPTS_DIR } from './helpers/run';
 import { freshDirFactory } from './helpers/workdir';
 import { transcriptDirFor } from '../scripts/lib/cc-compat';
 import {
-  inActiveHours, isNearDailyAutoClose, composeRestartMessage, composeWedgeMessage, composeStallQuestionMessage, composeSessionWedgedMessage, composePauseMessage, hasPendingQuestion, hasLapsedLogin, classifyQueueTail, classifyApiFailureTail, composeCompactSteeringMessage,
+  inActiveHours, isNearDailyAutoClose, composeRestartMessage, composeWedgeMessage, composeStallQuestionMessage, composeSessionWedgedMessage, composePauseMessage, hasPendingQuestion, hasLapsedLogin, classifyQueueTail, classifyApiFailureTail, classifyStopFailureStamp, composeCompactSteeringMessage,
   rearmDamperOpen, passesLifecycleGuards, setHygieneEval, stampHygieneEval,
   maybeContextClear, maybeContextCompact, MONITOR_REARM_DAMPER_SECS, type World,
 } from '../scripts/hermit-watchdog';
@@ -810,6 +810,53 @@ describe('classifyApiFailureTail', () => {
   test('reset capture stops at the subline instead of swallowing it', () => {
     const tail = apiErrorRec("You've hit your session limit · resets 2:30am, or switch models to keep working.");
     expect(classifyApiFailureTail(tail)).toEqual({ kind: 'usage-limit', resetAt: '2:30am' });
+  });
+});
+
+// The same verdict from CC's own typed category instead of rendered error text.
+// Shapes match what stop-failure-stamp.ts writes from a StopFailure payload.
+describe('classifyStopFailureStamp', () => {
+  const stamp = (error: unknown, last_assistant_message = '') =>
+    ({ error, session_id: 'x', at: '2026-08-17T13:59:00+0000', last_assistant_message });
+
+  test('rate_limit whose message carries the limit line → usage-limit with parsed reset', () => {
+    expect(classifyStopFailureStamp(stamp('rate_limit', "You've hit your session limit · resets 2:30am (Europe/Lisbon)")))
+      .toEqual({ kind: 'usage-limit', resetAt: '2:30am' });
+  });
+
+  test('rate_limit limit line without a reset clause → resetAt null', () => {
+    expect(classifyStopFailureStamp(stamp('rate_limit', "You've hit your session limit for now.")))
+      .toEqual({ kind: 'usage-limit', resetAt: null });
+  });
+
+  // Upstream throttling shares the category with a usage lockout, so the message
+  // is what separates "you are out of budget" from "the API is busy".
+  test('rate_limit without the limit line → api-unavailable', () => {
+    expect(classifyStopFailureStamp(stamp('rate_limit', 'API Error: 429 Too Many Requests')))
+      .toEqual({ kind: 'api-unavailable' });
+  });
+
+  test('overloaded → api-unavailable', () => {
+    expect(classifyStopFailureStamp(stamp('overloaded'))).toEqual({ kind: 'api-unavailable' });
+  });
+
+  test('server_error → api-unavailable', () => {
+    expect(classifyStopFailureStamp(stamp('server_error'))).toEqual({ kind: 'api-unavailable' });
+  });
+
+  test('a category this tier does not own → null', () => {
+    expect(classifyStopFailureStamp(stamp('model_not_found', 'It may not exist.'))).toBeNull();
+  });
+
+  // The docs spell the key `error_type`; the live payload uses `error`. A stamp
+  // carrying only the documented spelling classifies as null, which leaves the
+  // transcript tail to answer rather than inventing a category.
+  test('the documented error_type spelling alone → null', () => {
+    expect(classifyStopFailureStamp({ error_type: 'overloaded', at: '2026-08-17T13:59:00+0000' })).toBeNull();
+  });
+
+  test('a missing error key → null', () => {
+    expect(classifyStopFailureStamp({ at: '2026-08-17T13:59:00+0000' })).toBeNull();
   });
 });
 

--- a/tests/cross-plugin/hook-stdin-contract.test.ts
+++ b/tests/cross-plugin/hook-stdin-contract.test.ts
@@ -82,6 +82,20 @@ const SPECS: Spec[] = [
     failExit: 0,
   },
   {
+    name: 'core/stop-failure-stamp',
+    script: 'plugins/claude-code-hermit/scripts/stop-failure-stamp.ts',
+    // A StopFailure payload, not a tool call: this hook fires at turn end. The
+    // sandbox cwd has no hermit folder, so the stamp write fails open and the
+    // benign case stays independent of the dev box's own state dir.
+    benign: {
+      hook_event_name: 'StopFailure',
+      error: 'model_not_found',
+      session_id: '63d3ccda-cd07-4fd0-a88c-e56ac4ca311a',
+      last_assistant_message: 'There is an issue with the selected model.',
+    },
+    failExit: 0,
+  },
+  {
     name: 'dev/git-push-guard',
     script: 'plugins/claude-code-dev-hermit/scripts/git-push-guard.ts',
     benign: BASH_LS,


### PR DESCRIPTION
## Problem

The watchdog's API-failure notice decided an upstream outage was happening by regex-matching the *rendered* error text at the tail of the transcript, against undocumented `<synthetic>` markers. That inference is the only signal it had, and it is lossy: a `429 Too Many Requests` renders as text no pattern in `API_UNAVAILABLE_RE` matches (it covers 529/500/"Server error mid-response"), so a real rate-limit outage produced no operator notice at all.

Claude Code fires a `StopFailure` hook on exactly that turn, carrying a **typed** failure category. This takes the typed signal where it exists and keeps the text scan as the fallback, so a session that dies mid-failure still gets its post-mortem.

## Behavior

```
BEFORE: API-failed turn ──> CC writes synthetic transcript record ──> watchdog tick
        regex-matches the rendered error text (isApiErrorMessage + <synthetic>
        markers, undocumented) ──> one push per episode ──> newer healthy record clears

AFTER:  API-failed turn ──> CC writes synthetic record AND fires StopFailure ──> hook
        stamps {error, session_id, at, last_assistant_message} (resident only, guests
        ignored)
        ──> watchdog tick: stamp newer than transcript?
              yes ──> classify by native `error`
                      (rate_limit + limit text  → usage-limit
                       rate_limit/overloaded/server_error → api-unavailable
                       anything else            → nothing)
              no  ──> same regex path as BEFORE (dead-session post-mortem kept)
        ──> one push per episode ──> newer healthy record clears; a healthy Stop
            deletes the stamp
```

Notify-once and re-arm behavior (`api_failure_notified_at`) are unchanged.

### Decisions weighed

```
replace the transcript classifier? ─┬─ replace with hook ─> silent after session death,
                                    │                       no post-mortem
                                    └─ additive stamp, transcript fallback   ◀ SELECTED

adopt `claude agents --json` for liveness? ─┬─ adopt ─> resident never listed
                                            │           (foreground interactive);
                                            │           3 identity fields missing
                                            └─ no change to registry reader  ◀ SELECTED

bump min_claude_code_version? ─┬─ bump ─> churn for nothing
                               └─ none: StopFailure shipped 2.1.78,
                                  floor is already 2.1.258                   ◀ SELECTED
```

## Notes on the wire contract

The live payload key is **`error`**; the published hook docs spell it `error_type`. Both the code and its tests pin the live spelling, and a test asserts an `error_type`-only payload classifies to null rather than silently guessing.

The stamp/record comparison is at **whole-second granularity** (`stampAt + 999 >= newestRecord.ts`). This is not slack: `localISOStamp` emits no milliseconds, and Claude Code writes the synthetic transcript record ~22 ms *before* firing the hook, so a strict comparison loses the same-second tie the stamp always creates and would leave the stamp path dead except when the two straddle a second boundary. The cost is up to one second of ambiguity in the other direction.

The hook script gates on `hook_event_name !== 'StopFailure'` before writing, matching `precompact-stamp.ts`. These scripts are reachable through the wildcarded `Bash(bun */scripts/*.ts*)` grant, so without the gate any turn could hand-feed `{"error":"rate_limit", ...}` and make the watchdog announce an outage that never happened.

## Validation

Closing verification re-run in the worktree after the commit, every row exit 0:

```
0  cd plugins/claude-code-hermit && bun test --timeout=45000
0  cd "$(git rev-parse --show-toplevel)" && bun test tests/cross-plugin/ tests/lib/
0  cd "$(git rev-parse --show-toplevel)" && bunx tsc
0  cd "$(git rev-parse --show-toplevel)" && test "$(grep -c 'stop-failure' plugins/claude-code-hermit/docs/architecture.md)" = 2
0  cd "$(git rev-parse --show-toplevel)" && test "$(grep -c 'StopFailure' plugins/claude-code-hermit/CHANGELOG.md)" = 1
0  cd "$(git rev-parse --show-toplevel)" && ! grep -q 'min_claude_code_version.*2\.1\.2[6-9]' plugins/claude-code-hermit/.claude-plugin/hermit-meta.json
```

Core suite 5318 pass / 0 fail; cross-plugin hook-stdin corpus green; `tsc` clean.

Real-client smoke against the hook's wire contract, using the verbatim payload captured from a live Claude Code 2.1.261 `StopFailure`:

```
$ echo '{"hook_event_name":"StopFailure","error":"model_not_found",
  "session_id":"63d3ccda-cd07-4fd0-a88c-e56ac4ca311a",
  "last_assistant_message":"There is an issue with the selected model ..."}' \
    | bun plugins/claude-code-hermit/scripts/stop-failure-stamp.ts
rc=0
(no stdout)

$ cat .claude-code-hermit/state/stop-failure.json
{"error":"model_not_found","session_id":"63d3ccda-cd07-4fd0-a88c-e56ac4ca311a",
 "at":"2026-09-05T23:51:33+0100","last_assistant_message":"There is an issue with
 the selected model (not-a-real-model-xyz). It may not exist or you may not have
 access to it. Run /model to pick a different model."}
```

## Blast radius

- **Released surfaces touched:** `hermit-watchdog.ts` step 3d — the API-failure notice operators already receive. Its trigger widens (typed categories now fire where the text scan was silent); its wording, its once-per-episode rule and its re-arm rule are byte-identical. `stop-pipeline.ts` gains one unlink on the healthy-Stop path.
- **Unreleased surfaces touched:** `scripts/stop-failure-stamp.ts` and the `StopFailure` entry in `hooks.json` are both new; `state/stop-failure.json` is a new state file. All three land in core's `[Unreleased]`.
- **Downstream operators:** more truthful outage notices, no new message shapes and nothing to configure. The concrete gain is a rate-limit outage that produces no notice today. No behavior is removed, so a stamp that never appears leaves the current behavior exactly as-is.
- **Downstream hermits:** the new hook registers automatically on the next plugin update; no migration, no `hermit-evolve` step, no `min_claude_code_version` bump (`StopFailure` shipped in 2.1.78, the floor is already 2.1.258). A host that never fires the event simply keeps the transcript scan. Guest sessions are gated out, so multi-session installs keep one writer per hermit folder.
- **Per-actor ledger:** executor **claude** wrote all six plan steps (hook script, registration, Stop-pipeline unlink, watchdog classifier, tests, docs/changelog) and ran its own cleanup pass / **code-review high --fix** fixed the whole-second comparison that would have left the stamp path effectively dead, added the `hook_event_name` gate against the wildcarded-bun spoof path, and added the test pinning it / **operator** approved the whole-second comparison as a revision to the plan's step-4 contract (the plan file was edited to record it), and declined two low findings: the re-arm looseness when a stamp lands in a category this tier does not own, and confirming `StopFailure` against a 2.1.258 binary that is not installed here.

The step-4 review ran in this session with a fresh context: a subagent wrote the diff, this session did not.

## Known follow-ups (deliberately not in this PR)

1. `hermit-watchdog.ts:2287` — a newer stamp whose category this tier does not own (`model_not_found`, auth) also yields `apiFailure === null`, clearing `api_failure_notified_at` while the transcript's newest record is still the unresolved failure. A later `overloaded` tick can then re-notify the same outage. Fixing it means restructuring the branch to distinguish "no failure" from "not my category".
2. `StopFailure` is confirmed present in the 2.1.259 binary but was not verified against the declared 2.1.258 floor. Failure mode is benign: the hook never fires and the transcript scan still answers.
