### PR TITLE
fix(claude-code-hermit): route Docker channel pairing through channel-setup

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Changed
 - Peer requests inside the resident's existing authority are acted on rather than declined; peer messages still cannot expand authority, approve guarded actions, or change permissions.
 
+### Fixed
+- `/channel-setup` routes Docker hermits from the host (pair against the running container, or name the `hermit-docker` command that has to run first) instead of redirecting to `/docker-setup`, which refuses in-container and re-scaffolds on the host
+- Docker pairing confirmation notes it may take up to 1 min before the bot replies
+- Docker pairing's pane capture and `access.json` checks pass `-f docker-compose.hermit.yml`, so they no longer fail with no configuration file
+
 ## [1.3.6] - 2026-09-10
 
 ### Fixed

--- a/plugins/claude-code-hermit/docs/always-on.md
+++ b/plugins/claude-code-hermit/docs/always-on.md
@@ -204,7 +204,9 @@ Channel tokens live in `.claude.local/channels/<name>/.env` (project-local scope
 
 ### Docker
 
-The docker-setup wizard walks you through token setup, state dir configuration, and pairing. The docker-compose file bind-mounts `.claude.local/channels/<plugin>/` into `~/.claude/channels/<plugin>/` inside the container — channel skill commands write to the right place automatically, and state persists across container restarts.
+The docker-setup wizard pairs during first run. Afterwards `/claude-code-hermit:channel-setup` from the host pairs or re-pairs. A channel or token added later needs `hermit-docker restart` first (the bot is offline until then). Inside the container, use the two native `/<channel>:access` commands in the attached REPL; pair carries the "save access.json to `<state_dir>/` not `~/.claude`" hint.
+
+The docker-compose file bind-mounts `.claude.local/channels/<plugin>/` into `~/.claude/channels/<plugin>/` inside the container — channel skill commands write to the right place automatically, and state persists across container restarts.
 
 ### Local / tmux
 

--- a/plugins/claude-code-hermit/docs/troubleshooting.md
+++ b/plugins/claude-code-hermit/docs/troubleshooting.md
@@ -209,6 +209,7 @@ Usually a UID mismatch between the host and the container user. The generated Do
 ## Channel Messages Not Arriving
 
 **Docker:**
+- Pair or re-pair from the host with `/claude-code-hermit:channel-setup`. docker-setup pairs during first run; afterwards use channel-setup. A channel or token added later needs `hermit-docker restart` first (the bot is offline until then). Inside the container, `/<channel>:access pair <code>` (save access.json to `<state_dir>/` not `~/.claude`) and `/<channel>:access policy allowlist` in the attached REPL.
 - Verify the channel plugin is installed inside the container: `hermit-docker attach`, then check with `claude plugin list`.
 - Check bot pairing: send a test message to the bot and watch the logs (`hermit-docker logs`).
 - For Discord: ensure `channels.discord.state_dir` is set in `config.json` (e.g. `.claude.local/channels/discord`) and the directory is bind-mounted in `docker-compose.hermit.yml`. `hermit-start` resolves relative paths and derives `DISCORD_STATE_DIR` at boot.

--- a/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-setup/SKILL.md
@@ -5,20 +5,25 @@ disable-model-invocation: true
 ---
 # Channel Setup
 
-Activate a channel for local/tmux operation, adding the `config.json` entry first when there isn't one. This mirrors what `docker-setup` does for Docker users but targets the local environment.
+Activate a channel, adding the `config.json` entry first when there isn't one. Local/tmux pairing is this skill's own flow; a Docker hermit is routed by the check below.
 
 ## Plan
 
 ### 1. Read config and detect channels
 
-**Docker check (first):** read `.claude-code-hermit/state/runtime.json` if it exists.
+**Runtime routing (first):** evaluate in this order.
 
-- If `runtime_mode == "docker"`: stop and redirect —
-  > This project is running in Docker. Channel token and pairing must happen inside the container, not on the host.
-  > Run `/claude-code-hermit:docker-setup` — it configures channels container-side.
-  Stop.
-- If `runtime.json` is missing AND `.claude-code-hermit/docker/Dockerfile.hermit` exists (Docker scaffolded but not yet booted): same redirect.
-- Otherwise: proceed.
+1. **Inside the container.** Run `[ -f /.dockerenv ] || [ -f /run/.containerenv ] && echo container || echo host`. If `container`: read `.claude-code-hermit/config.json`. For each enabled channel object, resolve `state_dir` as step 4 does (config `state_dir`, default `.claude.local/channels/<channel>`; if relative, make it absolute against the project root) and print that absolute path literally. Print and stop:
+   > The channel is live in this session. DM the bot for a code, then type `/<channel>:access pair <code> — save access.json to <state_dir>/ not ~/.claude` and `/<channel>:access policy allowlist` here. Or run `/claude-code-hermit:channel-setup` from the host project root.
+   If no enabled channel, print only the host-run sentence and stop. No `AskUserQuestion` on this path.
+
+2. **No compose file.** If `docker-compose.hermit.yml` is absent at the project root, continue with the local/tmux flow below.
+
+3. **Live tmux hermit.** Run `bun ${CLAUDE_PLUGIN_ROOT}/scripts/docker-preflight.ts "$(pwd)"`. If its `liveOwner` is non-null, a host tmux hermit owns this project despite the compose file: continue with the local/tmux flow below.
+
+4. **Compose present.** Run `docker compose -f docker-compose.hermit.yml ps --status running --format '{{.Service}}'`. Non-zero exit → print its output, stop. If `hermit` is absent from the output: after channel selection, run steps 2 and 4, skip 3, then stop with `.claude-code-hermit/bin/hermit-docker up` and "re-run this skill to pair". If `hermit` is present: docker-running.
+
+5. **docker-running.** After channel selection, skip step 3 (the container installs channel plugins at boot). Run step 4; a `SKIP … HTTP 401` or `403` from its `channel-bot-id.ts` line is reported as "token rejected by <platform>, fix it before restarting". If this run created the config entry or wrote the token → stop: "The bot is offline until the container restarts and loads it: `.claude-code-hermit/bin/hermit-docker restart`, then DM the bot for a code and re-run this skill. Still no code after a restart: `hermit-docker logs --tail=60` shows the plugin's own error (wrong token, missing Message Content intent, install failure), and `/claude-code-hermit:hermit-doctor` checks the token." Otherwise skip steps 5 to 6c and run docker-setup's **Channel pairing** sub-steps 1 to 9 against the container (`Read` only the **Channel pairing** heading through sub-step 9 of `${CLAUDE_SKILL_DIR}/../docker-setup/SKILL.md`, not the rest of the wizard): `channel-pair.ts pair` / `policy` / `group-add` with `--compose-file docker-compose.hermit.yml --service hermit --session <session>`, session from `tmux_session_name` in `config.json` with `{project_name}` replaced by the project directory basename, `<state_dir>` absolute. Precondition `docker compose -f docker-compose.hermit.yml exec -T hermit tmux has-session -t <session>`; on failure stop with "container is still booting or the first-run screens were never accepted: `hermit-docker attach`, accept them, re-run". The "I have the code / Skip this channel" question on this branch adds one sentence: "No code from the bot? It has not loaded the token: `hermit-docker restart`, then re-run this skill."
 
 Read `.claude-code-hermit/config.json`. Collect all entries under `channels` that are valid objects, tracking which are disabled (`enabled: false`).
 
@@ -35,7 +40,7 @@ The script fills `enabled`, `dm_channel_id: null`, `default_chat_id: null`, and 
 - If exactly one enabled channel and nothing disabled: use it automatically.
 - Otherwise (several enabled, or enabled and disabled side by side): ask with `AskUserQuestion` (header: "Channel") — every channel name as an option, disabled ones labelled `<name> — disabled`, plus **All** (enabled channels only) — which to set up. If a disabled name is chosen, create the entry for it first (re-enabling it), then continue with it selected.
 
-Run steps 2–6 for each selected channel.
+Run steps 2–6 for each selected channel. On a Docker host (runtime routing 4–5), apply those overrides instead of the local/tmux default.
 
 ### 2. Check prerequisites
 

--- a/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
+++ b/plugins/claude-code-hermit/skills/docker-setup/SKILL.md
@@ -23,7 +23,7 @@ Run: `[ -f /.dockerenv ] || [ -f /run/.containerenv ] && echo container || echo 
 
 If the output is `container`, **stop immediately** — do not proceed to step 1. Print:
 
-> This skill generates host-side Docker scaffolding and then drives `docker compose up`. Run it from your host shell in the project root. To check what's already configured *inside* the running container, run `/claude-code-hermit:hermit-doctor`.
+> This skill generates host-side Docker scaffolding and then drives `docker compose up`. Run it from your host shell in the project root. To pair a channel later, run `/claude-code-hermit:channel-setup` from the host. To check what's already configured *inside* the running container, run `/claude-code-hermit:hermit-doctor`.
 
 ### 1. Prerequisites
 
@@ -468,7 +468,7 @@ Before pairing, confirm the operator has completed the first-run acceptance step
 
 Confirm the tmux session still exists (reuse the `has-session` check from the acceptance step). If it's gone, surface container logs and stop.
 
-For each channel, **first verify the token is configured** — check that `.claude.local/channels/<plugin>/.env` exists and contains the expected `*_BOT_TOKEN` var. If missing, skip pairing for this channel and tell the operator: "No token configured for `<channel>` — write it to `.claude.local/channels/<plugin>/.env`, restart the container, then re-run `/claude-code-hermit:docker-setup` to pair." Move to the next channel.
+For each channel, **first verify the token is configured** — check that `.claude.local/channels/<plugin>/.env` exists and contains the expected `*_BOT_TOKEN` var. If missing, skip pairing for this channel and tell the operator: "No token configured for `<channel>` — write it to `.claude.local/channels/<plugin>/.env`, restart the container, then re-run `/claude-code-hermit:channel-setup` to pair." Move to the next channel.
 
 If the token is present, ask if already paired. If not:
 1. Ask with `AskUserQuestion` (header: `"<channel> pairing"`) — `"I have the code"` / `"Skip this channel"`. On `"I have the code"`: ask for the 6-char code via `Other` (header: `"Bot code"`).
@@ -486,10 +486,10 @@ If the token is present, ask if already paired. If not:
      --channel <plugin> --session <session> \
      --compose-file docker-compose.hermit.yml --service hermit
    ```
-4. Ask with `AskUserQuestion` (header: `"Pair result"`) — `"Bot confirmed paired"` / `"No response"`. On `"No response"`: run `docker compose exec -T hermit tmux capture-pane -t <session> -p`, show output, and skip `access.json` verification for this channel — don't fail the whole setup.
-5. **Verify `access.json` landed in the right place** (only on `"Bot confirmed paired"`): Check `.claude.local/channels/<plugin>/access.json`. If absent, run `docker compose exec -T hermit tmux capture-pane -t <session> -p` and show output. If it landed in `~/.claude/channels/<plugin>/` instead, move it:
+4. Ask with `AskUserQuestion` (header: `"Pair result"`) — `"Bot confirmed paired"` / `"No response"` (description: `Still nothing after waiting up to 1 min`). On `"No response"`: run `docker compose -f docker-compose.hermit.yml exec -T hermit tmux capture-pane -t <session> -p`, show output, and skip `access.json` verification for this channel — don't fail the whole setup.
+5. **Verify `access.json` landed in the right place** (only on `"Bot confirmed paired"`): Check `.claude.local/channels/<plugin>/access.json`. If absent, run `docker compose -f docker-compose.hermit.yml exec -T hermit tmux capture-pane -t <session> -p` and show output. If it landed in `~/.claude/channels/<plugin>/` instead, move it:
    ```
-   docker compose exec -T hermit bash -c 'src="${CLAUDE_CONFIG_DIR:-/home/claude/.claude}/channels/<plugin>/access.json"; dst="<project_path>/.claude.local/channels/<plugin>/"; [ -f "$src" ] && mkdir -p "$dst" && mv "$src" "$dst" && echo moved'
+   docker compose -f docker-compose.hermit.yml exec -T hermit bash -c 'src="${CLAUDE_CONFIG_DIR:-/home/claude/.claude}/channels/<plugin>/access.json"; dst="<project_path>/.claude.local/channels/<plugin>/"; [ -f "$src" ] && mkdir -p "$dst" && mv "$src" "$dst" && echo moved'
    ```
 6. **Default delivery settings** (skip if `"Already paired"` was chosen or pairing was skipped this run):
    1. Use the `Read` tool on `<project_path>/.claude.local/channels/<plugin>/access.json` (host file). If `ackReaction` is already non-empty, skip — preserve operator customization.
@@ -516,7 +516,7 @@ If the token is present, ask if already paired. If not:
          Pass `--no-mention` only for `"No — respond to all messages"`; omit it to require an @mention.
       c. Confirm (text only): "Sent `group add` for `<channelId>`. Will verify after all channels are added."
       d. Ask with `AskUserQuestion` (header: `"Add another?"`) — `"Yes — add another"` with the next ID via `Other`; `"Done — continue"`. On `"Done — continue"`: exit the loop.
-   4. **Verify all added channels** (one `Read` after the loop): open `<project_path>/.claude.local/channels/<plugin>/access.json`. For each ID added in step 3, confirm `groups.<channelId>` is present with the expected `requireMention` value. For any missing: run `docker compose exec -T hermit tmux capture-pane -t <session> -p`, surface the output, and warn — do not fail the whole setup. Then proceed to sub-step 8.
+   4. **Verify all added channels** (one `Read` after the loop): open `<project_path>/.claude.local/channels/<plugin>/access.json`. For each ID added in step 3, confirm `groups.<channelId>` is present with the expected `requireMention` value. For any missing: run `docker compose -f docker-compose.hermit.yml exec -T hermit tmux capture-pane -t <session> -p`, surface the output, and warn — do not fail the whole setup. Then proceed to sub-step 8.
 8. **Capture the bot's own identity** (host-side, like `channel-pair.ts` — `config.json` and the channel `.env` are both on the host):
    ```bash
    bun ${CLAUDE_PLUGIN_ROOT}/scripts/channel-bot-id.ts <project_path>/.claude-code-hermit <plugin> --write

--- a/plugins/claude-code-hermit/skills/hatch/SKILL.md
+++ b/plugins/claude-code-hermit/skills/hatch/SKILL.md
@@ -149,7 +149,7 @@ questions: [
 
   > **Channel preference saved.** Activation depends on how you run hermit:
   >
-  > - **Docker (always-on):** `/claude-code-hermit:docker-setup` configures the token and pairing inside the container.
+  > - **Docker (always-on):** `/claude-code-hermit:docker-setup` pairs during first run. Afterwards run `/claude-code-hermit:channel-setup` from the host to pair or re-pair. A channel or token added later needs `hermit-docker restart` first (the bot is offline until then). Inside the container, pair from the attached REPL with `/<channel>:access pair <code> — save access.json to <state_dir>/ not ~/.claude` and `/<channel>:access policy allowlist`.
   > - **tmux (always-on, host):** boot with `.claude-code-hermit/bin/hermit-start` (passes `--channels` automatically), then run `/claude-code-hermit:channel-setup` to set the token and pair.
   > - **Interactive (just trying it):** run `/claude-code-hermit:channel-setup` for token + pairing, then restart with `claude --channels plugin:<channel>@claude-plugins-official` so the channel is active in your session.
   > - Full guide: https://code.claude.com/docs/en/channels

--- a/plugins/claude-code-hermit/tests/contracts.test.ts
+++ b/plugins/claude-code-hermit/tests/contracts.test.ts
@@ -1456,6 +1456,36 @@ describe('channel-setup empty-channels branch', () => {
 });
 
 // ============================================================
+// channel-setup docker routing (static SKILL.md scan, not a live probe)
+// ============================================================
+
+describe('channel-setup docker routing', () => {
+  const channelSetup = read(path.join(SKILLS, 'channel-setup', 'SKILL.md'));
+  const dockerSetup = read(path.join(SKILLS, 'docker-setup', 'SKILL.md'));
+
+  test('does not redirect Docker operators to docker-setup', () => {
+    // Old gate: runtime.json runtime_mode, or a scaffolded Dockerfile.hermit.
+    expect(channelSetup).not.toContain('docker/Dockerfile.hermit');
+    expect(channelSetup).not.toContain('runtime_mode');
+    expect(channelSetup).not.toMatch(/Run `\/claude-code-hermit:docker-setup`/);
+  });
+
+  test('keeps a live host tmux hermit on the local flow', () => {
+    expect(channelSetup).toContain('liveOwner');
+  });
+
+  test('names the hermit-docker command for each Docker host state', () => {
+    expect(channelSetup).toContain('hermit-docker restart');
+    expect(channelSetup).toContain('hermit-docker up');
+    expect(channelSetup).toContain('hermit-docker logs');
+  });
+
+  test('docker-setup pairing notes the bot may take up to 1 min', () => {
+    expect(dockerSetup).toContain('Still nothing after waiting up to 1 min');
+  });
+});
+
+// ============================================================
 // Stop payload snapshot (TestStopPayloadSnapshot)
 //
 // stop-pipeline.ts writes state/cc-stop-snapshot.json from the Stop payload.


### PR DESCRIPTION
## Problem

On a Docker-deployed hermit, `/claude-code-hermit:channel-setup` redirected to `/claude-code-hermit:docker-setup`. docker-setup refuses to run inside the container and, from the host, backs up and re-renders the scaffolding before it pairs. So pairing a channel after first boot had no working path. docker-setup's own pairing also asked "Bot confirmed paired / No response" immediately, before the bot could plausibly have answered, and several of its pairing commands called bare `docker compose exec`, which finds no configuration from the project root because the file is `docker-compose.hermit.yml`.

## What changes

channel-setup now routes on where it runs and what state the container is in, in this order:

1. Inside the container: prints the two native `/<channel>:access` commands (pair carries the "save access.json to `<state_dir>/` not `~/.claude`" hint) or points at the host. No `AskUserQuestion`, since the resident's ask-gate denies it there.
2. No `docker-compose.hermit.yml`: the existing local/tmux flow.
3. A live host tmux hermit (`docker-preflight.ts` `liveOwner`): the local/tmux flow, even with a compose file present.
4. Compose present: `docker compose ps` decides. An unreachable compose stops with its error; a stopped container saves the token and ends with `hermit-docker up`.
5. Container running: a newly added channel or token ends with `hermit-docker restart` (the plugin reads its token at process start), with `hermit-docker logs --tail=60` and hermit-doctor named for "still no code". Otherwise it runs docker-setup's pairing sub-steps against the container.

docker-setup's step 0 and no-token messages point at channel-setup, its pairing commands pass `-f docker-compose.hermit.yml`, and its "No response" option carries `Still nothing after waiting up to 1 min`. `hatch`, `docs/always-on.md` and `docs/troubleshooting.md` route Docker operators to channel-setup for anything after first run.

```
BEFORE  operator on a Docker hermit wants to pair a chat
  ├─ channel-setup inside container ──► "run docker-setup" ──► docker-setup: "run from host"          (loop)
  ├─ channel-setup on host, booted ───► "run docker-setup" ──► back up scaffolding, rebuild, then pair
  ├─ channel-setup on host, not booted ► local flow ──► "restart with hermit-start"                   (wrong runtime)
  └─ docker-setup first-run pairing ──► "Bot confirmed paired / No response" asked at once ──► false "No response"

AFTER   operator on a Docker hermit wants to pair a chat ──► channel-setup
  ├─ inside container ─────────────► two native /<ch>:access commands (+ state-dir hint), or run me on the host
  ├─ host, live tmux hermit ───────► local/tmux flow
  ├─ host, compose unreachable ────► the docker error, stop
  ├─ host, container stopped ──────► token saved ──► "hermit-docker up, then run me again"
  ├─ host, channel/token new ──────► token saved and checked ──► "bot offline until hermit-docker restart; DM it, run me again"
  │                                    └─ still no code after a restart ──► hermit-docker logs / hermit-doctor
  └─ host, bot online, code in hand ► docker-setup's pairing sub-steps against the container
                                         ──► "Bot confirmed paired / No response (Still nothing after waiting up to 1 min)"
  local/tmux hermits, custom channels, everything between pairings: unchanged
```

## Blast radius
- Released surfaces touched: core 1.3.6 skills `channel-setup` (Docker runtime routing replaces the redirect to docker-setup), `docker-setup` (step 0 and no-token messages point at channel-setup; pairing commands gain `-f docker-compose.hermit.yml`; "No response" option notes up to 1 min), `hatch` (Docker channel handoff text); docs `always-on.md` and `troubleshooting.md`.
- Unreleased surfaces touched: `CHANGELOG.md` `[Unreleased]` gains a `### Fixed` block (3 bullets); `tests/contracts.test.ts` adds a `channel-setup docker routing` describe (text-only).
- Downstream operators: on Docker hermits, `/claude-code-hermit:channel-setup` from the host now pairs against the running container, or ends with exactly one `hermit-docker` command (`up` when stopped, `restart` after a new channel or token); inside the container it prints the two native `/<channel>:access` commands with the state-dir hint. Local/tmux operators see no change, and a Docker-scaffolded project with a live host tmux hermit keeps the local flow.
- Downstream hermits: prose-only; no script, hook, config key, or `hermit-run` verb changes, so no domain-plugin core floor bump. Takes effect on the next core release via `/plugin update`.
- Per-actor ledger: executor grok (harness default model) wrote the routing, docker-setup notes, docs/hatch text, contract tests and CHANGELOG / code-review (high --fix) added `-f docker-compose.hermit.yml` to docker-setup's four bare pairing `docker compose exec` commands / operator approved that fix outside the plan's fence, approved routing a live host tmux hermit (docker-preflight.ts `liveOwner`) to the local flow, and skipped the owner-welcome gap on the Docker path as a follow-up.

## Test plan

- [x] Plan closing verification re-run after the last commit: 16/16 rows exit 0, including `bun test` in `plugins/claude-code-hermit` and the new `channel-setup docker routing` contract tests.
- [x] Manual, after merge, on a Docker hermit: channel-setup from the host with the bot online and a code in hand (pairs; "No response" shows the note).
- [ ] From the host after adding a new channel (ends with the `hermit-docker restart` message).
- [x] From the host after `hermit-docker down` (ends with `hermit-docker up`).
- [x] From the attached REPL (ends with the two native commands and the state-dir hint).

Protocol smoke skipped: prose-only diff, no wire format changed.

## Follow-ups

- The owner welcome (channel-setup step 7a) never fires on the Docker path, since it keys off step 5's "Ready to pair", which that path skips. docker-setup's first-run pairing has no welcome either.
- Two bare `docker compose` calls remain in docker-setup outside pairing: the credentials check and the boot-log tail.
