### PR TITLE
fix: drop hook-config keys Claude Code warns about and ignores

### DIFF
--- a/plugins/claude-code-dev-hermit/CHANGELOG.md
+++ b/plugins/claude-code-dev-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `unknown keys "description" ... ignored` warning printed at every session start. `description` is not part of Claude Code's hook schema on a matcher group; the prose now lives in each hook script's header, with one legal root-level `description` in `hooks.json`.
+
 ## [0.4.14] - 2026-09-07
 
 ### Changed

--- a/plugins/claude-code-dev-hermit/hooks/hooks.json
+++ b/plugins/claude-code-dev-hermit/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "description": "Safety guardrails for agent-driven dev work.",
   "hooks": {
     "PreToolUse": [
       {
@@ -9,8 +10,7 @@
             "command": "bun",
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/git-push-guard.ts"]
           }
-        ],
-        "description": "Block direct git push to protected branches, --no-verify, force-push (strict profile)"
+        ]
       },
       {
         "matcher": "Edit|Write",
@@ -20,8 +20,7 @@
             "command": "bun",
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/worktree-boundary-guard.ts"]
           }
-        ],
-        "description": "In a linked git worktree, block edits that escape into the main checkout (self-limiting; WORKTREE_GUARD=off to disable)"
+        ]
       }
     ],
     "PostToolUse": [
@@ -33,8 +32,7 @@
             "command": "bun",
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/record-test-result.ts"]
           }
-        ],
-        "description": "Record exit code + duration of the configured test command to state/last-test.json (consumed by /dev-pr)"
+        ]
       }
     ]
   }

--- a/plugins/claude-code-dev-hermit/scripts/git-push-guard.ts
+++ b/plugins/claude-code-dev-hermit/scripts/git-push-guard.ts
@@ -1,3 +1,6 @@
+// PreToolUse hook (matcher "Bash") — blocks direct pushes to protected branches,
+// --no-verify, and force-pushes.
+//
 // Adapted from Everything Claude Code (https://github.com/affaan-m/everything-claude-code) — MIT.
 // v0.3.0 simplified the original tokenizer-based parser to regex-only.
 // Strict-profile only (AGENT_HOOK_PROFILE=strict). Exit 2 hard-blocks the bash call.

--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `unknown keys "description" ... ignored` warning printed at every session start. `description` is not part of Claude Code's hook schema on a matcher group; the prose now lives in each hook script's header, with one legal root-level `description` per `hooks.json`. The same keys are gone from the per-boot launch overlay, which was a second source of the warning.
+
 ## [1.3.5] - 2026-09-09
 
 ### Added

--- a/plugins/claude-code-hermit/hooks/hooks.json
+++ b/plugins/claude-code-hermit/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "description": "Core hermit guardrails and session lifecycle hooks.",
   "hooks": {
     "PreToolUse": [
       {
@@ -10,8 +11,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/cache-edit-guard.ts"],
             "timeout": 3
           }
-        ],
-        "description": "Warn (or block, with HERMIT_CACHE_GUARD=block) when editing a marketplace cache copy whose runtime source is canonical"
+        ]
       },
       {
         "matcher": "Bash|Edit|Write",
@@ -22,8 +22,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/settings-gate.ts"],
             "timeout": 3
           }
-        ],
-        "description": "Raise the native permission prompt for execution-adjacent hermit settings, channel enrollment, and direct config.json edits"
+        ]
       },
       {
         "matcher": "Artifact",
@@ -34,8 +33,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/artifact-backend-guard.ts"],
             "timeout": 3
           }
-        ],
-        "description": "Deny Artifact publish when config.artifacts.backend is not claude, naming the backend and its MCP tools so the model publishes there instead"
+        ]
       }
     ],
     "PostToolUse": [
@@ -48,8 +46,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/channel-hook.ts"],
             "timeout": 5
           }
-        ],
-        "description": "Persist dm_channel_id to config.json after channel reply"
+        ]
       },
       {
         "matcher": "Edit|Write",
@@ -60,8 +57,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/validate-config.ts"],
             "timeout": 5
           }
-        ],
-        "description": "Validate config.json schema after edits"
+        ]
       },
       {
         "matcher": "Edit|Write",
@@ -72,8 +68,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/generate-summary.ts"],
             "timeout": 5
           }
