### PR TITLE
fix(homeassistant): remove unused native-permissions migration

### DIFF
--- a/plugins/claude-code-homeassistant-hermit/AGENTS.md
+++ b/plugins/claude-code-homeassistant-hermit/AGENTS.md
@@ -20,5 +20,3 @@ The plugin suite needs full Git history and Python with `python-dotenv` and `PyY
 Changes to `src/policy.ts` or `hooks/mcp-safety-gate.ts` must preserve the corpus/golden behavior in `tests/gate-corpus.test.ts` and the fail-closed properties in `tests/gate-fuzz.test.ts`. Keep YAML parity and apply-result verification intact; a successful tool call alone is not proof that the intended automation was installed.
 
 When using `tmpPath()` from `tests/helpers.ts`, register `afterAll(cleanupTmp)`. Cleanup after each test can delete fixtures still used by concurrent tests. Keep independent corpus and fuzz subprocess work asynchronous.
-
-The native-permissions installer owns `.claude-code-hermit/state/claude-code-homeassistant-hermit-native-permissions-v1.json`, a durable completion marker written only by a successful `--migrate` run. Preserve it across upgrades so later operator policy choices are not migrated again.

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## [0.4.14] - 2026-09-10
+## [Unreleased]
 
 ### Changed
 
 - The native-permissions installer accepts only a project settings path.
+
+## [0.4.14] - 2026-09-10
+
+### Changed
+
 - CLI writes use native approval without confirmation flags or confirmation-only retry responses.
 - Policy results use `decision: allow | ask | deny` consistently.
 - `ha_safety_mode` defaults to `ask` when absent from valid configuration.

--- a/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
+++ b/plugins/claude-code-homeassistant-hermit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- The native-permissions installer accepts only a project settings path.
 - CLI writes use native approval without confirmation flags or confirmation-only retry responses.
 - Policy results use `decision: allow | ask | deny` consistently.
 - `ha_safety_mode` defaults to `ask` when absent from valid configuration.
@@ -15,7 +16,7 @@
 
 ### Upgrade Instructions
 
-Before using the updated write commands, set `DOMAIN_PLUGIN_ROOT` to this installed plugin's absolute directory and run the following from the project root. Prepare `NATIVE_APPROVAL_BLOCK` as a temporary Markdown file containing the updated `state-templates/CLAUDE-APPEND.md` block merged with any operator edits from the installed block (`target_file` in preflight). Preserve those edits and the marker pair; the refresh replaces only this marked block, leaving surrounding project instructions intact. The installer preserves operator settings and denies. Do not run the older HA mode migration for this change.
+Before using the updated write commands, set `DOMAIN_PLUGIN_ROOT` to this installed plugin's absolute directory and run the following from the project root. Prepare `NATIVE_APPROVAL_BLOCK` as a temporary Markdown file containing the updated `state-templates/CLAUDE-APPEND.md` block merged with any operator edits from the installed block (`target_file` in preflight). Preserve those edits and the marker pair; the refresh replaces only this marked block, leaving surrounding project instructions intact. The installer preserves operator settings and denies.
 
 ```bash
 native_settings=$(.claude-code-hermit/bin/hermit-run domain-hatch preflight claude-code-homeassistant-hermit | bun -e 'const p = await Bun.stdin.json(); if (!p.ok || !["local", "committed"].includes(p.target)) throw new Error("Resolve the domain hatch target first"); console.log(p.target === "local" ? ".claude/settings.local.json" : ".claude/settings.json");') &&

--- a/plugins/claude-code-homeassistant-hermit/CLAUDE.md
+++ b/plugins/claude-code-homeassistant-hermit/CLAUDE.md
@@ -61,5 +61,3 @@ Core's `scripts/domain-hatch.ts` owns target resolution and `hatch-options.json`
 - When using `tmpPath()` from `tests/helpers.ts`, register `afterAll(cleanupTmp)`. Cleanup after each test can delete fixtures still used by concurrent tests. Keep independent corpus and fuzz subprocess work asynchronous.
 
 Static `permissions.ask` rules cover structural writes through `bin/ha-agent-lab`, not the `bun <root>/src/cli.ts` development form. `cli-approval.ts` covers `call-service` and `restore-states` in both forms because their policy depends on the target entities.
