### PR TITLE
fix(laravel-forge-hermit): surface Forge validation error details

### DIFF
--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Fixed
+- Forge validation failures now include scrubbed field-level error details in generic read and write output.
+
 ## [0.0.13] - 2026-09-06
 
 ### Changed

--- a/plugins/laravel-forge-hermit/php/forge-lib.php
+++ b/plugins/laravel-forge-hermit/php/forge-lib.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 // ---------------------------------------------------------------------------
 
 use Laravel\Forge\Forge;
+use Laravel\Forge\Exceptions\ValidationException;
 use Psr\Http\Message\RequestInterface;
 
 // ---------------------------------------------------------------------------
@@ -277,6 +278,21 @@ function scrubSecrets(string $text): string
 
         return $mixed ? '[REDACTED]' : $s;
     }, $text) ?? $text;
+}
+
+/**
+ * Keep the SDK summary and the complete validation response, including nested
+ * field errors. Scrub after rendering so API-provided details get the same
+ * protection as successful output.
+ */
+function formatSdkError(\Throwable $error): string
+{
+    $message = 'SDK error: ' . $error->getMessage();
+    if ($error instanceof ValidationException && $error->errors() !== []) {
+        $message .= "\n" . json_encode($error->errors(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+
+    return scrubSecrets($message) . "\n";
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/laravel-forge-hermit/php/forge.php
+++ b/plugins/laravel-forge-hermit/php/forge.php
@@ -427,7 +427,7 @@ if ($cmd === 'call' || $cmd === 'preview') {
         try {
             printResult($forge->$method(...$callArgs));
         } catch (\Throwable $e) {
-            fwrite(STDERR, "SDK error: " . $e->getMessage() . "\n");
+            fwrite(STDERR, formatSdkError($e));
             exit(1);
         }
         exit(0);
@@ -496,7 +496,7 @@ if ($cmd === 'execute') {
         fwrite(STDERR, $e->getMessage() . "\n");
         exit(1);
     } catch (\Throwable $e) {
-        fwrite(STDERR, "SDK error: " . $e->getMessage() . "\n");
+        fwrite(STDERR, formatSdkError($e));
         exit(1);
     }
     exit(0);

--- a/plugins/laravel-forge-hermit/php/tests/run.php
+++ b/plugins/laravel-forge-hermit/php/tests/run.php
@@ -52,7 +52,8 @@ function check(bool $cond, string $msg): void {
 function makeMockForge(array $responses): array {
     $mock    = new MockHandler($responses);
     $stack   = HandlerStack::create($mock);
-    $guzzle  = new Client(['handler' => $stack]);
+    // Match the SDK's default transport so it maps HTTP errors to SDK exceptions.
+    $guzzle  = new Client(['handler' => $stack, 'http_errors' => false]);
     $forge   = new Forge('test-token', $guzzle);
     return [$forge, $mock];
 }
@@ -497,6 +498,47 @@ check(str_contains(scrubSecrets('postgres://app:s3cr3t@db.internal/prod'), '[RED
 $ordinaryLog = "Cloning into '/home/forge/app'...\nHEAD is now at 4f2a1b9c8d3e5f6a7b8c9d0e1f2a3b4c5d6e7f80 Fix pagination\nnpm WARN deprecated";
 check(scrubSecrets($ordinaryLog) === $ordinaryLog,
     'an ordinary deploy log survives untouched, git SHA included');
+
+// ---------------------------------------------------------------------------
+// SDK error output
+// ---------------------------------------------------------------------------
+echo "\nSDK error output:\n";
+
+$validationBody = [
+    'message' => 'The given data was invalid.',
+    'errors' => [
+        'name' => ['The name has already been taken.', 'The name must be a valid domain.'],
+        'type' => ['The selected type is invalid.'],
+    ],
+];
+[$validationForge] = makeMockForge([new Response(422, [], json_encode($validationBody))]);
+try {
+    $validationForge->createSite('acme', 12, ['type' => 'php', 'name' => 'example.invalid']);
+    check(false, '422 raises a validation exception');
+} catch (\Laravel\Forge\Exceptions\ValidationException $e) {
+    $output = formatSdkError($e);
+    check(str_starts_with($output, "SDK error: The given data failed to pass validation.\n"),
+        'validation output retains the generic SDK summary');
+    $details = json_decode(substr($output, strpos($output, "\n") + 1), true);
+    check($details === $validationBody, '422 output retains the envelope, fields and every validation message');
+}
+
+$flatErrors = ['name' => ['The name is required.']];
+$flatOutput = formatSdkError(new \Laravel\Forge\Exceptions\ValidationException($flatErrors));
+check(json_decode(substr($flatOutput, strpos($flatOutput, "\n") + 1), true) === $flatErrors,
+    'flat validation details retain their structure');
+check(formatSdkError(new \Laravel\Forge\Exceptions\ValidationException([]))
+    === "SDK error: The given data failed to pass validation.\n",
+    'empty validation details retain the summary without an empty appendix');
+check(formatSdkError(new \RuntimeException('Connection failed.')) === "SDK error: Connection failed.\n",
+    'ordinary exceptions retain their message and trailing newline');
+$secretOutput = formatSdkError(new \Laravel\Forge\Exceptions\ValidationException([
+    'errors' => ['name' => ['Invalid DB_PASSWORD=hunter2trombone', 'Invalid https://app:s3cr3t@example.invalid/path']],
+]));
+check(!str_contains($secretOutput, 'hunter2trombone') && !str_contains($secretOutput, 's3cr3t')
+    && str_contains($secretOutput, '[REDACTED]'), 'validation details scrub assignments and URL credentials');
+check(!str_contains(formatSdkError(new \RuntimeException('Authorization: Bearer abcdef1234567890')), 'abcdef1234567890'),
+    'ordinary exception messages are scrubbed too');
 
 // ---------------------------------------------------------------------------
 // Block G — SDK surface tripwire


### PR DESCRIPTION
Forge API validation failures currently reach generic `call` and `execute` callers as only "The given data failed to pass validation." The SDK retains the decoded 422 response, but the wrapper drops it.

This change affects only `laravel-forge-hermit`. Both dispatch paths now append readable JSON from `ValidationException::errors()`, preserving nested field errors and multiple messages. The complete output passes through the existing secret scrubber. Stderr, exit status 1, request execution, and plan approval behavior are preserved.

```text
Forge rejects a request (HTTP 422)
  BEFORE -> generic message -> operator guesses or checks the dashboard
  AFTER  -> summary + scrubbed field errors -> model can identify the correction
```

The implementation follows the [official SDK exception documentation](https://github.com/laravel/forge-sdk/blob/4.x/_autodocs/exceptions.md), checked through Context7, and the pinned v4.0.0 source. The source preserves the full response envelope, so the formatter does not assume a flat field map.

Validation:

- `bash tests/run-all.sh` from `plugins/laravel-forge-hermit`: exit 0, including mocked SDK 422 regression coverage, flat and nested details, multiple messages, empty details, ordinary exceptions, and secret scrubbing.
- `bunx tsc` from the worktree root: exit 0.
- `git diff --staged --check`: exit 0 before commit.
- `bash scripts/graphify-refresh.sh`: exit 0, expected linked-worktree skip.
- Staged cleanup review found no changes needed. The stderr/exit wiring was inspected in both CLI catches; no live Forge request was made.
