### PR TITLE
fix(core): persist passive chat settings during channel setup

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `/spawn-session` passes `--remote-control` when `remote` is on in `config.json`, matching the resident session, and no longer takes `--rc` or refuses on auth method.
 
 ### Fixed
-- Passive-chat settings persist when channel setup updates an existing channel or creates a new one.
+- Passive-chat settings persist when channel setup updates an existing channel or creates a new one. Invalid replacements are rejected even when the existing value has the same validation error.
 - `.claude-code-hermit/RESIDENT.md`, `.claude-code-hermit/claude-settings.json`, `.claude-code-hermit/dashboard-render.ts`, and `.claude-code-hermit/OPERATOR.md.bak` are gitignored. All four shipped unignored, leaving the resident and renderer files as permanent `git status` noise and an operator `env` block one `git add -A` from being committed.
 - Workspace-mode backup no longer un-ignores `.claude-code-hermit/claude-settings.json`. It rewrites the project `.gitignore` from the template's line list, so adding the file there would have handed its `env` block to the backup commit; it now sits alongside `.claude.local/` in the keep-ignoring set.
 

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `/spawn-session` passes `--remote-control` when `remote` is on in `config.json`, matching the resident session, and no longer takes `--rc` or refuses on auth method.
 
 ### Fixed
+- Passive-chat settings persist when channel setup updates an existing channel or creates a new one.
 - `.claude-code-hermit/RESIDENT.md`, `.claude-code-hermit/claude-settings.json`, `.claude-code-hermit/dashboard-render.ts`, and `.claude-code-hermit/OPERATOR.md.bak` are gitignored. All four shipped unignored, leaving the resident and renderer files as permanent `git status` noise and an operator `env` block one `git add -A` from being committed.
 - Workspace-mode backup no longer un-ignores `.claude-code-hermit/claude-settings.json`. It rewrites the project `.gitignore` from the template's line list, so adding the file there would have handed its `env` block to the backup commit; it now sits alongside `.claude.local/` in the keep-ignoring set.
 

