### PR TITLE
fix: gate covered-by-memory suppression on operator-decision memory types

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## [Unreleased]
 
-### Fixed
-- `covered-by-memory` suppression in `proposal-triage` now requires a memory that records an operator decision: frontmatter `type` `feedback` or `project`, read at the top level or under `metadata:`, with untyped files falling back to their `feedback_`/`project_` filename prefix. A `reference` or `user` memory can be cited but no longer suppresses, so a probe verdict saved minutes earlier stops blocking the proposal that would act on it.
-- Step 5's precondition reads "no `covered-by-memory` suppression" instead of "no memory match", so a candidate that matches a `reference` memory still goes through the three-condition rule.
 ### Changed
 - `peer-post.ts` requires message text as an argument and no longer reads stdin.
 
 ### Fixed
 - Stdin hang in `routines.ts finish` and `proposal.ts patch`: stdin is read only behind the explicit `--outcome-stdin` and `--stdin` flags; a heredoc without the flag is ignored.
+- `covered-by-memory` suppression in `proposal-triage` now requires a memory that records an operator decision: frontmatter `type` `feedback` or `project`, read at the top level or under `metadata:`, with untyped files falling back to their `feedback_`/`project_` filename prefix. A `reference` or `user` memory can be cited but no longer suppresses, so a probe verdict saved minutes earlier stops blocking the proposal that would act on it.
+- Step 5's precondition reads "no `covered-by-memory` suppression" instead of "no memory match", so a candidate that matches a `reference` memory still goes through the three-condition rule.
 
 ## [1.3.2] - 2026-09-06
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `covered-by-memory` suppression in `proposal-triage` now requires a memory that records an operator decision: frontmatter `type` `feedback` or `project`, read at the top level or under `metadata:`, with untyped files falling back to their `feedback_`/`project_` filename prefix. A `reference` or `user` memory can be cited but no longer suppresses, so a probe verdict saved minutes earlier stops blocking the proposal that would act on it.
+- Step 5's precondition reads "no `covered-by-memory` suppression" instead of "no memory match", so a candidate that matches a `reference` memory still goes through the three-condition rule.
+
 ## [1.3.2] - 2026-09-06
 
 ### Added

--- a/plugins/claude-code-hermit/agents/proposal-triage.md
+++ b/plugins/claude-code-hermit/agents/proposal-triage.md
@@ -68,7 +68,7 @@ Note the nearest near-miss PROP-ID even if no exact duplicate is found — it go
 
 ## Step 1.5 — Operator memory cross-reference
 
-Read `<memory_dir>/MEMORY.md` (the operator-facing index of `- [title](file) — description` entries — distinct from your own private memory, which is auto-injected). Read each topic file beside it whose title or description keyword-matches the candidate. Missing or empty means nothing is covered. Each topic file carries `name`, `description`, body, `Why:`, and `How to apply:` — match against all of them. If memory already records the operator's decision, preference, or pattern that this candidate would propose:
+Read `<memory_dir>/MEMORY.md` (the operator-facing index of `- [title](file) — description` entries — distinct from your own private memory, which is auto-injected). Read each topic file beside it whose title or description keyword-matches the candidate. Missing or empty means nothing is covered. Each topic file carries `name`, `description`, body, `Why:`, and `How to apply:` — match against all of them. Check each topic file's frontmatter `type` (top level in some files, nested under `metadata:` in others, so check both). Only a topic file whose type is `feedback` or `project` can trigger `covered-by-memory`; type `reference` and type `user` inform the verdict but never trigger suppression. A topic file whose frontmatter carries no `type` at all falls back to its filename prefix: `feedback_`/`project_` is eligible, anything else is not. If eligible memory already records the operator's decision, preference, or pattern that this candidate would propose:
 - Return: `SUPPRESS: <title> — covered-by-memory: <one-sentence reason> ("<quoted memory line>")` (see Output for the full grammar)
 - Emit `memory_ref: <filename>` as metadata so the operator can locate and revise the source if it has gone stale.
 - Stop evaluating this candidate. Continue with any remaining candidates in the batch.
