### PR TITLE
fix(feed-hermit): reject earlier-run fetch output

### DIFF
--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Earlier-run fetch output is rejected before brief scoring when a new collection fails to replace it.
+
 ## [0.1.7] - 2026-09-07
 
 ### Changed

--- a/plugins/feed-hermit/agents/source-fetcher.md
+++ b/plugins/feed-hermit/agents/source-fetcher.md
@@ -5,7 +5,7 @@ tools: [WebFetch, Read, Write]
 description: Fetches web/RSS sources from feed-sources.md and writes compact, source-grounded candidate items to the JSON path supplied by feed-brief. Collection only; ranking and enrichment belong to the caller.
 ---
 
-Collect raw candidate items from the configured web/RSS sources. Your dispatch supplies the absolute project root, source list, slot, and output path. Read `<project-root>/feed-sources.md` and process only `web` and `rss` entries; the caller handles `chrome`, `reddit`, `reddit-home`, and `x`.
+Collect raw candidate items from the configured web/RSS sources. Your dispatch supplies the absolute project root, source list, slot, output path, and run ID. Read `<project-root>/feed-sources.md` and process only `web` and `rss` entries; the caller handles `chrome`, `reddit`, `reddit-home`, and `x`.
 
 ## Extraction
 
@@ -44,6 +44,7 @@ Write valid JSON, without prose or code fences:
 
 ```json
 {
+  "run_id": "<caller-supplied-run-id>",
   "fetch_date": "2026-01-15T09:00:00+00:00",
   "sources": [
     {
@@ -74,6 +75,7 @@ Write valid JSON, without prose or code fences:
 }
 ```
 
+- `run_id` is the exact caller-supplied run ID. Never reuse one from an existing file.
 - `fetch_date` is the actual fetch time in ISO 8601.
 - `sources[]` has one entry per eligible registry source, with `name`, `type`, `url`, and `status`.
 - Successful sources include `items[]` (possibly empty) and omit `error`.

--- a/plugins/feed-hermit/docs/schema.md
+++ b/plugins/feed-hermit/docs/schema.md
@@ -153,6 +153,7 @@ it carries are scored in Phase 3. Raw scratch — 3-day retention (§10).
 
 ```json
 {
+  "run_id": "<caller-supplied-run-id>",
   "fetch_date": "2026-01-15T09:00:00+00:00",
   "sources": [
     {
@@ -183,6 +184,7 @@ it carries are scored in Phase 3. Raw scratch — 3-day retention (§10).
 }
 ```
 
+- `run_id` is required and copied exactly from the caller, which generates a fresh UUID before dispatch.
 - Only `web` and `rss` sources appear (the agent skips `chrome`/`reddit`/`reddit-home`/`x`).
 - Per-source: `name`, `type`, `url`, `status` (`ok`|`failed`). `ok` carries `items[]`;
   `failed` carries `error` and omits items.
