### PR TITLE
fix(claude-code-hermit): report a rejected heartbeat evaluation instead of HEARTBEAT_OK

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Each API request billed once per turn instead of once per streamed transcript entry, in both the Stop hook and the async subagent hook.
 - Rate table refreshed for the current generations and keyed on the full model id.
 - 1-hour cache writes and fast mode priced at their own rates.
+- Heartbeat reports `HEARTBEAT_INDETERMINATE` and logs one Monitoring line when the evaluation return is rejected or alert state can't be read or written, instead of `HEARTBEAT_OK`.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/scripts/lib/heartbeat/alert-update.ts
+++ b/plugins/claude-code-hermit/scripts/lib/heartbeat/alert-update.ts
@@ -5,11 +5,13 @@
 // from their source-of-truth and runs the deterministic ladder over the union.
 // Zero npm dependencies, Node stdlib only.
 //
-// Fail-safe contract: ANY validation failure or write failure exits 0 with NO
-// stdout and NO persistent change. The caller (SKILL.md step 5) treats empty
-// stdout identically to a malformed subagent return — skip all writes, emit
-// HEARTBEAT_OK. Only a genuinely unparseable input payload exits 1 (unchanged
-// from before this refactor).
+// Fail-safe contract: ANY validation failure or write failure leaves
+// alert-state.json byte-identical, appends one `Heartbeat: evaluation
+// indeterminate` line to SHELL.md Monitoring, and prints one stdout JSON line
+// with heartbeat_result:"INDETERMINATE" and a reason. The caller (SKILL.md
+// step 5) echoes HEARTBEAT_INDETERMINATE (<reason>) instead of HEARTBEAT_OK.
+// Only a genuinely unparseable input payload exits 1; every other reject path
+// exits 0 (unchanged from before this refactor).
 //
 // On success, appends this tick's monitoring lines to SHELL.md itself and prints
 // one JSON line on stdout: how many landed, the operator notifications derived
@@ -113,20 +115,51 @@ function resolveFiring(entries: RawFiring[], canonical: Set<string> | null): Fir
   return out;
 }
 
