### PR TITLE
fix(claude-code-hermit): read stdin only behind an explicit flag in finish and patch

### DIFF
--- a/.agents/skills/stale-proposals/SKILL.md
+++ b/.agents/skills/stale-proposals/SKILL.md
@@ -75,7 +75,7 @@ For an unambiguous filename, append the metrics event before patching so regener
 bun plugins/claude-code-hermit/scripts/proposal.ts event .claude-code-hermit resolved --id="<PROP-ID>"
 
 bun plugins/claude-code-hermit/scripts/proposal.ts patch .claude-code-hermit <filename> \
-  --set status=resolved --set resolved_date=@now --request-compact <<'HERMIT_PATCH'
+  --set status=resolved --set resolved_date=@now --request-compact --stdin <<'HERMIT_PATCH'
 Decision: Resolved on @now — shipped in <plugin> <version>. <evidence sentence>
 HERMIT_PATCH
 ```

--- a/.claude/skills/stale-proposals/SKILL.md
+++ b/.claude/skills/stale-proposals/SKILL.md
@@ -85,7 +85,7 @@ bun plugins/claude-code-hermit/scripts/proposal.ts resolve-id .claude-code-hermi
 bun plugins/claude-code-hermit/scripts/proposal.ts event .claude-code-hermit resolved --id="<PROP-ID>"
 
 bun plugins/claude-code-hermit/scripts/proposal.ts patch .claude-code-hermit <filename> \
-    --set status=resolved --set resolved_date=@now --request-compact <<'HERMIT_PATCH'
+    --set status=resolved --set resolved_date=@now --request-compact --stdin <<'HERMIT_PATCH'
 Decision: Resolved on @now — shipped in <plugin> <version>. <evidence sentence>
 HERMIT_PATCH
 ```

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- `peer-post.ts` requires message text as an argument and no longer reads stdin.
+
+### Fixed
+- Stdin hang in `routines.ts finish` and `proposal.ts patch`: stdin is read only behind the explicit `--outcome-stdin` and `--stdin` flags; a heredoc without the flag is ignored.
+
 ## [1.3.2] - 2026-09-06
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/lib/cli.ts
+++ b/plugins/claude-code-hermit/scripts/lib/cli.ts
@@ -24,6 +24,11 @@ function readStdin(): Promise<string> {
   });
 }
 
+// A TTY never emits 'end' without Ctrl-D, so the flag alone is not enough to read.
+function readStdinIfFlagged(argv: string[], flag: string): Promise<string> {
+  return argv.includes(flag) && !process.stdin.isTTY ? readStdin() : Promise.resolve('');
+}
+
 function readJson(p: string): Json {
   try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch { return null; }
 }
@@ -41,4 +46,4 @@ function flagEq(argv: string[], name: string): string | undefined {
   return hit === undefined ? undefined : hit.slice(name.length + 3);
 }
 
-export { emit, readStdin, readJson, flagValue, flagEq };
+export { emit, readStdin, readStdinIfFlagged, readJson, flagValue, flagEq };

--- a/plugins/claude-code-hermit/scripts/lib/routines/finish.ts
+++ b/plugins/claude-code-hermit/scripts/lib/routines/finish.ts
@@ -1,10 +1,11 @@
-// `routines.ts finish <routine-id> [delivery]` — the single owner of a routine
-// fire's terminal ledger row. Called unconditionally after the skill is invoked,
-// replacing the old `log-event <id> fired`.
+// `routines.ts finish <routine-id> [delivery] [--outcome-stdin]` — the single
+// owner of a routine fire's terminal ledger row. Called unconditionally after the
+// skill is invoked, replacing the old `log-event <id> fired`.
 //
-// stdin (optional): the fire's one-line outcome, appended under SHELL.md's
-// `## Progress Log` as `[HH:MM] <line>`. Empty stdin writes nothing, and neither
-// does a replayed fire — one row per real fire, contract or not.
+// With --outcome-stdin, stdin carries the fire's one-line outcome, appended under
+// SHELL.md's `## Progress Log` as `[HH:MM] <line>`. Without the flag stdin is not
+// read. An empty outcome writes nothing, and neither does a replayed fire: one
+// row per real fire, contract or not.
 //
 // Why a finalizer instead of a verify-then-branch: the old contract asked the
 // model to decide which event to log, so a fire's success was recorded from the
