### PR TITLE
feat(core): route re-derived facts to a durable home at session close

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Proposal creation supports `--no-artifacts` (alias `--no-artifact`) to skip dashboard and proposals-page refreshes for one invocation.
 
 ### Changed
+- Session close and work-done archival write each re-derived fact to auto-memory or its `compiled/topic-*.md` page during the debrief; the Lessons line records the fact, its cost, and where it now lives.
 - The four resident-only hooks (`pause-gate`, `ask-gate`, `component-privacy`, and `permission-denied-notify`) now ride the per-boot launch overlay with absolute script paths, probed on Claude Code 2.1.265.
 - A boot that cannot write the launch overlay refuses to start.
 - Workspace trust for the project is seeded at boot.

--- a/plugins/claude-code-hermit/skills/session-close/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session-close/SKILL.md
@@ -71,7 +71,7 @@ This path is intentionally silent: no operator notification on queue or drain �
      1. *"What did I build ad-hoc this session (throwaway scripts, repeated manual procedures, long waits a tool would remove) that should persist?"*
      2. *"What did I have to re-derive or re-discover that a compiled note or memory entry should have told me?"*
      3. *"Did a skill produce output this session that was wrong, incomplete, or had to be reworked — and which skill + why? (Exclude preference, scope, or context changes — only genuine quality defects count. Settled-endpoint calibrations are recorded at settlement via `skill-preference:<skill>` per the placement rule, not here.)"*
-     One Lesson line per qualifying item, with quantified cost where known (e.g. `rebuilt wm pipeline in /tmp, 5 scripts, ~40 min/rerun`). Substantial re-derived knowledge goes to `compiled/` via the Artifacts bullet below instead of a Lesson line. If nothing qualifies, add nothing — no placeholder lines. These lines are the input procedure-capture recurs on (reflect reads `## Lessons` of archived reports).
+     One Lesson line per qualifying item, with quantified cost where known (e.g. `rebuilt wm pipeline in /tmp, 5 scripts, ~40 min/rerun`). If nothing qualifies, add nothing — no placeholder lines. These lines are the input procedure-capture recurs on (reflect reads `## Lessons` of archived reports).
      **For question 1** — on a positive answer that names a repeated manual procedure, also append one observations-ledger row. Name the slug for the capability the procedure provides (reflect § Procedure capture naming rule — no issue/PR numbers, error strings, dates, or `fix-<X>` phrasings):
      ```
      bun ${CLAUDE_PLUGIN_ROOT}/scripts/observations.ts observe .claude-code-hermit procedure-noticed --origin=own-work <<'HERMIT_OBSERVATION'
@@ -79,6 +79,13 @@ This path is intentionally silent: no operator notification on queue or drain �
      HERMIT_OBSERVATION
      ```
      The row is a bare recurrence counter; the Lessons line carries the procedure content. Same fail-open / operator-close gate as question 3.
+     **For question 2**: on a positive answer, write each item to its home now, before compiling the report:
+     - **Harness fact or session-wide preference:** issue the standard "remember it" reflection named in step 5. The native flow updates an existing memory file when one covers the fact; an update rather than a create means the home already held it.
+     - **Durable domain fact:** merge into the subject's `compiled/topic-<slug>.md` through the **Evolving subject** routing below. Put the fact in the body; `summary` stays a one-line subject description (the startup catalog prints only its first 100 characters). An already-present fact means the home already held it.
+     Record what was re-derived, its cost where known, and the destination (`[[compiled/topic-<slug>]]` or the memory file slug) in the Lessons line, with the destination early and the line under 150 characters (the frontmatter digest clips there). If the home already held it, say so instead.
+     ```
+     now in [[compiled/topic-deploys]]: deploy needs a cache clear first, ~20 min
+     ```
      **For question 3** — on a positive answer, for each defective skill: (a) record the what/why as a `## Lessons` line above (the durable content channel reflect reads at graduation); (b) append one observations-ledger counter row using the **canonical bare skill name** (read the `name:` frontmatter from `.claude/skills/<name>/SKILL.md`; strip any `claude-code-hermit:`/`<plugin>:` prefix; lowercase) — fail-open so the close never aborts:
      ```
      bun ${CLAUDE_PLUGIN_ROOT}/scripts/observations.ts observe .claude-code-hermit skill-correction --origin=own-work <<'HERMIT_OBSERVATION'

--- a/plugins/claude-code-hermit/skills/session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/session/SKILL.md
@@ -46,7 +46,7 @@ When the work is done, or the operator decides to move on (even if partial or bl
    - Ensure SHELL.md `## Blockers` reflects the final recorded state. It remains the factual floor. Payload Blockers can add missing facts or annotate a recorded blocker as resolved, but cannot erase recorded text.
    - `Status:` one of `completed` | `partial` | `blocked`
    - `Blockers:` optional additions, one line each. Use `~ <prefix>` to mark the first trimmed, case-insensitive prefix match in SHELL.md `## Blockers` resolved. The report keeps the full recorded text as `- [resolved] <recorded text>`; an unmatched `~` line becomes an ordinary addition with the tilde removed.