+// Reject path: prints the INDETERMINATE stdout contract and appends one
+// Monitoring line, without touching alert-state.json. Exit code matches
+// today's contract: 1 only for invalid-json (unparseable payload), 0 for
+// every other reason.
+function indeterminate(reason: string, exitCode: 0 | 1 = 0): never {
+  const config = readSettledConfig(stateDir);
+  const timezone = config.timezone ?? 'UTC';
+  const nowDate = new Date(resolveHermitNowMs());
+  const nowIso = nowDate.toISOString();
+  const hhmm = currentHHMM(timezone, nowDate) ?? nowIso.slice(11, 16);
+  const appendError = appendShellLine(
+    path.join(stateDir, 'sessions'),
+    'Monitoring',
+    `[${hhmm}] Heartbeat: evaluation indeterminate (${reason}) — state untouched.`,
+  );
+  process.stdout.write(JSON.stringify({
+    appended: appendError ? 0 : 1,
+    ...(appendError ? { append_error: appendError } : {}),
+    notifications: [],
+    self_eval_proposals: [],
+    heartbeat_result: 'INDETERMINATE',
+    reason,
+  }) + '\n');
+  process.exit(exitCode);
+}
+
 function apply(payloadJson: string): void {
   let payload: Json;
   try {
     payload = JSON.parse(payloadJson);
   } catch (err: any) {
     console.error(`update-alert-state: invalid payload JSON: ${err.message}`);
-    process.exit(1);
+    indeterminate('invalid-json', 1);
   }
 
+  // `JSON.parse('null')` parses fine but has no properties — reading `.firing`
+  // off it throws, which would bypass the reject contract entirely (no stdout,
+  // no monitoring line, a stack trace on exit 1).
+  if (!payload || typeof payload !== 'object') indeterminate('missing-or-malformed-firing');
+
   const validated = validateFiring(payload.firing);
-  if (validated === null) process.exit(0); // malformed firing shape — reject the tick, no write
+  if (validated === null) indeterminate('missing-or-malformed-firing'); // malformed firing shape — reject the tick, no write
   const canonical = canonicalChecklistKeys(stateDir);
   const resolved = resolveFiring(validated, canonical);
-  if (resolved === null) process.exit(0);
+  if (resolved === null) indeterminate('unresolvable-firing');
   const modelFiring = resolved.filter(
     f => !isStructuredKey(f.key) && f.key !== STALE_KEY && !f.key.startsWith(DOCTOR_PREFIX),
   );
@@ -145,7 +178,7 @@ function apply(payloadJson: string): void {
     state = defaultAlertState();
   } else {
     console.error(`update-alert-state: read failed (${r.code ?? 'unknown'}); skipping write`);
-    process.exit(0);
+    indeterminate(`read-failed:${r.code ?? 'unknown'}`);
   }
 
   const prevAlerts: Json = state.alerts && typeof state.alerts === 'object' ? state.alerts : {};
@@ -290,7 +323,7 @@ function apply(payloadJson: string): void {
   };
 
   const wrote = writeAlertState(stateFile, updated);
-  if (!wrote) process.exit(0); // fail-safe: no durable write → emit no side effects
+  if (!wrote) indeterminate('write-failed'); // fail-safe: no durable write → emit no side effects
 
   // Ordered, after the durable write. Every failure mode here is file-level (SHELL.md
   // unreadable, no ## Monitoring section, write refused), so the first error is the

--- a/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: heartbeat
-description: Executes the heartbeat checklist from HEARTBEAT.md. Reads the checklist, evaluates each item, and reports findings or acknowledges with HEARTBEAT_OK. Supports run/start/stop/status/edit subcommands.
+description: Executes the heartbeat checklist from HEARTBEAT.md. Reads the checklist, evaluates each item, and reports findings, acknowledges with HEARTBEAT_OK, or acknowledges a rejected evaluation with HEARTBEAT_INDETERMINATE. Supports run/start/stop/status/edit subcommands.
 ---
 # Heartbeat
 
@@ -55,21 +55,20 @@ This subcommand is the handler for `HEARTBEAT_EVALUATE` notifications emitted by
    > Read `${CLAUDE_PLUGIN_ROOT}/skills/heartbeat/reference.md` for the complete evaluation instructions. Execute the evaluation steps in that file against `.claude-code-hermit/` in the current project directory, using the file paths described there. Return the JSON object exactly as specified in reference.md § Return Schema (no prose). Do NOT write any files or send any notifications — the calling session handles all writes and notifications.
 
    Receive the structured JSON back from the subagent.
-5. **Apply writes** in the main session (to preserve cost attribution and channel/file access). First, validate the subagent return: if it cannot be parsed as JSON, or is missing the required **key** `firing`, **skip all writes and emit `HEARTBEAT_OK`** — fail-open, never corrupt persistent state. Otherwise:
-   - Pass the subagent return to the dedicated script on **stdin** via a quoted heredoc so free-text `text` values (which may contain apostrophes) can't break the command:
+5. **Apply writes** in the main session (to preserve cost attribution and channel/file access). Pass the subagent return to the dedicated script as-is, on **stdin**, via a quoted heredoc so free-text `text` values (which may contain apostrophes) can't break the command — the script is the validator, not this step:
      ```
      bun ${CLAUDE_PLUGIN_ROOT}/scripts/heartbeat.ts alert-state .claude-code-hermit/state/alert-state.json <<'HERMIT_ALERT_JSON'
      <subagent-return-json>
      HERMIT_ALERT_JSON
      ```
-     The script owns all bookkeeping: it derives the file-backed `micro-proposal-pending:*`/`proposal-pending:*` keys itself, unions them with the subagent's `firing` set, and runs the deterministic dedup/suppression/resolution/digest ladder. On success it writes `state/alert-state.json`, appends this tick's monitoring lines to SHELL.md `## Monitoring` itself, and prints one JSON line on stdout: `{"appended": <n>, "append_error": "<msg>"?, "notifications": [...], "self_eval_proposals": [{"key","kind","clean_ticks","noise_ticks","sessions_seen"}], "heartbeat_result": "OK"|"ALERT"}`. It also owns the every-20-ticks self-evaluation of the checklist, so `self_eval` is never yours to write. On any internal validation failure or write failure it writes nothing and prints nothing (exit 0 either way).
-   - **If stdout is empty or unparseable:** skip the remaining sub-steps and emit `HEARTBEAT_OK` — identical fail-open handling to a malformed subagent return; the next tick re-evaluates. Never treat this as an error.
-   - **Otherwise**, parse the script's stdout JSON:
-     - An `append_error` means SHELL.md is unreadable or has lost its `## Monitoring` section; mention it once in your reply and carry on — the durable state was still written.
+     The script owns all bookkeeping: it derives the file-backed `micro-proposal-pending:*`/`proposal-pending:*` keys itself, unions them with the subagent's `firing` set, and runs the deterministic dedup/suppression/resolution/digest ladder. On success it writes `state/alert-state.json`, appends this tick's monitoring lines to SHELL.md `## Monitoring` itself, and prints one JSON line on stdout: `{"appended": <n>, "append_error": "<msg>"?, "notifications": [...], "self_eval_proposals": [{"key","kind","clean_ticks","noise_ticks","sessions_seen"}], "heartbeat_result": "OK"|"ALERT"|"INDETERMINATE", "reason"?}`. It also owns the every-20-ticks self-evaluation of the checklist, so `self_eval` is never yours to write. On a rejected evaluation it leaves `state/alert-state.json` untouched, appends one `Heartbeat: evaluation indeterminate` line to SHELL.md `## Monitoring` itself, and prints `heartbeat_result:"INDETERMINATE"` with a `reason` (exit 1 only for an unparseable payload; exit 0 for every other reject).
+   - **Parse the script's stdout JSON:**
+     - `heartbeat_result: "INDETERMINATE"` means the evaluation was rejected and nothing was written; mention the `reason` once in your reply, respond `HEARTBEAT_INDETERMINATE (<reason>)`, and skip the rest of this bullet — a rejected tick carries no notifications and no proposals. Empty or unparseable stdout is a script crash rather than a rejected evaluation; report it the same way with reason `no-output`.
+     - On an `OK` or `ALERT` tick, an `append_error` means SHELL.md is unreadable or has lost its `## Monitoring` section; mention it once in your reply and carry on — the durable state was still written.
      - For each `notifications` entry: notify the operator (per CLAUDE-APPEND.md § Operator Notification). The script has already decided which ticks are notify-worthy (a new alert, a suppression transition, the daily digest) — send every entry it produced, unconditionally.
      - For each `self_eval_proposals` entry: invoke `/claude-code-hermit:proposal-create` with category `capability`, `source: auto-detected`, `self_eval_key: <key>`, and evidence written from the entry's `kind` and counts (a `clean` entry has been quiet for `clean_ticks` passes across `sessions_seen` sessions; a `noisy` one keeps firing after its proposal was dismissed; `weight` means the checklist has outgrown its recommended size). The list is empty on every tick but the every-20-ticks self-evaluation.
    - **`next_task` from step 1**, once the writes above are done: `"start"` → invoke `/claude-code-hermit:session-start` with no task argument; it adopts the queued task itself. Under `autonomous`, once that task completes, run the `session` skill's Work-done flow (§6) on it, never send a bare notification instead: a notified-but-`in_progress` session triggers stale-session alerts and delays archival. `"waiting"` → nothing further; step 3 owns delivery and the acknowledgement that parks the session.
-6. Respond with `HEARTBEAT_OK` or `HEARTBEAT_ALERT` per the **script's** `heartbeat_result`.
+6. Respond with `HEARTBEAT_OK`, `HEARTBEAT_ALERT`, or `HEARTBEAT_INDETERMINATE (<reason>)` per the **script's** `heartbeat_result`.
 
 ### start
 

--- a/plugins/claude-code-hermit/skills/heartbeat/reference.md
+++ b/plugins/claude-code-hermit/skills/heartbeat/reference.md
@@ -7,6 +7,7 @@ resolution, the daily digest, monitoring lines, operator notifications, `last_cl
 `heartbeat_result`) is derived deterministically by `heartbeat.ts alert-state` from the returned firing set —
 the subagent never authors any of it. This split exists because a small model (`heartbeat.model`,
 haiku by default) asked to author that bookkeeping fabricates fields and flips pending flags.
+`heartbeat_result` is `OK`, `ALERT`, or `INDETERMINATE` (this return was rejected — nothing written).
 
 This file is read only on the EVALUATE path, once the precheck determines a full LLM tick is warranted.
 

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -3704,8 +3704,8 @@ describe('proactive-notify unification contract', () => {
 // The subagent (reference.md) and the calling skill (SKILL.md) must agree on
 // the return shape, and neither may reintroduce the model-authored bookkeeping
 // fields that update-alert-state.ts now owns exclusively. A drift here (e.g.
-// SKILL.md validating a stale key list, or reference.md instructing the model
-// to emit `suppressed`/`resolved_keys` again) would silently reopen #594.
+// SKILL.md pre-validating the return itself, or reference.md instructing the
+// model to emit `suppressed`/`resolved_keys` again) would silently reopen #594.
 // ============================================================
 
 describe('heartbeat eval-runner return contract', () => {
@@ -3739,8 +3739,14 @@ describe('heartbeat eval-runner return contract', () => {
     expect(reference).toContain('**Never** emit a `micro-proposal-pending:*` or `proposal-pending:*` key, or the `stale-session` key.');
   });
 
-  test('SKILL.md step 5 validates exactly the new required-key list', () => {
-    expect(skill).toContain('missing the required **key** `firing`');
+  test('SKILL.md step 5 leaves validation to the script', () => {
+    // Pre-validating here is what made a rejected evaluation report
+    // HEARTBEAT_OK: the skill swallowed the reject and the script never saw it.
+    expect(skill).not.toContain('skip all writes and emit `HEARTBEAT_OK`');
+    // Positive half: a pure absence assertion also passes on a step 5 that lost
+    // the script call or the reject branch outright.
+    expect(skill).toContain('heartbeat.ts alert-state');
+    expect(skill).toContain('respond `HEARTBEAT_INDETERMINATE (<reason>)`');
     for (const field of REMOVED_MODEL_FIELDS) {
       expect(skill).not.toContain(`\`${field}\``);
     }