@@ -196,8 +198,17 @@ entirely, → `sources_skipped`; `status: "ok"` with empty `items[]` → `source
 `chrome`/`reddit`/`reddit-home`/`x` sources never appear here and are classified by
 `feed-brief` Phase 2 instead. A source that yielded items but lost all of them to Phase 3
 scoring is also `sources_quiet` per §2.
-`feed-brief` Phase 1 reconciles against this file, not the agent's reply — see
-`skills/feed-brief/SKILL.md`.
+`feed-brief` Phase 1 first verifies the file with `scripts/source-fetch-result.ts verify`
+using the ID it generated before dispatch. The helper reads once and prints the accepted
+JSON only when the top-level object has the matching `run_id` and a `sources` array.
+The caller reconciles that returned payload, not a second file read or the agent's reply.
+Run ID generation or verification failure sends every web/RSS source to `sources_skipped`,
+then Phase 2 continues without redispatch. Existing scratch files without `run_id` are
+rejected until a new fetch replaces them; no migration is needed.
+
+Matching run identity permits unchanged articles, quiet sources, and partial failures.
+It does not prove network fetching or enforce the model's invocation of the verifier.
+See `skills/feed-brief/SKILL.md`.
 
 Full contract lives in `agents/source-fetcher.md`.
 

--- a/plugins/feed-hermit/scripts/source-fetch-result.ts
+++ b/plugins/feed-hermit/scripts/source-fetch-result.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+import { readFileSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+
+function main(args: string[]): void {
+  if (args.length === 1 && args[0] === 'new-run') {
+    console.log(crypto.randomUUID());
+    return;
+  }
+
+  const [command, path, runId] = args;
+  if (args.length !== 3 || command !== 'verify' || !path || !isAbsolute(path) || !runId?.trim()) {
+    throw new Error('Usage: source-fetch-result.ts new-run | verify <absolute-output-path> <expected-run-id>');
+  }
+
+  const result: unknown = JSON.parse(readFileSync(path, 'utf8'));
+  if (typeof result !== 'object' || result === null || Array.isArray(result)
+    || !('run_id' in result) || result.run_id !== runId
+    || !('sources' in result) || !Array.isArray(result.sources)) {
+    throw new Error('Expected current-run source output with matching run_id and a sources array.');
+  }
+  console.log(JSON.stringify(result));
+}
+
+if (import.meta.main) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(`Source fetch verification failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/plugins/feed-hermit/skills/feed-brief/SKILL.md
+++ b/plugins/feed-hermit/skills/feed-brief/SKILL.md
@@ -31,19 +31,32 @@ Resolve `<slot>` from the flag before starting. All filenames below use that res
 
 ### Phase 1 — Web/RSS sources
 
+Before dispatch, run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/source-fetch-result.ts new-run`.
+Keep its returned UUID as the expected `run_id` for this invocation; never infer it from an
+existing file or the agent's reply. If generation fails, follow the wholesale fetch-failure
+path below without dispatching.
+
 Dispatch the `@feed-hermit:source-fetcher` subagent (model: haiku) to fetch all `web` and `rss`
-sources from `feed-sources.md`. Pass the full source list (URLs + names), the resolved `<slot>`, and the absolute project root and output path.
+sources from `feed-sources.md`. Pass the full source list (URLs + names), the resolved `<slot>`, the absolute project root and output path, and the generated `run_id` to copy exactly into the output JSON.
 
 **Output-path contract:** the agent writes its extracted items to `tmp/feed-source-items-<slot>.json`
 in the project root (never `/tmp/`). Pass `<absolute-project-root>/tmp/feed-source-items-<slot>.json` to the agent so its inherited working directory cannot redirect the write. Items are nested under `sources[]`, each item:
 `{title, summary, url, published_at, source, section, author}`. No scoring —
-extraction only. After the agent returns, read that file for the collected items.
+extraction only. After the agent returns, run:
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/source-fetch-result.ts verify "<absolute-output-path>" "<expected-run-id>"
+```
+
+Use the original expected ID, not an ID read from the output. On exit 0, consume only the
+accepted JSON printed by this command; do not re-read the raw file for candidate items.
+The verifier checks run identity and the envelope, not whether network fetches occurred.
 
 **Reconcile against the file, not the reply** (mapping owned by `docs/schema.md` §5). The
-agent's reply is a claim; the file is the only truth. This classifies `web`/`rss` sources only —
+agent's reply is a claim; only the verified file payload is eligible for reconciliation. This classifies `web`/`rss` sources only —
 `chrome`/`reddit`/`reddit-home`/`x` sources are absent from `sources[]` by design and are
 classified in Phase 2:
-- File missing or unparseable → every `web`/`rss` source in `feed-sources.md` goes to
+- Run ID generation or verification fails (including missing/unreadable/malformed output, an invalid envelope, or an absent/mismatched `run_id`) → every `web`/`rss` source in `feed-sources.md` goes to
   `sources_skipped`. Continue to Phase 2 — do not re-dispatch the agent — and note the wholesale
   fetch failure in the brief's Source notes.
 - A `web`/`rss` source with no entry in `sources[]` → `sources_skipped`, regardless of what the

