### PR TITLE
fix(core): only the registered resident answers channel messages

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- A session that is not the registered resident no longer answers channel messages, and is classified as a guest even when launched with the resident's environment. The verdict is taken at session start, so a session that started as a guest keeps leaving channel messages alone after the resident stops; `bin/hermit-start --resume` is the way back.
+
 ## [1.3.4] - 2026-09-08
 
 ### Added

--- a/plugins/claude-code-hermit/docs/always-on-ops.md
+++ b/plugins/claude-code-hermit/docs/always-on-ops.md
@@ -354,4 +354,4 @@ WantedBy=multi-user.target
 
 **Docker:** `restart: unless-stopped` handles it automatically — see [Always-On Setup](always-on.md). The entrypoint's SIGTERM trap ensures graceful session close on system shutdown.
 
-A manual `claude --resume` or a new Claude session launched from a shell opened through `hermit-attach` is a guest. Resume the resident with `.claude-code-hermit/bin/hermit-start --resume`.
+A manual `claude --resume` or a new Claude session launched from a shell opened through `hermit-attach` is a guest. Guests ignore channel messages, including sessions that inherit the resident's environment. The verdict is taken at session start and never revisited, so a guest keeps leaving channel messages alone even after the resident stops. Recognising an environment-inheriting session needs the resident's `session_pid` stamp in `state/runtime.json`, and a session already running when the plugin update lands is only classified at its next start. Use `.claude-code-hermit/bin/hermit-start --resume` to bring an old transcript back as the resident.

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -245,7 +245,8 @@ function buildCompactionPointers(agentDir: string): string {
 
 // --- Residency: resident vs guest ---------------------------------------
 // hermit-start marks resident launches with HERMIT_RESIDENT=1. Other sessions
-// are guests even when the resident is stopped. The tmux liveness check below
+// are guests even when the resident is stopped. A session carrying the flag but
+// not holding the registry stamp is also a guest. The tmux liveness check below
 // only determines whether the guest banner can point to a running resident.
 function residentSessionActive(agentDir: string): boolean {
   const runtime = readRuntimeJson(path.resolve(agentDir, 'state'));
@@ -375,7 +376,7 @@ function main(source: string | null, sessionId: string | null) {
   const stateDir = path.resolve(AGENT_DIR, 'state');
   stampSessionEnv(stateDir, sessionId);
   pruneGuestMarkers(stateDir);
-  if (process.env.HERMIT_RESIDENT !== '1') {
+  if (process.env.HERMIT_RESIDENT !== '1' || !ownsResidentIdentity(readRuntimeJson(stateDir))) {
     // The banner only reaches the model; the marker is what the state-writing
     // hooks read, since they run per turn with no model in the loop.
     markGuest(stateDir, sessionId);

--- a/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
@@ -35,6 +35,7 @@ import { hermitDir, transcriptPath as ccTranscriptPath, sessionId as ccSessionId
 import { parseChannelEnvelope } from './lib/channel-envelope';
 import { readConfigRaw } from './lib/config-read';
 import { readRuntimeJson } from './lib/runtime';
+import { ownsResidentIdentity } from './lib/session-registry';
 import { isGuest } from './lib/guest-marker';
 import type { StageContext, StageResult } from './lib/prompt-stages/types';
 
@@ -111,12 +112,24 @@ async function main(raw: string): Promise<void> {
       return configCache;
     },
     runtime() {
-      if (!runtimeRead) { runtimeRead = true; try { runtimeCache = readRuntimeJson(); } catch { runtimeCache = null; } }
+      if (!runtimeRead) { runtimeRead = true; try { runtimeCache = readRuntimeJson(path.join(dir, 'state')); } catch { runtimeCache = null; } }
       return runtimeCache;
     },
   };
 
-  // 1-3. Audit and context. These run on every prompt, including during a
+  const guest = isGuest(path.join(dir, 'state'), sessionId);
+
+  await stage('resident-gate', () => {
+    if (!ctx.envelope) return;
+    if (guest) {
+      return { block: 'guest session: channel message left to the resident' };
+    }
+    if (!ownsResidentIdentity(ctx.runtime())) {
+      return { block: 'channel message left to the resident session' };
+    }
+  }, ctx);
+
+  // 1-3. Audit and context. These run on every admitted prompt, including during a
   // shutdown — the operator's message is still recorded and the reply reminder
   // still names the chat to answer on.
   await stage('prompt-context', promptContext, ctx);
@@ -132,8 +145,9 @@ async function main(raw: string): Promise<void> {
   await stage('record-operator-action',
     () => { operatorActivityKept = recordOperatorAction(prompt, { envelope: ctx.envelope, config: ctx.config() }, { openTurn: false, sessionId }); }, ctx);
 
-  // Guest chat still receives context, but cannot control the resident.
-  if (isGuest(path.join(dir, 'state'), sessionId)) return;
+  // A guest's own prompts still receive context, but cannot control the resident.
+  // Its channel messages never get this far: the resident gate above blocks them.
+  if (guest) return;
 
   const rt = ctx.runtime();
   const shutdownPending = !!rt && !!rt.shutdown_requested_at && !rt.shutdown_completed_at;

--- a/plugins/claude-code-hermit/tests/startup-context-guest.test.ts
+++ b/plugins/claude-code-hermit/tests/startup-context-guest.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
+import { writeRegistryEntry } from './helpers/registry-fixture';
 import { runScript } from './helpers/run';
 import { setupWorkdir } from './helpers/workdir';
 
@@ -55,6 +56,28 @@ const markerFor = (dir: string, sessionId: string) =>
   path.join(dir, '.claude-code-hermit', 'state', `.guest-${sessionId}`);
 
 describe('startup-context.ts — resident vs guest', () => {
+  for (const ownParent of [false, true]) {
+    it(`resident flag with ${ownParent ? 'own parent' : 'foreign incumbent'} registry stamp`, async () => {
+      const wd = setupWorkdir();
+      try {
+        const env = fixture(wd.dir, { tmuxSession: SESSION });
+        const configDir = path.join(wd.dir, 'config');
+        const pid = ownParent ? process.pid : process.ppid;
+        writeRegistryEntry(configDir, pid);
+        fs.writeFileSync(path.join(wd.dir, '.claude-code-hermit', 'state', 'runtime.json'), JSON.stringify({
+          version: 1, session_state: 'idle', session_pid: pid, config_dir: configDir,
+        }));
+        const sessionId = 'registry-residency-test';
+        const res = await run(wd.dir, { ...env, HERMIT_RESIDENT: '1' }, sessionId);
+        expect(res.exitCode).toBe(0);
+        expect(res.stdout).toContain(ownParent ? '---Active Session---' : '---Guest Session---');
+        expect(fs.existsSync(markerFor(wd.dir, sessionId))).toBe(!ownParent);
+      } finally {
+        wd.cleanup();
+      }
+    });
+  }
+
   it('managed session gets the full framing even while its tmux session is alive', async () => {
     const wd = setupWorkdir();
     try {

--- a/plugins/claude-code-hermit/tests/user-prompt-pipeline.test.ts
+++ b/plugins/claude-code-hermit/tests/user-prompt-pipeline.test.ts
@@ -15,6 +15,7 @@
 import { afterAll, describe, test, expect } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
+import { writeRegistryEntry } from './helpers/registry-fixture';
 import { runScript } from './helpers/run';
 import { setupWorkdir, type Workdir } from './helpers/workdir';
 import { assistantEntry } from './helpers/transcript';
@@ -577,4 +578,53 @@ test('listed passive chat with allowed self-mention still records activity', asy
   });
   expect(result.exitCode).toBe(0);
   expect(fs.existsSync(hermit(wd.dir, 'state', 'last-operator-action.json'))).toBe(true);
+});
+
+describe('user-prompt-pipeline: resident gate', () => {
+  for (const scenario of [
+    { name: 'foreign live incumbent', pid: process.ppid, blocked: true },
+    { name: 'own parent', pid: process.pid },
+    { name: 'marker only', marker: true, blocked: true },
+    { name: 'foreign incumbent with plain prompt', pid: process.ppid, plain: true },
+    { name: 'no session_pid' },
+    { name: 'foreign incumbent from a subdirectory', pid: process.ppid, subdir: true, blocked: true },
+  ]) {
+    test(scenario.name, async () => {
+      const wd = setupChannelWorkdir();
+      const sessionId = 'resident-gate-test';
+      const configDir = path.join(wd.dir, 'config');
+      if (scenario.pid) writeRegistryEntry(configDir, scenario.pid);
+      writeRuntime(wd, { session_pid: scenario.pid, config_dir: configDir });
+      const stateDir = hermit(wd.dir, 'state');
+      if (scenario.marker) fs.writeFileSync(path.join(stateDir, `.guest-${sessionId}`), '');
+      const snapshot = () => fs.readdirSync(stateDir, { recursive: true }).sort().map(name => {
+        const file = path.join(stateDir, String(name));
+        return [name, fs.statSync(file).isFile() ? fs.readFileSync(file, 'hex') : null];
+      });
+      const before = snapshot();
+      const logPath = hermit(wd.dir, 'state', 'channel-log.sqlite');
+      const logBefore = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'hex') : null;
+      const cwd = scenario.subdir ? path.join(wd.dir, 'nested') : wd.dir;
+      fs.mkdirSync(cwd, { recursive: true });
+      const r = await runScript('user-prompt-pipeline.ts', {
+        stdin: JSON.stringify({ prompt: scenario.plain ? 'hello' : envelope('hello'), session_id: sessionId }),
+        cwd,
+      });
+      expect(r.exitCode).toBe(0);
+      if (scenario.blocked) {
+        expect(JSON.parse(r.stdout.trim())).toEqual({
+          decision: 'block',
+          reason: scenario.marker ? 'guest session: channel message left to the resident' : 'channel message left to the resident session',
+        });
+        expect(r.stdout.trim().split('\n')).toHaveLength(1);
+        expect(fs.existsSync(path.join(stateDir, 'last-operator-action.json'))).toBe(false);
+        expect(fs.existsSync(path.join(stateDir, 'operator-turn-open.json'))).toBe(false);
+        expect(snapshot()).toEqual(before);
+        expect(fs.existsSync(logPath) ? fs.readFileSync(logPath, 'hex') : null).toBe(logBefore);
+      } else {
+        expect(r.stdout).not.toContain('"decision":"block"');
+        if (!scenario.plain) expect(r.stdout).toContain('[channel reply reminder]');
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Problem

One Discord `/spawn-session` produced two helpers. Two hermit sessions were live in the same folder and both acted on the same envelope: the tmux resident, and a `claude --bg --resume` session that had inherited `HERMIT_RESIDENT=1` through its environment. Every channel command ran twice.

Residency was decided by an environment variable alone, so any session carrying the resident's environment was treated as the resident.

## Behavior

```
BEFORE: Discord message ─> resident (tmux) ──────────> executes, replies
                        └> second session, same folder ─> executes, replies   (duplicate)

AFTER:  Discord message ─> resident (tmux) ──────────> executes, replies
                        └> second session, same folder ─> hook blocks the prompt:
                                                          no model turn, no inbound
                                                          log row, no activity stamp

        SessionStart carrying HERMIT_RESIDENT=1 but not holding the registry
        stamp                                   ─> guest banner + .guest-<id> marker

        No registered resident (no session_pid, dead pid, unreadable registry,
        unhatched folder)                       ─> unchanged, falls open as today
```

The gate is a new `resident-gate` stage in `user-prompt-pipeline.ts`, placed before every state-writing stage, so a blocked envelope leaves nothing behind. It blocks when the prompt carries a channel envelope **and** the session is either marked a guest or does not hold the registry stamp.

The guest verdict is frozen at session start and is not revisited, which is the design this repo already chose for `lib/guest-marker.ts`. A session that started as a guest therefore keeps leaving channel messages alone after the resident stops; recovery is `bin/hermit-start --resume`, which the watchdog already owns.

## Decisions

```
where to fix ─┬─ /spawn-session dedupe ─> two sessions still reply to every other message
              └─ core residency + prompt gate ─> one session acts per folder      ◀ SELECTED

prompt gate ──┬─ incumbent pid only ─> a marked guest answers again once the resident dies
              └─ guest marker OR incumbent pid ─> guest stays silent, watchdog recovers ◀ SELECTED
```

A second fix rides along: the pipeline's runtime read is now anchored to the resolved hermit dir, so a hook run from a subdirectory of the project reads the same `runtime.json` as one run from the root. `harness-command`, `harness-verify` and `shutdown-gate` inherit it.

## Blast radius

- **Released surfaces touched:** the `UserPromptSubmit` pipeline (`scripts/user-prompt-pipeline.ts`) and the `SessionStart` injector (`scripts/startup-context.ts`), both shipped in core 1.3.4, plus `docs/always-on-ops.md`. Behavior changes only for sessions that are not the registered resident; the resident's path is untouched.
- **Unreleased surfaces touched:** a new `## [Unreleased]` section in the core CHANGELOG. No version bump, no tag.
- **Downstream operators:** nothing changes until they run `claude plugin update` — `/plugin update` only fires on a `version` change in `plugin.json`, so commits on `main` between releases are invisible to installed operators. After updating, a second session they open in a hermit folder stops answering channel messages, and their resident keeps answering as before. A session already running when the update lands is only classified at its next start.
- **Downstream hermits:** any hermit whose operator opens a second Claude session in the hermit folder (a manual `claude --resume`, a shell opened through `hermit-attach`, a `claude --bg`) gets one answering session instead of two. Residents launched on the tmux path hold the stamp and are protected. `--no-tmux` interactive residents never stamp `session_pid`, so they stay ungated by design (see Known limitations).
- **Per-actor ledger:** executor codex (harness-default model, effort low) wrote all four steps — the gate, the SessionStart classification, the runtime anchoring, both test suites, the changelog and the docs — and ran its own simplify pass / code-review high --fix hoisted a duplicated `isGuest` stat into one `const`, corrected a stale comment, and rewrote the changelog and docs prose to describe the frozen verdict accurately / operator approved the step 3 assertion repair, approved the step 4 prose and closing-verification repair, and decided to skip both remaining findings.

## Known limitations

Two review findings were deliberately not fixed here:

1. **The stamp requirement is inert for `--no-tmux` residents.** `stampSessionEnv` returns unless `HERMIT_MANAGED === '1'` (`startup-context.ts:320`), and `hermit-start` exports that only on the tmux path (`hermit-start.ts:1580`); the `--no-tmux` and tmux-died paths set `HERMIT_RESIDENT` alone (`:1559`, `:1700`). A duplicate launched from such a resident still falls open. This is fenced out of scope by the plan, and widening the gate would start stamping `cc_session_id`/`inbox_socket`/`env_auth` for interactive hermits, which the watchdog hygiene tiers consume. That is a design call, not a review fix.
2. **`findResident` does not check `cwd`.** It matches on `runtime.session_pid` and validates liveness, so any live session sharing the config dir that happens to occupy the resident's recorded pid is accepted as incumbent. Pre-existing, but this change raises the consequence from a skipped stamp refresh to the real resident being demoted to guest. The file is outside this diff and is also read by the watchdog, doctor and mcp-server, so it is left for a follow-up.

## Two contract repairs during implementation

The plan carried two prose defects, both caught by re-running its own checks and both approved by the operator before the fix:

1. Step 3's Verify asserted the own-parent case emits `---Operator Preferences---`. That header appears only when `operatorLanguage()` resolves a `config.json.language` the test fixture never writes, so no implementation could satisfy it. Changed to `---Active Session---`, the discriminator that file's pre-existing resident-branch test already uses.
2. Step 4 required the changelog to claim the guest stops answering only "while that resident is alive", and the docs to say the protection goes live after a *resident* restart. Both were false and contradicted the plan's own Decisions block: the verdict is frozen at session start, and the session that must restart is the guest, since the marker is written at its SessionStart. The closing-verification grep moved to `Guests ignore channel messages` for the same reason.

## Validation

Closing verification re-run in the worktree after the final commit, every row exit 0:

```
0  cd plugins/claude-code-hermit && bun test tests/user-prompt-pipeline.test.ts tests/startup-context-guest.test.ts tests/startup-context-stamp.test.ts
0  cd plugins/claude-code-hermit && bun test
0  cd plugins/claude-code-hermit && grep -q '^## \[Unreleased\]' CHANGELOG.md && grep -q 'registered resident' CHANGELOG.md && grep -q 'Guests ignore channel messages' docs/always-on-ops.md
0  bunx tsc
```

Full plugin suite: **5391 pass, 0 fail** across 181 files. `bunx tsc` clean.

New coverage: six cases on the gate (foreign live incumbent, own parent, marker only, foreign incumbent with a plain prompt, no `session_pid`, and a hook `cwd` in a subdirectory that proves the runtime anchoring), each asserting exact stdout plus the absence of any `state/` or channel-log write; and two cases on SessionStart classification (foreign incumbent gets the guest banner and a marker, own parent does not).

Not yet verified live. The plan defers that deliberately: on a scratch hatched project, start a resident with `hermit-start`, launch a second `claude --channels …` in the same folder, send one message, and confirm only the resident executed it. That needs the merged plugin installed and the resident restarted, so it belongs after this merges.