-        ],
-        "description": "Regenerate state-summary.md after state/ file edits"
+        ]
       },
       {
         "matcher": "Read",
@@ -84,8 +79,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/usage-track.ts"],
             "timeout": 3
           }
-        ],
-        "description": "Append compiled/ reads to state/usage-metrics.jsonl (weekly-review consumes it for untouched-knowledge suggestions)"
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -98,8 +92,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-pipeline.ts"],
             "timeout": 15
           }
-        ],
-        "description": "Single prompt pipeline: records operator action, injects time + channel reply reminder, then applies pause / harness-command / shutdown / status in explicit precedence (shutdown is terminal)"
+        ]
       }
     ],
     "SessionStart": [
@@ -111,8 +104,7 @@
             "command": "bun",
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/startup-context.ts"]
           }
-        ],
-        "description": "Classify residency, seed resident activity if absent, and load session context"
+        ]
       }
     ],
     "Stop": [
@@ -125,8 +117,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/stop-pipeline.ts"],
             "timeout": 15
           }
-        ],
-        "description": "Stop pipeline: cost tracking, session diff, evaluation, heartbeat"
+        ]
       }
     ],
     "StopFailure": [
@@ -139,8 +130,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/stop-failure-stamp.ts"],
             "timeout": 10
           }
-        ],
-        "description": "Stamp the typed upstream failure the watchdog classifies from"
+        ]
       }
     ],
     "SubagentStop": [
@@ -153,8 +143,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/subagent-cost.ts"],
             "timeout": 10
           }
-        ],
-        "description": "Capture async-dispatched subagent token cost (invisible to Stop-time cost-tracker)"
+        ]
       }
     ],
     "PreCompact": [
@@ -167,8 +156,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/precompact-stamp.ts"],
             "timeout": 5
           }
-        ],
-        "description": "Stamp SHELL.md Progress Log before context compaction (manual /compact or native auto-compaction) — a breadcrumb only, never blocks compaction. Does not fire on /clear; the watchdog's own emergency /clear flushes separately in hermit-watchdog.ts"
+        ]
       }
     ]
   }

--- a/plugins/claude-code-hermit/scripts/ask-gate.ts
+++ b/plugins/claude-code-hermit/scripts/ask-gate.ts
@@ -2,7 +2,8 @@
 process.stdout.on('error', () => {});
 
 // PreToolUse hook (matcher "AskUserQuestion") — binds the last unbound
-// synchronous-ask path on unattended sessions. PROP-017 covers hermit-owned
+// synchronous-ask path on unattended sessions, denying the call with a redirect
+// to the channel reply tool and the micro-proposal bridge. PROP-017 covers hermit-owned
 // skills cooperatively (Step-0 marker + static contract test); this gate
 // binds everything else — built-ins, other plugins' skills, spontaneous
 // model-initiated questions — the caller surface that grows with every

--- a/plugins/claude-code-hermit/scripts/lib/settings/overlay-hooks.ts
+++ b/plugins/claude-code-hermit/scripts/lib/settings/overlay-hooks.ts
@@ -11,7 +11,6 @@ export function overlayHooks(pluginRoot: string) {
           args: [path.resolve(pluginRoot, 'scripts', 'pause-gate.ts')],
           timeout: 3,
         }],
-        description: 'Deny every tool call while state/pause.json is set, except a channel reply tool and PushNotification',
       },
       {
         matcher: 'AskUserQuestion',
@@ -21,7 +20,6 @@ export function overlayHooks(pluginRoot: string) {
           args: [path.resolve(pluginRoot, 'scripts', 'ask-gate.ts')],
           timeout: 3,
         }],
-        description: 'Deny AskUserQuestion on always-on channel-primary sessions with a redirect to the channel reply tool + micro-proposal bridge (binds the callers the static contract test cannot see)',
       },
     ],
     PermissionDenied: [
@@ -33,7 +31,6 @@ export function overlayHooks(pluginRoot: string) {
           args: [path.resolve(pluginRoot, 'scripts', 'permission-denied-notify.ts')],
           timeout: 12,
         }],
-        description: 'Record a deduped maintainer-tier denial diagnostic on the managed unattended session: tool name and reason to the maintainer chat, else Findings; no client message',
       },
     ],
     PostToolUse: [
@@ -45,7 +42,6 @@ export function overlayHooks(pluginRoot: string) {
           args: [path.resolve(pluginRoot, 'scripts', 'component-privacy.ts')],
           timeout: 5,
         }],