--- a/plugins/claude-code-hermit/tests/scripts.test.ts
+++ b/plugins/claude-code-hermit/tests/scripts.test.ts
@@ -1130,20 +1130,40 @@ describe('update-alert-state', () => {
     write(stateFile, before);
     let r = await runScript('heartbeat.ts', { args: ['alert-state', stateFile], stdin: JSON.stringify({ firing: 'not-an-array', self_eval_updates: {} }), env: { HERMIT_NOW: NOW } });
     expect(r.exitCode).toBe(0);
-    expect(r.stdout.trim()).toBe('');
+    expect(JSON.parse(r.stdout.trim())).toMatchObject({ heartbeat_result: 'INDETERMINATE', reason: 'missing-or-malformed-firing' });
     expect(readJson(stateFile)).toEqual(JSON.parse(before)); // untouched — never coerced to empty and aged
 
     write(stateFile, before);
     r = await runScript('heartbeat.ts', { args: ['alert-state', stateFile], stdin: JSON.stringify({ firing: [{ key: 'checklist:x' }], self_eval_updates: {} }), env: { HERMIT_NOW: NOW } }); // missing text
     expect(r.exitCode).toBe(0);
-    expect(r.stdout.trim()).toBe('');
+    expect(JSON.parse(r.stdout.trim())).toMatchObject({ heartbeat_result: 'INDETERMINATE', reason: 'missing-or-malformed-firing' });
     expect(readJson(stateFile)).toEqual(JSON.parse(before));
 
     write(stateFile, before);
     r = await runScript('heartbeat.ts', { args: ['alert-state', stateFile], stdin: JSON.stringify({ firing: [{ text: 'x' }], self_eval_updates: {} }), env: { HERMIT_NOW: NOW } }); // neither item nor key
     expect(r.exitCode).toBe(0);
-    expect(r.stdout.trim()).toBe('');
+    expect(JSON.parse(r.stdout.trim())).toMatchObject({ heartbeat_result: 'INDETERMINATE', reason: 'missing-or-malformed-firing' });
     expect(readJson(stateFile)).toEqual(JSON.parse(before));
+  }));
+
+  test('update-alert-state (rejected tick leaves state untouched and logs one indeterminate Monitoring line)', withDir(async (dir) => {
+    const before = '{"alerts":{"stale-session":{"count":1,"consecutive_clean":0,"suppressed":false,"first_seen":"2026-07-01","last_seen":"2026-07-01","text":"t"}},"self_eval":{},"total_ticks":9,"last_clean_eval_at":"2026-07-09T12:00:00.000Z"}';
+    write(hermit(dir, 'state', 'alert-state.json'), before);
+    const { state, stdout, monitoring } = await updateAlertState(dir, '{"firing":null}');
+    expect(state).toEqual(JSON.parse(before)); // untouched — last_clean_eval_at and the live alert both survive
+    expect(stdout).toMatchObject({ heartbeat_result: 'INDETERMINATE', reason: 'missing-or-malformed-firing' });
+    expect(monitoring).toHaveLength(1);
+    expect(monitoring[0]).toContain('evaluation indeterminate (missing-or-malformed-firing)');
+  }));
+
+  // A bare `null` return parses but has no properties — the reject path must
+  // still produce the contract, not a TypeError with empty stdout.
+  test('update-alert-state (payload that parses to a non-object still reports INDETERMINATE)', withDir(async (dir) => {
+    const before = '{"alerts":{},"self_eval":{},"total_ticks":1}';
+    write(hermit(dir, 'state', 'alert-state.json'), before);
+    const { state, stdout } = await updateAlertState(dir, 'null');
+    expect(state).toEqual(JSON.parse(before));
+    expect(stdout).toMatchObject({ heartbeat_result: 'INDETERMINATE', reason: 'missing-or-malformed-firing' });
   }));
 
   test('update-alert-state (duplicate firing keys deduped — first occurrence wins)', withDir(async (dir) => {
@@ -1254,13 +1274,20 @@ describe('update-alert-state', () => {
     expect(r.stdout.trim()).toBe('OK');
   }));
 
-  test('update-alert-state (write failure — no stdout, no side effects)', withDir(async (dir) => {
+  test('update-alert-state (write failure — no side effects)', withDir(async (dir) => {
     const stateFile = hermit(dir, 'state', 'alert-state.json');
-    fs.mkdirSync(stateFile); // path is a directory → write throws EISDIR
-    const r = await runScript('heartbeat.ts', { args: ['alert-state', stateFile], stdin: firingPayload([{ key: 'stale-session', text: 'x' }]), env: { HERMIT_NOW: NOW } });
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout.trim()).toBe('');
-    expect(fs.statSync(stateFile).isDirectory()).toBe(true); // untouched
+    const before = '{"alerts":{},"self_eval":{},"total_ticks":1}';
+    write(stateFile, before);
+    const stateSubdir = path.dirname(stateFile);
+    fs.chmodSync(stateSubdir, 0o555); // read-only dir — the tmp-file write inside writeAlertState fails
+    try {
+      const r = await runScript('heartbeat.ts', { args: ['alert-state', stateFile], stdin: firingPayload([{ key: 'stale-session', text: 'x' }]), env: { HERMIT_NOW: NOW } });
+      expect(r.exitCode).toBe(0);
+      expect(JSON.parse(r.stdout.trim())).toMatchObject({ heartbeat_result: 'INDETERMINATE', reason: 'write-failed' });
+      expect(fs.readFileSync(stateFile, 'utf-8')).toBe(before); // untouched
+    } finally {
+      fs.chmodSync(stateSubdir, 0o755);
+    }
   }));
 
   test('update-alert-state (apostrophe in free-text value round-trips intact)', withDir(async (dir) => {


### PR DESCRIPTION
## Problem

Every reject path in `heartbeat.ts alert-state` was fail-open and silent. A subagent return that would not parse, carried no usable `firing`, or hit an unreadable or unwritable `alert-state.json` left the tick reporting `HEARTBEAT_OK`. The operator saw a healthy heartbeat while nothing had actually been evaluated, and no surface — status, brief, or the SHELL.md Monitoring section — carried a trace of it.

The failure mode is worst exactly where it matters: a persistent `EACCES` on the state file makes an always-on hermit report health forever while its checklist is never evaluated.

## Behavior

```
tick ──> BEFORE: evaluator return rejected ─> state kept ─> nothing logged ─> "HEARTBEAT_OK"
    └──> AFTER:  evaluator return rejected ─> state kept ─> 1 Monitoring line ─> "HEARTBEAT_INDETERMINATE (<reason>)"
```

Healthy and alerting ticks are unchanged. The damper keys off `last_clean_eval_at`, which a rejected tick never rewrites, so the next tick re-evaluates exactly as before.

The five reject exits in `apply()` now share one `indeterminate(reason)` path: `alert-state.json` stays byte-identical, one `evaluation indeterminate (<reason>)` line is appended to SHELL.md `## Monitoring`, and stdout carries `heartbeat_result: "INDETERMINATE"` with the reason. Reasons: `invalid-json`, `missing-or-malformed-firing`, `unresolvable-firing`, `read-failed:<code>`, `write-failed`. Exit codes are unchanged (1 for `invalid-json`, 0 otherwise).

`skills/heartbeat/SKILL.md` step 5 no longer pre-validates the subagent return at all; it pipes it to the script as-is and echoes the script's verdict. That collapses two validators that could disagree into one, and it is the reason the skill can no longer swallow a reject.

### Decision

```
where does the reject get reported? ─┬─ script prints INDETERMINATE + logs one line ─> one validator, testable   ◀ SELECTED
                                     └─ skill stays the validator, emits a new token ─> transcript-only, still invisible to status/brief

persistent failure ──────────────────┬─ Monitoring line per failed tick, no channel notice ─> needs no state write   ◀ SELECTED
                                     └─ once-per-day channel notice ─> needs a stamp on a path that must not write state (deferred)
```

## Blast radius

- **Released surfaces touched:** none. `claude-code-hermit` core only, and the entry lands under `[Unreleased] › Fixed`; no version bump, no tag.
- **Unreleased surfaces touched:** `scripts/lib/heartbeat/alert-update.ts` (the `apply()` reject exits and the header contract comment), `skills/heartbeat/SKILL.md` (step 5 and step 6, plus the frontmatter `description`), `skills/heartbeat/reference.md` (the `heartbeat_result` value list). No config key, state-file schema, template, or migration changes, so `hermit-evolve` has nothing to run and the CHANGELOG entry carries no `### Upgrade Instructions`.
- **Downstream operators:** a rejected tick now surfaces where a healthy one used to. Operators running an always-on hermit will see `Heartbeat: evaluation indeterminate (<reason>) — state untouched.` lines in the Monitoring section on ticks that previously logged nothing, and the session response reads `HEARTBEAT_INDETERMINATE (<reason>)` instead of `HEARTBEAT_OK`. No channel or push notification is sent for a rejected tick, so nobody's chat gets noisier. Anyone who had a genuinely broken heartbeat has been seeing false health and will now see the truth — that is the point of the change, but it means a hermit can start reporting indeterminate immediately after update without anything new having broken.
- **Downstream hermits:** no cross-plugin surface. `HEARTBEAT_INDETERMINATE` is a response token read by a human, not a machine: nothing in `scripts/` or `hooks/` parses heartbeat response tokens, and `heartbeat-monitor.sh` only emits the inbound `HEARTBEAT_EVALUATE`. Domain plugins are untouched and no `required_core_version` floor moves.
- **Per-actor ledger:**
  - `executor claude:sonnet` — implemented plan steps 1 to 5 (the `indeterminate()` path and its five call sites, the test updates in `scripts.test.ts`, the SKILL.md and reference.md rewrites, the CHANGELOG bullet), then halted on the plan's own stop-and-ask when a test outside the plan's named files went red.
  - `code-review high --fix` — found and fixed a null-payload crash (below), scoped the `append_error` bullet in SKILL.md to `OK`/`ALERT` ticks after the rewrite made it reachable on the reject path where it would have falsely claimed state was written, and added positive assertions to the retired contract test. Two low findings left unfixed by operator decision.
  - `operator` — approved widening the plan's scope fence to `tests/contracts.test.ts`, chose the negative-pin shape for the replacement assertion, and refuted both remaining low findings.

The step-4 review ran in this session with fresh context: a subagent wrote the diff, this session did not.

## Notable fixes found in review

`JSON.parse('null')` succeeds, so a `null` payload skipped the `invalid-json` catch entirely and threw an uncaught `TypeError` on the `firing` lookup — empty stdout, a stack trace, exit 1. That is the same shape this change exists to remove, so it is now routed through `indeterminate('missing-or-malformed-firing')` with a regression test.

## Contract test

`tests/contracts.test.ts` pinned `'missing the required **key** \`firing\`'`, a substring of the very sentence step 5 had to lose. The positive pin is retired because SKILL.md pre-validates nothing now, so it could no longer catch drift; the invariant it approximated is covered executably by the `missing-or-malformed-firing` reject-reason assertions. The replacement asserts the fail-open sentence stays gone and that step 5 still calls the script and still emits the token — pins on stable identifiers rather than on prose.

## Validation

Full closing verification re-run in the worktree after the final commit, every row exit 0:

```
0  cd plugins/claude-code-hermit && bun test --parallel --timeout=45000
0  cd "$(git rev-parse --show-toplevel)" && bunx tsc
0  grep -c "expect(r.stdout.trim()).toBe('')" plugins/claude-code-hermit/tests/scripts.test.ts | grep -qx 0
0  grep -c 'skip all writes and emit `HEARTBEAT_OK`' plugins/claude-code-hermit/skills/heartbeat/SKILL.md | grep -qx 0
0  grep -c 'HEARTBEAT_INDETERMINATE' plugins/claude-code-hermit/CHANGELOG.md | grep -qx 1
```

Core suite: **5303 pass, 0 fail** across 176 files. `bunx tsc` clean at the repo root.

## Follow-up

Not fixed here, deliberately:

- On the corrupt-read branch, `quarantineAlertState` renames `alert-state.json` before the ladder runs. If `writeAlertState` then fails, the Monitoring line still reads `— state untouched.` while the file has been renamed away. Needs corrupt state *and* a write failure; making the shared line conditional reads worse in the common case.
- The reject path has no damper, so a persistent `read-failed:EACCES` or a full disk appends one Monitoring line per tick indefinitely. Damping requires persisting a stamp on a path whose whole contract is that it does not write state; the alternative was weighed and deferred in the plan.
