### PR TITLE
feat(spawn-session): derive an unnamed helper's name from its prompt

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- `/spawn-session` names an unnamed helper from its prompt, with `session-<epoch>` only as the fallback.
 - Scheduled routines more than 60 minutes late are skipped before Monitor dispatch, with one global `routine_max_lateness_minutes` setting (1–1440). Existing installations use the same default; CronCreate fallback warns that it cannot enforce the limit.
 
 ### Upgrade Instructions

--- a/plugins/claude-code-hermit/skills/spawn-session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/spawn-session/SKILL.md
@@ -54,7 +54,14 @@ Four limits sit on that command:
    Remaining text is the prompt. Empty prompt: stop with a one-line ask for
    the work to run.
 
-   - `<n>` defaults to `session-<epoch>` (`date +%s`) when `--name` is omitted.
+   - When `--name` is omitted, derive `<n>` from the prompt: drop a leading `/`
+     and any `<plugin>:` namespace, lowercase, replace every non-`[a-z0-9]` run
+     with `-`, keep the first five nonempty tokens joined by `-`, cap the slug
+     at 40 characters, trim any leading or trailing `-`, then append `-` plus
+     the last four digits of `date +%s`. The trim is what keeps a prompt like
+     `#220 fix the parser` from producing a name the launch command reads as a
+     flag. If no token survives, use `session-<epoch>` (`date +%s`).
+     Example: `/tackle-issue PROP #220` becomes `tackle-issue-prop-220-9689`.
    - `<m>` / `<e>` are omitted when the operator does not name them, so the
      helper takes the box defaults.
 

--- a/plugins/claude-code-hermit/skills/spawn-session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/spawn-session/SKILL.md
@@ -58,10 +58,15 @@ Four limits sit on that command:
      and any `<plugin>:` namespace, lowercase, replace every non-`[a-z0-9]` run
      with `-`, keep the first five nonempty tokens joined by `-`, cap the slug
      at 40 characters, trim any leading or trailing `-`, then append `-` plus
-     the last four digits of `date +%s`. The trim is what keeps a prompt like
+     the full epoch (`date +%s`). The trim is what keeps a prompt like
      `#220 fix the parser` from producing a name the launch command reads as a
-     flag. If no token survives, use `session-<epoch>` (`date +%s`).
-     Example: `/tackle-issue PROP #220` becomes `tackle-issue-prop-220-9689`.
+     flag. The epoch is not truncated because `claude --worktree <n>` silently
+     reuses an existing `.claude/worktrees/<n>`, its branch and uncommitted
+     state included, and those directories are never pruned, so a repeated
+     name is a wrong-branch start with no error. If no token survives the slug
+     is `session`, which is what makes the fallback `session-<epoch>`.
+     Example: `/tackle-issue PROP #220` becomes
+     `tackle-issue-prop-220-1788889689`.
    - `<m>` / `<e>` are omitted when the operator does not name them, so the
      helper takes the box defaults.
 


### PR DESCRIPTION
## Problem

`/spawn-session` invoked without `--name` called the helper `session-<epoch>`. That name is the helper's identity everywhere it is visible: the `ListAgents` row, the Claude app, the Remote Control status line, and the directory under `.claude/worktrees/`. None of them said anything about the work. Two helpers on the same task differed only in their epoch, so telling them apart meant opening one.

## Behavior

```
operator: /spawn-session /tackle-issue PROP #220 …   (no --name)

BEFORE: helper named session-1788889689
        ListAgents / Claude app / RC status line / .claude/worktrees/ all show the epoch
        a second helper on the same task is session-1788889770,
        tellable apart only by opening it

AFTER:  helper named tackle-issue-prop-220-1788889689
        the same slug appears in every one of those places
        a second helper on the same task is tackle-issue-prop-220-1788889770
        a prompt of only punctuation still falls back to session-<epoch>
```

Step 1 of the skill now derives `<n>` from the prompt: drop a leading `/` and any `<plugin>:` namespace, lowercase, replace every non-`[a-z0-9]` run with `-`, keep the first five nonempty tokens, cap at 40 characters, trim leading and trailing `-`, then append `-` plus the full `date +%s` epoch. When no token survives, the slug is `session`, which is what makes the fallback `session-<epoch>`. The same `<n>` still feeds `--worktree`, `--name`, `--remote-control`, and the skill's step 4 watch.

Two details in that rule are load-bearing, and both are there for a reason found during review:

- **The trim.** `<n>` is substituted into `claude --bg --worktree <n> --name <n> … --remote-control <n>`, so a prompt like `#220 fix the parser` slugifying to `-220-fix-the-parser` would be read as a flag.
- **The untruncated epoch.** See below.

## Why the epoch is not truncated

The first draft of this rule used the last four digits of `date +%s`, which is periodic: two spawns of the *same* prompt an exact multiple of 10000 seconds (2h 46m 40s) apart produce the same name. A probe against Claude Code 2.1.265 settled what a repeat actually costs, and the answer is worse than a naming annoyance:

```
fixture: a scratch repo with a pre-existing .claude/worktrees/dup
         on branch `existing-branch`, holding an uncommitted MARKER file

$ claude --bg --worktree dup …
backgrounded · c78fa16f            # exit 0, no error, nothing about reuse

$ git worktree list
…/.claude/worktrees/dup  7a4ce01 [existing-branch] locked
$ ls .claude/worktrees/dup
MARKER-0748.txt  base.txt          # pre-existing uncommitted state intact
$ ls .claude/worktrees
dup                                # no dup-1 variant was created
```

`claude --worktree <n>` **silently reuses** an existing `.claude/worktrees/<n>`, branch and uncommitted state included. A second `--bg` launched onto the same worktree while the first session held it `locked` was also accepted, exit 0, still no variant: two live sessions then share one working tree on one branch. And `claude stop <id>` prints `worktree retained at <path>`, so only `claude rm <id>` removes it; stale worktrees accumulate indefinitely (89 on disk in this repo at probe time), which means a colliding name can land in a worktree whose session ended months ago.

So a repeated name is a wrong-branch start with no error, not a resolution failure anyone would notice. The full epoch is monotonic and therefore cannot repeat at all, which removes the periodicity rather than lengthening it: six more characters, none of them in the part of the name you actually read, and 51 chars stays under the 64-char worktree-name limit. It also folds the `session-<epoch>` fallback into the same rule as the slug-empty case, leaving one time source instead of two.

## Blast radius

- **Released surfaces touched:** `plugins/claude-code-hermit/skills/spawn-session/SKILL.md` — shipped skill text. It reaches installed operators on the next core release, not before.
- **Unreleased surfaces touched:** the `[Unreleased] / ### Changed` section of `plugins/claude-code-hermit/CHANGELOG.md`.
- **Downstream operators:** an operator who spawns a helper without `--name` gets a readable name instead of an epoch. No command changes, no new flag, no config key, nothing to learn. An operator who passes `--name` is unaffected.
- **Downstream hermits:** nothing on disk migrates, so no `### Upgrade Instructions` entry. Existing worktrees and watch-registry entries named `session-<epoch>` keep their names; the rule only decides what a *new* unnamed spawn is called.
- **Per-actor ledger:** executor codex (effort low) wrote both hunks from the frozen plan and ran its own cleanup pass / code-review high --fix added the leading-and-trailing-dash trim and its one-clause reason, and flagged the truncated-suffix collision / operator approved the plan, then chose to widen the suffix once the probe showed the failure was silent / the plan file was edited to record that reversed contract.

## Scope

Skill text only. Nothing parses the helper name, so no script, no test, and no new config surface. `watch/SKILL.md` resolves a session watch by exact whole-name `ListAgents` match and builds its own watch id independently, so it needs no change. The `--model`/`--effort` parsing and the `--remote-control` gating in the same step are untouched.

## Validation

The plan's closing verification, re-run in the worktree after the last commit — all three rows exit 0:

```
0  grep -q 'the full epoch' …/spawn-session/SKILL.md && ! grep -q 'last four digits' …/spawn-session/SKILL.md && ! grep -q 'defaults to `session-<epoch>`' …/spawn-session/SKILL.md
0  awk '/^## \[Unreleased\]/,/^## \[1/' plugins/claude-code-hermit/CHANGELOG.md | grep -q 'spawn-session'
0  cd plugins/claude-code-hermit && bun test
```

`bun test` in `plugins/claude-code-hermit`: 5426 pass, 0 fail, 181 files.

Not covered by automated tests, and deliberately so: no script consumes the name, so the rule is prose the model follows. It wants the operator check the plan names — with the skill loaded fresh, spawn `/claude-code-hermit:spawn-session /tackle-issue PROP #222` without `--name`, confirm the `ListAgents` row starts with `tackle-issue-prop-222-`, then spawn it again and confirm the second row carries a later epoch.

One residual, accepted: two spawns of the *same* slug within the same second would still collide. Not reachable by typing, and closing it would need an existence check on `.claude/worktrees/<n>` rather than a wider suffix.