-        description: 'Keep a hermit-created skill/agent private to this install (git-common-dir info/exclude) when hatch_target is local and the write came from the managed always-on session',
       },
     ],
   };

--- a/plugins/claude-code-hermit/scripts/permission-denied-notify.ts
+++ b/plugins/claude-code-hermit/scripts/permission-denied-notify.ts
@@ -5,7 +5,7 @@ process.stdout.on('error', () => {});
 // classifier (or the permissions system) has already denied a tool call. The
 // payload carries tool_name, tool_input, tool_use_id, and reason (usually the
 // fixed text "Blocked by classifier"). This hook cannot block or retry the call;
-// it records a maintainer-tier diagnostic, routed by tier: the maintainer chat
+// it records a deduped maintainer-tier diagnostic, routed by tier: the maintainer chat
 // when one is configured, the primary chat on a technical profile without one,
 // and SHELL.md Findings on a non-technical profile (fail-closed on disclosure)
 // or whenever the channel is absent or unreachable.

--- a/plugins/claude-code-hermit/scripts/startup-context.ts
+++ b/plugins/claude-code-hermit/scripts/startup-context.ts
@@ -2,6 +2,7 @@
 process.stdout.on('error', () => {});
 
 // startup-context.ts — SessionStart hook
+// Classifies residency, seeds resident activity when absent, and loads session context.
 // Replaces the inline bash blob with a capped, priority-ordered context injection.
 // Emits only startup-relevant SHELL.md sections with per-section budgets.
 // Hard cap: 9000 chars total (~2250 tokens). Source-gated: `compact` emits only

--- a/plugins/claude-code-hermit/scripts/stop-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/stop-pipeline.ts
@@ -1,5 +1,6 @@
 // stop-pipeline.ts — unified Stop hook
 // Reads stdin once, runs all stop stages in sequence, touches heartbeat.
+// Stages, in order: cost tracking, session diff, evaluation, heartbeat.
 // All stage output goes to stderr; nothing is emitted on stdout.
 
 import { run as costTracker } from './cost-tracker';

--- a/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
+++ b/plugins/claude-code-hermit/scripts/user-prompt-pipeline.ts
@@ -3,6 +3,9 @@ process.stdout.on('error', () => {});
 
 // UserPromptSubmit hook — the single process for the whole prompt path.
 //
+// Records the operator action, injects time + the channel reply reminder, then
+// applies pause / harness-command / shutdown / status in explicit precedence.
+//
 // Replaces seven separately-registered hooks. Each of those re-read stdin,
 // re-parsed the channel envelope, and re-read config; the operator paid all
 // seven process launches on every message they sent. This reads stdin once,

--- a/plugins/claude-code-hermit/tests/hermit-start.test.ts
+++ b/plugins/claude-code-hermit/tests/hermit-start.test.ts
@@ -1572,7 +1572,8 @@ describe('renderLaunchOverlay', () => {
         type: 'command', command: 'bun',
         args: [path.join(PLUGIN_ROOT, 'scripts', script)], timeout,
       }]);
-      expect(entry.description.length).toBeGreaterThan(0);
+      // Claude Code warns about and ignores anything outside {matcher, hooks} here.
+      expect(Object.keys(entry).sort()).toEqual(['hooks', 'matcher']);
     }
     expect(JSON.stringify(hooks)).not.toContain('${CLAUDE_PLUGIN_ROOT}');
     renderLaunchOverlay({});

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `unknown keys "description" ... ignored` warning printed at every session start. Neither `description` nor `profile` is part of Claude Code's hook schema on a matcher group; the prose now lives in each hook script's header, with one legal root-level `description` in `hooks.json`. The `profile` key was documentation only, since the gates read `AGENT_HOOK_PROFILE` directly.
+
 ## [0.4.13] - 2026-09-07
 
 ### Fixed

--- a/plugins/claude-code-homeassistant-hermit/hooks/hooks.json
+++ b/plugins/claude-code-homeassistant-hermit/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "description": "Home Assistant safety gates.",
   "hooks": {
     "PreToolUse": [
       {
@@ -9,12 +10,10 @@
             "command": "bun",
             "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/mcp-safety-gate.ts"]
           }
-        ],
-        "description": "Default-deny chokepoint for the whole homeassistant MCP server: gates every mcp__homeassistant__* call. Read-only tools (GetLiveContext/GetDateTime) are allow-listed in the gate; sensitive entities are blocked or asked per ha_safety_mode; any unverifiable target fails closed. Tool IDs assume the HA MCP Server is registered in Claude Code as 'homeassistant'."
+        ]
       },
       {
         "matcher": "Bash",
-        "profile": "standard,strict",
         "hooks": [
           {
             "type": "command",
@@ -22,8 +21,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/curl-host-gate.ts"],
             "timeout": 5
           }
-        ],
-        "description": "Auto-approve curl/wget calls whose command string contains a known HA URL (from .env). All other Bash commands pass through unchanged."
+        ]
       }
     ]
   }

