### PR TITLE
fix(channel-responder): resolve the reply tool from a bare chat key

### DIFF
--- a/plugins/claude-code-hermit/CHANGELOG.md
+++ b/plugins/claude-code-hermit/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Docker pairing's pane capture and `access.json` checks pass `-f docker-compose.hermit.yml`, so they no longer fail with no configuration file
 - Helpers that need a decision go idle and surface the question in their chat instead of parking.
 - Resumed conversation helpers keep their full history on later resumes.
+- Replies to a remembered chat key on a custom channel plugin are delivered or reported as undeliverable rather than dropped.
 
 ### Upgrade Instructions
 

--- a/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
+++ b/plugins/claude-code-hermit/skills/channel-responder/SKILL.md
@@ -24,7 +24,12 @@ differ fills each slot from its own wire segment (e.g. `plugin:acme-crm:crm` →
 `mcp__plugin_acme-crm_crm__reply`) — build the tool name from the raw `source`,
 not by doubling one segment. Every `config.channels` key below instead uses the
 normalized bare server name (`discord`, not the qualified string — see
-`lib/channel-envelope.ts`'s `normalizeChannelSource`). Pass the
+`lib/channel-envelope.ts`'s `normalizeChannelSource`). When only that bare
+`<sourceKey>` is available (a `later` row's `chat`, a conversation binding key),
+the reply tool is the loaded `…__reply` tool whose server segment is exactly
+`<sourceKey>` (`mcp__plugin_<plugin-name>_<sourceKey>__reply`); when none matches,
+or more than one does, the chat is unreachable and the undelivered message is
+reported per § Operator Notification instead of replying. Pass the
 inbound `chat_id` back. Optionally pass `reply_to` (the inbound `message_id`)
 to thread under the operator's message. The tool result names the sent
 message (`sent (id: N)`); the same plugin's `edit_message` tool rewrites that


### PR DESCRIPTION
## Problem

`channel-responder` §0 tells the responder to build the reply tool name from the raw
`source` of the inbound envelope. That works while an envelope is in hand, but two paths
hold only a bare `<sourceKey>:<chat_id>` and no envelope: a `later` row's `chat`
(`scripts/later.ts:15`) and a conversation binding key (`scripts/lib/conversations.ts:39-46`).
The source half of that key is normalized, and `normalizeChannelSource`
(`scripts/lib/channel-envelope.ts:53`) keeps only the server segment.

For the built-in channels the plugin and server segments coincide
(`plugin:discord:discord` → `mcp__plugin_discord_discord__reply`), so the rule happens to
work. For a custom channel plugin whose names differ (`plugin:acme-crm:crm`) the qualified
tool name cannot be reconstructed from the bare key, §0 becomes unfollowable, and the reply
is silently dropped: nothing reaches the chat, and nothing tells the operator.

## Resulting behavior

```
remembered chat key ──> BEFORE: rebuild the tool name from an envelope it no longer has
                              ──> built-in channel: works
                              ──> differing-name custom plugin: silent drop

                     ──> AFTER:  match the loaded `…__reply` tool whose server segment
                                 is exactly <sourceKey>
                              ──> exactly one match: reply there
                              ──> none, or more than one: report undeliverable
                                  per § Operator Notification
```

One sentence in §0, next to the `normalizeChannelSource` cross-reference the bare key comes
from. No storage, no config key, no schema field, no code change. `watch` and `later` are
untouched: both already defer to "channel-responder §0".

The option chosen, and what it was weighed against:

```
recover the plugin name ─┬─ store the qualified source in the later + conversation stores
                         │    ─> schema field, migration, two stores
                         ├─ map the bare key back via config.channels
                         │    ─> config holds no qualified source, lookup fails for this case
                         └─ match the loaded tool by its exact server segment   ◀ SELECTED
                              ─> no storage, no config, one sentence
```

## Blast radius

- **Released surfaces touched:** `plugins/claude-code-hermit/skills/channel-responder/SKILL.md`
  §0, loaded on every inbound channel message. The edit itself is unreleased: it reaches
  installed operators only at the next core release.
- **Unreleased surfaces touched:** one `### Fixed` bullet under `## [Unreleased]` in
  `plugins/claude-code-hermit/CHANGELOG.md`. No `### Upgrade Instructions` entry: nothing to
  migrate.
- **Downstream operators:** no action, no config or command change. The visible difference is
  confined to a custom channel plugin whose plugin name differs from its server name: a reply
  into a remembered chat now either lands or is reported undeliverable, where before it
  vanished. Built-in Telegram and Discord behavior is unchanged.
- **Downstream hermits:** picked up with the next plugin update; no migration step, no state
  rewrite, no `hermit-evolve` action.
- **Per-actor ledger:** executor `codex` wrote the §0 sentence and the changelog bullet /
  `code-review high --fix` rewrote the sentence: moved it after the `normalizeChannelSource`
  cross-reference so the "instead" contrast in the preceding sentence still reads, replaced
  the `mcp__plugin_*_<sourceKey>__reply` glob with an exact server-segment match (a greedy
  `*` would match another plugin whose server name merely ends with the key, misrouting the
  reply), added the more-than-one-match guard, and rewrapped to the file's column width /
  operator decided nothing: no finding was left unfixed and none reversed a plan contract.

## Validation

The plan's closing verification, re-run in the worktree after the commit, all five rows exit 0:

```
0  cd plugins/claude-code-hermit && grep -c '_<sourceKey>__reply' skills/channel-responder/SKILL.md | grep -qx 1
0  cd plugins/claude-code-hermit && grep -c 'not by doubling one segment' skills/channel-responder/SKILL.md | grep -qx 1
0  cd plugins/claude-code-hermit && grep -c 'remembered chat key' CHANGELOG.md | grep -qx 1
0  cd plugins/claude-code-hermit && git diff --quiet -- skills/watch/SKILL.md skills/later/SKILL.md scripts
0  cd plugins/claude-code-hermit && bun test --parallel --timeout=45000
```

The last row is the core CI spine (`.github/workflows/test-hooks.yml:67-68`). The suites that
read `channel-responder/SKILL.md` (`tests/contracts.test.ts`, `tests/channel-ask-contract.test.ts`,
`tests/channel-responder-reply-rule.test.ts`) are inside it and green.

No live protocol smoke: the diff is skill prose, it defines no wire format and changes no
transport code, and no custom channel plugin with differing plugin and server names is loaded
here to exercise the branch it describes.
