### PR TITLE
ci: speed up macOS compatibility checks

### DIFF
--- a/.github/workflows/test-macos-compat.yml
+++ b/.github/workflows/test-macos-compat.yml
@@ -1,11 +1,7 @@
 name: macOS Compat
 
-# Answers "does hermit run on macOS" on free public-repo runners. Deliberately
-# NOT matrixed into the per-plugin suites: the parallelism flags are already
-# fragile across core counts (see test-hooks.yml's comment block, which reverted
-# a --parallel=4 pin after CI contention), and macOS runners are a third one.
-# Running serial sidesteps that question instead of re-tuning it on a platform
-# with no confirmed operators.
+# macOS compatibility checks on one runner. Keep suites sequential and
+# bound core file workers so subprocess-heavy tests do not consume every CPU.
 on:
   workflow_dispatch:
   schedule:
@@ -20,21 +16,37 @@ on:
       # is load-bearing: the first run of this job failed on test fixtures, not on
       # product code (unresolved os.tmpdir() compared against resolved
       # process.cwd()), so a test-only push has to be able to retrigger it.
-      - 'plugins/claude-code-hermit/scripts/**'
+      - 'plugins/*/scripts/**'
+      - 'plugins/*/hooks/**'
       - 'plugins/*/state-templates/bin/**'
       - 'plugins/*/tests/**'
+      - 'plugins/*/bunfig.toml'
       - '.github/workflows/test-macos-compat.yml'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tsconfig.json'
   pull_request:
     paths:
-      - 'plugins/claude-code-hermit/scripts/**'
+      - 'plugins/*/scripts/**'
+      - 'plugins/*/hooks/**'
       - 'plugins/*/state-templates/bin/**'
       - 'plugins/*/tests/**'
+      - 'plugins/*/bunfig.toml'
       - '.github/workflows/test-macos-compat.yml'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tsconfig.json'
+
+# Only revisions of the same PR supersede each other. Manual comparisons,
+# scheduled runs, and main pushes retain their own run groups.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   macos:
     runs-on: macos-latest
-    # Serial across six suites, and 20+ core test files spawn real tmux: a wedged pane
+    # Sequential across six suites, and 20+ core test files spawn real tmux: a wedged pane
     # would otherwise sit on the 6h job default and the weekly run reports
     # nothing at all. 60m is well above the observed Linux wall time.
     timeout-minutes: 60
@@ -60,12 +72,14 @@ jobs:
       # exercising tmux rather than silently skipping.
       - name: Ensure tmux
         run: tmux -V || (brew install tmux && tmux -V)
-      # Serial: no --parallel. --timeout stays at 45s as headroom for the in-test
+      # Two core file workers overlap subprocess waits. Tests within each file
+      # also run concurrently via bunfig.toml, so keep the worker count bounded.
+      # --timeout stays at 45s as headroom for the in-test
       # Date.now() poll deadlines (harness-command-delivery, proc-survivor,
       # hermit-stop) that --timeout does not itself extend.
       - name: Core suite
         if: '!cancelled()'
-        run: bun test --timeout=45000
+        run: bun test --parallel=2 --timeout=45000
         working-directory: plugins/claude-code-hermit
       - name: Home Assistant suite
         if: '!cancelled()'


### PR DESCRIPTION
The macOS compatibility job spends most of its time running core test files sequentially. Run core with two file workers while retaining the existing six complete suites, sequential plugin execution, and test timeouts. Cancel superseded revisions of the same PR while keeping manual, scheduled, and main runs independent.

The path filters also cover sibling scripts and hooks, plugin Bun configuration, and root dependency/typecheck files so those changes receive macOS coverage.

```text
Before: six suites in sequence -> core files execute one at a time
After:  six suites in sequence -> core uses two bounded file workers
        new PR revision -> obsolete run is cancelled
```

Only the macOS workflow changes. No plugin runtime, tests, versions, or test coverage change.

### Measured macOS results

Two manual runs per revision on identical application/test sources, Bun 1.4.0, and runner image `macos-26-arm64` version `20260831.0337.3`:

| Workflow | Job durations | Core durations |
| --- | --- | --- |
| Baseline | [170s](https://github.com/gtapps/claude-code-hermit/actions/runs/34270208196), [144s](https://github.com/gtapps/claude-code-hermit/actions/runs/34270211664) | 129s, 102s |
| Two core workers | [124s](https://github.com/gtapps/claude-code-hermit/actions/runs/34270561192), [129s](https://github.com/gtapps/claude-code-hermit/actions/runs/34270563993) | 79s, 87s |

Median job duration decreased from 157s to 126.5s (19.4%); median core duration decreased from 115.5s to 83s (28.1%). These are small-sample measurements on separate hosted runners, not a guaranteed runtime. All four runs passed all six suites, including 5,391 core tests, 678 Home Assistant tests, and 61 Feed tests each.

### Validation

- The four complete macOS runs above passed.
- The [final PR macOS check](https://github.com/gtapps/claude-code-hermit/actions/runs/34270915122) passed all six suites in 114s, with core taking 72s.
- Local `bun test --parallel=2 --timeout=45000` in core: 5,391 passed, zero failed.
- `bun install --frozen-lockfile` and `bunx tsc` passed.
- `actionlint .github/workflows/test-macos-compat.yml` and `git diff --check` passed.
- Graph refresh correctly skipped the linked worktree.