--- a/plugins/claude-code-homeassistant-hermit/hooks/mcp-safety-gate.ts
+++ b/plugins/claude-code-homeassistant-hermit/hooks/mcp-safety-gate.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env bun
 // PreToolUse hook: gate mcp__homeassistant__* calls targeting sensitive entities.
 //
+// Default-deny chokepoint for the whole homeassistant MCP server: the matcher
+// covers every mcp__homeassistant__* call, and the read-only tools
+// (GetLiveContext/GetDateTime) are allow-listed here in the gate rather than
+// excluded by the matcher. Tool IDs assume the HA MCP Server is registered in
+// Claude Code under the name 'homeassistant'.
+//
 // WP8 port of hooks/mcp-safety-gate.py. Imports the policy from ../src/policy
 // (same plugin, same language) — the Python original imported the deleted
 // ha_agent_lab.policy package, which never resolved on standard operator

--- a/plugins/feed-hermit/CHANGELOG.md
+++ b/plugins/feed-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Earlier-run fetch output is rejected before brief scoring when a new collection fails to replace it.
+- `unknown keys "description" ... ignored` warning printed at every session start. `description` is not part of Claude Code's hook schema on a matcher group; the prose now lives in each hook script's header, with one legal root-level `description` in `hooks.json`.
 
 ## [0.1.7] - 2026-09-07
 

--- a/plugins/feed-hermit/hooks/hooks.json
+++ b/plugins/feed-hermit/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "description": "Feed source guardrails.",
   "hooks": {
     "PreToolUse": [
       {
@@ -10,8 +11,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/fetch-guard.ts"],
             "timeout": 5
           }
-        ],
-        "description": "Block WebFetch to any domain not in feed-sources.md (plus a hardcoded infra allowlist). Fails open if feed-sources.md is missing."
+        ]
       }
     ],
     "PostToolUse": [
@@ -24,8 +24,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/validate-sources.ts"],
             "timeout": 10
           }
-        ],
-        "description": "Validate the feed-sources.md table format after any edit to it. Passes through for non-feed-sources.md files."
+        ]
       }
     ]
   }

--- a/plugins/laravel-forge-hermit/CHANGELOG.md
+++ b/plugins/laravel-forge-hermit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — laravel-forge-hermit
 
+## [Unreleased]
+
+### Fixed
+- `unknown keys "description" ... ignored` warning printed at every session start. Neither `description` nor `profile` is part of Claude Code's hook schema on a matcher group; the prose now lives in `write-confirm-gate.ts`'s header, with one legal root-level `description` in `hooks.json`. The `profile` key was documentation only, since the gate reads `AGENT_HOOK_PROFILE` directly.
+
 ## [0.0.14] - 2026-09-07
 
 ### Fixed

--- a/plugins/laravel-forge-hermit/hooks/hooks.json
+++ b/plugins/laravel-forge-hermit/hooks/hooks.json
@@ -1,9 +1,9 @@
 {
+  "description": "Forge write guardrails.",
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "profile": "standard,strict",
         "hooks": [
           {
             "type": "command",
@@ -11,8 +11,7 @@
             "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/write-confirm-gate.ts"],
             "timeout": 5
           }
-        ],
-        "description": "Block forge.php deploy/server-reboot calls lacking --confirm. Previews, policy inspection, generic reads and plan execution pass through; the generic write path is gated in PHP by hash-checked plans, not by a flag."
+        ]
       }
     ]
   }

--- a/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
+++ b/plugins/laravel-forge-hermit/hooks/write-confirm-gate.ts
@@ -7,8 +7,10 @@
 // Strategy: look for "forge.php" in the command string, extract the
 // subcommand token that follows it, and gate on "deploy" / "server-reboot".
 // preview-deploy and preview-reboot are distinct tokens — they pass through
