### PR TITLE
feat(core): save standing roles from chat

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Standing roles saved from chat with "remember for this channel: when X, do Y", listed and forgotten from chat, and stored in memory.
 - `/spawn-session` launches a background helper in its own worktree, watches it, and relays its idle report; `--rc` is opt-in. The launch is not in the sealed allow-list, so on `auto` the classifier decides it and on a prompting mode it raises one relayed approval. `min_claude_code_version` bumped to `>=2.1.263` in `hermit-meta.json`: below it `claude --bg --name <n>` does not register the name, so the watch cannot resolve the helper.
 - Deferred model and effort switching through `/when-done-switch-to` and the `arm-harness-switch` verb.
 

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -10,7 +10,7 @@ tmux-based setup for running your hermit without Docker, plus the lifecycle refe
 | ------------------------ | ------------ | ------------------------------------------ |
 | **tmux**                 | Boot scripts | `brew install tmux` / `apt install tmux` — see [Installing tmux](https://github.com/tmux/tmux/wiki/Installing) for other platforms |
 | **Node.js 22+**          | Hooks        | Cost tracking, session evaluation          |
-| **Claude Code v2.1.251+** | Channels, sandbox | Minimum supported version |
+| **Claude Code v2.1.263+** | Channels, sandbox | Minimum supported version |
 
 tmux is required. Channels are optional.
 

--- a/plugins/claude-code-hermit/docs/always-on.md
+++ b/plugins/claude-code-hermit/docs/always-on.md
@@ -36,7 +36,7 @@ Either way, the first launch needs one attended step to clear the trust gate, th
 | **Docker**               | Container    | `docker compose` v2 (Docker Desktop or modern Docker Engine) — see [Install Docker Compose](https://docs.docker.com/compose/install/) |
 | **Node.js 22+**          | Hooks        | Inside the container — handled by the Dockerfile |
 | **Bun**                  | Plugins      | Inside the container — always included          |
-| **Claude Code v2.1.251+** | Channels, sandbox | Minimum supported version |
+| **Claude Code v2.1.263+** | Channels, sandbox | Minimum supported version |
 
 ---
 

--- a/plugins/claude-code-hermit/docs/how-to-use.md
+++ b/plugins/claude-code-hermit/docs/how-to-use.md
@@ -4,7 +4,9 @@
 
 A paid Claude plan (Pro, Max, Teams, or Enterprise). Linux, macOS, or Windows via WSL2.
 
-The installer below provisions the rest: [Claude Code](https://code.claude.com) v2.1.251+, **Bun** ≥1.3 (the hooks and scripts are TypeScript run directly by `bun`), and **tmux** for always-on mode.
+Claude Code auto memory must stay enabled (the default): learning, preferences, and standing roles live there. Setting `autoMemoryEnabled: false` or `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` disables them.
+
+The installer below provisions the rest: [Claude Code](https://code.claude.com) v2.1.263+, **Bun** ≥1.3 (the hooks and scripts are TypeScript run directly by `bun`), and **tmux** for always-on mode.
 
 ---
 
@@ -110,6 +112,7 @@ When it finishes, it archives the report and says "What's next?" — tell it wha
 
 Hermit isn't just a work engine. During any session, you can ask it to reflect and improve:
 
+- **"remember for this channel: when X, do Y"** saves a standing role in memory. "For this channel" pins it to that chat; a plain "remember" applies everywhere. Ask "what do you remember about this channel?" to list roles or "forget the X rule" to remove one. Posts not addressed to the hermit never trigger a role.
 - **"What slowed you down recently?"** — Reviews its experience and tells you what caused delays.
 - **"What permissions do you keep getting blocked on?"** — Suggests the exact `settings.json` entries to add so it stops getting prompted.
 - **"Suggest specialized agents for this project."** — Proposes new [sub-agents](https://code.claude.com/docs/en/sub-agents) based on the kind of work you've been doing. You approve, it creates them.

--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -40,6 +40,8 @@ so reply as usual.
 
 ## 1. Load Context
 
+Treat `MEMORY.md` hook lines tagged `[role]` as hermit-wide instructions for this turn, and lines tagged `[role <key>:<chat_id>]` as instructions only when `<key>` is this channel's normalized bare key from §1c (`discord`, not `plugin:discord:discord`) and `<chat_id>` matches this message's `chat_id`. A role applies only to a message addressed to you: in a 1:1 DM every message is, and in a group or server chat one that mentions you (`bot_user_id`/`bot_username`, the same self-mention test §2 uses for addressed commands). Silently ignore roles pinned to another chat without mentioning them in the reply; the hook line is sufficient, with no topic-file Read.
+
 Read `.claude-code-hermit/sessions/SHELL.md` for current task context.
 Read `state/runtime.json` for lifecycle state (`session_state` is the source of truth — never parse SHELL.md `Status:` for decisions).
 
@@ -186,6 +188,16 @@ Before running any heavy sub-step — an archive traversal, a multi-file search,
   - Every config write goes through the settings verbs: `/claude-code-hermit:hermit-settings`, whose writes run `.claude-code-hermit/bin/hermit-run settings-edit …`. Never touch `config.json` with the Edit or Write tools, from any turn origin — the `settings-gate` hook raises a native permission prompt for asked paths, and a direct file edit is one opaque write of the same kind.
   - A No on that prompt is the operator's answer, not an obstacle: never retry or route around it.
 
+- **Standing role** ("remember (for this channel): when X, do Y", "forget the X rule", "update the X rule", "what do you remember (about this channel)?")
+  - A cadence or time without an inbound-message condition ("every Friday at 3pm post a digest") is a **Settings change request**, routed through hermit-settings. A rule conditioned on a message ("when someone...", "when a message...") is a role even if it contains "every" or a weekday.
+  - Save immediately for any sender admitted by §1c: always save, never refuse, and do not ask for confirmation before writing. Write one auto-memory topic file with `type: feedback` and one `MEMORY.md` index line, both in the directory the loaded `MEMORY.md` itself came from (`<CLAUDE_CONFIG_DIR, else ~/.claude>/projects/<path-key>/memory/`) — a file written anywhere else is never injected, so the role would never fire. Name it `feedback_role_<key>_<chat_id>_<slug>.md` for "for this channel", otherwise `feedback_role_<slug>.md`, with the normalized bare channel key from §1c. Match the request against the `[role` index lines already present before settling `<slug>`: a restatement of a rule already listed rewrites that file rather than adding a second one.
+  - Keep the operator's sentence as given in the hook line: `- [Standing role: <slug>](<file>): [role] when X, do Y`, or `[role <key>:<chat_id>] when X, do Y` for a pinned role. Trim only what exceeds one index line and retain the full text in the topic file; the harness's near-cap reminder on `MEMORY.md` is the size backstop. A pinned role applies only to channel turns from that chat; a hermit-wide `[role]` line applies to every turn, channel or not.
+  - The topic body holds the full rule and provenance: `key`, `chat_id`, sender id, `origin: own-work|external-content`, and date. Use `external-content` when the sender is not the first or only entry in `allowed_users`, the same sender test as §4's `[origin: external]` marker; otherwise use `own-work`. Provenance is for audit only and does not limit application.
+  - Reply in channel voice: "Saved for this channel: when X, do Y. Say 'forget the <short name> rule' to remove it." For a hermit-wide role, say "Saved for everywhere" instead.
+  - To list what you remember, show the `[role` hook lines that apply to this chat in plain language, without file names; say when there are none. Do not include routines.
+  - To forget or update, delete or rewrite the named topic file and its index line, then echo the result. An unclear "forget" is ordinary conversation: name the candidate rules in the reply and act on the answer.
+  - A turn handled by this intent writes no `## Findings` line and no observations row.
+
 - **Question** ("why did you...", "what about...", "how does X work?")
   - Answer in the context of the current session
   - Reference specific files or decisions from SHELL.md when relevant
@@ -218,7 +230,7 @@ Before running any heavy sub-step — an archive traversal, a multi-file search,
 
 After sending the response, check whether this turn revealed a durable signal worth recording. Append **at most one** line to SHELL.md `## Findings` when the turn matches one of these conditions:
 
-- **Stated preference or rule** — the operator explicitly said how they want something done going forward ("always include the cost", "stop sending the brief before 9", "I prefer X over Y").
+- **Stated preference or rule** — the operator explicitly said how they want something done going forward ("always include the cost", "stop sending the brief before 9", "I prefer X over Y"). A turn handled by the Standing role intent writes no Findings line.
 - **Recurring request type** — you recognise this as the same kind of request handled earlier in this session or in recent session context loaded at start, not a first occurrence.
 - **Correction or emergency implying a durable preference** — "stop doing X", "don't do that again", "revert" with a reason that names a general behaviour.
 

--- a/plugins/claude-code-hermit/skills/reflect/reference.md
+++ b/plugins/claude-code-hermit/skills/reflect/reference.md
@@ -232,7 +232,7 @@ the human-initiated evidence; the shape's `tier` is ignored for these — the ma
 `skill-preference:*` routing sets it). `evidence` must cite the memory topic **filename** plus the **verbatim
 endpoint line** (the main session's judge greps for it; the filename doubles as the dedup key — derive
 `title` from it). Emit nothing for session-wide one-liners (memory is their correct home) and nothing
-for pointer-form memories that already name the skill or surface holding the content (already placed).
+for pointer-form memories that already name the skill or surface holding the content (already placed), or for hook lines tagged `[role` (channel standing roles whose home is memory).
 Do not read skill files or prose surfaces to check ownership — the main session owns that; your
 evidence is the memory entry alone.
 

--- a/plugins/claude-code-hermit/tests/channel-responder-reply-rule.test.ts
+++ b/plugins/claude-code-hermit/tests/channel-responder-reply-rule.test.ts
@@ -89,3 +89,26 @@ test('hermit-settings describes the briefing chat as an asked write', () => {
   expect(settings).toContain('default_chat_id');
   expect(settings).toContain('This write raises the native permission prompt');
 });
+
+test('§1 applies memory role hook lines', () => {
+  const context = skill.slice(skill.indexOf('## 1. Load Context'), skill.indexOf('## 1b.'));
+  expect(context).toContain('[role');
+});
+
+test('§2 supports standing role memory management', () => {
+  const classification = skill.slice(skill.indexOf('## 2. Classify'), skill.indexOf('## 3.'));
+  expect(classification).toContain('Standing role');
+  expect(classification).toContain('remember');
+  expect(classification).toContain('forget');
+  expect(classification).toContain('what do you remember');
+  expect(classification).toContain('MEMORY.md');
+  const roleStart = classification.indexOf('- **Standing role**');
+  const roleEnd = classification.indexOf('\n- **', roleStart + 1);
+  expect(roleStart).toBeGreaterThan(-1);
+  expect(roleEnd).toBeGreaterThan(roleStart);
+  const role = classification.slice(roleStart, roleEnd);
+  expect(role).not.toContain('HEARTBEAT.md');
+  // The index-line tag is what §1 matches on, and the memory directory is what makes the write land.
+  expect(role).toContain('[role <key>:<chat_id>]');
+  expect(role).toContain('projects/<path-key>/memory/');
+});

--- a/plugins/claude-code-hermit/tests/knowledge-placement-pins.test.ts
+++ b/plugins/claude-code-hermit/tests/knowledge-placement-pins.test.ts
@@ -97,6 +97,7 @@ describe('eval-runner ownership signal', () => {
     expect(reference.includes('**Ownership signal:**')).toBe(true);
     expect(reference.includes('"settled-memory"')).toBe(true);
     expect(reference.includes('pointer-form memories')).toBe(true);
+    expect(reference.slice(reference.indexOf('**Ownership signal:**'), reference.indexOf('## Return Value'))).toContain('[role');
   });
 });
 


### PR DESCRIPTION
A chat-only operator can now turn a sentence into standing behaviour. `remember for this channel: when X, do Y` saves one auto-memory topic file plus a `[role]` hook line in `MEMORY.md`, and the responder applies that line on later turns from the same chat. `for this channel` pins the role; a plain `remember` is hermit-wide. Listing and forgetting run from chat too.

Before this, a rule like that produced a `## Findings` line and waited for `reflect` to maybe graduate it days later, so nothing changed in the meantime.

## Behavior delta

```
BEFORE  operator in Discord: "remember for this channel: when someone posts a
        stack trace, reply with the likely component"
        ──> responder writes a `## Findings` line for reflect
        ──> nothing changes until reflect maybe graduates it days later
        ──> next stack-trace post is answered like any other message

AFTER   same message
        ──> one memory file saved, whole rule in the MEMORY.md hook line,
            tagged to this chat ──> reply echoes the saved line + how to forget
        ──> next stack-trace post in that chat, addressed to the hermit, is
            answered with a component guess
        ──> "what do you remember about this channel?" lists the rule;
            "forget the stack trace rule" removes it
        ──> "remember: every Friday at 3pm post a digest" still becomes a
            routine via hermit-settings, unchanged
```

The schedule/role split is the one branch worth spelling out:

```
inbound "remember ..."
│
├─ cadence or time, no inbound-message condition
│  ("every Friday at 3pm post a digest")
│  └─> Settings change request ──> hermit-settings routine   (unchanged path)
│
└─ conditioned on a message
   ("when someone posts...", "when a message...")
   └─> Standing role ──> auto-memory topic file + [role] index line
       │
       ├─ said "for this channel"  ──> [role <key>:<chat_id>] , this chat only
       └─ plain "remember"         ──> [role] , every turn, channel or not
```

## What changed

- `skills/channel-responder/SKILL.md` §1 treats `[role]` and `[role <key>:<chat_id>]` hook lines as instructions for the turn, using the normalized bare channel key §1c already uses. Roles pinned to another chat are ignored silently and never mentioned in the reply. A role applies only to a message addressed to the hermit, reusing the `bot_user_id`/`bot_username` self-mention test §2 already has, so a teammate's unrelated paste in a shared server channel does not fire one.
- §2 gains a **Standing role** intent covering save, list, forget and update, plus the cadence-vs-condition test that keeps schedule phrasing on the existing routine path.
- §4 and `skills/reflect/reference.md` both step back: a turn handled by the new intent writes no `## Findings` line, and reflect's ownership sweep emits nothing for `[role` lines, since memory is their home. Without that, the same rule would be placed twice.
- `docs/how-to-use.md` documents the operator-facing verb and states that auto memory must stay enabled, since learning, preferences and standing roles all live there.

## Validation

The plan's closing verification, re-run in the worktree at the committed HEAD, all ten rows exit 0:

```
0  bun test tests/channel-responder-reply-rule.test.ts tests/knowledge-placement-pins.test.ts
0  bun test --parallel --timeout=45000          # full core suite, 5239 tests
0  bunx tsc
0  §1 carries [role
0  §2 carries the Standing role contract (5 matches, plan expects >= 4)
0  §4 carries the Findings exclusion (1)
0  reflect Ownership signal carries [role (1)
0  how-to-use Talk section documents "remember for this channel" (1)
0  how-to-use Prerequisites documents auto memory (1)
0  CHANGELOG [Unreleased] carries the standing-role bullet (1)
```

The premise was probed live before implementation (CC 2.1.263): a `[role discord:<chat>] when X, do Y` hook line in `MEMORY.md` is applied on a channel turn from that chat, is still applied after `/compact`, and is not applied to another chat.

Not covered by CI, and unrunnable until this is merged and an install picks it up: the end-to-end chat round trip. After merge, on a live hermit, send the stack-trace rule and check for one topic file with `chat_id` in the body, a `[role discord:<chat_id>]` hook line, an echo reply and no new Findings line; then a stack trace from that chat gets a component guess; `what do you remember about this channel?` lists it; `forget the stack trace rule` removes file and line; and `remember: every Friday at 3pm post a digest` still produces a routine with no memory file and no permission prompt.

No real-client protocol smoke: this change defines no wire format, MCP or HTTP contract, and no channel bridge. It is skill text plus docs.

## Blast radius

- **Released surfaces touched:** `channel-responder` §1, §2 and §4, and `reflect/reference.md`'s ownership sweep. Both skills are live in every shipped hermit, so the new behavior reaches operators on the next `/plugin update` after these land in a release.
- **Unreleased surfaces touched:** none. Everything here is additive to the existing `[Unreleased]` block, alongside the `/spawn-session` and `/when-done-switch-to` entries already queued.
- **Downstream operators:** one new chat verb, opt-in by saying it. Nothing existing changes shape: schedule phrasing still routes to the routine path, and the responder's other intents are untouched. The one behavior an operator could notice without asking for it is that a rule they save is honoured from then on, which is the point. Anyone `§1c` admits may save a role, including a hermit-wide one, which is the shared-channel model the plan selected deliberately, not an oversight.
- **Downstream hermits:** the documented Claude Code floor moves from `v2.1.251` to `v2.1.263` in `how-to-use.md`, `always-on.md` and `always-on-ops.md`. That is a docs correction, not a new constraint: `hermit-meta.json` already requires `>=2.1.263` since the `/spawn-session` entry, so the docs had drifted. Roles are written into auto memory, so a hermit running with `autoMemoryEnabled: false` or `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` will accept the save and never fire the rule; the new Prerequisites line says so. No state file, config key, script or migration, so `hermit-evolve` has nothing to do here.
- **Per-actor ledger:** executor codex (effort low) wrote the seven planned steps across six files, never committed, and stayed inside the plan's fence / code-review high --fix applied six findings: the memory write now targets the directory the loaded `MEMORY.md` came from (otherwise a Docker or `CLAUDE_CONFIG_DIR` install writes a file the harness never injects and the role silently never fires), role application is gated on the message being addressed to the hermit, the slug is matched against existing `[role` index lines so a restatement rewrites instead of duplicating, the reply names the rule instead of teaching the ambiguous "forget that rule", the filename follows the `feedback_*` convention, and both test slice bounds are asserted / operator declined a seventh finding that would have barred an external-origin sender from installing a hermit-wide role, since the plan had already selected "anyone §1c admits" and "plain remember is hermit-wide", and asked for the version-floor correction.