@@ -39,7 +40,8 @@ import { readRunRecord, markOutcome, statIdentity, identityChanged } from './run
 
 type Json = any;
 
-const USAGE = 'Usage: routines.ts finish <routine-id> [delivery]';
+const USAGE = 'Usage: routines.ts finish <routine-id> [delivery] [--outcome-stdin]';
+const OUTCOME_FLAG = '--outcome-stdin';
 
 // Function declaration, not an arrow: TS only uses a `never` return for
 // control-flow narrowing when the callee is a declared name (same shape as
@@ -77,7 +79,9 @@ function appendOutcome(hermit: string, outcome: string): void {
 }
 
 export function run(args: string[], outcome = ''): void {
-  const [id, deliveryArg] = args;
+  // The dispatcher already consumed the flag's stdin; strip it here so it can
+  // never be taken as the delivery positional (the ledger accepts any string).
+  const [id, deliveryArg] = args.filter(arg => arg !== OUTCOME_FLAG);
   const delivery = deliveryArg || 'cron-create';
   if (!id) {
     process.stderr.write(`${USAGE}\n`);

--- a/plugins/claude-code-hermit/scripts/peer-post.ts
+++ b/plugins/claude-code-hermit/scripts/peer-post.ts
@@ -1,6 +1,6 @@
 // Posts one message into another Claude Code session's inbox socket.
 // Zero npm dependencies, Node stdlib only.
-// Usage: bun peer-post.ts <socket-path> [text]     (text on stdin when omitted)
+// Usage: bun peer-post.ts <socket-path> <text>
 //
 // Exit 0 and print "sent" when the payload reached the socket; exit 1 and print
 // "dead" when nothing was listening or the connect timed out. "sent" is not
@@ -11,19 +11,14 @@
 // which is how a script posting to its OWN session identifies itself.
 
 import { postToSession } from './lib/peer-post';
-import { readStdin } from './lib/cli';
 
 const socketPath = process.argv[2];
-const inlineText = process.argv[3];
+const text = process.argv[3];
 
 if (!socketPath) {
-  console.error('Usage: bun peer-post.ts <socket-path> [text]');
+  console.error('Usage: bun peer-post.ts <socket-path> <text>');
   process.exit(1);
 }
-
-// A TTY stdin never emits 'end', so reading it would hang until the caller's own
-// timeout. Treat "no argument, nothing piped" as the empty message it is.
-const text = inlineText ?? (process.stdin.isTTY ? '' : (await readStdin()).trim());
 
 if (!text) {
   console.error('[hermit] peer-post: empty message — nothing to send.');

--- a/plugins/claude-code-hermit/scripts/proposal.ts
+++ b/plugins/claude-code-hermit/scripts/proposal.ts
@@ -28,12 +28,12 @@
 //     proposals-index + state-summary regen. Output: the canonical ID, or
 //     `ERROR|<token>` with zero writes.
 //
-//   patch <stateDir> <filename> [--set key=value]... [--request-compact]
+//   patch <stateDir> <filename> [--set key=value]... [--request-compact] [--stdin]
 //     <filename> must be a direct-child basename of the proposals dir (no `/`,
 //     no leading `.`) — it is joined onto that dir, so a `../` prefix would
 //     otherwise reach any frontmatter-bearing .md on disk. Rejected the same
 //     way a genuinely absent proposal is: `ERROR|no-such-proposal`.
-//     stdin (optional, heredoc): `Decision: <line>` and/or `Set: key=value`
+//     stdin (opt-in with --stdin, heredoc): `Decision: <line>` and/or `Set: key=value`
 //     lines (free-text values — argv --set is for enum/bool/date/@now values
 //     only). `@now` in any --set value or stdin line expands to the current
 //     zoned ISO timestamp. Frontmatter patch + Operator Decision append apply
@@ -78,7 +78,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { emit, readStdin, readJson, flagValue } from './lib/cli';
+import { emit, readStdin, readStdinIfFlagged, readJson, flagValue } from './lib/cli';
 import { pinStateDirOrExit, memoryDirFor } from './lib/cc-compat';
 import { appendJsonlLine } from './lib/append-jsonl';
 import { auditConfigChange } from './lib/config-audit';
@@ -517,10 +517,7 @@ async function main(): Promise<void> {
   switch (verb) {
     case 'create': return emit(verbCreate(stateDir, await readStdin()));
     case 'patch': {
-      // patch is the one verb documented as stdin-optional (defer/dismiss with
-      // no note omit the heredoc) — skip the read on a TTY so an interactive
-      // invocation with no piped input doesn't hang waiting for EOF.
-      const stdin = process.stdin.isTTY ? '' : await readStdin();
+      const stdin = await readStdinIfFlagged(rest, '--stdin');
       return emit(verbPatch(stateDir, stdin, rest));
     }
     case 'shell-append': return emit(verbShellAppend(stateDir, await readStdin(), rest));

--- a/plugins/claude-code-hermit/scripts/routines.ts
+++ b/plugins/claude-code-hermit/scripts/routines.ts
@@ -16,10 +16,10 @@
 //   bun routines.ts tz-shift "<cron-expr>" "<from-tz>"
 //     Rewrites a cron expression into the machine's local timezone.
 //
-//   bun routines.ts finish <routine-id> [delivery]
+//   bun routines.ts finish <routine-id> [delivery] [--outcome-stdin]
 //     Terminal gate for a fire. Verifies any declared `expect_artifact` contract
 //     against the baseline `precheck` froze, writes the one terminal ledger row,
-//     and prints `fired` or `failed|<reason>|<detail>`. Optional stdin: the fire's
+//     and prints `fired` or `failed|<reason>|<detail>`. With --outcome-stdin: the fire's
 //     one-line outcome, appended to SHELL.md's `## Progress Log`.
 //
 //   bun routines.ts log-event <routine-id> <event> [delivery]
@@ -70,8 +70,8 @@ switch (verb) {
     break;
   }
   case 'finish': {
-    const { readStdin } = await import('./lib/cli');
-    const outcome = process.stdin.isTTY ? '' : await readStdin();
+    const { readStdinIfFlagged } = await import('./lib/cli');
+    const outcome = await readStdinIfFlagged(rest, '--outcome-stdin');
     const { run } = await import('./lib/routines/finish');
     run(rest, outcome);
     break;

--- a/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hermit-routines/SKILL.md
@@ -83,7 +83,7 @@ Base execution, one routine, `<delivery>` = `cron-create` (fallback prompt) or `
 ```
 Run: bun <pluginRoot>/scripts/routines.ts precheck <id> <rdw> <delivery>
 If the output is SKIP, stop. If PROCEED, then invoke /<skill> (or dispatch per the model-override rule above). After it completes, run:
-bun <pluginRoot>/scripts/routines.ts finish <id> <delivery> <<'HERMIT_LINE'
+bun <pluginRoot>/scripts/routines.ts finish <id> <delivery> --outcome-stdin <<'HERMIT_LINE'
 <one line: the routine id and what the fire actually did or found>
 HERMIT_LINE
 ```

--- a/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-act/SKILL.md
@@ -73,7 +73,7 @@ When the operator accepts a proposal:
    ```bash
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/proposal.ts patch .claude-code-hermit <filename> \
        --set status=accepted --set accepted_date=@now \
-       [--set responded=true] [--set accepted_in_session=<session_id>] <<'HERMIT_PATCH'
+       [--set responded=true] [--set accepted_in_session=<session_id>] --stdin <<'HERMIT_PATCH'
    Decision: Accepted on @now.
    [Set: success_signal=<predicate line>]
    HERMIT_PATCH
@@ -257,7 +257,7 @@ When invoked as `accept PROP-NNN --answer "<label>"` (channel-responder resolvin
 4. Patch:
    ```bash
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/proposal.ts patch .claude-code-hermit <filename> \
-       --set status=deferred --set deferred_date=@now [--set responded=true] <<'HERMIT_PATCH'
+       --set status=deferred --set deferred_date=@now [--set responded=true] --stdin <<'HERMIT_PATCH'
    Decision: Deferred on @now. Reason: [operator's note]
    HERMIT_PATCH
    ```
@@ -278,7 +278,7 @@ Deferred proposals still appear in `/proposal-list` but are sorted below open pr
 4. Patch:
    ```bash
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/proposal.ts patch .claude-code-hermit <filename> \
-       --set status=dismissed --set dismissed_date=@now --set resolved_date=@now [--set responded=true] <<'HERMIT_PATCH'
+       --set status=dismissed --set dismissed_date=@now --set resolved_date=@now [--set responded=true] --stdin <<'HERMIT_PATCH'
    Decision: Dismissed on @now. Reason: [operator's reason]
    HERMIT_PATCH
    ```
@@ -300,7 +300,7 @@ Used when reflect has surfaced a sparse-cadence proposal as a resolution candida
 3. Patch — frontmatter flip, Operator Decision timestamp, and the compaction-boundary marker in one call:
    ```bash
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/proposal.ts patch .claude-code-hermit <filename> \
-       --set status=resolved --set resolved_date=@now --request-compact <<'HERMIT_PATCH'
+       --set status=resolved --set resolved_date=@now --request-compact --stdin <<'HERMIT_PATCH'
    Decision: Resolved on @now.
    HERMIT_PATCH
    ```

--- a/plugins/claude-code-hermit/tests/helpers/run.ts
+++ b/plugins/claude-code-hermit/tests/helpers/run.ts
@@ -44,6 +44,12 @@ export interface RunResult {
 
 export interface RunOptions {
   stdin?: string;
+  /**
+   * Leave stdin an open pipe that never reaches EOF (the shape the Bash tool
+   * hands a script). A child that waits on 'end' is killed after 2s, so a
+   * regression shows as a non-zero exit with empty stdout, not a suite hang.
+   */
+  openStdin?: boolean;
   env?: Record<string, string>;
   cwd?: string;
   args?: string[];
@@ -108,14 +114,16 @@ export async function runScript(script: string, opts: RunOptions = {}): Promise<
     cmd: [process.execPath, path.join(SCRIPTS_DIR, script), ...(opts.args ?? [])],
     cwd: opts.cwd,
     env: { ...process.env, ...opts.env },
-    stdin: Buffer.from(opts.stdin ?? ''),
+    stdin: opts.openStdin ? 'pipe' : Buffer.from(opts.stdin ?? ''),
     stdout: 'pipe',
     stderr: 'pipe',
   });
+  const timer = opts.openStdin ? setTimeout(() => proc.kill(), 2000) : undefined;
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
   ]);
+  clearTimeout(timer);
   return { exitCode, stdout, stderr };
 }

--- a/plugins/claude-code-hermit/tests/peer-post.test.ts
+++ b/plugins/claude-code-hermit/tests/peer-post.test.ts
@@ -132,10 +132,9 @@ describe('postToSession', () => {
 });
 
 describe('peer-post CLI', () => {
-  async function runCli(args: string[], stdin?: string) {
+  async function runCli(args: string[]) {
     const { stdout, exitCode } = await runScript('peer-post.ts', {
       args,
-      stdin,
       // The token is inherited from the ambient session when Claude Code runs
       // the suite; blank it so the frame count is the same on CI and locally.
       env: { CLAUDE_CODE_MESSAGING_TOKEN: '' },
@@ -152,24 +151,6 @@ describe('peer-post CLI', () => {
       expect(stdout).toBe('sent');
       await waitForLines(inbox.lines, 1);
       expect(JSON.parse(inbox.lines[0]).message.content).toBe('HEARTBEAT_EVALUATE');
-    } finally {
-      inbox.close();
-    }
-  });
-
-  test('text on stdin when the argument is omitted', async () => {
-    const inbox = await inboxServer();
-    try {
-      const { exitCode } = await runCli(
-        [inbox.socketPath],
-        'ROUTINE_DUE [hermit-routine:daily-auto-close]\n',
-      );
-
-      expect(exitCode).toBe(0);
-      await waitForLines(inbox.lines, 1);
-      expect(JSON.parse(inbox.lines[0]).message.content).toBe(
-        'ROUTINE_DUE [hermit-routine:daily-auto-close]',
-      );
     } finally {
       inbox.close();
     }
@@ -209,5 +190,17 @@ describe('peer-post CLI', () => {
   test('no socket path → usage error, exit 1', async () => {
     const { exitCode } = await runCli([]);
     expect(exitCode).toBe(1);
+  });
+
+  test('no text argument → exit 1, nothing on the wire', async () => {
+    const inbox = await inboxServer();
+    try {
+      const { stdout, exitCode } = await runCli([inbox.socketPath]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe('');
+      expect(inbox.lines).toHaveLength(0);
+    } finally {
+      inbox.close();
+    }
   });
 });

--- a/plugins/claude-code-hermit/tests/proposal-write.test.ts
+++ b/plugins/claude-code-hermit/tests/proposal-write.test.ts
@@ -262,6 +262,15 @@ describe('proposal.ts event', () => {
 });
 
 describe('proposal.ts patch', () => {
+  test('patches with an open stdin pipe without a stdin flag', withDir(async (dir) => {
+    seedState(dir);
+    const id = await createProposal(dir);
+    const r = await runProposal(stateArg(dir), ['patch', id, '--set', 'status=accepted'], { openStdin: true, cwd: dir });
+    expect(r.stdout.trim()).toBe(`OK|${id}`);
+    expect(r.exitCode).toBe(0);
+    expect(fs.readFileSync(propPath(dir, id), 'utf-8')).toContain('status: accepted');
+  }));
+
   function createProposal(dir: string, extra: Record<string, string> = {}): Promise<string> {
     const stdin = heredoc({ Title: 'Patch target', ...extra }, MIN_BODY);
     return runProposal(stateArg(dir), ['create'], { stdin }).then(r => r.stdout.trim());
@@ -272,7 +281,7 @@ describe('proposal.ts patch', () => {
     const id = await createProposal(dir);
     const before = fs.readFileSync(propPath(dir, id), 'utf-8');
 
-    const r = await runProposal(stateArg(dir), ['patch', id, '--set', 'status=accepted', '--set', 'accepted_date=@now', '--set', 'responded=true'], { stdin: 'Decision: Accepted on @now.\n' });
+    const r = await runProposal(stateArg(dir), ['patch', id, '--stdin', '--set', 'status=accepted', '--set', 'accepted_date=@now', '--set', 'responded=true'], { stdin: 'Decision: Accepted on @now.\n' });
     expect(r.stdout.trim()).toBe(`OK|${id}`);
     const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(after).toContain('status: accepted');
@@ -311,7 +320,7 @@ describe('proposal.ts patch', () => {
     const id = await createProposal(dir);
     const before = fs.readFileSync(propPath(dir, id), 'utf-8');
     const fmBefore = before.slice(0, before.indexOf('\n---', 3) + 4);
-    await runProposal(stateArg(dir), ['patch', id], { stdin: 'Decision: just a note.\n' });
+    await runProposal(stateArg(dir), ['patch', id, '--stdin'], { stdin: 'Decision: just a note.\n' });
     const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     const fmAfter = after.slice(0, after.indexOf('\n---', 3) + 4);
     expect(fmAfter).toBe(fmBefore);
@@ -357,7 +366,7 @@ describe('proposal.ts patch', () => {
   test('Set: stdin line carries a free-text multi-word predicate into frontmatter', withDir(async (dir) => {
     seedState(dir);
     const id = await createProposal(dir);
-    const r = await runProposal(stateArg(dir), ['patch', id], { stdin: 'Set: success_signal=avg_session_cost_usd < 5 over 7 sessions\n' });
+    const r = await runProposal(stateArg(dir), ['patch', id, '--stdin'], { stdin: 'Set: success_signal=avg_session_cost_usd < 5 over 7 sessions\n' });
     expect(r.stdout.trim()).toBe(`OK|${id}`);
     const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(after).toContain('success_signal: "avg_session_cost_usd < 5 over 7 sessions"');
@@ -366,7 +375,7 @@ describe('proposal.ts patch', () => {
   test('re-running an identical patch call is idempotent — no duplicate Decision line', withDir(async (dir) => {
     seedState(dir);
     const id = await createProposal(dir);
-    const call = () => runProposal(stateArg(dir), ['patch', id], { stdin: 'Decision: Fixed timestamp note.\n' });
+    const call = () => runProposal(stateArg(dir), ['patch', id, '--stdin'], { stdin: 'Decision: Fixed timestamp note.\n' });
     await call();
     await call();
     const content = fs.readFileSync(propPath(dir, id), 'utf-8');
@@ -385,7 +394,7 @@ describe('proposal.ts patch', () => {
     const seeded = fs.readFileSync(propPath(dir, id), 'utf-8')
       .replace('## Operator Decision\n', '## Operator Decision\nAccepted on 2001-01-01T00:00:00Z.\n');
     fs.writeFileSync(propPath(dir, id), seeded);
-    await runProposal(stateArg(dir), ['patch', id, '--set', 'status=accepted', '--set', 'accepted_date=@now'], { stdin: 'Decision: Accepted on @now.\n' });
+    await runProposal(stateArg(dir), ['patch', id, '--stdin', '--set', 'status=accepted', '--set', 'accepted_date=@now'], { stdin: 'Decision: Accepted on @now.\n' });
     const content = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(content.match(/Accepted on \d{4}-/g)?.length).toBe(1);
     expect(content).toContain('Accepted on 2001-01-01T00:00:00Z.');
@@ -394,7 +403,7 @@ describe('proposal.ts patch', () => {
   test('a bare Decision: line does not swallow the following Set: line', withDir(async (dir) => {
     seedState(dir);
     const id = await createProposal(dir);
-    const r = await runProposal(stateArg(dir), ['patch', id], { stdin: 'Decision:\nSet: success_signal=avg_session_cost_usd < 5 over 7 sessions\n' });
+    const r = await runProposal(stateArg(dir), ['patch', id, '--stdin'], { stdin: 'Decision:\nSet: success_signal=avg_session_cost_usd < 5 over 7 sessions\n' });
     expect(r.stdout.trim()).toBe(`OK|${id}`);
     const after = fs.readFileSync(propPath(dir, id), 'utf-8');
     expect(after).toContain('success_signal: "avg_session_cost_usd < 5 over 7 sessions"');
@@ -800,7 +809,7 @@ describe('proposal.ts patch — pending-ask reconciliation', () => {
     const id = await createProposal(dir);
     seedAsk(dir, id.slice(0, 8));
 
-    const r = await runProposal(stateArg(dir), ['patch', id], { stdin: 'Set: status=resolved\nDecision: Done.\n' });
+    const r = await runProposal(stateArg(dir), ['patch', id, '--stdin'], { stdin: 'Set: status=resolved\nDecision: Done.\n' });
     expect(r.stdout.trim()).toBe(`OK|${id}`);
     expect(pending(dir)).toHaveLength(0);
   }));

--- a/plugins/claude-code-hermit/tests/routine-finish.test.ts
+++ b/plugins/claude-code-hermit/tests/routine-finish.test.ts
@@ -42,7 +42,7 @@ const writeArtifact = (dir: string, rel: string, body: string) => {
 const precheck = (dir: string, id: string) =>
   runScript('routines.ts', { args: ['precheck', id, 'true'], cwd: dir });
 const finish = (dir: string, id: string, stdin = '') =>
-  runScript('routines.ts', { args: ['finish', id], cwd: dir, stdin });
+  runScript('routines.ts', { args: ['finish', id, '--outcome-stdin'], cwd: dir, stdin });
 
 const progressLog = (dir: string) => {
   const shell = fs.readFileSync(hermit(dir, 'sessions', 'SHELL.md'), 'utf-8');
@@ -206,6 +206,12 @@ describe('routines.ts finish — declared artifact contract', () => {
 });
 
 describe('routines.ts finish — outcome line on stdin', () => {
+  test('finishes with an open stdin pipe without an outcome flag', withDir(async (dir) => {
+    const r = await runScript('routines.ts', { args: ['finish', 'plain', 'monitor'], cwd: dir, openStdin: true });
+    expect(r.stdout.trim()).toBe('fired');
+    expect(r.exitCode).toBe(0);
+  }));
+
   test('lands exactly one Progress Log row, and never a second on a replayed fire', withDir(async (dir) => {
     writeConfig(dir, [
       { id: 'cal', schedule: '0 6 * * *', skill: 'x', enabled: true, expect_artifact: 'raw/s-{date}.md' },


### PR DESCRIPTION
## Problem

`routines.ts finish` and `proposal.ts patch` read stdin whenever it was not a TTY. When fd 0 is a non-TTY stream that never closes (an inherited socket, or a pipe with no writer, as happens when the call runs in a Bash batch after a heredoc), the read never sees EOF and the process blocks forever. The routine ledger row is never written and the session turn stalls until the process is killed. Reproduced: `sleep 30 | bun scripts/routines.ts finish <id> monitor` hangs; `</dev/null` returns `fired` at once.

## Change

- `finish` reads stdin only with `--outcome-stdin`; `patch` only with `--stdin`. Without the flag stdin is never touched and the verdict prints immediately. A heredoc without the flag is ignored.
- Shared `readStdinIfFlagged` in `lib/cli.ts` (keeps the TTY guard so an interactive call without a heredoc does not block either).
- `peer-post.ts` drops its unused stdin mode; message text is a required argument.
- Callers updated: `hermit-routines` template, the four `proposal-act` patch blocks, and the repo-internal `stale-proposals` skill (plus its `.agents/` mirror).
- Held-open-pipe regression tests for both verbs via a new `openStdin` option on the test runner; peer-post gains a "no text argument, exit 1" case.

```
BEFORE: finish / patch read fd 0 whenever it is not a TTY
        ─┬─ heredoc ─> verdict + outcome line
         └─ open socket/pipe, no writer ─> blocks forever, no ledger row, turn stalls

AFTER:  finish --outcome-stdin / patch --stdin ─> reads the heredoc as today
        flag absent ─> never touches fd 0, verdict at once
        peer-post <socket> <text> ─> argv only, stdin mode removed
```

Considered and rejected: a timeout on `readStdin` (races slow writers, partial payloads); flag on `finish` only (patch had the identical guard and runs on every accept/defer/dismiss/resolve).

## Blast radius

- Released surfaces touched: `routines.ts finish`, `proposal.ts patch`, `peer-post.ts` CLI, `hermit-routines` and `proposal-act` skill text, core CHANGELOG `[Unreleased]`.
- Unreleased surfaces touched: none.
- Downstream operators: no visible change on the happy path. An operator who customized `proposal-act` or the routine template must add the flag to keep the Decision or outcome line; without it the patch or fire still succeeds, only the note is dropped.
- Downstream hermits: routine fires no longer stall when the session's fd 0 is an open socket. CronCreate fallback prompts baked before the upgrade drop the outcome line until the next re-arm (benign, best-effort field).
- Per-actor ledger: executor codex (harness default model, effort low) wrote the flag gate, helper, peer-post removal, skill edits, tests and changelog / code-review high --fix moved the flag strip into `finish.ts` `run()`, re-added the TTY guard, added `--stdin` to `stale-proposals`, folded the two hand-rolled pipe tests into `runScript` `openStdin`, added the peer-post no-arg test, fixed changelog order and backticks / operator approved the plan and delegated; no findings needed a decision.

## Validation

From `plugins/claude-code-hermit`: `bun test --parallel --timeout=45000` green, `bunx tsc` clean, re-run in the worktree after the review fixes. The open-pipe hang is pinned by the new tests in `routine-finish.test.ts` and `proposal-write.test.ts`.

Closes #984