--- a/plugins/claude-code-hermit/scripts/hatch-config.ts
+++ b/plugins/claude-code-hermit/scripts/hatch-config.ts
@@ -192,7 +192,11 @@ if (Object.hasOwn(answers, 'channels')) {
     if (!Object.hasOwn(merged, 'default_chat_id')) merged.default_chat_id = null;
     if (!Object.hasOwn(merged, 'state_dir')) merged.state_dir = `.claude.local/channels/${name}`;
     if (Object.hasOwn(ans, 'allowed_users')) merged.allowed_users = ans.allowed_users;
-    if (Object.hasOwn(ans, 'passive_chats')) merged.passive_chats = ans.passive_chats;
+    if (Object.hasOwn(ans, 'passive_chats')) {
+      merged.passive_chats = ans.passive_chats;
+      // An explicit replacement must pass validation even if the old value had the same error.
+      priorErrors = priorErrors.filter((e) => !e.startsWith(`channels.${name}.passive_chats:`));
+    }
     // Outbound-only second destination for maintainer-tier alerts; a freshly
     // answered value must survive re-init (existing values ride the ...existing spread).
     if (Object.hasOwn(ans, 'maintainer_channel_id')) merged.maintainer_channel_id = ans.maintainer_channel_id;

--- a/plugins/claude-code-hermit/scripts/hatch-config.ts
+++ b/plugins/claude-code-hermit/scripts/hatch-config.ts
@@ -192,6 +192,7 @@ if (Object.hasOwn(answers, 'channels')) {
     if (!Object.hasOwn(merged, 'default_chat_id')) merged.default_chat_id = null;
     if (!Object.hasOwn(merged, 'state_dir')) merged.state_dir = `.claude.local/channels/${name}`;
     if (Object.hasOwn(ans, 'allowed_users')) merged.allowed_users = ans.allowed_users;
+    if (Object.hasOwn(ans, 'passive_chats')) merged.passive_chats = ans.passive_chats;
     // Outbound-only second destination for maintainer-tier alerts; a freshly
     // answered value must survive re-init (existing values ride the ...existing spread).
     if (Object.hasOwn(ans, 'maintainer_channel_id')) merged.maintainer_channel_id = ans.maintainer_channel_id;

--- a/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
@@ -276,6 +276,67 @@ describe('hatch-config.ts', () => {
     expect(out.channels.discord.state_dir).toBe('.claude.local/channels/discord');
   });
 
+  test('re-init: passive_chats can be added, replaced, cleared, and omitted without losing channel state', async () => {
+    const dir = freshDir();
+    const channel = {
+      enabled: true, dm_channel_id: 'D1', default_chat_id: 'D1',
+      state_dir: '.claude.local/channels/discord', allowed_users: ['999'], custom_key: 'keep',
+    };
+    const seed = {
+      ...JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8')),
+      _hermit_versions: { 'claude-code-hermit': CORE_VERSION },
+      foo_custom: true,
+      channels: { discord: channel, telegram: { enabled: false } },
+    };
+    seedConfig(dir, seed);
+
+    for (const passive_chats of [['123'], ['456', '789'], ['456', '789'], []]) {
+      const r = await runHatchConfig(dir, { channels: { discord: { passive_chats } } }, true);
+      expect(r.exitCode).toBe(0);
+      const expected = { ...seed, channels: { ...seed.channels, discord: { ...channel, passive_chats } } };
+      expect(JSON.parse(fs.readFileSync(configPathFor(dir), 'utf8'))).toEqual(expected);
+      expect(JSON.parse(r.stdout)).toEqual(expected);
+
+      const omitted = await runHatchConfig(dir, { channels: { discord: {} } }, true);
+      expect(omitted.exitCode).toBe(0);
+      expect(JSON.parse(fs.readFileSync(configPathFor(dir), 'utf8'))).toEqual(expected);
+    }
+  });
+
+  for (const reinit of [false, true]) {
+    test(`passive_chats is written on channel creation (reinit=${reinit})`, async () => {
+      const dir = freshDir();
+      if (reinit) {
+        seedConfig(dir, { ...JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8')), channels: {} });
+      }
+      const r = await runHatchConfig(dir, {
+        project_name: 'my-project', channels: { discord: { passive_chats: ['123'] } },
+      }, reinit);
+      expect(r.exitCode).toBe(0);
+      const out = JSON.parse(fs.readFileSync(configPathFor(dir), 'utf8'));
+      expect(out.channels.discord).toEqual({
+        enabled: true, dm_channel_id: null, default_chat_id: null,
+        state_dir: '.claude.local/channels/discord', passive_chats: ['123'],
+      });
+      expect(JSON.parse(r.stdout)).toEqual(out);
+    });
+  }
+
+  for (const passive_chats of [null, '123', [123]]) {
+    test(`re-init: invalid passive_chats ${JSON.stringify(passive_chats)} is refused without writing`, async () => {
+      const dir = freshDir();
+      seedConfig(dir, {
+        ...JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8')),
+        channels: { discord: { enabled: true, passive_chats: ['keep'] } },
+      });
+      const before = fs.readFileSync(configPathFor(dir), 'utf8');
+      const r = await runHatchConfig(dir, { channels: { discord: { passive_chats } } }, true);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.stderr).toContain('channels.discord.passive_chats');
+      expect(fs.readFileSync(configPathFor(dir), 'utf8')).toBe(before);
+    });
+  }
+
   test('re-init: morning_brief_time=null disables an existing morning brief', async () => {
     const dir = freshDir();
     const seed = {

--- a/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
+++ b/plugins/claude-code-hermit/tests/hatch-config-contract.test.ts
@@ -322,12 +322,19 @@ describe('hatch-config.ts', () => {
     });
   }
 
-  for (const passive_chats of [null, '123', [123]]) {
-    test(`re-init: invalid passive_chats ${JSON.stringify(passive_chats)} is refused without writing`, async () => {
+  for (const { existing, passive_chats } of [
+    { existing: ['keep'], passive_chats: null },
+    { existing: ['keep'], passive_chats: '123' },
+    { existing: ['keep'], passive_chats: [123] },
+    { existing: null, passive_chats: '123' },
+    { existing: '123', passive_chats: null },
+    { existing: [123], passive_chats: [456] },
+  ]) {
+    test(`re-init: invalid passive_chats ${JSON.stringify(existing)} -> ${JSON.stringify(passive_chats)} is refused without writing`, async () => {
       const dir = freshDir();
       seedConfig(dir, {
         ...JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8')),
-        channels: { discord: { enabled: true, passive_chats: ['keep'] } },
+        channels: { discord: { enabled: true, passive_chats: existing } },
       });
       const before = fs.readFileSync(configPathFor(dir), 'utf8');
       const r = await runHatchConfig(dir, { channels: { discord: { passive_chats } } }, true);
@@ -336,6 +343,23 @@ describe('hatch-config.ts', () => {
       expect(fs.readFileSync(configPathFor(dir), 'utf8')).toBe(before);
     });
   }
+
+  test('re-init: an existing passive_chats error tolerates omission and allows repair', async () => {
+    const dir = freshDir();
+    seedConfig(dir, {
+      ...JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8')),
+      channels: { discord: { enabled: true, passive_chats: [123] } },
+    });
+    const omitted = await runHatchConfig(dir, { channels: { discord: { enabled: false } } }, true);
+    expect(omitted.exitCode).toBe(0);
+    expect(JSON.parse(fs.readFileSync(configPathFor(dir), 'utf8')).channels.discord.passive_chats).toEqual([123]);
+    const repaired = await runHatchConfig(dir, { channels: { discord: { passive_chats: ['456'] } } }, true);
+    expect(repaired.exitCode).toBe(0);
+    expect(repaired.stderr).not.toContain('channels.discord.passive_chats');
+    const out = JSON.parse(fs.readFileSync(configPathFor(dir), 'utf8'));
+    expect(out.channels.discord.passive_chats).toEqual(['456']);
+    expect(out.channels.discord.enabled).toBe(false);
+  });
 
   test('re-init: morning_brief_time=null disables an existing morning brief', async () => {
     const dir = freshDir();


### PR DESCRIPTION
Channel setup submits `passive_chats` through `hatch-config --reinit`, but the channel overlay ignored that field and returned success without applying it. Core now copies an explicitly supplied array, including an empty array, while preserving the existing value when omitted and retaining existing validation.

Closes #1010.

```text
Channel setup submits passive chats
  Before -> answer ignored -> exit 0 -> setting unchanged
  After  -> array applied and validated -> exit 0 -> setting persisted
```

Regression coverage checks adding, replacing, clearing, omission, repeated input, fresh hatch, new channel creation, preservation of unrelated state, and invalid values leaving existing config bytes unchanged.

Validation:
- Focused hatch-config tests: six new tests failed before the fix; all 27 passed afterward.
- Core `bun test`: 5,379 passed, zero failures. The initial sandbox run could not bind local test servers; the complete rerun with local-server access passed.
- Root `bunx tsc`: exit 0.
- `git diff --staged --check`: exit 0.
- `bash scripts/graphify-refresh.sh`: exit 0, expected linked-worktree skip.
- Three independent simplify lenses: no findings.
