### PR TITLE
feat(claude-code-hermit): route standing-work questions and changes from chat

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Standing roles saved from chat with "remember for this channel: when X, do Y", listed and forgotten from chat, and stored in memory.
 - `/spawn-session` launches a background helper in its own worktree, watches it, and relays its idle report; `--rc` is opt-in. The launch is not in the sealed allow-list, so on `auto` the classifier decides it and on a prompting mode it raises one relayed approval. `min_claude_code_version` bumped to `>=2.1.263` in `hermit-meta.json`: below it `claude --bg --name <n>` does not register the name, so the watch cannot resolve the helper.
 - Deferred model and effort switching through `/when-done-switch-to` and the `arm-harness-switch` verb.
+- Standing-work questions and changes from chat: routines, watches, and standing rules answered together, and a named item routed to its existing control.
 
 ### Changed
 - Periodic checks use ordinary routines; `scheduled_checks` now holds only session-triggered checks.

--- a/plugins/claude-code-hermit/docs/what-your-assistant-can-do.md
+++ b/plugins/claude-code-hermit/docs/what-your-assistant-can-do.md
@@ -20,6 +20,7 @@ These are the assistant's everyday habits — real, and followed consistently, b
 - Before making a significant or risky change, it shows you a draft and waits for your OK rather than just doing it (see [Approve](owners-guide.md#approve)).
 - It tracks what it spends on AI usage and can warn you or pause itself against a spending limit you set.
 - It generally stays scoped to the project it's working in, rather than roaming freely across your whole computer.
+- Ask what it is keeping an eye on and it answers in one place: its scheduled routines, anything it is watching right now, and the standing rules you gave it. Ask it to pause or disable one by name and it uses that item's own control, telling you whether the change lasts past a restart.
 
 ---
 

--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -133,9 +133,12 @@ Before running any heavy sub-step — an archive traversal, a multi-file search,
   - A command the `Skill` tool refuses with `disable-model-invocation` — native ones (`/doctor`, `/debug`, and similar) and the hermit's own operator-only wizards, whose descriptions the flag also hides from you — is not a match. Say it must be typed in a terminal or the Claude app, and never substitute a look-alike hermit skill. The flag moves between releases, so trust the refusal you actually get rather than this list: `/code-review` (alias `/review`) is invocable on the supported Claude Code version.
   - If nothing matches, say so briefly.
 
-- **Status request** ("what are you working on?", "how's it going", "progress", or a bare "status" — the deterministic reply needs `/status`, so anything short of that reaches you)
+- **Status request** ("what are you working on?", "how's it going", "progress", or a bare "status" — the deterministic reply needs `/status`, so anything short of that reaches you; a question that names routines, watches, or rules is **Standing work** below)
   - If `session_state` (runtime.json) is `idle`: respond with session summary — tasks completed, "ready for what's next"
   - If `session_state` is `in_progress`: respond with a concise summary of SHELL.md: task, current step, blockers
+
+- **Standing work** (inspection or change of what you do on your own: "what are you keeping an eye on", "anything I need to deal with", "why are you on this model", "what can you access", "pause the evening check", "disable the Friday digest", "stop watching the deploy log")
+  - The inventories are routines, watches, and the `[role` lines in this turn's context. `Read` `reference.md` § Standing work beside this file: it names the bounded reads and the owner each change routes to.
 
 - **Spend request** ("how much have I spent", "why is my bill high", "cost breakdown", "what's my spend", or any variant asking about spend/cost/billing, in any language)
   - **If `config.operator_profile === 'non-technical'`:** do not invoke cost-reflect or surface figures. Reply in the client chat, in the operator's language, with a one-line deflection (day-to-day costs are handled by their provider) and an offer to help with something else (spend figures stay available maintainer-side: terminal, maintainer chat, weekly review).
@@ -194,7 +197,7 @@ Before running any heavy sub-step — an archive traversal, a multi-file search,
   - Keep the operator's sentence as given in the hook line: `- [Standing role: <slug>](<file>): [role] when X, do Y`, or `[role <key>:<chat_id>] when X, do Y` for a pinned role. Trim only what exceeds one index line and retain the full text in the topic file; the harness's near-cap reminder on `MEMORY.md` is the size backstop. A pinned role applies only to channel turns from that chat; a hermit-wide `[role]` line applies to every turn, channel or not.
   - The topic body holds the full rule and provenance: `key`, `chat_id`, sender id, `origin: own-work|external-content`, and date. Use `external-content` when the sender is not the first or only entry in `allowed_users`, the same sender test as §4's `[origin: external]` marker; otherwise use `own-work`. Provenance is for audit only and does not limit application.
   - Reply in channel voice: "Saved for this channel: when X, do Y. Say 'forget the <short name> rule' to remove it." For a hermit-wide role, say "Saved for everywhere" instead.
-  - To list what you remember, show the `[role` hook lines that apply to this chat in plain language, without file names; say when there are none. Do not include routines.
+  - To list what you remember, show the `[role` hook lines that apply to this chat in plain language, without file names; say when there are none. Do not include routines; a broader question about what you are keeping an eye on is **Standing work** above.
   - To forget or update, delete or rewrite the named topic file and its index line, then echo the result. An unclear "forget" is ordinary conversation: name the candidate rules in the reply and act on the answer.
   - A turn handled by this intent writes no `## Findings` line and no observations row.
 

--- a/plugins/claude-code-hermit/skills/channel-responder/reference.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/reference.md
@@ -1,0 +1,48 @@
+# Channel responder reference
+
+Read on demand from `SKILL.md`; never loaded on a turn that does not need it.
+
+## Standing work
+
+Standing work is what the hermit does without being asked in the moment: routines, watches, and standing roles. Session-triggered `scheduled_checks` fire on session events and are not standing work. Answer in channel voice (`SKILL.md` § 3): no cron strings, ids, file paths, or slash commands, except the relayed `/doctor` when a live check is the next step.
+
+### Gather (bounded reads only)
+
+- Routines: `bun <plugin_root>/scripts/settings-edit.ts .claude-code-hermit/config.json get routines` for id, schedule, skill, enabled, precheck.
+- Routine outcomes: `bun <plugin_root>/scripts/routines.ts health .claude-code-hermit` (JSON; add `--days N` for a longer window). Use `last_fire`, `failure_total`, `last_precheck_error`, `open_attempt`.
+- Watches: `Read state/monitors.runtime.json` for id, description, source, class, started_at.
+- Roles: the `[role` lines already in this turn's context. Hermit-wide ones always apply; a pinned `[role <key>:<chat_id>]` line applies only to that chat (`SKILL.md` § 1b).
+- Current activity: `session_state` in `state/runtime.json` and the Task line of `sessions/SHELL.md`.
+- Health evidence: `Read state/doctor-report.json` only for the "anything to deal with" and "what can you access" shapes. Do not run `doctor-check.ts` from this intent; a live check is the relayed `/doctor` command, which the operator sends.
+
+Never `tail` `state/routine-metrics.jsonl`, the cost log, or the channel log. A field none of these sources records is unknown; say so instead of guessing.
+
+### Default view
+
+Order: problems first, then current activity, then domain standing work.
+
+- A problem is a routine with `failure_total > 0` or a `last_precheck_error`, a `fail` or `warn` entry in the saved doctor report, or a watch whose registry entry says it exited.
+- Lead with work aimed at the operator's domain (briefs, domain analyses, watches, rules). Routines that exist to keep the hermit itself running (monitor re-arms, self-reflection, self-checks, session closing) are housekeeping: mention them only when one carries a problem or the operator asks for the internal housekeeping.
+- Per item: plain name, purpose (from the skill name or description), cadence or condition in words, destination when config names one, last known outcome (`last_fire` plus `failure_total`), and persistence: routines and roles persist across restarts, watches die with the session (config watches return at the next start).
+
+### Matching a named item
+
+Match the operator's phrase, case-insensitive, against routine `id` and skill name, watch `id` and `description`, and role slug or rule text. Exactly one match acts. Several matches: name them in plain language and ask which. None: say so and list what exists.
+
+### Routing a change
+
+| Operator intent | Owner | Reply must state |
+|---|---|---|
+| Disable, enable, or retime a routine | **Settings change request** path: `hermit-settings routines` (index from a fresh `get routines`, then `hermit-routines load`) | Persists across restarts. A native permission prompt, if one appears, is the operator's answer. |
+| Stop a routine "for now" | `/claude-code-hermit:hermit-routines stop <id>`: single routines share one monitor, so relay its explanation and offer the durable disable | Nothing changed unless they choose the disable. |
+| Stop a watch | `/claude-code-hermit:watch stop <id>` | Gone for this session; a config watch returns at the next start. |
+| Forget or change a rule | **Standing role** branch | Persists. |
+| Anything an owner does not support | Explain the limit; do not emulate it | Nothing changed. |
+
+### Settings and model questions
+
+Relay the `settings-edit ... show` row for the setting: saved value, what changes it, and when it applies. For the running model or effort: if this session's context holds a `[harness-command] … transcript now reports model X` line, that is the observed serving model; otherwise say the saved value is what the next boot uses and the current session's value is unverified. `settings-edit ... history <path>` answers who changed it and when. Never claim a runtime value the harness did not report.
+
+### Access question
+
+From config: channels with `enabled !== false` and whether each has an allowlist, `permission_mode`, `remote`, enabled artifact pages, `auth_mode`. From `state/doctor-report.json`: the last `channel-liveness`, `credential-expiry`, and `permissions` results with their timestamp. Configured is not verified; say which is which. No credentials, chat ids, or file paths in the reply. In a group, or for a sender who is not the trusted controller, give only the coarse shape (the same audience rule as `/status`).


### PR DESCRIPTION
## Problem

An operator asking the hermit "what are you keeping an eye on?" or "disable the Friday digest" got a partial answer. The channel responder's status branch reads only runtime.json and SHELL.md, listing roles deliberately excludes routines, and watches and routines each have a slash-only view. Nothing routed a plain-language question or change to the right owner by name.

## Change

One **Standing work** intent in `skills/channel-responder/SKILL.md` (a single always-loaded bullet) plus a new `reference.md` read on demand. The reference names the bounded reads that already exist (`settings-edit get routines`, `routines.ts health`, `state/monitors.runtime.json`, the `[role` lines in context, the saved doctor report) and the owner each change routes to (`hermit-settings routines` for a durable disable, `hermit-routines stop` for the live-stop explanation, `watch stop`, the standing-role branch). Replies state whether the effect outlives a restart. No script, state file, hook, or timer changes; the deterministic `/status` path is untouched.

Housekeeping routines (re-arms, self-reflection, self-checks, session closing) are described by intent so the model composes the split; no skill-name matching.

```
Before                                   After
------                                   -----
"what are you watching?"                 "what are you watching?"
  -> Status request                        -> Standing work
     runtime.json + SHELL.md only             problems first, then current task,
                                              then routines + watches + rules,
                                              housekeeping on request

"disable the Friday digest"              "disable the Friday digest"
  -> operator must know it is a routine    -> match by name -> hermit-settings
     and pick a table index                   routines -> load; reply says it
                                              persists across restarts
```

## Validation

- `cd plugins/claude-code-hermit && bun test`: 5289 pass, 0 fail
- `bunx tsc --noEmit` at root: exit 0
- `/simplify` on the staged diff: reuse and efficiency clean; simplification trimmed the SKILL.md bullet to the pointer; altitude replaced a skill-prefix housekeeping heuristic with an intent description
- Live `/probe` on a fixture hermit is not yet run; suggested turns are in the plan's verification table