-// unconditionally (they are read-only). The in-PHP --confirm refusal is the
-// authoritative gate; this hook is defense-in-depth.
+// unconditionally (they are read-only), as do policy inspection, generic reads
+// and plan execution. The in-PHP --confirm refusal is the authoritative gate;
+// this hook is defense-in-depth. The generic write path is gated in PHP by
+// hash-checked plans, not by a flag.
 //
 // Fail-open on transient/unexpected input (per the hermit hook rule: a hook
 // must never block Claude Code on a parse glitch). We exit non-zero (block)

--- a/tests/cross-plugin/hook-schema-contract.test.ts
+++ b/tests/cross-plugin/hook-schema-contract.test.ts
@@ -1,0 +1,86 @@
+// Cross-plugin guard for the hook config schema Claude Code enforces.
+//
+// Claude Code validates hook config against a closed schema and prints
+// `unknown keys "…" ignored` at every session start for anything outside it.
+// Documenting a hook inline — a `description` or `profile` sitting next to
+// `matcher` — is the tempting way to earn that warning, and it earned one on
+// every hermit install until this guard existed. The keys below are the
+// documented schema: https://code.claude.com/docs/en/hooks, /plugins-reference
+//
+// Two emission sites, one schema: every plugin's hooks/hooks.json, and the
+// per-boot launch overlay that hermit-start writes to its --settings file.
+// A fix that covers only the first leaves always-on hermits still warning.
+//
+// Lives at the repo root (outside every plugin's `bun test` / run-all.sh
+// discovery) so it never blocks a plugin release; the path-scoped
+// test-cross-plugin.yml workflow already runs it on `plugins/*/hooks/**` and
+// `plugins/claude-code-hermit/scripts/**`, which is every path that can break
+// it. Core's own suite is not wired to `plugins/*/hooks/**`, so a sibling-only
+// hooks.json edit would not have triggered this guard there.
+
+import { test, expect } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dir, '..', '..');
+
+const ROOT_KEYS = new Set(['description', 'hooks']);
+const GROUP_KEYS = new Set(['matcher', 'hooks']);
+// Every hook in the fleet is `type: command`, so this is the command surface
+// only. Claude Code's real schema is a discriminated union per `type`; adding
+// the http/mcp_tool/prompt/agent keys here would widen this into a flat union
+// that accepts a stray `server` or `prompt` on a command entry. When the fleet
+// gains a second hook type, give this a per-type set rather than merging.
+const ENTRY_KEYS = new Set([
+  'type', 'timeout', 'statusMessage', 'once', 'if',
+  'command', 'args', 'async', 'asyncRewake', 'shell',
+]);
+
+// A failure here means one of two things: someone documented a hook inline
+// (delete the key, the prose belongs in the hook script's header), or Claude
+// Code legalized a new key (add it above, citing the docs).
+function checkEventMap(events: Record<string, any>, where: string): string[] {
+  const problems: string[] = [];
+  for (const [event, groups] of Object.entries(events ?? {})) {
+    (groups as any[]).forEach((group, i) => {
+      for (const k of Object.keys(group)) {
+        if (!GROUP_KEYS.has(k)) problems.push(`${where} ${event}[${i}]: unknown matcher-group key "${k}"`);
+      }
+      for (const entry of group.hooks ?? []) {
+        for (const k of Object.keys(entry)) {
+          if (!ENTRY_KEYS.has(k)) problems.push(`${where} ${event}[${i}].hooks: unknown hook key "${k}"`);
+        }
+      }
+    });
+  }
+  return problems;
+}
+
+test('every fleet hooks.json and the launch overlay use only schema keys', async () => {
+  const pluginsDir = path.join(ROOT, 'plugins');
+  const hookFiles = fs
+    .readdirSync(pluginsDir)
+    .map((slug) => path.join(pluginsDir, slug, 'hooks', 'hooks.json'))
+    .filter((p) => fs.existsSync(p))
+    .sort();
+
+  const problems: string[] = [];
+
+  for (const file of hookFiles) {
+    const rel = path.relative(ROOT, file);
+    const doc = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    for (const k of Object.keys(doc)) {
+      if (!ROOT_KEYS.has(k)) problems.push(`${rel}: unknown root key "${k}"`);
+    }
+    problems.push(...checkEventMap(doc.hooks, rel));
+  }
+
+  const { overlayHooks } = await import(
+    path.join(ROOT, 'plugins', 'claude-code-hermit', 'scripts', 'lib', 'settings', 'overlay-hooks.ts')
+  );
+  problems.push(...checkEventMap(overlayHooks(path.join(ROOT, 'plugins', 'claude-code-hermit')), 'launch overlay'));
+
+  expect(problems).toEqual([]);
+  // Path-resolution guard: zero files means the scan is broken, not that all is well.
+  expect(hookFiles.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Problem

Opening any Claude Code session in a project with a hermit installed printed a schema warning at startup:

```
claude-code-hermit: hooks.json: unknown keys "description" in hooks.PreToolUse[0], … and 12 more ignored
```

Claude Code's hook schema allows only `matcher` and `hooks` on a matcher group. Our manifests carried a `description` there, and the HA and Forge gates also carried a `profile`. Both keys are inert: nothing in the fleet reads either, and the profile-gated hooks read `AGENT_HOOK_PROFILE` from the environment (`hermit-start.ts:87-121`, `stop-pipeline.ts:59`), never from `hooks.json`.

Harmless, but it fires on every session start of every install, on a plugin whose pitch is a clean managed session, and it trains operators to ignore the one line that might carry a real warning.

## Why v1.3.5 did not already fix it

`c4af27e0` moved the four resident-only hooks to the per-boot launch overlay. Their four `description` keys moved with them into `scripts/lib/settings/overlay-hooks.ts`, which `hermit-start.ts:1156` writes into the `--settings` overlay. So the count dropped from 17 to 13 and the warning stayed.

```
                        before                          after
  hooks.json      ──► 13 bad keys ──► warning     ──► 0 ──► silent
  launch overlay  ──►  4 bad keys ──► warning     ──► 0 ──► silent
                       (2 sources, 2 warning lines)
```

Fixing only `hooks.json` would have left always-on hermits still warning from the second source.

## What changed

- 27 non-schema keys removed across six sites: five `plugins/*/hooks/hooks.json` and `overlay-hooks.ts`.
- The prose is preserved. Every hook script's header already carried it; the ~8 gaps are folded into those headers, so the description now sits next to the code it describes.
- Each `hooks.json` keeps one root-level `description`, which **is** schema-legal. Deliberately generic ("Core hermit guardrails and session lifecycle hooks.") so it does not drift as hooks are added or removed, which is what rotted the per-hook copies.
- New guard: `tests/cross-plugin/hook-schema-contract.test.ts` pins the allowed keys at all three levels for every plugin **and** the overlay.

## Why the guard lives in `tests/cross-plugin/`

It was in core's suite first. `test-cross-plugin.yml:31` triggers on `plugins/*/hooks/**` and `plugins/claude-code-hermit/scripts/**`; `test-hooks.yml:6-18` has no `plugins/*/hooks/**` filter. A PR touching only `plugins/feed-hermit/hooks/hooks.json` would not have run the guard from core's suite. No workflow edit was needed for the new location.

`ENTRY_KEYS` covers the `command` surface only. Every hook in the fleet is `type: command`, and Claude Code's real schema is a discriminated union per type, so listing the http/mcp_tool/prompt/agent keys would widen this into a flat union that accepts a stray `server` on a command entry.

## Validation

| Suite | Result |
|---|---|
| `plugins/claude-code-hermit` (`bun test --parallel=2`) | 5456 pass, 0 fail |
| `plugins/claude-code-homeassistant-hermit` | 677 pass, 0 fail |
| dev / feed / forge / fitness / scribe / root | PASS |
| `bunx tsc --noEmit` | exit 0 |

The new guard was verified non-vacuous: injecting a `description` into `feed-hermit/hooks/hooks.json` and into `overlay-hooks.ts` each failed it with the exact file, event and key named.

Two notes for the reviewer, neither introduced here:

- The HA suite needs a Python with `python-dotenv` + `PyYAML`; without `GATE_PARITY_PYTHON` set, `tests/gate-corpus.test.ts` throws at `resolvePython` before running.
- `bun run test` cannot go green on any branch right now. `scripts/test-all.sh:17` sets `CORE_WORKERS=$(bun -e '…')`, and bun 1.4.2 colorizes that output, so the value is `\033[0m\033[33m2\033[0m` and `--parallel=<that>` is rejected. Core's suite dies in 0s without running a test. Reproduces on `main`; left alone here as out of scope.

## Effect on installs

Code-only. The warning stops for an install when the plugin it came from is next released and that install updates.
