### PR TITLE
fix: gitignore the resident launch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Thumbs.db
 # claude-code-hermit
 # Hermit local state (fully local in this monorepo)
 .claude-code-hermit/OPERATOR.md
+.claude-code-hermit/OPERATOR.md.bak
 .claude-code-hermit/sessions/
 .claude-code-hermit/templates/
 .claude-code-hermit/cost-log.jsonl
@@ -65,6 +66,7 @@ Thumbs.db
 .claude-code-hermit/knowledge-schema.md
 .claude-code-hermit/RESIDENT.md
 .claude-code-hermit/claude-settings.json
+.claude-code-hermit/dashboard-render.ts
 
 
 # Claude Code internal state

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ Thumbs.db
 .claude-code-hermit/bin/
 .claude-code-hermit/HEARTBEAT.md
 .claude-code-hermit/knowledge-schema.md
+.claude-code-hermit/RESIDENT.md
+.claude-code-hermit/claude-settings.json
 
 
 # Claude Code internal state

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -6,11 +6,12 @@
 - `/spawn-session` passes `--remote-control` when `remote` is on in `config.json`, matching the resident session, and no longer takes `--rc` or refuses on auth method.
 
 ### Fixed
-- `.claude-code-hermit/RESIDENT.md` and `.claude-code-hermit/claude-settings.json` are gitignored. Both shipped unignored, leaving the resident file as permanent `git status` noise and an operator `env` block one `git add -A` from being committed.
+- `.claude-code-hermit/RESIDENT.md`, `.claude-code-hermit/claude-settings.json`, `.claude-code-hermit/dashboard-render.ts`, and `.claude-code-hermit/OPERATOR.md.bak` are gitignored. All four shipped unignored, leaving the resident and renderer files as permanent `git status` noise and an operator `env` block one `git add -A` from being committed.
+- Workspace-mode backup no longer un-ignores `.claude-code-hermit/claude-settings.json`. It rewrites the project `.gitignore` from the template's line list, so adding the file there would have handed its `env` block to the backup commit; it now sits alongside `.claude.local/` in the keep-ignoring set.
 
 ### Upgrade Instructions
 
-**Gitignore the resident launch files.** If the project's `.gitignore` contains the line `# .claude-code-hermit state is tracked here`, skip this step entirely: workspace-mode backup owns that file and deliberately un-ignores hermit state. Otherwise check the `.gitignore` for `.claude-code-hermit/RESIDENT.md` and `.claude-code-hermit/claude-settings.json`, and add each missing line alongside the other `.claude-code-hermit/` entries. If either file was tracked, run `git rm --cached <path>` so it leaves the index without being deleted from disk.
+**Gitignore the resident launch files.** If the project's `.gitignore` contains the line `# .claude-code-hermit state is tracked here`, skip this step entirely: workspace-mode backup owns that file and deliberately un-ignores hermit state. Otherwise check the `.gitignore` for `.claude-code-hermit/RESIDENT.md`, `.claude-code-hermit/claude-settings.json`, `.claude-code-hermit/dashboard-render.ts`, and `.claude-code-hermit/OPERATOR.md.bak`, and add each missing line alongside the other `.claude-code-hermit/` entries. If any of them was tracked, run `git rm --cached <path>` so it leaves the index without being deleted from disk.
 
 ## [1.3.3] - 2026-09-07
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Changed
 - `/spawn-session` passes `--remote-control` when `remote` is on in `config.json`, matching the resident session, and no longer takes `--rc` or refuses on auth method.
 
+### Fixed
+- `.claude-code-hermit/RESIDENT.md` and `.claude-code-hermit/claude-settings.json` are gitignored. Both shipped unignored, leaving the resident file as permanent `git status` noise and an operator `env` block one `git add -A` from being committed.
+
+### Upgrade Instructions
+
+**Gitignore the resident launch files.** If the project's `.gitignore` contains the line `# .claude-code-hermit state is tracked here`, skip this step entirely: workspace-mode backup owns that file and deliberately un-ignores hermit state. Otherwise check the `.gitignore` for `.claude-code-hermit/RESIDENT.md` and `.claude-code-hermit/claude-settings.json`, and add each missing line alongside the other `.claude-code-hermit/` entries. If either file was tracked, run `git rm --cached <path>` so it leaves the index without being deleted from disk.
+
 ## [1.3.3] - 2026-09-07
 
 ### Added

--- a/plugins/claude-code-hermit/scripts/lib/backup.ts
+++ b/plugins/claude-code-hermit/scripts/lib/backup.ts
@@ -441,8 +441,17 @@ export function syncMirror(root: string, mirror: string, refused: RefusedPath[])
 // .gitignore (workspace mode)
 // ---------------------------------------------------------------------------
 