-
-The native-permissions installer owns `.claude-code-hermit/state/claude-code-homeassistant-hermit-native-permissions-v1.json`, a durable completion marker written only by a successful `--migrate` run. Preserve it across upgrades so later operator policy choices are not migrated again.

--- a/plugins/claude-code-homeassistant-hermit/scripts/native-permissions.test.ts
+++ b/plugins/claude-code-homeassistant-hermit/scripts/native-permissions.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, afterAll } from 'bun:test';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 const dirs: string[] = [];
@@ -11,39 +11,41 @@ function fixture() {
   mkdirSync(join(root, '.claude')); mkdirSync(join(root, '.claude-code-hermit'));
   return root;
 }
-function run(root: string, migrate = false) {
-  return Bun.spawnSync(['bun', script, join(root, '.claude/settings.local.json'), ...(migrate ? ['--migrate'] : [])]);
+function run(root: string, args: string[] = [], target = 'settings.local.json') {
+  return Bun.spawnSync(['bun', script, join(root, '.claude', target), ...args]);
 }
-test('install preserves unrelated settings and denies; repeated seeding is stable', () => {
-  const root = fixture(), file = join(root, '.claude/settings.local.json');
-  writeFileSync(file, JSON.stringify({ env: { KEEP: 'yes' }, permissions: { deny: ['Bash(custom *)'], ask: ['Read(private)'] } }));
-  expect(run(root).exitCode).toBe(0);
+test.each(['settings.json', 'settings.local.json'])('install into %s preserves operator settings and is repeatable', (target) => {
+  const root = fixture(), file = join(root, '.claude', target);
+  writeFileSync(file, JSON.stringify({ env: { KEEP: 'yes' }, permissions: { allow: ['Read(public)'], deny: [rules[0], 'Bash(custom *)'], ask: ['Read(private)'] } }));
+  const result = run(root, [], target);
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout.toString()).toContain(`Existing denies remain: ${rules[0]}`);
   const once = readFileSync(file, 'utf8'), data = JSON.parse(once);
-  expect(data.env.KEEP).toBe('yes'); expect(data.permissions.deny).toEqual(['Bash(custom *)']);
+  expect(data.env.KEEP).toBe('yes'); expect(data.permissions.deny).toEqual([rules[0], 'Bash(custom *)']);
+  expect(data.permissions.allow).toEqual(['Read(public)']);
+  expect(data.permissions.ask).toContain('Read(private)');
   for (const rule of rules) expect(data.permissions.ask).toContain(rule);
-  expect(run(root).exitCode).toBe(0); expect(readFileSync(file, 'utf8')).toBe(once);
+  expect(run(root, [], target).exitCode).toBe(0); expect(readFileSync(file, 'utf8')).toBe(once);
+  expect(existsSync(join(root, '.claude-code-hermit/state'))).toBe(false);
+  expect(existsSync(join(root, '.claude-code-hermit/config.json'))).toBe(false);
 });
-test('migration flips ha_safety_mode once and validates all files before writing', () => {
-  const root = fixture(), local = join(root, '.claude/settings.local.json'), shared = join(root, '.claude/settings.json');
-  writeFileSync(local, '{}'); writeFileSync(shared, '{bad');
-  expect(run(root, true).exitCode).not.toBe(0); expect(readFileSync(local, 'utf8')).toBe('{}');
-  writeFileSync(shared, JSON.stringify({ permissions: { deny: [...rules, 'Bash(custom *)'] } }));
-  writeFileSync(join(root, '.claude-code-hermit/config.json'), JSON.stringify({ ha_safety_mode: 'strict', custom: 7 }));
-  expect(run(root).exitCode).toBe(0); // a plain hatch install must not consume the one-time migration
-  expect(run(root, true).exitCode).toBe(0);
-  const data = JSON.parse(readFileSync(shared, 'utf8'));
-  expect(data.permissions.deny).toContain('Bash(custom *)');
-  const before = readFileSync(local, 'utf8'); expect(run(root, true).exitCode).toBe(0); expect(readFileSync(local, 'utf8')).toBe(before);
-  {
-    const configFile = join(root, '.claude-code-hermit/config.json');
-    expect(JSON.parse(readFileSync(configFile, 'utf8'))).toEqual({ ha_safety_mode: 'ask', custom: 7 });
-    writeFileSync(configFile, '{"ha_safety_mode":"strict"}');
-    expect(run(root, true).exitCode).toBe(0); expect(JSON.parse(readFileSync(configFile, 'utf8')).ha_safety_mode).toBe('strict');
-  }
-});
-test('malformed permission arrays are not overwritten', () => {
+test.each([['--migrate'], ['--unknown'], ['extra'], [''], ['--migrate', 'extra']].map(args => ({ args })))('extra arguments fail without writes: $args', ({ args }) => {
   const root = fixture(), file = join(root, '.claude/settings.local.json');
-  const original = '{"permissions":{"ask":"bad"}}'; writeFileSync(file, original);
+  expect(run(root, args).exitCode).not.toBe(0);
+  expect(existsSync(file)).toBe(false);
+  const original = '{}';
+  writeFileSync(file, original);
+  const config = join(root, '.claude-code-hermit/config.json');
+  const strict = '{"ha_safety_mode":"strict"}';
+  writeFileSync(config, strict);
+  expect(run(root, args).exitCode).not.toBe(0);
+  expect(readFileSync(file, 'utf8')).toBe(original);
+  expect(readFileSync(config, 'utf8')).toBe(strict);
+  expect(existsSync(join(root, '.claude-code-hermit/state'))).toBe(false);
+});
+test.each(['{bad', '[]', '{"permissions":null}', '{"permissions":{"ask":"bad"}}', '{"permissions":{"deny":[1]}}'])('invalid settings are not overwritten: %s', (original) => {
+  const root = fixture(), file = join(root, '.claude/settings.local.json');
+  writeFileSync(file, original);
   expect(run(root).exitCode).not.toBe(0); expect(readFileSync(file, 'utf8')).toBe(original);
 });
 
@@ -58,4 +60,12 @@ test('ordinary upgrades preserve safety configuration, other scopes, and existin
   for (const [name, content] of Object.entries(files)) writeFileSync(join(root, name), content);
   expect(run(root).exitCode).toBe(0);
   for (const [name, content] of Object.entries(files)) expect(readFileSync(join(root, name), 'utf8')).toBe(content);
+});
+
+test('unrelated malformed files are not read', () => {
+  const root = fixture();
+  const files = ['.claude/settings.json', '.claude-code-hermit/config.json'];
+  for (const file of files) writeFileSync(join(root, file), '{bad');
+  expect(run(root).exitCode).toBe(0);
+  for (const file of files) expect(readFileSync(join(root, file), 'utf8')).toBe('{bad');
 });

--- a/plugins/claude-code-homeassistant-hermit/scripts/native-permissions.ts
+++ b/plugins/claude-code-homeassistant-hermit/scripts/native-permissions.ts
@@ -1,17 +1,15 @@
 #!/usr/bin/env bun
-// Install this plugin's fixed native asks. --migrate runs the one-time legacy conversion.
+// Install this plugin's fixed native asks.
 import fs from 'node:fs';
 import path from 'node:path';
 
-const [target, mode] = process.argv.slice(2);
-if (!target || !['settings.json', 'settings.local.json'].includes(path.basename(target)) || (mode && mode !== '--migrate')) {
-  throw new Error('Usage: native-permissions.ts <project .claude/settings[.local].json> [--migrate]');
+const args = process.argv.slice(2);
+const [target] = args;
+if (args.length !== 1 || !target || !['settings.json', 'settings.local.json'].includes(path.basename(target))) {
+  throw new Error('Usage: native-permissions.ts <project .claude/settings[.local].json>');
 }
 const settingsPath = path.resolve(target);
 if (path.basename(path.dirname(settingsPath)) !== '.claude') throw new Error('Expected a project .claude settings file');
-const project = path.dirname(path.dirname(settingsPath));
-const migrationFile = path.join(project, '.claude-code-hermit/state/claude-code-homeassistant-hermit-native-permissions-v1.json');
-const migrate = mode === '--migrate' && !fs.existsSync(migrationFile);
 const rules: string[] = JSON.parse(fs.readFileSync(path.join(import.meta.dir, '../state-templates/native-permissions.json'), 'utf8')).ask;
 function read(file: string): any {
   let value: any;
@@ -27,44 +25,15 @@ function validate(settings: any): void {
     if (entries !== undefined && (!Array.isArray(entries) || entries.some((v: unknown) => typeof v !== 'string'))) throw new Error(`Invalid permissions.${key}`);
   }
 }
-const files = new Map<string, any>();
-files.set(settingsPath, read(settingsPath));
-if (migrate) {
-  for (const name of ['settings.json', 'settings.local.json']) {
-    const file = path.join(project, '.claude', name);
-    if (fs.existsSync(file)) files.set(file, read(file));
-  }
+const settings = read(settingsPath);
+validate(settings);
+const before = JSON.stringify(settings);
+settings.permissions ??= {};
+settings.permissions.ask = [...new Set([...(settings.permissions.ask ?? []), ...rules])];
+if (JSON.stringify(settings) !== before) {
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
 }
-for (const settings of files.values()) validate(settings);
-const stateFile = path.join(project, '.claude-code-hermit/config.json');
-const config = migrate ? read(stateFile) : null;
-for (const [file, settings] of files) {
-  const before = JSON.stringify(settings);
-  if (file === settingsPath) {
-    settings.permissions ??= {};
-    settings.permissions.ask = [...new Set([...(settings.permissions.ask ?? []), ...rules])];
-  }
-  if (JSON.stringify(settings) !== before) {
-    fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, JSON.stringify(settings, null, 2) + '\n');
-  }
-  const conflicts = settings.permissions?.deny?.filter((rule: string) => rules.includes(rule)) ?? [];
-  if (conflicts.length) console.log(`Existing denies remain: ${conflicts.join(', ')}`);
-}
-// `config` is non-null only on the first --migrate (the marker gates it), which
-// is what keeps this one-time. A second run must not re-flip a `strict` the
-// operator deliberately set back after upgrading.
-if (config && (config.ha_safety_mode === undefined || config.ha_safety_mode === 'strict')) {
-  config.ha_safety_mode = 'ask';
-  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
-  fs.writeFileSync(stateFile, JSON.stringify(config, null, 2) + '\n');
-  console.log('Home Assistant sensitive actions now request native approval.');
-}
-// Only a --migrate run may claim the marker: writing it on a plain install
-// would make the one-time legacy conversion a no-op for anyone who hatches
-// before running the upgrade instruction.
-if (migrate) {
-  fs.mkdirSync(path.dirname(migrationFile), { recursive: true });
-  fs.writeFileSync(migrationFile, JSON.stringify({ version: 1 }) + '\n');
-}
+const conflicts = settings.permissions?.deny?.filter((rule: string) => rules.includes(rule)) ?? [];
+if (conflicts.length) console.log(`Existing denies remain: ${conflicts.join(', ')}`);
 console.log('Native approval rules installed.');

--- a/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-homeassistant-hermit/skills/hatch/SKILL.md
@@ -266,7 +266,7 @@ Each routine owns its cadence and passes findings through reflection gates into 
 
 Resolve the project settings target through `.claude-code-hermit/bin/hermit-run domain-hatch preflight claude-code-homeassistant-hermit`. Map `target` (or `target_default` when absent): `local` to `.claude/settings.local.json`, `committed` to `.claude/settings.json`. Its `target_file` is the instruction destination, not the settings file.
 
-Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/native-permissions.ts <resolved-settings-file>`. Do not pass `--migrate` during ordinary hatch.
+Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/native-permissions.ts <resolved-settings-file>`.
 
 ### 8. Final report
 


### PR DESCRIPTION
The HA native-permissions installer retained an unused `--migrate` mode that could change explicit `ha_safety_mode: strict` to `ask` and write a completion marker, although hatch and upgrade already use plain installation.

Remove that mode outright and reject all extra arguments before mutation. Installation remains additive and repeatable, preserves operator settings and denies, and retains validation and denial-conflict reporting. Remove obsolete migration guidance while preserving the executable upgrade sequence and operator-edited instruction-block handling. Only `claude-code-homeassistant-hermit` is affected.

```text
Before: --migrate could change strict to ask and write a marker
After:  extra arguments fail; only supplied settings receive ask rules
```

Validation:

- Complete HA `bun test` with `python-dotenv` and `PyYAML`: 696 passed, 0 failed.
- Installer coverage includes repeat stability, preserved operator state, untouched other settings/config/markers, no marker creation, and extra-argument rejection without writes.
- Root `bunx tsc` and `git diff --check`: passed.
- `bash scripts/graphify-refresh.sh`: expected linked-worktree skip.