@@ -91,7 +91,7 @@ Glob `*.md` with `path: <root>/compiled`. Read YAML frontmatter (`title`, `type`
 
 ## Step 5 — Three-Condition Rule
 
-Only if no duplicate found and no memory match, check applicable conditions:
+Only if no duplicate found and no `covered-by-memory` suppression, check applicable conditions:
 
 1. **Repeated pattern** — required only when `Evidence Source` is `archived-session` (or absent) and the candidate cites no machine-written `Artifact:`; then a single incident does not qualify. Every other source, and any artifact-cited candidate, had recurrence established upstream (the check's own interval analysis, the operator's request, the brainstorm pass, or `reflection-judge`'s verification of the cited sessions, ledger, or file). Do not re-check it here.
 2. **Meaningful consequence** — does something actually go wrong without fixing this? (Mild inconvenience does not qualify.) Always required.

--- a/plugins/claude-code-hermit/tests/reflect-loop.test.ts
+++ b/plugins/claude-code-hermit/tests/reflect-loop.test.ts
@@ -193,6 +193,13 @@ describe('observations ledger phrases', () => {
     expect(triage).toContain('never suppressed `covered-by-memory`');
   });
 
+  test('triage: covered-by-memory only from feedback/project memory types', () => {
+    expect(triage).toContain('topic file whose type is `feedback` or `project` can trigger `covered-by-memory`');
+    // Both frontmatter shapes occur in a real memory dir; pinning one would
+    // make the eligible-type gate miss the other.
+    expect(triage).toContain('top level in some files, nested under `metadata:` in others');
+  });
+
   test('hatch: seeds observations.jsonl', () => {
     expect(hatch).toContain('state/observations.jsonl');
   });

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `ha-pattern-analyst` and `ha-safety-reviewer` only let a memory that records an operator decision suppress a finding or change a verdict: frontmatter `type` `feedback` or `project`, or the `feedback_`/`project_` filename prefix where auto-injected memory hides the frontmatter. A `reference` memory recording an observed fact no longer silences the finding it describes. The safety carve-out is unchanged: memory still cannot move `ha_safety_mode`.
+
 ## [0.4.12] - 2026-09-06
 
 ### Changed

--- a/plugins/claude-code-homeassistant-hermit/agents/ha-pattern-analyst.md
+++ b/plugins/claude-code-homeassistant-hermit/agents/ha-pattern-analyst.md
@@ -37,7 +37,7 @@ Analyze artifacts to find:
 
 ## Memory Cross-Reference
 
-Auto memory is loaded in your context. Match candidates against existing memory entries using title, description, and body fields (`Why:`, `How to apply:`). For any candidate pattern, anomaly, opportunity, or reliability issue: if memory already records the operator's decision, preference, or pattern this candidate would surface, do not emit it under the regular arrays. Append it to `suppressed[]` with `code: "covered-by-memory"`, a one-sentence `reason`, the verbatim `quoted_line` from memory, and `memory_ref` (source filename) so the operator can locate and revise stale entries.
+Auto memory is loaded in your context. Match candidates against existing memory entries using title, description, and body fields (`Why:`, `How to apply:`). Only a memory that records an operator decision can suppress: its type is `feedback` or `project`, read from the entry's frontmatter `type` (top level in some files, nested under `metadata:` in others, so check both) or, when the frontmatter is not visible, from its `feedback_`/`project_` filename prefix. Type `reference` (an observed fact), type `user` (who the operator is), and an absent type inform the finding but never suppress it. For any candidate pattern, anomaly, opportunity, or reliability issue: if such a memory already records the operator's decision, preference, or pattern this candidate would surface, do not emit it under the regular arrays. Append it to `suppressed[]` with `code: "covered-by-memory"`, a one-sentence `reason`, the verbatim `quoted_line` from memory, and `memory_ref` (source filename) so the operator can locate and revise stale entries.
 
 ## Output Format
 

--- a/plugins/claude-code-homeassistant-hermit/agents/ha-safety-reviewer.md
+++ b/plugins/claude-code-homeassistant-hermit/agents/ha-safety-reviewer.md
@@ -39,7 +39,9 @@ Review YAML files in `.claude-code-hermit/raw/` (named `automation-*.yaml` or `s
 
 Auto memory is loaded in your context. Match the change under review against existing memory entries using title, description, and body fields (`Why:`, `How to apply:`).
 
-If memory already records the operator's preference or decision that would change your verdict:
+Only a memory that records an operator decision can change your verdict: its type is `feedback` or `project`, read from the entry's frontmatter `type` (top level in some files, nested under `metadata:` in others, so check both) or, when the frontmatter is not visible, from its `feedback_`/`project_` filename prefix. Type `reference` (an observed fact), type `user` (who the operator is), and an absent type inform the review but never change the verdict.
+
+If such a memory already records the operator's preference or decision that would change your verdict:
 - Set verdict to `approve` (memory has already adjudicated the concern).
 - Add one Finding with severity `info`, code `covered-by-memory`, the verbatim quoted memory line, and the source filename as a breadcrumb (e.g. `[memory: feedback_<topic>.md]`) so the operator can locate and revise it if stale.
 - Skip Recommendation for that finding.


### PR DESCRIPTION
## Problem

`proposal-triage` Step 1.5 suppressed a candidate as `covered-by-memory` against **any** keyword-matching auto-memory file. Most of the live corpus is `reference`-type probe verdicts, which record an observed harness fact rather than an operator decision, so a verdict saved minutes earlier would block the very proposal that would act on it. That misfire happened on 2026-09-06 (the candidate that became PROP-200) and the false-negative rate grows with every probe.

`user` memories have the same problem: they say who the operator is, not what they decided.

## Behavior

```
BEFORE: candidate ─> Step 1.5 keyword-matches ANY memory ─> SUPPRESS covered-by-memory
        (a probe verdict blocks the proposal that would act on it; operator asks by hand)

AFTER:  candidate ─> Step 1.5 keyword-matches memory ─┬─ type feedback|project ─> SUPPRESS covered-by-memory
                                                       └─ type reference|user  ─> continue to Step 2
                                                                                  (may be cited, never suppresses)
```

Eligibility is read from the memory's frontmatter `type`, checked in **both** shapes that occur in a real memory dir (top level, and nested under `metadata:`). A file carrying no `type` at all falls back to its `feedback_`/`project_` filename prefix, so every file in the corpus adjudicates deterministically.

Step 5's precondition moves from "no memory match" to "no `covered-by-memory` suppression". A `reference` match now passes Step 1.5, and the old wording would have read as unsatisfied and let the three-condition rule be skipped for exactly those candidates.

The same untyped suppression existed in the HA hermit's `ha-pattern-analyst` (suppresses findings) and `ha-safety-reviewer` (flips a verdict to `approve`), and gets the same gate. Their memory is auto-injected rather than read from disk, so the frontmatter may not be visible; hence the filename-prefix fallback there too. **The HA safety carve-out is untouched**: memory still cannot move `ha_safety_mode`, and `lock` / `alarm_control_panel` / security-domain changes stay hard-blocked under `strict`.

## Validation

The plan's closing verification, re-run in the worktree after the commit, all rows exit 0:

```
0  cd plugins/claude-code-hermit && bun test tests/reflect-loop.test.ts tests/recurrence-gate-matrix.test.ts tests/claude-append-budget.test.ts tests/knowledge-placement-pins.test.ts
0  cd plugins/claude-code-hermit && bun test --parallel --timeout=45000
0  grep -c 'topic file whose type is `feedback` or `project` can trigger `covered-by-memory`' plugins/claude-code-hermit/agents/proposal-triage.md
0  cd plugins/claude-code-homeassistant-hermit && bun test --parallel --timeout=45000 $(ls tests/*.test.ts | grep -v gate-corpus)
```

Core: 5218 pass, 0 fail. HA: 595 pass, 0 fail.

`tests/gate-corpus.test.ts` is excluded from the HA line only because it hard-fails on this machine with "No Python with python-dotenv + PyYAML found" before reaching any assertion. It is byte-identical to the base commit and this diff touches only Markdown and one test file. CI provisions that Python and still runs it.

A new pin in `reflect-loop.test.ts` asserts both the eligibility phrase and the both-shapes clause, so trimming either from the agent turns the suite red.

## Blast radius

- **Released surfaces touched:** `claude-code-hermit` `agents/proposal-triage.md` (shipped in 1.3.2) and `claude-code-homeassistant-hermit` `agents/ha-pattern-analyst.md`, `agents/ha-safety-reviewer.md` (shipped in 0.4.12). Both get `[Unreleased] / ### Fixed` bullets; no version bump here.
- **Unreleased surfaces touched:** none.
- **Downstream operators:** fewer false suppressions. A proposal previously swallowed because a probe memory mentioned the same subject now reaches the queue. Slightly more candidates survive triage, which is the intent, and the three-condition rule (no longer skippable for those candidates) is what keeps the weak ones out. No config, no migration, no action required.
- **Downstream hermits:** the gate is agent prose, so it takes effect on the next `/plugin update` for each plugin, independently. A hermit with an empty or absent memory dir is unaffected. HA hermits get strictly more findings and strictly fewer memory-driven `approve` verdicts, which is the safer direction; the safety-mode carve-out is unchanged.
- **Per-actor ledger:** executor `codex` (effort `low`) wrote the Step 1.5 gate and its pin test against the plan's original `metadata.type`-only contract / `code-review high --fix` found that the contract missed the top-level-`type` frontmatter shape (6 of 145 live files, 4 of them `feedback`) and the untyped file, rewrote the gate to check both shapes, added the prefix fallback, fixed Step 5's stale precondition, and repointed the pin / operator approved the contract reversal, authorized amending the plan file, and directed the HA fix into this PR rather than a follow-up issue; declined a regression pin for the HA agent prose.

## Known gap

The HA gate wording has no regression pin, unlike the core change. HA pins agent prose elsewhere (`domain-brainstorm-skill.test.ts`, `claude-append-trim.test.ts`), so a future trim of those two agents could drop the gate with a green suite. Raised in review and deliberately skipped: it needs a new HA test file, outside this diff's footprint.

Closes #985
