### PR TITLE
fix(claude-code-hermit): report watchdog storage failures

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -23,6 +23,7 @@ Immediately after `hermit-update` or `hermit-docker update` finishes, stop the r
 To retain the previous 24-hour catch-up window, set top-level `routine_max_lateness_minutes` to `1440` in `.claude-code-hermit/config.json`, preserving all other fields. Otherwise leave the setting absent to use the new 60-minute default. Preserve any existing explicit value. The running Monitor reads the setting on its next poll.
 
 ### Fixed
+- Watchdog state-write failures notify the operator on each failed tick instead of silently preventing recovery.
 - The watchdog's staged-login commit now writes `oauthAccount` to `~/.claude.json` on host installs, where Claude Code reads it, instead of `~/.claude/.claude.json`.
 - A cited `compiled/` or `raw/` doc that has since been archived no longer reads as a stale path when a proposal is accepted. The falsification gate, its `## Skill Draft` `source_artifact` check, the procedure-capture install flow's read of that brief, and the queued session task all fall back to the same basename in that directory's `.archive/` and verify against the archived copy; a doc in neither location is still stale.
 - A session that is not the registered resident no longer answers channel messages, and is classified as a guest even when launched with the resident's environment. The verdict is taken at session start, so a session that started as a guest keeps leaving channel messages alone after the resident stops; `bin/hermit-start --resume` is the way back.

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -1967,7 +1967,9 @@ async function main(): Promise<void> {
   // the liveness signal. Stamped even when watchdog.enabled is false.
   const liveness = readWatchdogState();
   liveness.last_run = utcStamp();
-  writeWatchdogState(liveness);
+  liveness.last_check_at = worldStamp(REAL_WORLD);
+  // Surface storage failures before recovery work so the fatal handler can notify.
+  writeFileAtomic(path.join(STATE_DIR, 'watchdog-state.json'), JSON.stringify(liveness, null, 2) + '\n');
 
   // Pause enforcement (PROP-015) — independent of watchdog.enabled; see
   // maybeEscapePausedSession for why this doesn't wait for the later
@@ -2767,6 +2769,7 @@ if (import.meta.main) {
       await main();
     } catch (e) {
       process.stderr.write(`[watchdog] fatal: ${e}\n`);
+      pushOperatorMessage(`[hermit] Watchdog failed; this tick could not complete: ${e}`);
       process.exit(0); // fail-open: watchdog must never crash the calling shell
     }
   } else if (subcommand === 'install') {

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -586,6 +586,82 @@ function configureChannel(h: Hermit): void {
   fs.writeFileSync(path.join(stateDir, '.env'), 'TELEGRAM_BOT_TOKEN=test-token\n');
 }
 
+describe('watchdog state-write failure', () => {
+  for (const lastStartError of [null, 'resident-missing']) {
+    test(`notifies each tick and recovers after permissions return (${lastStartError})`, withHermit(async (h) => {
+      writeConfig(h);
+      configureChannel(h);
+      patchRuntime(h, { last_start_error: lastStartError });
+      writeFakeTmux(h, 1);
+      writeFakePgrep(h, 1);
+      const runtimeBefore = fs.readFileSync(state(h, 'runtime.json'), 'utf8');
+      const stub = startHttpStub();
+      const env = { HERMIT_TELEGRAM_API_URL: stub.url };
+      fs.chmodSync(state(h), 0o500);
+      try {
+        // Prove permissions actually deny writes for the executing user.
+        expect(() => fs.writeFileSync(state(h, 'write-probe'), '')).toThrow();
+        for (let tick = 1; tick <= 2; tick++) {
+          const r = await watchdog(h, 'run', { env });
+          expect(r.exitCode).toBe(0);
+          expect(r.stderr).toContain('[watchdog] fatal:');
+          expect(r.stderr).toContain('EACCES');
+          expect(stub.requests.length).toBe(tick);
+          expect(stub.requests[tick - 1].body.text).toContain('Watchdog failed');
+          expect(stub.requests[tick - 1].body.text).toContain('EACCES');
+          expect(fs.readFileSync(state(h, 'runtime.json'), 'utf8')).toBe(runtimeBefore);
+          expect(fs.existsSync(path.join(h.dir, 'hermit-start-called'))).toBe(false);
+        }
+        fs.chmodSync(state(h), 0o700);
+        fs.writeFileSync(path.join(h.dir, '.claude-code-hermit', 'RESIDENT.md'), '# Resident');
+        const recovered = await watchdog(h, 'run', { env });
+        expect(recovered.exitCode).toBe(0);
+        expect(recovered.stderr).not.toContain('[watchdog] fatal:');
+        expect(await waitForStartMarker(h)).toBe(true);
+        expect(stub.requests.length).toBe(3);
+        expect(stub.requests[2].body.text).not.toContain('Watchdog failed');
+      } finally {
+        fs.chmodSync(state(h), 0o700);
+        stub.stop();
+      }
+    }), 45000);
+  }
+
+  test('notification failure still exits zero', withHermit(async (h) => {
+    writeConfig(h);
+    configureChannel(h);
+    const stub = startHttpStub();
+    stub.setStatus(403);
+    fs.chmodSync(state(h), 0o500);
+    try {
+      expect(() => fs.writeFileSync(state(h, 'write-probe'), '')).toThrow();
+      const r = await watchdog(h, 'run', { env: { HERMIT_TELEGRAM_API_URL: stub.url } });
+      expect(r.exitCode).toBe(0);
+      expect(r.stderr).toContain('[watchdog] fatal:');
+      expect(stub.requests.length).toBe(1);
+      expect(stub.requests[0].body.text).toContain('Watchdog failed');
+    } finally {
+      fs.chmodSync(state(h), 0o700);
+      stub.stop();
+    }
+  }));
+
+  test('successful initial write preserves fields and updates both timestamps', withHermit(async (h) => {
+    writeConfig(h, '2h', { enabled: false });
+    writeFakeTmux(h, 1);
+    writeFakePgrep(h, 1);
+    const oldStamp = '2026-01-01T00:00:00Z';
+    fs.writeFileSync(state(h, 'watchdog-state.json'), JSON.stringify({
+      last_run: oldStamp, last_check_at: oldStamp, consecutive_stale: 2,
+    }));
+    expect((await watchdog(h, 'run')).exitCode).toBe(0);
+    const ws = readJson(state(h, 'watchdog-state.json'));
+    expect(ws.consecutive_stale).toBe(2);
+    expect(Date.parse(ws.last_run)).toBeGreaterThan(Date.parse(oldStamp));
+    expect(Date.parse(ws.last_check_at)).toBeGreaterThan(Date.parse(oldStamp));
+  }));
+});
+
 describe('dead session with channel configured', () => {
   let h: Hermit;
   let stub: Stub;


### PR DESCRIPTION
When the watchdog's state directory is unwritable, ordinary restart attempts can be mistaken for lock contention and leave the operator without a notification. Core now lets its initial liveness write reach the fatal handler, which attempts an operator notification and retains exit code 0.

The change reuses the existing atomic-write and notification helpers. It attempts one notice per failed tick without new storage or configuration. Once storage is writable, normal operation resumes. Delivery remains best effort through the configured channel.

```text
Before: state unwritable -> restart skipped -> stderr only -> exit 0
After:  state unwritable -> notification attempt -> exit 0
        storage restored -> normal watchdog operation
```

Validation:
- `bun test tests/watchdog.test.ts` from the core plugin: 335 passed.
- `bun test` from the core plugin: 5,455 passed across 182 files.
- `bunx tsc` and `git diff --check` from the repository root: passed.
- `bash scripts/graphify-refresh.sh`: expected linked-worktree skip.

Regression coverage exercises actual permission failures, repeated notices, restored-permission recovery, failed delivery, and preservation of liveness state. Notification tests use a local HTTP stub.
