### PR TITLE
docs(spawn-session): spell a helper's required file as an @<abs-path> mention

### DIFF
--- a/plugins/claude-code-hermit/skills/spawn-session/SKILL.md
+++ b/plugins/claude-code-hermit/skills/spawn-session/SKILL.md
@@ -25,7 +25,8 @@ Four limits sit on that command:
 
 - The helper's worktree `.claude-code-hermit/` is a projection (`OPERATOR.md`,
   `config.json`, `compiled/` only). Any file the helper must Read is passed as
-  an absolute path in the prompt.
+  an absolute path in the prompt, spelled as an `@<abs-path>` mention so
+  Claude Code injects it at launch.
 - A worktree carries no `.claude/settings.local.json` (it is gitignored, so
   nothing checks it out), so the helper inherits none of this hermit's
   permission rules. `--permission-mode <p>` from `config.json`'s


### PR DESCRIPTION
## Problem

The spawn-session skill told the resident to pass any file a helper must read as an absolute path in the prompt. That leaves the helper's model to decide whether and when to open it.

## Change

The first "Four limits" bullet now says the path is spelled as an `@<abs-path>` mention so Claude Code injects it at launch. One sentence, docs-only skill prose, no CHANGELOG entry.

```
BEFORE: helper prompt names a file as prose; the helper decides whether to open it
AFTER:  helper prompt carries @<abs-path>; Claude Code injects the file before the first turn
```

## Evidence

Probed live on Claude Code 2.1.268 in a real tmux session (Haiku, thinking off):

- An `@<path>` mention inside the CLI-positional launch prompt is resolved and its content injected, with no other instruction to read the file.
- `--add-dir <main>/.claude-code-hermit` does not suppress the Read permission prompt inside a `--worktree` session under `acceptEdits`, although the same flag makes the read silent without `--worktree`. So it is not a lever for spawned helpers and is deliberately not documented here.
- `--append-system-prompt` text never reaches non-fork subagents (earlier probe, 2.1.263), so the state-path boilerplate stays in the prompt.

## Not claimed

Whether the `@` form avoids the Read prompt under `acceptEdits` is untested (the `@` probe ran under bypassPermissions). The bullet says "injects at launch" and nothing about prompts.

## Validation

```
cd plugins/claude-code-hermit && bun test
```

5481 pass, 0 fail, exit 0. No test reads the skill text, so this is a no-regression check.
