### PR TITLE
fix(core): preserve watchdog recovery after systemd ticks

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Watchdog recovery processes survive systemd tick completion on Linux and WSL2; restart notices describe attempts rather than confirmed startup.
 - Doctor notifications check the completed audience text against the configured language before sending, without changing the routine's model.
 - Channel replies and scheduled notifications preserve intended message text during tool argument encoding, including literal HTML and code.
 - `unknown keys "description" ... ignored` warning printed at every session start. `description` is not part of Claude Code's hook schema on a matcher group; the prose now lives in each hook script's header, with one legal root-level `description` per `hooks.json`. The same keys are gone from the per-boot launch overlay, which was a second source of the warning.
@@ -11,6 +12,8 @@
 - The channel reply reminder covers every reply, including short acknowledgements.
 
 ### Upgrade Instructions
+
+For existing Linux or WSL2 systemd watchdog installations, run `.claude-code-hermit/bin/hermit-watchdog install` from the project root after updating to regenerate and reload the service. Preserve any operator customizations to the generated service when reapplying them. macOS installations need no scheduler migration.
 
 Read `.claude-code-hermit/state/channel-chats.json`; if it contains a `discord.guilds` object, delete that object and write the file back, preserving `discord.chats` and all other fields. Skip when the file or object is absent. This clears cached guild lookup errors and is safe to repeat.
 

