### PR TITLE
feat(spawn-session): cap a bypass resident's helpers at auto

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Interactive boots clear `HERMIT_MANAGED` so attended questions and edits keep their interactive behavior.
 - Scheduled routines more than 60 minutes late after downtime are skipped before Monitor dispatch, with one global `routine_max_lateness_minutes` setting (1–1440). Time an occurrence spends deferred by an open operator turn does not count toward lateness, so a routine held by a live conversation still runs when it ends; downtime during the deferral counts as before. Existing installations use the same default; CronCreate fallback warns that it cannot enforce the limit.
 - `/spawn-session` names an unnamed helper from its prompt, with `session-<epoch>` only as the fallback.
+- `/spawn-session` launches a `bypassPermissions` resident's helpers with `--permission-mode auto`; `default`, `null` and an absent key still drop the flag, and every other `permission_mode` still passes through.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/skills/spawn-session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/spawn-session/SKILL.md
@@ -34,9 +34,13 @@ Four limits sit on that command:
   operator who is not watching. `config.json` accepts one value the CLI has no
   choice for, `default`, so it and `null` and an absent key all mean: leave the
   flag off entirely and let the helper take the box default.
-  `scripts/hermit-start.ts` resolves the same value the same way; match it
-  rather than inventing a second answer. Every other value passes through
-  unchanged, `bypassPermissions` included.
+  `scripts/hermit-start.ts` resolves `default` and `null` the same way;
+  match that rather than inventing a second answer. It does not agree on an
+  absent key, which it reads as `auto` rather than as no flag.
+  `bypassPermissions` is the one value that does not pass through: it
+  becomes `--permission-mode auto` because a helper has no approval
+  surface of its own, and `auto` is the only mode that stays unattended
+  behind a gate.
 - The prompt is one single-quoted argument. An apostrophe in it ends the quote,
   so replace every `'` with `'\''` before composing. Anything after the closing
   quote is a second command the operator never asked for.
@@ -74,10 +78,12 @@ Four limits sit on that command:
    Bash tool's working directory, which persists across calls and can sit in a
    subdirectory. Read `<p>` from `<abs>/.claude-code-hermit/config.json`
    (`permission_mode`), dropping the flag for `default`, `null` or an absent
-   key. Read `remote` from the same config and include `--remote-control <n>`
-   only when the key is present and `true`; `false`, `null` and an absent key
-   all leave the flag off, which is the resident session's own answer for that
-   config. Append this sentence to the operator's prompt:
+   key, mapping `bypassPermissions` to `auto` (Four limits), and passing
+   every other value through unchanged. Read `remote` from the same config
+   and include `--remote-control <n>` only when the key is present and
+   `true`; `false`, `null` and an absent key all leave the flag off, which
+   is the resident session's own answer for that config. Append this
+   sentence to the operator's prompt:
 
    `The hermit project is at <abs>; its state lives in <abs>/.claude-code-hermit/. Resolve any project-relative .claude-code-hermit/ reads/writes against <abs>; pass the absolute <abs>/.claude-code-hermit path to any hermit script rather than relying on your cwd.`
 


### PR DESCRIPTION
## Problem

`/spawn-session` composed the helper's launch flag by passing the resident's `permission_mode` straight through, `bypassPermissions` included. A helper is the one session in this design that has no approval surface of its own: its worktree carries no `.claude/settings.local.json` (gitignored, never checked out), so it inherits none of the hermit's permission rules, and nobody is watching a `--bg` session to answer a prompt. Passing bypass through meant the one place a gate could exist had none.

## Behavior

```
BEFORE
  resident permission_mode ──► helper launch flag
    auto / acceptEdits / plan / dontAsk ──► --permission-mode <same>
    default / null / absent ────────────► (flag omitted)
    bypassPermissions ──────────────────► --permission-mode bypassPermissions
                                            helper runs with no gate at all

AFTER
  resident permission_mode ──► helper launch flag
    auto / acceptEdits / plan / dontAsk ──► --permission-mode <same>      (unchanged)
    default / null / absent ────────────► (flag omitted)                 (unchanged)
    bypassPermissions ──────────────────► --permission-mode auto
                                            helper stays unattended, classifier gates each call,
                                            idle notice still reaches the resident
```

