### PR TITLE
feat(core): voice-notes skill and setup doc

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- `voice-notes` skill: a voice note the hermit cannot read gets a plain reply and an offer to set up transcription, which routes install through `docker-customize` and the command through a standing role; the recipe is in `docs/voice-notes.md`.
+
 ### Changed
 - `/spawn-session` passes `--remote-control` when `remote` is on in `config.json`, matching the resident session, and no longer takes `--rc` or refuses on auth method.
 

--- a/plugins/claude-code-hermit/docs/how-to-use.md
+++ b/plugins/claude-code-hermit/docs/how-to-use.md
@@ -113,6 +113,7 @@ When it finishes, it archives the report and says "What's next?" — tell it wha
 Hermit isn't just a work engine. During any session, you can ask it to reflect and improve:
 
 - **"remember for this channel: when X, do Y"** saves a standing role in memory. "For this channel" pins it to that chat; a plain "remember" applies everywhere. Ask "what do you remember about this channel?" to list roles or "forget the X rule" to remove one. Posts not addressed to the hermit never trigger a role.
+- **"Can you understand voice notes?"** Not out of the box. [Voice Notes](voice-notes.md) is the two-step setup: a speech-to-text tool where the hermit runs, then one standing role.
 - **"What slowed you down recently?"** — Reviews its experience and tells you what caused delays.
 - **"What permissions do you keep getting blocked on?"** — Suggests the exact `settings.json` entries to add so it stops getting prompted.
 - **"Suggest specialized agents for this project."** — Proposes new [sub-agents](https://code.claude.com/docs/en/sub-agents) based on the kind of work you've been doing. You approve, it creates them.
@@ -287,5 +288,5 @@ Most common actions auto-trigger from natural language — just say what you mea
 | **Learning**   | `proposal-create`, `proposal-list`, `proposal-act`, `reflect`      |
 | **Config**     | `hermit-settings`, `hatch`, `hermit-evolve`                        |
 | **Docker**     | `docker-customize`; `docker-setup`, `docker-security` (type the last two; they never auto-trigger) |
-| **Channels**   | `channel-responder`                                                |
+| **Channels**   | `channel-responder`, `voice-notes`                                 |
 | **Summaries**  | `hermit-evolution`, `hermit-health`, `weekly-review`              |

--- a/plugins/claude-code-hermit/docs/voice-notes.md
+++ b/plugins/claude-code-hermit/docs/voice-notes.md
@@ -1,0 +1,63 @@
+# Voice Notes
+
+Send a voice note to your hermit over Discord or Telegram and it downloads the file on its own, the same way it handles photos and documents. It cannot listen to it: the model reads text, images, and PDFs, not audio. Out of the box the hermit tells you so and offers to set transcription up. This page is the setup.
+
+Two steps: put a speech-to-text tool where the hermit runs, then tell the hermit to use it.
+
+## 1. Install a speech-to-text tool
+
+Where the tool goes depends on how the hermit runs:
+
+- **Docker:** it has to be in the image or the bind mount. Ask the hermit "install whisper.cpp and ffmpeg in the container" and the [`docker-customize`](../skills/docker-customize/SKILL.md) skill routes it.
+- **tmux:** the hermit runs on the host, so install the tool on the host and make sure it is on the PATH of the shell that runs `hermit-start`.
+
+Then pick a tool. Self-hosted keeps the audio on the box, which is the point of a hermit.
+
+### Self-hosted: whisper.cpp (default)
+
+One binary and a model file, no Python, a few hundred megabytes of RAM while a note is transcribed and nothing resident afterwards. Voice notes arrive as OGG/Opus and whisper.cpp wants 16 kHz mono WAV, so install `ffmpeg` alongside it. Download a model once, next to the binary; `base` is a good first pick, `small` is more accurate on non-English speech and several times slower.
+
+The command the hermit will run:
+
+```bash
+ffmpeg -loglevel error -y -i "$IN" -ar 16000 -ac 1 /tmp/note.wav && whisper-cli -m /path/to/ggml-base.bin -f /tmp/note.wav -nt
+```
+
+### Self-hosted: the `openai-whisper` package (GPU hosts)
+
+Same models and the same transcripts, on Python and PyTorch. On a CPU box it is heavier on every axis: PyTorch is a multi-gigabyte install, and the README's table puts `base` at about 1 GB and `small` at about 2 GB of memory to load. On a host with a GPU it is the fastest self-hosted option, and its `turbo` model runs at roughly eight times the speed of `large`. Needs `ffmpeg` too.
+
+```bash
+pip install -U openai-whisper
+whisper "$IN" --model turbo --output_format txt --output_dir /tmp && cat /tmp/note.txt
+```
+
+`faster-whisper` is a third self-hosted runtime, generally the quickest on CPU, but it is a Python library rather than a command and needs a short wrapper script.
+
+### Hosted: a transcription API
+
+Audio is uploaded to the provider. No install beyond `curl` and `jq`, which the image has, and the same command on Docker and tmux. Put the key in `.env` (never in `config.json` or the role text). OpenAI lists `whisper-1` and `gpt-4o-transcribe` at $0.006 per minute and `gpt-4o-mini-transcribe` at $0.003 per minute as of September 2026; check your provider's pricing and endpoint. Shape of the call:
+
+```bash
+curl -sS https://api.openai.com/v1/audio/transcriptions -H "Authorization: Bearer $OPENAI_API_KEY" -F "file=@$IN" -F model=whisper-1 | jq -r .text
+```
+
+## 2. Tell the hermit to use it
+
+Save a standing role from chat, in your own words. Example:
+
+> remember: when a voice note arrives, download it, run `ffmpeg -loglevel error -y -i "<file>" -ar 16000 -ac 1 /tmp/note.wav && whisper-cli -m /path/to/ggml-base.bin -f /tmp/note.wav -nt` on the downloaded file, and treat the transcript as my message
+
+Pinning the role to one chat, listing roles, and forgetting one are covered in [Talk to Your Hermit](how-to-use.md#talk-to-your-hermit).
+
+The downloaded file lands in the channel plugin's inbox under `.claude.local/channels/<channel>/inbox/`; the hermit gets the exact path from the download and substitutes it into the command.
+
+Then send a voice note and check the reply addresses what you said.
+
+## Permissions
+
+Under the default `auto` permission mode a local binary reading an inbox file ran without a prompt in testing on Claude Code 2.1.263; expect the same, not a guarantee. On a prompting mode the first run raises one relayed approval; to stop that, add an allow rule for the binary, for example `Bash(whisper-cli *)`, in `.claude/settings.local.json`.
+
+## Not covered
+
+The hermit can transcribe a note, not send one. Reply audio would need text-to-speech, which nothing here provides.

--- a/plugins/claude-code-hermit/docs/voice-notes.md
+++ b/plugins/claude-code-hermit/docs/voice-notes.md
@@ -2,6 +2,8 @@
 
 Send a voice note to your hermit over Discord or Telegram and it downloads the file on its own, the same way it handles photos and documents. It cannot listen to it: the model reads text, images, and PDFs, not audio. Out of the box the hermit tells you so and offers to set transcription up. This page is the setup.
 
+Only a channel delivers an audio file. Through the Claude app, [dictation and voice mode](https://support.claude.com/en/articles/11101966-use-voice-mode) transcribe as you speak, so nothing here is needed.
+
 Two steps: put a speech-to-text tool where the hermit runs, then tell the hermit to use it.
 
 ## 1. Install a speech-to-text tool
@@ -20,8 +22,10 @@ One binary and a model file, no Python, a few hundred megabytes of RAM while a n
 The command the hermit will run:
 
 ```bash
-ffmpeg -loglevel error -y -i "$IN" -ar 16000 -ac 1 /tmp/note.wav && whisper-cli -m /path/to/ggml-base.bin -f /tmp/note.wav -nt
+ffmpeg -loglevel error -y -i "$IN" -ar 16000 -ac 1 /tmp/note-$$.wav && whisper-cli -m /path/to/ggml-base.bin -f /tmp/note-$$.wav -nt
 ```
+
+The `$$` keeps the scratch WAV per-invocation, so a second note (or a second hermit on the same host) never lands on a file the first one owns.
 
 ### Self-hosted: the `openai-whisper` package (GPU hosts)
 
@@ -29,8 +33,10 @@ Same models and the same transcripts, on Python and PyTorch. On a CPU box it is 
 
 ```bash
 pip install -U openai-whisper
-whisper "$IN" --model turbo --output_format txt --output_dir /tmp && cat /tmp/note.txt
+whisper "$IN" --model turbo --output_format txt --output_dir /tmp && cat "/tmp/$(basename "${IN%.*}").txt"
 ```
+
+`whisper` names its output after the input file, not after a fixed name, which is what the `basename` does. The container image ships no Python, and on Ubuntu 24.04 and newer the system Python is externally managed, so the `pip` line needs `python3` plus a virtualenv (or `pipx`) first. `docker-customize` § 2 is where that boot-time work goes.
 
 `faster-whisper` is a third self-hosted runtime, generally the quickest on CPU, but it is a Python library rather than a command and needs a short wrapper script.
 
@@ -46,17 +52,17 @@ curl -sS https://api.openai.com/v1/audio/transcriptions -H "Authorization: Beare
 
 Save a standing role from chat, in your own words. Example:
 
-> remember: when a voice note arrives, download it, run `ffmpeg -loglevel error -y -i "<file>" -ar 16000 -ac 1 /tmp/note.wav && whisper-cli -m /path/to/ggml-base.bin -f /tmp/note.wav -nt` on the downloaded file, and treat the transcript as my message
+> remember: when a voice note arrives, download it, run `ffmpeg -loglevel error -y -i "<file>" -ar 16000 -ac 1 /tmp/note-$$.wav && whisper-cli -m /path/to/ggml-base.bin -f /tmp/note-$$.wav -nt` on the downloaded file, and treat the transcript as my message
 
 Pinning the role to one chat, listing roles, and forgetting one are covered in [Talk to Your Hermit](how-to-use.md#talk-to-your-hermit).
 
-The downloaded file lands in the channel plugin's inbox under `.claude.local/channels/<channel>/inbox/`; the hermit gets the exact path from the download and substitutes it into the command.
+The downloaded file lands in the `inbox/` of the channel plugin's state dir: `.claude.local/channels/<channel>/inbox/` on a bare-host boot, and `~/.claude/channels/<channel>/inbox/` as the container sees it (compose bind-mounts the first onto the second). Either way the hermit gets the exact path from the download and substitutes it into the command.
 
 Then send a voice note and check the reply addresses what you said.
 
 ## Permissions
 
-Under the default `auto` permission mode a local binary reading an inbox file ran without a prompt in testing on Claude Code 2.1.263; expect the same, not a guarantee. On a prompting mode the first run raises one relayed approval; to stop that, add an allow rule for the binary, for example `Bash(whisper-cli *)`, in `.claude/settings.local.json`.
+Under the default `auto` permission mode a local binary reading an inbox file ran without a prompt in testing on Claude Code 2.1.263; expect the same, not a guarantee. On a prompting mode the first run raises one relayed approval; to stop that, add an allow rule in `.claude/settings.local.json` for every binary in the chain (`Bash(ffmpeg:*)` and `Bash(whisper-cli:*)` for the whisper.cpp recipe).
 
 ## Not covered
 

--- a/plugins/claude-code-hermit/skills/voice-notes/SKILL.md
+++ b/plugins/claude-code-hermit/skills/voice-notes/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: voice-notes
+description: Handle a voice note or audio attachment the hermit cannot read, and set up transcription when the operator wants it. Activates when a channel message carries an audio attachment (Telegram voice message, Discord voice-message.ogg), or on "can you understand voice notes", "transcribe my voice message", "set up voice notes".
+---
+# Voice Notes
+
+The channel plugin downloads an audio attachment on its own; the model cannot read audio. Transcription is an operator choice, not a shipped default: it needs a speech-to-text tool where the hermit runs, and possibly a provider key. The recipe lives in `docs/voice-notes.md` beside this plugin; this skill routes, it does not repeat it.
+
+## An audio attachment arrives
+
+With no standing role covering it, reply in channel voice: you received a voice note, you cannot listen to it yet, and you can set that up if they want. Do not guess at the content or ask them to retype it unless they decline setup.
+
+## The operator asks to set it up
+
+Walk them through `docs/voice-notes.md` from chat:
+
+1. Settle one thing over the reply tool, then continue when the answer arrives: should the audio stay on this machine, or is uploading it to a transcription provider acceptable? Self-hosted is the default. Then read only the matching section of the doc, self-hosted or hosted, plus step 2.
+2. Install: in Docker, delegate to `/claude-code-hermit:docker-customize` with the tool the doc names. On tmux the hermit runs on the host, so name the host install for the operator rather than running it yourself. A hosted provider needs its key in `.env`; never put a key in the role text or `config.json`.
+3. Role: once the tool is in place, save the standing role from the doc through the ordinary "remember" path, substituting the command they ended up with. Offer "for this channel" if they only want it in one chat.
+4. Verify: ask them to send a voice note and confirm the reply addresses what they said.
+
+On a prompting permission mode, mention the allow rule from the doc after the first run raises an approval.

--- a/plugins/claude-code-hermit/skills/voice-notes/SKILL.md
+++ b/plugins/claude-code-hermit/skills/voice-notes/SKILL.md
@@ -4,19 +4,32 @@ description: Handle a voice note or audio attachment the hermit cannot read, and
 ---
 # Voice Notes
 
-The channel plugin downloads an audio attachment on its own; the model cannot read audio. Transcription is an operator choice, not a shipped default: it needs a speech-to-text tool where the hermit runs, and possibly a provider key. The recipe lives in `docs/voice-notes.md` beside this plugin; this skill routes, it does not repeat it.
+The channel plugin downloads the audio; the model cannot read it. Transcription is an operator choice, not a shipped default. The recipe lives in `${CLAUDE_PLUGIN_ROOT}/docs/voice-notes.md`; route to it, do not repeat it.
+
+## Step 0 — Channel reply
+
+If this skill was invoked from a channel-arrived message (the inbound prompt contains a `<channel source="...">` tag), reply via that channel's reply tool. Otherwise emit to conversation. On a channel-tagged turn, step 1's bounded ask also queues a durable micro-proposal entry via `proposal.ts queue-micro` (see `channel-responder` § Channel-safe ask bridge), so the answer re-enters this skill in a later turn instead of stranding the setup half-done.
 
 ## An audio attachment arrives
 
-With no standing role covering it, reply in channel voice: you received a voice note, you cannot listen to it yet, and you can set that up if they want. Do not guess at the content or ask them to retype it unless they decline setup.
+With no standing role covering it, reply: you received a voice note, you cannot listen to it yet, and you can set that up if they want. Do not guess at the content or ask them to retype it unless they decline setup.
 
 ## The operator asks to set it up
 
-Walk them through `docs/voice-notes.md` from chat:
+Read `.claude-code-hermit/config.json`: no channel with `enabled !== false` means no audio ever arrives (the Claude app transcribes before sending), so say so and stop.
 
-1. Settle one thing over the reply tool, then continue when the answer arrives: should the audio stay on this machine, or is uploading it to a transcription provider acceptable? Self-hosted is the default. Then read only the matching section of the doc, self-hosted or hosted, plus step 2.
-2. Install: in Docker, delegate to `/claude-code-hermit:docker-customize` with the tool the doc names. On tmux the hermit runs on the host, so name the host install for the operator rather than running it yourself. A hosted provider needs its key in `.env`; never put a key in the role text or `config.json`.
-3. Role: once the tool is in place, save the standing role from the doc through the ordinary "remember" path, substituting the command they ended up with. Offer "for this channel" if they only want it in one chat.
-4. Verify: ask them to send a voice note and confirm the reply addresses what they said.
+Otherwise walk them through the doc from chat:
 
-On a prompting permission mode, mention the allow rule from the doc after the first run raises an approval.
+1. Settle one thing: should the audio stay on this machine, or is uploading it to a transcription provider acceptable? Self-hosted is the default. Then read only the matching doc section, self-hosted or hosted, plus its step 2.
+
+   **Channel-tagged turn:** send the question via the reply tool, queue the bridge entry below, and stop. The answer comes back as a `--answer self-hosted` / `--answer hosted` re-entry, which skips the ask and resumes here.
+   ```bash
+   bun ${CLAUDE_PLUGIN_ROOT}/scripts/proposal.ts queue-micro .claude-code-hermit <<'HERMIT_MP'
+   {"tier":1,"question":"Voice notes: should the audio stay on this machine, or is sending it to a transcription provider acceptable?","options":["self-hosted","hosted"],"on_resolve":"/claude-code-hermit:voice-notes setup --answer {answer}"}
+   HERMIT_MP
+   ```
+2. Install: read `runtime_mode` from `.claude-code-hermit/state/runtime.json`. On `docker`, delegate to `/claude-code-hermit:docker-customize` with the tool the doc names; otherwise name the host install for the operator rather than running it yourself. A hosted provider needs its key in `.env`, never in the role text or `config.json`.
+3. Role: save the standing role from the doc through the ordinary "remember" path, substituting the command they ended up with. Offer "for this channel" if they only want it in one chat.
+4. Verify: have them send a voice note and confirm the reply addresses what they said.
+
+On a prompting permission mode, mention the doc's allow rules after the first run raises an approval.


### PR DESCRIPTION
## Problem

A voice note sent over Discord or Telegram downloads fine: the channel plugin lists it in the envelope and the model calls `download_attachment` on its own. Then nothing happens, because the model cannot read audio and the Messages API has no audio block. The hermit was left to improvise a reply.

## What changes

A routing-only `voice-notes` skill plus a setup doc. No config key, no script, no pipeline.

```text
Before                                    After
------                                    -----
voice note arrives                        voice note arrives
  -> plugin downloads .ogg                  -> plugin downloads .ogg
  -> model cannot read it                   -> no standing role?
  -> improvised reply                          -> plain reply + offer to set up
                                            -> operator says yes
                                               -> self-hosted or hosted? (one question)
                                               -> install via docker-customize (Docker)
                                                  or named host install (tmux)
                                               -> save one standing role with the command
                                               -> verify with a test note
```

- `skills/voice-notes/SKILL.md` recognises the situation and delegates: install goes through `docker-customize`, the command lives in a standing role saved through the existing "remember" path, details point at the doc. It reads only the doc section matching the operator's choice.
- `docs/voice-notes.md` is the single home for the recipe: Docker versus tmux placement, self-hosted whisper.cpp first (lightest runtime for a CPU box), the `openai-whisper` package for GPU hosts, a hosted API last with dated per-minute prices, the role text, the inbox path, and permissions.
- `docs/how-to-use.md` gains one line in the skills table and one "Can you understand voice notes?" bullet.
- `[Unreleased]` changelog bullet.

## Why not a core pipeline

Attachments already work end to end natively. The only gap is the last step, and any backend needs an image rebuild or a provider key, so it cannot be default-on. A skill costs one description line and makes the setup discoverable from chat, which a doc alone does not.

## Validation

- Live: a voice note sent to a running hermit on this repo downloaded natively and drew a sensible "can't transcribe yet" reply with no changes, confirming the native path.
- Probe on Claude Code 2.1.263, auto mode, Sonnet: `whisper-cli -m <model> -f <inbox>.ogg -nt` ran without a permission prompt, bare and piped through `head`. Documented as observed behaviour, not a guarantee.
- `cd plugins/claude-code-hermit && bun test`: 5371 pass. The `channel-ask-contract` test caught an unguarded ask in the first draft; fixed.
- Plugin validator: 0 failures.