--- a/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
+++ b/plugins/claude-code-hermit/scripts/hermit-watchdog.ts
@@ -920,8 +920,8 @@ async function doRestart(sessionName: string, reason: string, runtime: Json, tim
     child.on('error', (e) => process.stderr.write(`[watchdog] restart failed: ${e}\n`));
     child.unref();
     appendEvent('restart', `${reason}, tree-verified, ${resumeDetail}`);
-    process.stderr.write(`[watchdog] restarted "${sessionName}", reason: ${reason}\n`);
-    // Only claim a restart to the operator when the start binary is actually
+    process.stderr.write(`[watchdog] attempting restart of "${sessionName}", reason: ${reason}\n`);
+    // Only announce a restart attempt when the start binary is actually
     // present — a missing/ENOENT binary makes spawn fail asynchronously via the
     // 'error' handler above, after this synchronous path already returned, so
     // guard the push on the binary existing rather than on spawn's async result.

--- a/plugins/claude-code-hermit/scripts/lib/messages.ts
+++ b/plugins/claude-code-hermit/scripts/lib/messages.ts
@@ -276,7 +276,7 @@ export interface WatchdogMessages {
 
 export const WATCHDOG: Localized<WatchdogMessages> = {
   en: {
-    restart: (hhmm, cause) => `I restarted your agent at ${hhmm} — ${cause}.`,
+    restart: (hhmm, cause) => `Attempting to restart your agent at ${hhmm}: ${cause}.`,
     restartCauseNotRunning: () => "it wasn't running",
     restartCauseFrozen: () => 'it had frozen',
     wedgeWaking: (hhmm) => `Your agent's heartbeat hasn't checked in, waking it (${hhmm}).`,
@@ -306,7 +306,7 @@ export const WATCHDOG: Localized<WatchdogMessages> = {
       `Your agent is affected by a temporary Claude service outage (${hhmm}). It will resume on its own. https://status.claude.com`,
   },
   'pt-PT': {
-    restart: (hhmm, cause) => `Reiniciei o seu agente às ${hhmm} — ${cause}.`,
+    restart: (hhmm, cause) => `A tentar reiniciar o seu agente às ${hhmm}: ${cause}.`,
     restartCauseNotRunning: () => 'não estava a correr',
     restartCauseFrozen: () => 'tinha bloqueado',
     wedgeWaking: (hhmm) => `O heartbeat do seu agente não fez check-in, estou a acordá-lo (${hhmm}).`,

--- a/plugins/claude-code-hermit/state-templates/watchdog/hermit-watchdog@.service
+++ b/plugins/claude-code-hermit/state-templates/watchdog/hermit-watchdog@.service
@@ -4,6 +4,8 @@ After=network.target
 
 [Service]
 Type=oneshot
+# Recovery children must outlive each watchdog tick; Hermit owns their shutdown.
+KillMode=process
 WorkingDirectory={{ROOT}}
 # Snapshot of the installer's PATH. A user unit does not inherit ~/.bun/bin, so
 # the shim's bare `bun` would exit 127 on every tick; claude and tmux must resolve

--- a/plugins/claude-code-hermit/tests/helpers/watchdog-recovery-probe.ts
+++ b/plugins/claude-code-hermit/tests/helpers/watchdog-recovery-probe.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env bun
+// Explicit native probe, excluded from bun test discovery. No Claude process or
+// operator channels are used. Run from the checkout root with Bun.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = path.resolve(import.meta.dir, '../../../..');
+const plugin = path.join(root, 'plugins/claude-code-hermit');
+const quote = (value: string) => "'" + value.replaceAll("'", "'\\''") + "'";
+const platform = process.platform;
+if (platform !== 'linux' && platform !== 'darwin') throw new Error('Requires native Linux/WSL2 or macOS');
+
+function run(cmd: string[], required = true): string {
+  const result = spawnSync(cmd[0], cmd.slice(1), { encoding: 'utf8', timeout: 15000 });
+  if (required && (result.error || result.status !== 0)) {
+    throw new Error(`${cmd[0]} failed: ${result.error ?? result.stderr ?? result.status}`);
+  }
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+async function until(label: string, check: () => boolean): Promise<void> {
+  const deadline = Date.now() + 20000;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error(`Timed out: ${label}`);
+    await Bun.sleep(100);
+  }
+}
+
+const tmux = Bun.which('tmux');
+if (!tmux) throw new Error('Missing prerequisite: tmux');
+const domain = `gui/${process.getuid!()}`;
+if (platform === 'linux') run(['systemctl', '--user', 'show-environment']);
+else run(['launchctl', 'print', domain]);
+console.log(JSON.stringify({ platform, release: os.release(), bun: Bun.version, tmux: run([tmux, '-V']) }));
+
+const fixture = fs.mkdtempSync(path.join(root, '.watchdog-recovery-probe-'));
+const id = `hermit-probe-${process.pid}-${Date.now()}`;
+const unit = `${id}.service`;
+const label = `com.hermit.watchdog.${id}`;
+const hermit = path.join(fixture, '.claude-code-hermit');
+const state = path.join(hermit, 'state');
+const bin = path.join(fixture, 'bin');
+const completed = path.join(fixture, 'completed');
+const ready = path.join(fixture, 'ready');
+const starts = path.join(fixture, 'starts');
+const session = 'replacement';
+let registered = false;
+const tmuxArgs = [tmux, '-L', id, '-f', '/dev/null'];
+// has-session has no stdout: use the pane identity as the liveness signal.
+const identity = (name: string) => run([...tmuxArgs, 'display-message', '-p', '-t', name, '#{pid}:#{pane_pid}'], false);
+const executable = (file: string, body: string) => fs.writeFileSync(file, body, { mode: 0o755 });
+
+try {
+  for (const dir of [state, path.join(hermit, 'bin'), bin, path.join(fixture, 'claude-config')]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(path.join(hermit, 'config.json'), JSON.stringify({
+    watchdog: { enabled: true }, heartbeat: { enabled: false }, routines: { enabled: false },
+    telemetry_export: { enabled: false }, backup: { enabled: false },
+  }));
+  const writeRuntime = () => fs.writeFileSync(path.join(state, 'runtime.json'), JSON.stringify({
+    version: 1, session_state: 'in_progress', runtime_mode: 'tmux', tmux_session: session,
+    shutdown_requested_at: null, shutdown_completed_at: null, last_error: null,
+    updated_at: '2020-01-01T00:00:00Z', config_dir: path.join(fixture, 'claude-config'),
+  }));
+  executable(path.join(bin, 'tmux'), `#!/bin/sh\nexec ${tmuxArgs.map(quote).join(' ')} "$@"\n`);
+  const pane = path.join(fixture, 'pane');
+  executable(pane, `#!/bin/sh\nprintf ready > ${quote(ready)}\nexec sleep 120\n`);
+  executable(path.join(hermit, 'bin/hermit-start'), `#!/bin/sh\nprintf start >> ${quote(starts)}\nexec ${tmuxArgs.map(quote).join(' ')} new-session -d -s ${session} ${quote(pane)}\n`);
+  // Execute the actual watchdog CLI. The completion marker captures its exit;
+  // scheduler state below separately confirms cleanup has finished.
+  executable(path.join(hermit, 'bin/hermit-watchdog'), `#!/bin/sh
+export PATH=${quote(`${bin}:${process.env.PATH ?? '/usr/bin:/bin'}`)}
+export CLAUDE_CONFIG_DIR=${quote(path.join(fixture, 'claude-config'))}
+unset TMUX CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+${quote(process.execPath)} ${quote(path.join(plugin, 'scripts/hermit-watchdog.ts'))} run > ${quote(path.join(fixture, 'tick.log'))} 2>&1
+result=$?
+printf '%s' "$result" > ${quote(completed)}
+exit "$result"
+`);
+  const templateName = platform === 'linux' ? 'hermit-watchdog@.service' : 'com.hermit.watchdog.plist';
+  const template = fs.readFileSync(path.join(plugin, 'state-templates/watchdog', templateName), 'utf8');
+  const escape = (s: string) => platform === 'darwin'
+    ? s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
+    : s.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('%', '%%');
+  const rendered = template.replaceAll('{{NAME}}', id).replaceAll('{{ROOT}}', escape(fixture))
+    .replaceAll('{{UNIT_PATH}}', escape(`${bin}:${process.env.PATH ?? '/usr/bin:/bin'}`));
+  const registration = path.join(fixture, platform === 'linux' ? unit : `${label}.plist`);
+  fs.writeFileSync(registration, rendered);
+  if (platform === 'linux') {
+    run(['systemctl', '--user', 'link', '--runtime', registration]);
+    registered = true;
+    run(['systemctl', '--user', 'daemon-reload']);
+  } else {
+    run(['launchctl', 'bootstrap', domain, registration]);
+    registered = true;
+  }
+
+  async function tick(): Promise<void> {
+    fs.rmSync(completed, { force: true });
+    if (platform === 'linux') run(['systemctl', '--user', 'start', '--no-block', unit]);
+    else run(['launchctl', 'kickstart', `${domain}/${label}`]);
+    await until('watchdog completion', () => fs.existsSync(completed));
+    if (fs.readFileSync(completed, 'utf8') !== '0') throw new Error('Watchdog exited unsuccessfully');
+    await until('scheduler completion', () => {
+      if (platform === 'linux') {
+        const status = run(['systemctl', '--user', 'show', unit, '-p', 'ActiveState', '-p', 'Result']);
+        return status.includes('ActiveState=inactive') && status.includes('Result=success');
+      }
+      const status = run(['launchctl', 'print', `${domain}/${label}`]);
+      return /state = (not running|waiting)/.test(status) && /last exit code = 0/.test(status);
+    });
+  }
+
+  for (const existing of [false, true]) {
+    writeRuntime();
+    fs.rmSync(ready, { force: true });
+    fs.rmSync(starts, { force: true });
+    if (existing) run([...tmuxArgs, 'new-session', '-d', '-s', 'sentinel', 'sleep 120']);
+    const sentinel = existing ? identity('sentinel') : null;
+    await tick();
+    await until('replacement ready after scheduler exit', () => fs.existsSync(ready) && identity(session) !== '');
+    const replacement = identity(session);
+    const launchCount = fs.readFileSync(starts, 'utf8');
+    if (!launchCount) throw new Error('Restart path did not invoke hermit-start');
+    await tick();
+    if (identity(session) !== replacement || fs.readFileSync(starts, 'utf8') !== launchCount) {
+      throw new Error('Subsequent tick replaced or killed the resident');
+    }
+    if (existing && identity('sentinel') !== sentinel) throw new Error('Existing server session was disturbed');
+    console.log(`PASS: ${existing ? 'existing' : 'fresh'} server recovery survives both ticks`);
+    run([...tmuxArgs, 'kill-session', '-t', session]);
+    if (existing) run([...tmuxArgs, 'kill-session', '-t', 'sentinel']);
+  }
+} catch (error) {
+  const log = path.join(fixture, 'tick.log');
+  if (fs.existsSync(log)) console.error(fs.readFileSync(log, 'utf8').slice(-8000));
+  throw error;
+} finally {
+  if (registered) {
+    if (platform === 'linux') {
+      run(['systemctl', '--user', 'stop', unit], false);
+      run(['systemctl', '--user', 'disable', '--runtime', unit], false);
+      run(['systemctl', '--user', 'reset-failed', unit], false);
+      run(['systemctl', '--user', 'daemon-reload'], false);
+    } else run(['launchctl', 'bootout', `${domain}/${label}`], false);
+  }
+  for (const name of [session, 'sentinel']) run([...tmuxArgs, 'kill-session', '-t', name], false);
+  fs.rmSync(fixture, { recursive: true, force: true });
+}

--- a/plugins/claude-code-hermit/tests/localization-regression.test.ts
+++ b/plugins/claude-code-hermit/tests/localization-regression.test.ts
@@ -61,7 +61,7 @@ describe('en catalog byte-identity (pre-refactor literals)', () => {
   });
 
   test('WATCHDOG lifecycle messages', () => {
-    expect(WATCHDOG.en.restart('08:30', 'it had frozen')).toBe('I restarted your agent at 08:30 — it had frozen.');
+    expect(WATCHDOG.en.restart('08:30', 'it had frozen')).toBe('Attempting to restart your agent at 08:30: it had frozen.');
     expect(WATCHDOG.en.restartCauseNotRunning()).toBe("it wasn't running");
     expect(WATCHDOG.en.restartCauseFrozen()).toBe('it had frozen');
     expect(WATCHDOG.en.wedge('08:30')).toBe("Your agent hasn't responded in a while — checking on it now (08:30).");

--- a/plugins/claude-code-hermit/tests/watchdog.test.ts
+++ b/plugins/claude-code-hermit/tests/watchdog.test.ts
@@ -3206,7 +3206,12 @@ test.if(isLinux)('re-install over an existing timer → leaves a deliberate fals
   await withFakeHome(async (fakeHome) => {
     await watchdog(h, 'install', { env: { HOME: fakeHome } });
     writeConfig(h, '2h', { enabled: false });
+    const unitDir = path.join(fakeHome, '.config', 'systemd', 'user');
+    const serviceFile = fs.readdirSync(unitDir).find((f) => f.endsWith('.service'))!;
+    const servicePath = path.join(unitDir, serviceFile);
+    fs.writeFileSync(servicePath, fs.readFileSync(servicePath, 'utf-8').replace(/^KillMode=process\n/m, ''));
     const r = await watchdog(h, 'install', { env: { HOME: fakeHome } });
+    expect(fs.readFileSync(servicePath, 'utf-8')).toMatch(/^KillMode=process$/m);
     expect(r.exitCode).toBe(0);
     expect(r.stdout + r.stderr).toContain('Restarts stay off until watchdog.enabled is true');
     const config = readJson(configPath(h));
@@ -3321,6 +3326,7 @@ test.if(isLinux)('systemd unit keeps every inherited PATH entry and adds bun\'s 
     const serviceFile = fs.readdirSync(unitDir).find((f) => f.endsWith('.service'));
     expect(serviceFile).toBeDefined();
     const unit = fs.readFileSync(path.join(unitDir, serviceFile!), 'utf-8');
+    expect(unit).toMatch(/^KillMode=process$/m);
 
     const baked = unit.match(/^Environment="PATH=(.*)"$/m)?.[1];
     expect(baked).toBeDefined();
@@ -4707,24 +4713,24 @@ describe('state backup (step 0e)', () => {
 
 // -------------------------------------------------------
 // 14. Compose-function localization (PROP-059): the four watchdog message
-//     families compose through WatchdogMessages. `en` stays byte-identical to
-//     the pre-refactor literals (frame asserted around the live HH:MM clock);
+//     families compose through WatchdogMessages (frames asserted around the
+//     live HH:MM clock);
 //     `pt-PT` is exercised with an explicit locale arg.
 // -------------------------------------------------------
 
 describe('watchdog message localization', () => {
-  test('composeRestartMessage en byte-identity (both causes)', () => {
+  test('composeRestartMessage en describes an attempt (both causes)', () => {
     expect(composeRestartMessage('dead-process', 'UTC', 'en')).toMatch(
-      /^I restarted your agent at \d{2}:\d{2} — it wasn't running\.$/);
+      /^Attempting to restart your agent at \d{2}:\d{2}: it wasn't running\.$/);
     expect(composeRestartMessage('pane-frozen', 'UTC', 'en')).toMatch(
-      /^I restarted your agent at \d{2}:\d{2} — it had frozen\.$/);
+      /^Attempting to restart your agent at \d{2}:\d{2}: it had frozen\.$/);
   });
 
   test('composeRestartMessage pt-PT', () => {
     expect(composeRestartMessage('dead-process', 'UTC', 'pt-PT')).toMatch(
-      /^Reiniciei o seu agente às \d{2}:\d{2} — não estava a correr\.$/);
+      /^A tentar reiniciar o seu agente às \d{2}:\d{2}: não estava a correr\.$/);
     expect(composeRestartMessage('pane-frozen', 'UTC', 'pt-PT')).toMatch(
-      /^Reiniciei o seu agente às \d{2}:\d{2} — tinha bloqueado\.$/);
+      /^A tentar reiniciar o seu agente às \d{2}:\d{2}: tinha bloqueado\.$/);
   });
 
   test('composeWedgeMessage en / pt-PT', () => {


### PR DESCRIPTION
A watchdog tick can launch a replacement Hermit and then have systemd kill it as the oneshot service exits. Core now generates the service with `KillMode=process`, allowing recovery children to survive. English and Portuguese notices and stderr describe a restart attempt rather than claiming successful startup.

The detached launch and macOS launchd behavior remain unchanged. Existing systemd installations must rerun `.claude-code-hermit/bin/hermit-watchdog install` after updating; the changelog includes this migration. Stopping the watchdog service leaves its children running, with Hermit lifecycle commands retaining responsibility for resident shutdown.

```text
Before: restart launched -> scheduler kills replacement -> reconnect fails
After:  restart launched -> replacement survives tick -> reconnect available if startup succeeds
```

Validation:
- Complete core suite: `bun test`, 5,456 passed, exit 0.
- `bunx tsc` and `git diff --check`: exit 0.
- Native Linux probe: fresh-server and existing-server recovery survive scheduler completion and a subsequent tick. Linux 7.0.0-31-generic, Bun 1.4.2, tmux 3.6.
- Added an explicitly invoked isolated native probe using the actual watchdog and scheduler templates.
- Three simplify review lenses returned no findings.
- Graphify refresh reported its expected linked-worktree skip.
- Native macOS and WSL2 probes were not run. Existing simulated launchd installation tests passed.
