### PR TITLE
feat(core): allow proposal creation without artifact refreshes

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Proposal creation supports `--no-artifacts` (alias `--no-artifact`) to skip dashboard and proposals-page refreshes for one invocation.
+
 ### Changed
 - The four resident-only hooks (`pause-gate`, `ask-gate`, `component-privacy`, and `permission-denied-notify`) now ride the per-boot launch overlay with absolute script paths, probed on Claude Code 2.1.265.
 - A boot that cannot write the launch overlay refuses to start.

--- a/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
+++ b/plugins/claude-code-hermit/skills/proposal-create/SKILL.md
@@ -4,6 +4,8 @@ description: Creates a proposal for a high-leverage improvement discovered durin
 ---
 # Create Proposal
 
+**Options:** `--no-artifacts` (alias `--no-artifact`) skips the final artifact refreshes and artifact URL announcement. Useful for batches or callers that refresh afterward.
+
 Create a proposal only when you discover something with real leverage:
 - A missing helper or utility that would save significant time across sessions
 - A missing validation or guardrail that could prevent real errors
@@ -128,7 +130,7 @@ Body guidance:
 - Leave `## Operator Decision` blank — the operator fills that in.
 - Do NOT write bullet-point metadata (`- **Created:**`, etc.) — all metadata lives in the header lines / frontmatter only.
 
-Finally, refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md` (silently — no URL re-post; the proposal queue changed). Also refresh the proposals page (`config.artifacts.proposals`) per the same doc. Unlike the dashboard, when the proposals page returns a URL, surface it for whatever flow announces this proposal to the operator: append **at most one** `📎 <url>` line to that flow's message, regardless of how many proposals it created in this run — never one per proposal, and never one at all when no URL was returned.
+Skip this paragraph when either opt-out flag is supplied. Finally, refresh the dashboard per `${CLAUDE_PLUGIN_ROOT}/docs/artifacts.md` (silently — no URL re-post; the proposal queue changed). Also refresh the proposals page (`config.artifacts.proposals`) per the same doc. Unlike the dashboard, when the proposals page returns a URL, surface it for whatever flow announces this proposal to the operator: append **at most one** `📎 <url>` line to that flow's message, regardless of how many proposals it created in this run — never one per proposal, and never one at all when no URL was returned.
 
 ## Do NOT Create Proposals For
 


### PR DESCRIPTION
Proposal creation always requested dashboard and proposals-page refreshes, even when a caller planned to refresh those pages afterward.

Core's `proposal-create` skill now supports `--no-artifacts` (alias `--no-artifact`) to skip those refreshes and the artifact URL announcement for one invocation. Default behavior is unchanged. The change is limited to skill instructions and a changelog entry.

```text
Before: create proposal -> bookkeeping -> refresh configured pages -> announce
After:  create proposal -> bookkeeping -> either opt-out flag?
                                         yes: announce without artifact URL
                                         no:  existing refresh and announcement
```

Validation: core `bun test`, root `bunx tsc`, and `git diff --check`. Interactive model compliance was not tested; the flags are a documented skill convention, not parsed script arguments.