-/** Lines the template ignores that workspace-mode backup must keep ignoring. */
-const GITIGNORE_KEEP = new Set(['.claude/scheduled_tasks.lock', '.claude.local/']);
+/**
+ * Lines the template ignores that workspace-mode backup must keep ignoring.
+ * `claude-settings.json` is here for the same reason as `.claude.local/`: it
+ * carries the operator's `env` block, so un-ignoring it would commit live
+ * tokens into the backup repo on the next `git add -A`.
+ */
+const GITIGNORE_KEEP = new Set([
+  '.claude/scheduled_tasks.lock',
+  '.claude.local/',
+  '.claude-code-hermit/claude-settings.json',
+]);
 
 const GITIGNORE_ALWAYS = [
   '.claude.local/',

--- a/plugins/claude-code-hermit/scripts/settings-gate.ts
+++ b/plugins/claude-code-hermit/scripts/settings-gate.ts
@@ -95,7 +95,7 @@ function resolveTarget(verb: string, target: string): string {
 }
 
 /** The hermit-dir files a shell write must raise the native prompt for. */
-const PROTECTED_FILES = ['config.json', 'RESIDENT.md', 'claude-settings.json'];
+export const PROTECTED_FILES = ['config.json', 'RESIDENT.md', 'claude-settings.json'];
 const PROTECTED_FILE_ALT = PROTECTED_FILES.map((n) => n.replace(/\./g, String.raw`\.`)).join('|');
 
 function targetsConfigFile(p: string): boolean {

--- a/plugins/claude-code-hermit/state-templates/GITIGNORE-APPEND.txt
+++ b/plugins/claude-code-hermit/state-templates/GITIGNORE-APPEND.txt
@@ -14,11 +14,13 @@
 .claude-code-hermit/compiled/
 .claude-code-hermit/bin/
 .claude-code-hermit/OPERATOR.md
+.claude-code-hermit/OPERATOR.md.bak
 .claude-code-hermit/HEARTBEAT.md
 .claude-code-hermit/knowledge-schema.md
 .claude-code-hermit/cost-summary.md
 .claude-code-hermit/RESIDENT.md
 .claude-code-hermit/claude-settings.json
+.claude-code-hermit/dashboard-render.ts
 .claude/output-styles/hermit-voice.md
 .claude.local/
 CLAUDE.local.md

--- a/plugins/claude-code-hermit/state-templates/GITIGNORE-APPEND.txt
+++ b/plugins/claude-code-hermit/state-templates/GITIGNORE-APPEND.txt
@@ -17,6 +17,8 @@
 .claude-code-hermit/HEARTBEAT.md
 .claude-code-hermit/knowledge-schema.md
 .claude-code-hermit/cost-summary.md
+.claude-code-hermit/RESIDENT.md
+.claude-code-hermit/claude-settings.json
 .claude/output-styles/hermit-voice.md
 .claude.local/
 CLAUDE.local.md

--- a/plugins/claude-code-hermit/tests/hatch-options-contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-options-contract.test.ts
@@ -21,6 +21,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { PLUGIN_ROOT } from './helpers/run';
+import { PROTECTED_FILES } from '../scripts/settings-gate';
 
 const CANONICAL_PATH = '.claude-code-hermit/state/hatch-options.json';
 const TARGET_KEY = '"target"';
@@ -40,6 +41,18 @@ describe('GITIGNORE-APPEND.txt', () => {
 
   test('GITIGNORE-APPEND.txt lists .claude/settings.local.json', () => {
     expect(lines).toContain('.claude/settings.local.json');
+  });
+
+  // Derived from the settings gate's own list rather than spelled out here:
+  // a file sensitive enough to need a native prompt on edit is sensitive
+  // enough not to be committed, and claude-settings.json carries an operator
+  // `env` block. RESIDENT.md and claude-settings.json both shipped unignored,
+  // the second time a new hermit-dir file missed this template, so the check
+  // now tracks the list instead of the two names that happened to be missing.
+  test('GITIGNORE-APPEND.txt lists every settings-gate protected file', () => {
+    for (const name of PROTECTED_FILES) {
+      expect(lines).toContain(`.claude-code-hermit/${name}`);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

Core 1.3.3 shipped two new files under `.claude-code-hermit/` without adding either to `state-templates/GITIGNORE-APPEND.txt`:

- `RESIDENT.md`, the resident duties the launcher appends and `hermit-evolve` rewrites
- `claude-settings.json`, the optional operator-owned native settings for the resident

They are the only two top-level entries the hermit writes into that directory that the template does not list. Every other one is there, and `scripts/hatch-scaffold.ts` maps onto that list one for one, so the enumeration is meant to be exhaustive.

Verified on this repo's own hermit before the fix:

```
git check-ignore -v .claude-code-hermit/RESIDENT.md          -> no match
git check-ignore -v .claude-code-hermit/claude-settings.json -> no match
git check-ignore -v .claude-code-hermit/OPERATOR.md          -> .gitignore:51
```

Two consequences. `RESIDENT.md` sits as permanent untracked noise in every project hosting a hermit, and since evolve rewrites it, committing it would produce recurring churn. The more serious one is `claude-settings.json`: it merges an `env` block into the resident's settings (`docs/config-reference.md`), which is where operators put tokens, so an unignored copy is one `git add -A` from a committed credential. Removing `project` scope was justified on exactly that risk.

This is the second recurrence of the same class. A prior release closed it for `bin/` and the operator-editable files under "complete local-scope coverage".

## Resulting behavior

Both paths now resolve, and `docs/faq.md`'s moving-hosts answer (which already groups both files with `OPERATOR.md` and `HEARTBEAT.md` as files to hand-copy, true only of gitignored files) becomes accurate rather than aspirational.

```
git check-ignore -v .claude-code-hermit/RESIDENT.md          -> .gitignore:66
git check-ignore -v .claude-code-hermit/claude-settings.json -> .gitignore:67
```

The CHANGELOG carries an `### Upgrade Instructions` step so existing hermits get the lines too. It skips on the workspace-backup marker (`# .claude-code-hermit state is tracked here`), where backup deliberately un-ignores hermit state, and it runs `git rm --cached` for either file that was already tracked.

`state-templates/WORKTREEINCLUDE-APPEND.txt` is deliberately untouched. `OPERATOR.md` is gitignored partly so `.worktreeinclude` can copy it into worktrees, but neither resident file belongs in one: worktree sessions are guests, never residents.

## The test tracks the list, not the two names

The obvious test asserts the two missing paths are present. That pins today's gap and would miss the third recurrence, which is how this became the second one.

Instead the check derives from `PROTECTED_FILES` in `scripts/settings-gate.ts`, now exported:

```ts
test('GITIGNORE-APPEND.txt lists every settings-gate protected file', () => {
  for (const name of PROTECTED_FILES) {
    expect(lines).toContain(`.claude-code-hermit/${name}`);
  }
});
```

That list already enumerates the hermit-dir files sensitive enough to require a native prompt on edit, which is the same property that makes them unfit to commit. All three entries are already in the template, so it passes with no false positives today, and a fourth protected file cannot be added without tripping this check. It lives in the existing `describe('GITIGNORE-APPEND.txt')` block in `tests/hatch-options-contract.test.ts`, alongside the three sibling line-presence assertions and reusing that block's `lines` binding.

Rejected as canonical sources while designing this: `hatch-scaffold.ts` never writes either file (`RESIDENT.md` comes from `domain-hatch.ts` sync-block, `claude-settings.json` is never written by the plugin), so a scaffold-derived test would still have missed exactly these two; and the `docs/plugin-hermit-storage.md` table is circular, since it would need the same edit by the same person at the same time.

## Validation

- `bun test tests/hatch-options-contract.test.ts tests/contracts.test.ts tests/settings-gate.test.ts` from `plugins/claude-code-hermit`: 383 pass, 0 fail. `settings-gate.test.ts` is included because this PR adds an `export` to that hook; `import.meta.main` guards its execution, so importing it from a test is inert.
- `git check-ignore` on both paths, output above.

Two failures in the full `bun run test` sweep are pre-existing and outside this diff, which touches only core plugin files and the root `.gitignore`:

- `claude-code-homeassistant-hermit` `tests/gate-corpus.test.ts` aborts with "No Python with python-dotenv + PyYAML found" — a missing local toolchain, not a code failure.
- `claude-code-dev-hermit` push-guard: "push to main passes through when unset — expected exit 0, got 2".

Neither plugin is modified here. CI is path-filtered per plugin, but the root `.gitignore` change is not one of the root files that triggers every suite, so those two suites should not be pulled in by this PR.

## Follow-up, not addressed here

`SECRET_NAME_RES` in `scripts/lib/backup.ts` screens `.env`, `*.pem`, `*.key`, `id_rsa*` and `.credentials.json`, but not `claude-settings.json`. A workspace-mode backup therefore still commits an `env` block with a live token into the backup repo. Pre-existing and unchanged by this PR, but it is the remaining half of the same leak and deserves its own issue.