--- a/plugins/feed-hermit/tests/schema-contract.test.ts
+++ b/plugins/feed-hermit/tests/schema-contract.test.ts
@@ -37,3 +37,21 @@ test("schema.md documents the source Type enum", () => {
     expect(schema).toContain(t);
   }
 });
+
+test('scratch producer and schema agree on caller-supplied run identity', () => {
+  const agent = readFileSync(join(import.meta.dir, '..', 'agents', 'source-fetcher.md'), 'utf8');
+  const scratch = schema.split('## 5. source-items JSON')[1].split('## 6.')[0];
+  for (const text of [agent.split('## Output contract')[1], scratch]) {
+    const example = JSON.parse(text.match(/```json\n([\s\S]*?)\n```/)![1]);
+    expect(example.run_id).toBe('<caller-supplied-run-id>');
+    expect(Array.isArray(example.sources)).toBe(true);
+    expect(text).toContain('`run_id`');
+  }
+  expect(agent).toContain('Never reuse one from an existing file');
+  expect(agent).toContain('After writing, `Read` the same absolute path');
+  expect(agent).toContain('Report a failed write');
+  expect(scratch).toContain('source-fetch-result.ts verify');
+  expect(scratch).toContain('Existing scratch files without `run_id`');
+  expect(scratch).toContain('`sources_skipped`');
+  expect(scratch).toContain('`sources_quiet`');
+});

--- a/plugins/feed-hermit/tests/skill-structure.test.ts
+++ b/plugins/feed-hermit/tests/skill-structure.test.ts
@@ -123,3 +123,23 @@ test("feed-brief Phase 1 reconciles the fetch file, not the agent's reply", () =
   const body = readFileSync(join(ROOT, "skills", "feed-brief", "SKILL.md"), "utf8");
   expect(body).toMatch(/Reconcile against the file, not the reply/);
 });
+
+test('feed-brief binds dispatch and verification to the original run ID', () => {
+  const body = readFileSync(join(ROOT, 'skills', 'feed-brief', 'SKILL.md'), 'utf8');
+  const phase = body.split('### Phase 1')[1].split('### Phase 2')[0];
+  const generate = phase.indexOf('source-fetch-result.ts new-run');
+  const dispatch = phase.indexOf('Dispatch the `@feed-hermit:source-fetcher`');
+  const verify = phase.indexOf('source-fetch-result.ts verify "<absolute-output-path>" "<expected-run-id>"');
+  expect(generate).toBeGreaterThanOrEqual(0);
+  expect(dispatch).toBeGreaterThan(generate);
+  expect(verify).toBeGreaterThan(dispatch);
+  expect(phase).toContain('the generated `run_id` to copy exactly');
+  expect(phase).toContain('Use the original expected ID');
+  expect(phase).toContain('do not re-read the raw file');
+  expect(phase).toContain('Run ID generation or verification fails');
+  expect(phase).toContain('without dispatching');
+  expect(phase).toContain('`sources_skipped`');
+  expect(phase).toContain('do not re-dispatch');
+  expect(phase).toContain('`sources_quiet`');
+  expect(phase).toContain('Phase 6 splits');
+});