-   - `Lessons:` only genuinely useful ones
+   - `Lessons:` only genuinely useful ones: before compiling the report, ask "what did I re-derive that a compiled note or memory entry should have told me?" Write each item to its home now: for a harness fact or session-wide preference, issue the standard "remember it" reflection, which updates an existing memory file when one covers the fact; for a durable domain fact, merge into the subject's `compiled/topic-<slug>.md`, putting the fact in the body, keeping `summary` a one-line subject description, and stamping `session: S-NNN` in its frontmatter so the archive's stamped scan cites the page under `Artifacts:`. Record the fact, cost where known, and destination (topic wikilink or memory file slug) in the Lessons line, destination early and under 150 characters; say "already held" when the home had it.
    - `Changed:` list of files modified
    - `Artifacts:` optional `[[compiled/...]]` links not already recorded in SHELL.md or found by the session-stamped scan
 2. Verify quality in-context before archiving:

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -3779,6 +3779,19 @@ describe('heartbeat eval-runner return contract', () => {
 // ============================================================
 
 describe('determinized lifecycle wiring contract', () => {
+  test('curated session archives route re-derived knowledge to a durable home', () => {
+    const close = read(path.join(SKILLS, 'session-close', 'SKILL.md'));
+    const session = read(path.join(SKILLS, 'session', 'SKILL.md'));
+    expect(close).toContain('For question 2');
+    const question2 = close.slice(close.indexOf('For question 2'), close.indexOf('For question 3'));
+    expect(question2).toContain('remember it');
+    expect(question2).toContain('compiled/topic-');
+    expect(session).toContain('remember it');
+    expect(session).toContain('compiled/topic-');
+    expect(close).not.toContain('Substantial re-derived knowledge');
+    expect(close).toContain('Lessons: none');
+  });
+
   test('session-close SKILL.md routes the --scheduled branch through the auto-close-decision verb', () => {
     const skill = read(path.join(SKILLS, 'session-close', 'SKILL.md'));
     expect(skill).toContain('auto-close-decision');


### PR DESCRIPTION
## Problem

A hermit that learned a fact the hard way recorded it in a session report, and nothing ever re-surfaced it. Weeks later it re-derived the same fact and told the operator again. A read-only Lessons scan across the fleet on 2026-09-09 found recurring subjects five to seven sessions apart on three hermits (Reddit block, calendar UTC offset, routine-queue buildup, empty Discord allowlist).

The session report was a dead end by construction: reflect reads `## Lessons` looking for repeated *procedures*, not for facts, and nothing routed a fact to a place a later session would actually load.

## What changed

Both curated archive paths now run close-debrief question 2 ("what did I re-derive that a compiled note or memory entry should have told me?") to a destination instead of to a report line:

- **Harness fact or session-wide preference** goes through the existing "remember it" reflection. The native flow updates an existing memory file when one covers the fact, so an update rather than a create is itself the signal that the home already held it.
- **Durable domain fact** merges into the subject's `compiled/topic-<slug>.md` via the existing Evolving-subject routing, fact in the body, `summary` left as a one-line subject description.

The Lessons line then records what was re-derived, its cost where known, and where it now lives, destination first and under 150 characters (`session-archive.ts:456` clips the frontmatter digest there). A close that filed nothing new says "already held" instead.

The "substantial re-derived knowledge goes to `compiled/` instead of a Lesson line" exception is removed. It made the routing conditional on a size judgement the model had no criteria for, and the two homes now cover both sizes.

## Behavior delta

```
BEFORE:  learns a fact the hard way ──> line in the session report ──> nothing re-surfaces it
         weeks later: learns it again ──> tells the operator again

AFTER:   learns a fact the hard way ──> mid-session memory save (already native)
         task done / day end ──> "what did I re-derive?" ──┬─ home already had it ──> Lessons line says so
                                                           └─ not there ──> written to memory or topic page
         next session ──> memory index loaded, page found by recall ──> no repeat
```

## Why capture, not a recurrence reader

```
where to act ─┬─ reflect-time recurrence reader ──> repeat detected only after the 2nd occurrence;
              │                                     runner pass + judge + triage + operator question per hit
              └─ capture at the moment of recognition ──> fact written once, no operator question,
                                                          no new script                            ◀ SELECTED
```

The alternative also had to be paid on every reflect run whether or not anything recurred. This costs two skill-text blocks and no new code.

## Blast radius

- **Released surfaces touched:** `skills/session-close/SKILL.md` and `skills/session/SKILL.md` in `claude-code-hermit` core. Both are shipped skill text, so the change reaches operators at the next core release. No script, hook, config key, version floor, or migration is touched, and there are no `### Upgrade Instructions`.
- **Unreleased surfaces touched:** one `### Changed` bullet under `## [Unreleased]` in the core CHANGELOG, and one new contract test.
- **Downstream operators:** visible only at session close. Lessons lines now name a destination (`[[compiled/topic-...]]` or a memory slug) or say the home already held the fact, and a close may now write a memory file or merge into a topic page that it previously would not have. Nothing to configure, nothing to migrate, no new prompts. The `--auto` close path is untouched and still files nothing.
- **Downstream hermits:** every hermit on core picks it up through the normal `/plugin update` plus `hermit-evolve` cycle. No `required_core_version` bump, so no fleet plugin needs to move.

- **Per-actor ledger:** executor `codex` wrote all four files against the frozen plan at `82f07ff3` (both skill blocks, the contract test, the CHANGELOG bullet) and ran its own cleanup pass. `code-review high --fix` added the `session: S-NNN` frontmatter stamp to the work-done bullet, without which `recordedArtifacts` (`session-archive.ts:578-580`) never cites the new topic page under `Artifacts:`, and reordered the example line destination-first to match the rule directly above it. The operator replaced the example's subject with a generic one, shortened it, and, after `/review-findings` verified the three remaining findings, decided to skip all three.

## Findings left open

Verified against live code and deliberately not fixed here:

1. `contentLines()` caps the `lessons` frontmatter array at 6 (`session-archive.ts:455`), and that array is procedure capture's input (`skills/reflect/reference.md:194-195`, body read only as a legacy fallback). A third question source raises the pressure on that cap. Not fixed: it is pre-existing, the plan fences the fix out of scope, and it is rarer than it sounds, roughly 12% of archived reports across the fleet carry any Lessons line at all. Worth its own change, since the real issue is that a digest is being read as if it were complete.
2. Reflect graduating a filed-knowledge Lessons line into a Tier-3 skill draft: refuted. The recurrence signal at `reference.md:204` requires "the same multi-step procedure", which a re-derived fact is not, and Tier 3 still passes through triage.
3. `expect(close).toContain('Lessons: none')` reads as a weak assertion: refuted. It is the guard for the plan's fence that the `--auto` payload template at `SKILL.md:35` stays untouched.

## Validation

The plan's Closing verification, re-run in the worktree after the final commit:

```
0  cd plugins/claude-code-hermit && bun test --parallel --timeout=45000
0  cd "$(git rev-parse --show-toplevel)" && bunx tsc
```

5452 pass, 0 fail across 182 files. No external protocol is named in the plan, so no client smoke applies.

Operator-run after merge, not covered here: one session close with a new domain fact, expecting the topic page body to gain it and the Lessons line to carry the wikilink; one work-done archive with a harness fact already saved in-turn, expecting no new memory file and a Lessons line saying the home already held it. Fleet success signal four weeks after release: re-extract `## Lessons` over SSH and count a failure only where a subject recurs in a later same-area session.