The alternative shapes were weighed before picking `auto`:

```
What does a bypass resident's helper get?
├── acceptEdits
│     helper has no allow rules in its worktree, stalls on its first Bash prompt
│     in a headless container; the watch expires
├── bypassPermissions (previous behavior)
│     helper runs with no gate; same container, so no new blast radius, but the
│     one place a gate could exist has none
└── auto ◀ SELECTED
      unattended behind the classifier, and the idle relay survives (probed below)
```

## Validation

`cd plugins/claude-code-hermit && bun test` green, plus the three grep assertions from the plan's closing verification, re-run by the shipping session after the final commit — all four exit 0.

The change rests on a claim about the cross-session idle relay, so it was probed against real sessions rather than assumed. A code-review finding argued that mapping the helper to `auto` would break `/watch`, on the grounds that CC holds peer messages by sender permission class: a bypass resident subscribing to a prompting helper would be held behind an approval dialog no `--bg` helper can answer. Three arms on CC 2.1.266, sonnet throughout, differing in exactly one variable each:

| Arm | Parent | Child | SendMessage result | Notice arrived | Hold dialog at child |
|---|---|---|---|---|---|
| A control | bypass + `crossSessionInbound: accept` | bypass | `Subscribed — you will get one notice here when …` | yes | none |
| B test | bypass + `crossSessionInbound: accept` | **auto** | `Subscribed — you will get one notice here when …` | **yes** | **none** |
| C neg-ctrl | bypass, **no overlay** | auto | `Subscribed — "probe-child-c" will send one notice … It is delivered to you if that session runs in the same permission class as this one …` | no | none |

```
PROBE_VERDICT_98e1:CONFIRMED - cross-session idle notice arrived with expected sentinel «CHILD_DONE_98e1» from probe-child-a's harness.
PROBE_VERDICT_9d2e:CONFIRMED - real cross-session idle notice arrived reporting probe-child-b idle at 10:55.
```

The finding is refuted. `/watch` subscribes with `SendMessage(to, notify_when_idle: true)` and **omits `message`** — a pure subscription carries no body, so the sender-permission-class hold never engages; no child in any arm logged a `Held message` / `Deliver this message` dialog. Arm C makes the real dependency explicit and measured rather than assumed: the relay works because `hermit-start.ts:1161` launches the resident with `crossSessionInbound: 'accept'`. Remove that overlay and the notice is silently never delivered, with no error and no dialog.

Two incidental corrections to the surrounding text, both caught by review: `hermit-start.ts:805` reads an **absent** `permission_mode` key as `auto`, not as "drop the flag", so the skill no longer claims the two resolvers agree there; and the changelog bullet now names the flag-dropping values instead of implying every non-bypass value passes through.

## Blast radius

- **Released surfaces touched:** none. `skills/spawn-session/SKILL.md` is skill text that ships with the plugin, and the entry sits under `[Unreleased]`; installed operators see nothing until `version` in `plugin.json` changes.
- **Unreleased surfaces touched:** `/spawn-session`'s composed launch command, for `bypassPermissions` residents only. Every other `permission_mode` resolves exactly as before, so a hermit not running bypass sees no change at all.
- **Downstream operators:** on a bypass hermit, a spawned helper's tool calls are now gated by the auto-mode classifier rather than running ungated. A helper doing something the classifier refuses will stop where it previously proceeded; that is the intended trade. No config change and no migration is required, so there are no `### Upgrade Instructions`.
- **Downstream hermits:** the `/watch session` idle relay is unaffected (probed above), so `/spawn-session`'s spawn-watch-relay path behaves as before. Hermits whose resident overlay lacks `crossSessionInbound: accept` would lose the relay, but `hermit-start.ts:1161` sets it on every resident boot.
- **Per-actor ledger:** executor grok wrote the three-step diff (skill text, step 2 resolution, changelog bullet) / code-review high --fix corrected the `hermit-start.ts` absent-key claim and the changelog wording, and raised the relay finding that was then probed / operator chose `auto` over `acceptEdits` and passthrough when reshaping the source proposal, kept the corrected changelog wording, and directed the re-probe that settled the finding.