--- a/plugins/feed-hermit/tests/source-fetch-result.test.ts
+++ b/plugins/feed-hermit/tests/source-fetch-result.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const script = join(import.meta.dir, '../scripts/source-fetch-result.ts');
+const fixtures: string[] = [];
+
+function fixture(content: string): string {
+  const dir = mkdtempSync(join(import.meta.dir, '.source-fetch-result-'));
+  fixtures.push(dir);
+  const path = join(dir, 'items.json');
+  writeFileSync(path, content);
+  return path;
+}
+
+function run(...args: string[]) {
+  const result = Bun.spawnSync([process.execPath, script, ...args]);
+  return { code: result.exitCode, stdout: result.stdout.toString(), stderr: result.stderr.toString() };
+}
+
+function expectRejected(...args: string[]) {
+  const result = run(...args);
+  expect(result.code).toBe(1);
+  expect(result.stdout).toBe('');
+  expect(result.stderr).toContain('Source fetch verification failed:');
+}
+
+afterEach(() => {
+  for (const dir of fixtures.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+test('new-run emits distinct UUIDs without candidate data', () => {
+  const first = run('new-run');
+  const second = run('new-run');
+  for (const result of [first, second]) {
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout.trim()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  }
+  expect(first.stdout).not.toBe(second.stdout);
+});
+
+test('an unsuccessful replacement leaves an old file rejected and untouched', () => {
+  const original = JSON.stringify({ run_id: 'earlier-run', sources: [{ name: 'Example', status: 'ok', items: [] }] });
+  const path = fixture(original);
+  // A failed writer leaves this previous payload in place, regardless of its reply.
+  expectRejected('verify', path, 'current-run');
+  expect(readFileSync(path, 'utf8')).toBe(original);
+});
+
+test('current-run output preserves unchanged articles, quiet sources, and partial failures', () => {
+  const sources = [
+    { name: 'Example', status: 'ok', items: [{ title: 'Unchanged article', url: 'https://example.com/article' }] },
+    { name: 'Quiet', status: 'ok', items: [] },
+    { name: 'Unavailable', status: 'failed', error: 'timeout' },
+  ];
+  const payload = { run_id: 'current-run', fetch_date: '2026-01-15T09:00:00Z', sources };
+  const path = fixture(JSON.stringify(payload));
+  const result = run('verify', path, 'current-run');
+  expect(result.code).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(JSON.parse(result.stdout)).toEqual(payload);
+  expectRejected('verify', path, 'overlapping-run');
+});
+
+test('current-run empty sources array is accepted', () => {
+  const payload = { run_id: 'current-run', sources: [] };
+  const result = run('verify', fixture(JSON.stringify(payload)), 'current-run');
+  expect(result.code).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual(payload);
+});
+
+for (const payload of [null, [], 'text', 1, {}, { sources: [] }, { run_id: 1, sources: [] },
+  { run_id: 'current-run' }, { run_id: 'current-run', sources: {} }]) {
+  test(`rejects invalid envelope ${JSON.stringify(payload)}`, () => {
+    expectRejected('verify', fixture(JSON.stringify(payload)), 'current-run');
+  });
+}
+
+test('malformed, missing, and unreadable file targets emit no candidate data', () => {
+  const path = fixture('not json');
+  expectRejected('verify', path, 'current-run');
+  expectRejected('verify', `${path}.missing`, 'current-run');
+  expectRejected('verify', fixtures[0], 'current-run');
+});
+
+for (const args of [[], ['unknown'], ['new-run', 'extra'], ['verify'], ['verify', 'relative.json', 'run'],
+  ['verify', '/file.json', ''], ['verify', '/file.json', 'run', 'extra']]) {
+  test(`rejects invalid invocation ${JSON.stringify(args)}`, () => expectRejected(...args));
+}


### PR DESCRIPTION
When a fetcher fails to replace its output, the previous valid JSON can still enter brief scoring. Feed now generates a run ID before dispatch and accepts only output carrying that same ID through a small deterministic verifier. Failed verification skips web/RSS sources and continues with other source types.

The existing path, retention, and per-source reconciliation are preserved. Unchanged articles remain valid in a current-run payload. This normally adds one caller tool call overall, with no new scheduled wakes or precheck changes. The model still directs verifier invocation; this does not fix write failures or prove network fetching.

```text
BEFORE: failed save -> old output remains eligible -> stale items may reach the operator
AFTER:  failed save -> run check rejects old output -> sources skipped and failure noted
```

Validation:
- `cd plugins/feed-hermit && bun test`: 84 passed.
- `bunx tsc`: passed.
- `git diff --check`: passed.
- `bash scripts/graphify-refresh.sh`: expected linked-worktree skip.
- Three independent simplify lenses returned no findings.

Affected plugin: Feed. No version bump or installed-state migration.

Closes #1021.
